### PR TITLE
Fix parsing double/float from string

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -118,7 +118,8 @@ absl::StatusOr<double> FilterParser::ParseNumber() {
   while (!IsEnd() && (std::isdigit(Peek()) || Peek() == '.')) {
     number_str += expression_[pos_++];
   }
-  if (absl::SimpleAtod(number_str, &value)) {
+  if (absl::AsciiStrToLower(number_str) != "nan" &&
+      absl::SimpleAtod(number_str, &value)) {
     return value * multiplier;
   }
   return absl::InvalidArgumentError(

--- a/src/indexes/numeric.cc
+++ b/src/indexes/numeric.cc
@@ -53,7 +53,7 @@ namespace valkey_search::indexes {
 namespace {
 std::optional<double> ParseNumber(absl::string_view data) {
   double value;
-  if (!absl::SimpleAtod(data, &value)) {
+  if (absl::AsciiStrToLower(data) == "nan" || !absl::SimpleAtod(data, &value)) {
     return std::nullopt;
   }
   return value;

--- a/vmsdk/src/type_conversions.h
+++ b/vmsdk/src/type_conversions.h
@@ -101,7 +101,7 @@ static inline absl::StatusOr<T> ToNumeric(absl::string_view str) {
 template <>
 inline absl::StatusOr<float> To(absl::string_view str) {
   float value;
-  if (!absl::SimpleAtof(str, &value)) {
+  if (absl::AsciiStrToLower(str) == "nan" || !absl::SimpleAtof(str, &value)) {
     return absl::InvalidArgumentError(
         absl::StrCat(str, " is not a valid float"));
   }
@@ -140,7 +140,7 @@ inline absl::StatusOr<uint64_t> To(absl::string_view str) {
 template <>
 inline absl::StatusOr<double> To(absl::string_view str) {
   double value;
-  if (!absl::SimpleAtod(str, &value)) {
+  if (absl::AsciiStrToLower(str) == "nan" || !absl::SimpleAtod(str, &value)) {
     return absl::InvalidArgumentError(
         absl::StrCat(str, " is not a valid double"));
   }


### PR DESCRIPTION
absl::SimpleAtod has a special handling for "nan" where it returns true but copy "nan" to the out value. Addressing this by checking for the string "nan".

This PR addresses the issue described in https://github.com/valkey-io/valkey-search/issues/53