### PR TITLE
Small aarch64 fixes

### DIFF
--- a/cmake/Modules/valkey_search.cmake
+++ b/cmake/Modules/valkey_search.cmake
@@ -138,4 +138,7 @@ macro(finalize_test_flags __TARGET)
   set_target_properties(${__TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY
                                                "${CMAKE_BINARY_DIR}/tests")
   target_link_libraries(${__TARGET} PRIVATE lib_to_add_end_group_flag)
+  if (VALKEY_SEARCH_IS_ARM)
+    target_link_libraries(${__TARGET} PRIVATE pthread)
+  endif()
 endmacro()

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -31,6 +31,7 @@
 #ifndef VMSDK_SRC_UTILS_H_
 #define VMSDK_SRC_UTILS_H_
 #include <cassert>
+#include <optional>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
- CMake: explicitly link against pthread
- Add missing include header (`optional`) when building on aarch64