### PR TITLE
Update printed binary file path

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -124,11 +124,11 @@ function build() {
         cd ${ROOT_DIR}
 
         printf "\n${GREEN}Build Successful!${RESET}\n\n"
-        printf "${BOLD_PINK}Module path:${RESET} .build_${BUILD_CONFIG}/libsearch.so\n\n"
+        printf "${BOLD_PINK}Module path:${RESET} .build-${BUILD_CONFIG}/libsearch.so\n\n"
         printf "You may want to run the unit tests by executing:\n"
         printf "    ./build.sh --run-tests\n\n"
         printf "To load the module, execute the following command:\n"
-        printf "    valkey-server --loadmodule %s/.build_${BUILD_CONFIG}/libsearch.so\n\n" "$PWD"
+        printf "    valkey-server --loadmodule %s/.build-${BUILD_CONFIG}/libsearch.so\n\n" "$PWD"
     fi
 }
 


### PR DESCRIPTION
```
Module path: .build_release/libsearch.so
4495.2 
4495.2 You may want to run the unit tests by executing:
4495.2     ./build.sh --run-tests
4495.2 
4495.2 To load the module, execute the following command:
4495.2     valkey-server --loadmodule /opt/valkey-search/.build_release/libsearch.so
```

However the built binary is located in the `.build_release` repository