### PR TITLE
Fixed crash when loading RDB

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -111,9 +111,11 @@ function configure() {
 
 function build() {
     printf "${BOLD_PINK}Building${RESET}\n"
-    cd ${BUILD_DIR}
-    ${NINJA_TOOL} ${VERBOSE_ARGS} ${CMAKE_TARGET}
-    cd ${ROOT_DIR}
+    if [ -d ${BUILD_DIR} ]; then
+        cd ${BUILD_DIR}
+        ${NINJA_TOOL} ${VERBOSE_ARGS} ${CMAKE_TARGET}
+        cd ${ROOT_DIR}
+    fi
 }
 
 function print_test_prefix() {
@@ -121,7 +123,7 @@ function print_test_prefix() {
 }
 
 function print_test_ok() {
-    printf "...${GREEN}ok${RESET}\n"
+    printf " ... ${GREEN}ok${RESET}\n"
 }
 
 function print_test_summary() {
@@ -129,7 +131,7 @@ function print_test_summary() {
 }
 
 function print_test_error_and_exit() {
-    printf "...${RED}failed${RESET}\n"
+    printf " ... ${RED}failed${RESET}\n"
     if [[ "${DUMP_TEST_ERRORS_STDOUT}" == "yes" ]]; then
         cat ${TEST_OUTPUT_FILE}
     fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,6 +8,7 @@ set(SRCS_MODULE_LOADER ${CMAKE_CURRENT_LIST_DIR}/module_loader.cc)
 # This is the module target
 valkey_search_add_shared_library(valkeysearch ${SRCS_MODULE_LOADER})
 target_include_directories(valkeysearch PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_options(valkeysearch PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/vmsdk/versionscript.lds")
 
 target_link_libraries(valkeysearch PUBLIC keyspace_event_manager)
 target_link_libraries(valkeysearch PUBLIC valkey_search)

--- a/third_party/hnswlib/CMakeLists.txt
+++ b/third_party/hnswlib/CMakeLists.txt
@@ -13,6 +13,7 @@ target_link_libraries(hnswlib_vmsdk INTERFACE iostream)
 target_link_libraries(hnswlib_vmsdk INTERFACE simsimd)
 target_link_libraries(hnswlib_vmsdk INTERFACE memory_allocation_overrides)
 target_link_libraries(hnswlib_vmsdk INTERFACE status_macros)
+target_compile_definitions(hnswlib_vmsdk INTERFACE VMSDK_ENABLE_MEMORY_ALLOCATION_OVERRIDES)
 
 set(SRCS_SIMSIMD ${CMAKE_CURRENT_LIST_DIR}/simsimd.h)
 


### PR DESCRIPTION
The crash was caused due to hnswlib not using
the memory override methods (CMake only).

Details:

- Any library consuming `hnswlib` will now have the macro `VMSDK_ENABLE_MEMORY_ALLOCATION_OVERRIDES` set during build time.
- Use version script `vmsdk/versionscript.lds`
- Fixed `build.sh --clean` when the build folder does not exist
