### PR TITLE
chore: avoid reserved gid, group name when setup for local dev env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,6 +55,13 @@ ENV USER_GID=${USER_GID}
 ARG USER_GNAME=ubuntu
 ENV USER_GNAME=${USER_GNAME}
 
+# Check if the target group name exists and has a different GID. If so, delete it.
+RUN EXISTING_GID=$(getent group $USER_GNAME | cut -d: -f3 || true); \
+    if [ ! -z "$EXISTING_GID" ] && [ "$EXISTING_GID" != "$USER_GID" ]; then \
+    echo "Deleting existing group '$USER_GNAME' (GID $EXISTING_GID) to avoid conflict with target GID $USER_GID."; \
+    groupdel $USER_GNAME; \
+    fi
+
 RUN if getent group $USER_GID > /dev/null; then \
     CURRENT_GROUP_NAME=$(getent group $USER_GID | cut -d: -f1); \
     if [ "$CURRENT_GROUP_NAME" != "$USER_GNAME" ]; then \

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,14 +12,6 @@ user_name=$(whoami)
 group_id=$(id -g)
 group_name=$(id -gn)
 
-# Check for potential GID/GName conflicts (e.g., with 'staff' GID 50)
-if [[ "$group_id" == "50" ]] || [[ "$group_name" == "staff" ]]; then
-    printf "\n${BLUE}Detected host GID ($group_id) or GName ($group_name) potentially conflicts with system groups (e.g., staff)."
-    printf "\nUsing GID=1000 and GName=ubuntu inside the container instead.${RESET}\n"
-    group_id="1000"
-    group_name="ubuntu"
-fi
-
 # Define source and destination file paths
 source_file=".devcontainer/devcontainer_base.json"
 destination_file=".devcontainer/devcontainer.json"

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -12,6 +12,14 @@ user_name=$(whoami)
 group_id=$(id -g)
 group_name=$(id -gn)
 
+# Check for potential GID/GName conflicts (e.g., with 'staff' GID 50)
+if [[ "$group_id" == "50" ]] || [[ "$group_name" == "staff" ]]; then
+    printf "\n${BLUE}Detected host GID ($group_id) or GName ($group_name) potentially conflicts with system groups (e.g., staff)."
+    printf "\nUsing GID=1000 and GName=ubuntu inside the container instead.${RESET}\n"
+    group_id="1000"
+    group_name="ubuntu"
+fi
+
 # Define source and destination file paths
 source_file=".devcontainer/devcontainer_base.json"
 destination_file=".devcontainer/devcontainer.json"
@@ -41,7 +49,7 @@ if [[ $? -eq 0 ]]; then
     echo "  USER_UID: $user_id"
     echo "  USER_UNAME: $user_name"
     echo "  USER_GID: $group_id"
-    echo "  USER_GNAME: $user_name"
+    echo "  USER_GNAME: $group_name"
 else
     printf "\n${RED}Failed to create the file ${destination_file}.${RESET}\n\n" >&2
     exit 1


### PR DESCRIPTION
when i run 
```
id -g
id -gn
```

commands In My Mac OS, I got

```
20
staff
```

`ubuntu:stable` has already "staff" group. so when build docker got error
```
groupmod: group 'staff' already exists
```

If conflict with reserved group, then use default group in the script.
