### PR TITLE
Make backfill batch/block size configurable

### DIFF
--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -65,7 +65,7 @@
 
 namespace valkey_search::indexes {
 
-inline constexpr uint32_t kHNSWBlockSize = 1024 * 10;
+uint32_t kHNSWBlockSize{1024 * 10};
 
 std::vector<char> NormalizeEmbedding(absl::string_view record, size_t type_size,
                                      float* magnitude = nullptr);

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -65,8 +65,6 @@
 
 namespace valkey_search::indexes {
 
-uint32_t g_hnsw_block_size{1024 * 10};
-
 std::vector<char> NormalizeEmbedding(absl::string_view record, size_t type_size,
                                      float* magnitude = nullptr);
 

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -65,7 +65,7 @@
 
 namespace valkey_search::indexes {
 
-uint32_t kHNSWBlockSize{1024 * 10};
+uint32_t g_hnsw_block_size{1024 * 10};
 
 std::vector<char> NormalizeEmbedding(absl::string_view record, size_t type_size,
                                      float* magnitude = nullptr);

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -57,6 +57,7 @@
 #include "src/metrics.h"
 #include "src/rdb_serialization.h"
 #include "src/utils/string_interning.h"
+#include "src/valkey_search.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/utils.h"
@@ -271,10 +272,11 @@ absl::Status VectorHNSW<T>::ResizeIfFull() {
       // it was expanded.
       // 2. Once multithreaded is supported we'll have to make sure that no
       // thread is reading/writing during resize
-      algo_->resizeIndex(algo_->getMaxElements() + block_size_);
+      auto block_size = ValkeySearch::Instance().GetDefaultBlockSize();
+      algo_->resizeIndex(algo_->getMaxElements() + block_size);
       VMSDK_LOG(WARNING, nullptr)
           << "Resizing HNSW Index, current size: " << max_elements
-          << ", expand by: " << block_size_ << ", resize time took: "
+          << ", expand by: " << block_size << ", resize time took: "
           << absl::FormatDuration(stop_watch.Duration());
     }
   } catch (const std::exception &e) {

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -272,7 +272,7 @@ absl::Status VectorHNSW<T>::ResizeIfFull() {
       // it was expanded.
       // 2. Once multithreaded is supported we'll have to make sure that no
       // thread is reading/writing during resize
-      auto block_size = ValkeySearch::Instance().GetDefaultBlockSize();
+      auto block_size = ValkeySearch::Instance().GetHNSWBlockSize();
       algo_->resizeIndex(algo_->getMaxElements() + block_size);
       VMSDK_LOG(WARNING, nullptr)
           << "Resizing HNSW Index, current size: " << max_elements

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -85,8 +85,7 @@ class VectorHNSW : public VectorBase {
   size_t GetEfRuntime() const ABSL_SHARED_LOCKS_REQUIRED(resize_mutex_) {
     return algo_->ef_;
   }
-  // Used just for testing
-  void SetBlockSize(uint32_t block_size) { block_size_ = block_size; }
+
   absl::StatusOr<std::deque<Neighbor>> Search(
       absl::string_view query, uint64_t count,
       std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr,
@@ -126,7 +125,6 @@ class VectorHNSW : public VectorBase {
   std::unique_ptr<hnswlib::HierarchicalNSW<T>> algo_
       ABSL_GUARDED_BY(resize_mutex_);
   std::unique_ptr<hnswlib::SpaceInterface<T>> space_;
-  uint32_t block_size_{g_hnsw_block_size};
   mutable absl::Mutex resize_mutex_;
   mutable absl::Mutex tracked_vectors_mutex_;
   std::deque<InternedStringPtr> tracked_vectors_

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -126,7 +126,7 @@ class VectorHNSW : public VectorBase {
   std::unique_ptr<hnswlib::HierarchicalNSW<T>> algo_
       ABSL_GUARDED_BY(resize_mutex_);
   std::unique_ptr<hnswlib::SpaceInterface<T>> space_;
-  uint32_t block_size_{kHNSWBlockSize};
+  uint32_t block_size_{g_hnsw_block_size};
   mutable absl::Mutex resize_mutex_;
   mutable absl::Mutex tracked_vectors_mutex_;
   std::deque<InternedStringPtr> tracked_vectors_

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -57,6 +57,7 @@
 #include "src/metrics.h"
 #include "src/rdb_section.pb.h"
 #include "src/rdb_serialization.h"
+#include "src/valkey_search.h"
 #include "src/vector_externalizer.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -639,8 +640,10 @@ void SchemaManager::OnServerCronCallback(RedisModuleCtx *ctx,
                                          [[maybe_unused]] RedisModuleEvent eid,
                                          [[maybe_unused]] uint64_t subevent,
                                          [[maybe_unused]] void *data) {
+  auto index_schema_backfill_batch_size =
+      ValkeySearch::Instance().GetDefaultBlockSize();
   SchemaManager::Instance().PerformBackfill(ctx,
-                                            g_index_schema_backfill_batch_size);
+                                            index_schema_backfill_batch_size);
 }
 
 }  // namespace valkey_search

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -116,6 +116,8 @@ SchemaManager::SchemaManager(
   }
 }
 
+constexpr uint32_t kIndexSchemaBackfillBatchSize{10240};
+
 absl::Status GenerateIndexNotFoundError(absl::string_view name) {
   return absl::NotFoundError(
       absl::StrFormat("Index with name '%s' not found", name));
@@ -640,10 +642,7 @@ void SchemaManager::OnServerCronCallback(RedisModuleCtx *ctx,
                                          [[maybe_unused]] RedisModuleEvent eid,
                                          [[maybe_unused]] uint64_t subevent,
                                          [[maybe_unused]] void *data) {
-  auto index_schema_backfill_batch_size =
-      ValkeySearch::Instance().GetDefaultBlockSize();
-  SchemaManager::Instance().PerformBackfill(ctx,
-                                            index_schema_backfill_batch_size);
+  SchemaManager::Instance().PerformBackfill(ctx, kIndexSchemaBackfillBatchSize);
 }
 
 }  // namespace valkey_search

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -115,8 +115,6 @@ SchemaManager::SchemaManager(
   }
 }
 
-constexpr uint32_t kIndexSchemaBackfillBatchSize{10240};
-
 absl::Status GenerateIndexNotFoundError(absl::string_view name) {
   return absl::NotFoundError(
       absl::StrFormat("Index with name '%s' not found", name));

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -639,7 +639,8 @@ void SchemaManager::OnServerCronCallback(RedisModuleCtx *ctx,
                                          [[maybe_unused]] RedisModuleEvent eid,
                                          [[maybe_unused]] uint64_t subevent,
                                          [[maybe_unused]] void *data) {
-  SchemaManager::Instance().PerformBackfill(ctx, kIndexSchemaBackfillBatchSize);
+  SchemaManager::Instance().PerformBackfill(ctx,
+                                            g_index_schema_backfill_batch_size);
 }
 
 }  // namespace valkey_search

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -55,6 +55,7 @@ namespace valkey_search {
 
 constexpr absl::string_view kSchemaManagerMetadataTypeName{"vs_index_schema"};
 constexpr uint32_t kMetadataEncodingVersion = 1;
+uint32_t kIndexSchemaBackfillBatchSize{10240};
 
 class SchemaManager {
  public:

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -55,7 +55,7 @@ namespace valkey_search {
 
 constexpr absl::string_view kSchemaManagerMetadataTypeName{"vs_index_schema"};
 constexpr uint32_t kMetadataEncodingVersion = 1;
-uint32_t kIndexSchemaBackfillBatchSize{10240};
+uint32_t g_index_schema_backfill_batch_size{10240};
 
 class SchemaManager {
  public:

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -55,7 +55,6 @@ namespace valkey_search {
 
 constexpr absl::string_view kSchemaManagerMetadataTypeName{"vs_index_schema"};
 constexpr uint32_t kMetadataEncodingVersion = 1;
-uint32_t g_index_schema_backfill_batch_size{10240};
 
 class SchemaManager {
  public:

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -75,7 +75,7 @@ namespace valkey_search {
 
 static absl::NoDestructor<std::unique_ptr<ValkeySearch>> valkey_search_instance;
 constexpr size_t kMaxWorkerThreadPoolSuspensionSec{60};
-std::atomic<uint32_t> ValkeySearch::hnsw_block_size_{10240};
+static std::atomic<uint32_t> hnsw_block_size{10240};
 const absl::string_view kHNSWBlockSizeConfig{"vs-hnsw-block-size"};
 
 namespace options {
@@ -141,6 +141,10 @@ ValkeySearch &ValkeySearch::Instance() { return **valkey_search_instance; };
 
 void ValkeySearch::InitInstance(std::unique_ptr<ValkeySearch> instance) {
   *valkey_search_instance = std::move(instance);
+}
+
+uint32_t ValkeySearch::GetHNSWBlockSize() const {
+  return hnsw_block_size.load();
 }
 
 static std::string ConvertToMB(double bytes_value) {
@@ -543,7 +547,7 @@ void ValkeySearch::ResumeWriterThreadPool(RedisModuleCtx *ctx,
 long long ValkeySearch::BlockSizeGetConfig(
     [[maybe_unused]] const char *config_name,
     [[maybe_unused]] void *priv_data) {
-  return hnsw_block_size_.load();
+  return hnsw_block_size.load();
 }
 
 int ValkeySearch::BlockSizeSetConfig([[maybe_unused]] const char *config_name,
@@ -557,7 +561,7 @@ int ValkeySearch::BlockSizeSetConfig([[maybe_unused]] const char *config_name,
     }
     return REDISMODULE_ERR;
   }
-  hnsw_block_size_ = static_cast<uint32_t>(value);
+  hnsw_block_size = static_cast<uint32_t>(value);
   return REDISMODULE_OK;
 }
 

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -85,6 +85,7 @@ constexpr absl::string_view kReaderThreadsParam{"--reader-threads"};
 constexpr absl::string_view kWriterThreadsParam{"--writer-threads"};
 constexpr absl::string_view kUseCoordinator{"--use-coordinator"};
 constexpr absl::string_view kLogLevel{"--log-level"};
+constexpr absl::string_view kResizeBlockSize{"--resize-block-size"};
 
 struct Parameters {
   size_t reader_threads{vmsdk::GetPhysicalCPUCoresCount()};
@@ -92,6 +93,7 @@ struct Parameters {
   std::optional<int> threads;
   bool use_coordinator{false};
   std::optional<std::string> log_level;
+  uint32_t resize_backfill_block{10240};
 };
 
 absl::StatusOr<Parameters> Load(RedisModuleString **argv, int argc) {
@@ -107,6 +109,8 @@ absl::StatusOr<Parameters> Load(RedisModuleString **argv, int argc) {
                         GENERATE_FLAG_PARSER(Parameters, use_coordinator));
   parser.AddParamParser(kLogLevel,
                         GENERATE_VALUE_PARSER(Parameters, log_level));
+  parser.AddParamParser(kResizeBlockSize,
+                        GENERATE_VALUE_PARSER(Parameters, resize_backfill_block));
   vmsdk::ArgsIterator itr{argv, argc};
   VMSDK_RETURN_IF_ERROR(parser.Parse(parameters, itr));
   if (parameters.threads.has_value()) {
@@ -469,6 +473,11 @@ absl::Status ValkeySearch::LoadOptions(RedisModuleCtx *ctx,
   writer_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
       "write-worker-", options.writer_threads);
   writer_thread_pool_->StartWorkers();
+
+  if (options.resize_backfill_block > 10240) {
+    kIndexSchemaBackfillBatchSize = options.resize_backfill_block;
+    valkey_search::indexes::kHNSWBlockSize = options.resize_backfill_block;
+  }
 
   if (options.log_level) {
     VMSDK_RETURN_IF_ERROR(vmsdk::InitLogging(ctx, options.log_level));

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -144,7 +144,7 @@ void ValkeySearch::InitInstance(std::unique_ptr<ValkeySearch> instance) {
 }
 
 uint32_t ValkeySearch::GetHNSWBlockSize() const {
-  return hnsw_block_size.load();
+  return hnsw_block_size.load(std::memory_order_relaxed);
 }
 
 static std::string ConvertToMB(double bytes_value) {
@@ -547,7 +547,7 @@ void ValkeySearch::ResumeWriterThreadPool(RedisModuleCtx *ctx,
 long long ValkeySearch::BlockSizeGetConfig(
     [[maybe_unused]] const char *config_name,
     [[maybe_unused]] void *priv_data) {
-  return hnsw_block_size.load();
+  return hnsw_block_size.load(std::memory_order_relaxed);
 }
 
 int ValkeySearch::BlockSizeSetConfig([[maybe_unused]] const char *config_name,
@@ -561,7 +561,8 @@ int ValkeySearch::BlockSizeSetConfig([[maybe_unused]] const char *config_name,
     }
     return REDISMODULE_ERR;
   }
-  hnsw_block_size = static_cast<uint32_t>(value);
+  hnsw_block_size.store(static_cast<uint32_t>(value),
+                        std::memory_order_relaxed);
   return REDISMODULE_OK;
 }
 

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -85,7 +85,7 @@ constexpr absl::string_view kReaderThreadsParam{"--reader-threads"};
 constexpr absl::string_view kWriterThreadsParam{"--writer-threads"};
 constexpr absl::string_view kUseCoordinator{"--use-coordinator"};
 constexpr absl::string_view kLogLevel{"--log-level"};
-constexpr absl::string_view kResizeBlockSize{"--resize-block-size"};
+constexpr absl::string_view kBlockSize{"--block-size"};
 
 struct Parameters {
   size_t reader_threads{vmsdk::GetPhysicalCPUCoresCount()};
@@ -93,7 +93,7 @@ struct Parameters {
   std::optional<int> threads;
   bool use_coordinator{false};
   std::optional<std::string> log_level;
-  uint32_t resize_backfill_block{10240};
+  uint32_t block_size{10240};
 };
 
 absl::StatusOr<Parameters> Load(RedisModuleString **argv, int argc) {
@@ -109,8 +109,8 @@ absl::StatusOr<Parameters> Load(RedisModuleString **argv, int argc) {
                         GENERATE_FLAG_PARSER(Parameters, use_coordinator));
   parser.AddParamParser(kLogLevel,
                         GENERATE_VALUE_PARSER(Parameters, log_level));
-  parser.AddParamParser(kResizeBlockSize,
-                        GENERATE_VALUE_PARSER(Parameters, resize_backfill_block));
+  parser.AddParamParser(kBlockSize,
+                        GENERATE_VALUE_PARSER(Parameters, block_size));
   vmsdk::ArgsIterator itr{argv, argc};
   VMSDK_RETURN_IF_ERROR(parser.Parse(parameters, itr));
   if (parameters.threads.has_value()) {
@@ -474,9 +474,9 @@ absl::Status ValkeySearch::LoadOptions(RedisModuleCtx *ctx,
       "write-worker-", options.writer_threads);
   writer_thread_pool_->StartWorkers();
 
-  if (options.resize_backfill_block > 10240) {
-    kIndexSchemaBackfillBatchSize = options.resize_backfill_block;
-    valkey_search::indexes::kHNSWBlockSize = options.resize_backfill_block;
+  if (options.block_size > 10240) {
+    kIndexSchemaBackfillBatchSize = options.block_size;
+    valkey_search::indexes::kHNSWBlockSize = options.block_size;
   }
 
   if (options.log_level) {

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -76,7 +76,7 @@ namespace valkey_search {
 static absl::NoDestructor<std::unique_ptr<ValkeySearch>> valkey_search_instance;
 constexpr size_t kMaxWorkerThreadPoolSuspensionSec{60};
 static std::atomic<uint32_t> hnsw_block_size{10240};
-const absl::string_view kHNSWBlockSizeConfig{"vs-hnsw-block-size"};
+const absl::string_view kHNSWBlockSizeConfig{"hnsw-block-size"};
 
 namespace options {
 
@@ -87,7 +87,7 @@ constexpr absl::string_view kReaderThreadsParam{"--reader-threads"};
 constexpr absl::string_view kWriterThreadsParam{"--writer-threads"};
 constexpr absl::string_view kUseCoordinator{"--use-coordinator"};
 constexpr absl::string_view kLogLevel{"--log-level"};
-constexpr absl::string_view kHNSWBlockSize{"--vs-hnsw-block-size"};
+constexpr absl::string_view kHNSWBlockSize{"--hnsw-block-size"};
 
 struct Parameters {
   size_t reader_threads{vmsdk::GetPhysicalCPUCoresCount()};
@@ -554,7 +554,7 @@ int ValkeySearch::BlockSizeSetConfig([[maybe_unused]] const char *config_name,
                                      long long value,
                                      [[maybe_unused]] void *priv_data,
                                      RedisModuleString **err) {
-  if (value < 0 || value > UINT32_MAX) {
+  if (value <= 0 || value > UINT32_MAX) {
     if (err) {
       *err = RedisModule_CreateStringPrintf(
           nullptr, "Block size must be between 10240 and %u", UINT32_MAX);

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -128,6 +128,13 @@ class ValkeySearch {
   static bool IsChildProcess();
   void ProcessIndexSchemaBackfill(RedisModuleCtx *ctx, uint32_t batch_size);
 
+  static long long BlockSizeGetConfig([[maybe_unused]] const char *cofig_name,
+                                      [[maybe_unused]] void *priv_data);
+  static int BlockSizeSetConfig([[maybe_unused]] const char *cofig_name,
+                                long long value,
+                                [[maybe_unused]] void *priv_data,
+                                [[maybe_unused]] RedisModuleString **err);
+
   void ResumeWriterThreadPool(RedisModuleCtx *ctx, bool is_expired);
 
   uint64_t inc_id_{0};

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -122,7 +122,7 @@ class ValkeySearch {
   // of the program.
   RedisModuleCtx *GetBackgroundCtx() const { return ctx_; }
 
-  uint32_t GetDefaultBlockSize() const { return block_size_.load(); }
+  uint32_t GetHNSWBlockSize() const { return hnsw_block_size_.load(); }
 
  protected:
   std::unique_ptr<vmsdk::ThreadPool> reader_thread_pool_;
@@ -145,7 +145,7 @@ class ValkeySearch {
   std::unique_ptr<coordinator::Server> coordinator_;
   std::unique_ptr<coordinator::ClientPool> client_pool_;
 
-  static std::atomic<uint32_t> block_size_;
+  static std::atomic<uint32_t> hnsw_block_size_;
 };
 void ModuleInfo(RedisModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -70,9 +70,9 @@ class ValkeySearch {
   }
   void Info(RedisModuleInfoCtx *ctx) const;
 
-  static long long BlockSizeGetConfig([[maybe_unused]] const char *cofig_name,
+  static long long BlockSizeGetConfig([[maybe_unused]] const char *config_name,
                                       [[maybe_unused]] void *priv_data);
-  static int BlockSizeSetConfig([[maybe_unused]] const char *cofig_name,
+  static int BlockSizeSetConfig([[maybe_unused]] const char *config_name,
                                 long long value,
                                 [[maybe_unused]] void *priv_data,
                                 [[maybe_unused]] RedisModuleString **err);
@@ -93,6 +93,7 @@ class ValkeySearch {
   void AfterForkParent();
   static ValkeySearch &Instance();
   static void InitInstance(std::unique_ptr<ValkeySearch> instance);
+  uint32_t GetHNSWBlockSize() const;
 
   absl::Status OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
   void OnUnload(RedisModuleCtx *ctx);
@@ -122,8 +123,6 @@ class ValkeySearch {
   // of the program.
   RedisModuleCtx *GetBackgroundCtx() const { return ctx_; }
 
-  uint32_t GetHNSWBlockSize() const { return hnsw_block_size_.load(); }
-
  protected:
   std::unique_ptr<vmsdk::ThreadPool> reader_thread_pool_;
   std::unique_ptr<vmsdk::ThreadPool> writer_thread_pool_;
@@ -144,8 +143,6 @@ class ValkeySearch {
 
   std::unique_ptr<coordinator::Server> coordinator_;
   std::unique_ptr<coordinator::ClientPool> client_pool_;
-
-  static std::atomic<uint32_t> hnsw_block_size_;
 };
 void ModuleInfo(RedisModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -70,6 +70,13 @@ class ValkeySearch {
   }
   void Info(RedisModuleInfoCtx *ctx) const;
 
+  static long long BlockSizeGetConfig([[maybe_unused]] const char *cofig_name,
+                                      [[maybe_unused]] void *priv_data);
+  static int BlockSizeSetConfig([[maybe_unused]] const char *cofig_name,
+                                long long value,
+                                [[maybe_unused]] void *priv_data,
+                                [[maybe_unused]] RedisModuleString **err);
+
   IndexSchema::Stats::ResultCnt<uint64_t> AccumulateIndexSchemaResults(
       absl::AnyInvocable<const IndexSchema::Stats::ResultCnt<
           std::atomic<uint64_t>> &(const IndexSchema::Stats &) const>
@@ -115,6 +122,8 @@ class ValkeySearch {
   // of the program.
   RedisModuleCtx *GetBackgroundCtx() const { return ctx_; }
 
+  uint32_t GetDefaultBlockSize() const { return block_size_.load(); }
+
  protected:
   std::unique_ptr<vmsdk::ThreadPool> reader_thread_pool_;
   std::unique_ptr<vmsdk::ThreadPool> writer_thread_pool_;
@@ -127,14 +136,6 @@ class ValkeySearch {
   static void FreeIndexSchema(void *value);
   static bool IsChildProcess();
   void ProcessIndexSchemaBackfill(RedisModuleCtx *ctx, uint32_t batch_size);
-
-  static long long BlockSizeGetConfig([[maybe_unused]] const char *cofig_name,
-                                      [[maybe_unused]] void *priv_data);
-  static int BlockSizeSetConfig([[maybe_unused]] const char *cofig_name,
-                                long long value,
-                                [[maybe_unused]] void *priv_data,
-                                [[maybe_unused]] RedisModuleString **err);
-
   void ResumeWriterThreadPool(RedisModuleCtx *ctx, bool is_expired);
 
   uint64_t inc_id_{0};
@@ -143,6 +144,8 @@ class ValkeySearch {
 
   std::unique_ptr<coordinator::Server> coordinator_;
   std::unique_ptr<coordinator::ClientPool> client_pool_;
+
+  static std::atomic<uint32_t> block_size_;
 };
 void ModuleInfo(RedisModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -325,8 +325,15 @@ TEST_F(VectorIndexTest, ResizeHNSW) ABSL_NO_THREAD_SAFETY_ANALYSIS {
                                    kM, kEFConstruction, kEFRuntime),
         "attribute_identifier_1",
         data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH);
-    const uint32_t block_size = 1024;
-    index.value()->SetBlockSize(block_size);
+    RedisModuleString* err = nullptr;
+    EXPECT_EQ(
+        ValkeySearch::BlockSizeSetConfig("vs-block-size", 1024, nullptr, &err),
+        REDISMODULE_OK);
+    if (err) {
+      RedisModule_FreeString(nullptr, err);
+      err = nullptr;
+    }
+    uint32_t block_size = ValkeySearch::Instance().GetDefaultBlockSize();
     EXPECT_EQ(index.value()->GetCapacity(), initial_cap);
     auto vectors = DeterministicallyGenerateVectors(
         initial_cap + block_size + 100, kDimensions, 10.0);

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -326,14 +326,13 @@ TEST_F(VectorIndexTest, ResizeHNSW) ABSL_NO_THREAD_SAFETY_ANALYSIS {
         "attribute_identifier_1",
         data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH);
     RedisModuleString* err = nullptr;
-    EXPECT_EQ(
-        ValkeySearch::BlockSizeSetConfig("vs-block-size", 1024, nullptr, &err),
-        REDISMODULE_OK);
+    EXPECT_EQ(ValkeySearch::BlockSizeSetConfig(NULL, 1024, nullptr, &err),
+              REDISMODULE_OK);
     if (err) {
       RedisModule_FreeString(nullptr, err);
       err = nullptr;
     }
-    uint32_t block_size = ValkeySearch::Instance().GetDefaultBlockSize();
+    uint32_t block_size = ValkeySearch::Instance().GetHNSWBlockSize();
     EXPECT_EQ(index.value()->GetCapacity(), initial_cap);
     auto vectors = DeterministicallyGenerateVectors(
         initial_cap + block_size + 100, kDimensions, 10.0);


### PR DESCRIPTION
Ran benchmark test with GIST dataset from ann-benchmark on valkey-search module resulted performance fluctuations and observed that lot of backfill/resize during the test. For large datasets the vector backfill process is triggered so frequent as it is hard coded to 10240. So making the constant to be configurable would help to adjust based on the number of documents be loaded and the frequency of backfill can be controlled based on the expected dataset size. this helps for reducing the indexing time and also perfomance fluctuation. 

Added '--resize-block-size' option in module load optins and this will be reflcted on kIndexSchemaBackfillBatchSize and kHNSWBlockSize for consistency and default value is 10240 as before. The values get modified for above default 10240 and does not reflect for lower sizes.