### PR TITLE
fixing github integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # allow manual triggering
 
 concurrency:
-  group: clang-${{ github.head_ref || github.ref }}
+  group: integration-tests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,4 +31,4 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Tests
-      run: docker run --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image sudo ./build.sh --run-integration-tests --test-errors-stdout
+      run: docker run --privileged --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image sudo ./build.sh --run-integration-tests --test-errors-stdout

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # allow manual triggering
 
 concurrency:
-  group: clang-${{ github.head_ref || github.ref }}
+  group: unittests-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -49,6 +49,7 @@
 #include "src/utils/string_interning.h"
 #include "testing/common.h"
 #include "testing/coordinator/common.h"
+#include "vmsdk/src/memory_allocation.h"
 #include "vmsdk/src/module.h"
 #include "vmsdk/src/testing_infra/module.h"
 #include "vmsdk/src/testing_infra/utils.h"
@@ -282,10 +283,11 @@ TEST_P(LoadTest, load) {
         .WillRepeatedly(testing::Return(0));
   }
   vmsdk::module::Options options;
-  EXPECT_EQ(vmsdk::module::OnLoadDone(ValkeySearch::Instance().OnLoad(
-                                          &fake_ctx_, args.data(), args.size()),
-                                      &fake_ctx_, options),
-            test_case.expected_load_ret);
+  auto load_res = vmsdk::module::OnLoadDone(
+      ValkeySearch::Instance().OnLoad(&fake_ctx_, args.data(), args.size()),
+      &fake_ctx_, options);
+  vmsdk::ResetValkeyAlloc();
+  EXPECT_EQ(load_res, test_case.expected_load_ret);
   auto writer_thread_pool = ValkeySearch::Instance().GetWriterThreadPool();
   auto reader_thread_pool = ValkeySearch::Instance().GetReaderThreadPool();
   if (test_case.expect_thread_pool_started) {


### PR DESCRIPTION
Fixes:

1. Running the docker in github workspaces as a privileged user.
2. Fixing valkey_search_test to turn-off memory tracking after OnLoad is called.
3. Fixing github workflows grouping 