### PR TITLE
Fixed crash in UT

### DIFF
--- a/cmake/Modules/valkey_search.cmake
+++ b/cmake/Modules/valkey_search.cmake
@@ -164,9 +164,6 @@ macro(finalize_test_flags __TARGET)
   endforeach()
 
   target_link_options(${__TARGET} PRIVATE "LINKER:--allow-multiple-definition")
-  if(NOT ASAN_BUILD)
-    target_link_options(${__TARGET} PRIVATE "LINKER:-S")
-  endif()
   target_compile_options(${__TARGET} PRIVATE -O1)
   valkey_search_target_update_compile_flags(${__TARGET})
   set_target_properties(${__TARGET} PROPERTIES RUNTIME_OUTPUT_DIRECTORY

--- a/vmsdk/src/testing_infra/module.h
+++ b/vmsdk/src/testing_infra/module.h
@@ -193,6 +193,12 @@ class MockRedisModule {
                RedisModuleConfigGetEnumFunc getfn,
                RedisModuleConfigSetEnumFunc setfn,
                RedisModuleConfigApplyFunc applyfn, void *privdata));
+  MOCK_METHOD(int, RegisterNumericConfig,
+              (RedisModuleCtx * ctx, const char *name, long long default_val,
+               unsigned int flags, long long min, long long max,
+               RedisModuleConfigGetNumericFunc getfn,
+               RedisModuleConfigSetNumericFunc setfn,
+               RedisModuleConfigApplyFunc applyfn, void *privdata));
   MOCK_METHOD(int, LoadConfigs, (RedisModuleCtx * ctx));
   MOCK_METHOD(int, SetConnectionProperties,
               (const RedisModuleConnectionProperty *properties, int length));
@@ -993,6 +999,16 @@ inline int TestRedisModule_RegisterEnumConfig(
       getfn, setfn, applyfn, privdata);
 }
 
+inline int TestRedisModule_RegisterNumericConfig(
+    RedisModuleCtx *ctx, const char *name, long long default_val,
+    unsigned int flags, long long min, long long max,
+    RedisModuleConfigGetNumericFunc getfn,
+    RedisModuleConfigSetNumericFunc setfn, RedisModuleConfigApplyFunc applyfn,
+    void *privdata) {
+  return kMockRedisModule->RegisterNumericConfig(
+      ctx, name, default_val, flags, min, max, getfn, setfn, applyfn, privdata);
+}
+
 inline int TestRedisModule_LoadConfigs(RedisModuleCtx *ctx) {
   return kMockRedisModule->LoadConfigs(ctx);
 }
@@ -1522,6 +1538,8 @@ inline void TestRedisModule_Init() {
   RedisModule_RdbSave = &TestRedisModule_RdbSave;
   RedisModule_RdbLoad = &TestRedisModule_RdbLoad;
   RedisModule_GetCurrentUserName = &TestRedisModule_GetCurrentUserName;
+  RedisModule_RegisterNumericConfig = &TestRedisModule_RegisterNumericConfig;
+
   kMockRedisModule = new testing::NiceMock<MockRedisModule>();
 
   // Implement basic key registration functions with simple implementations by


### PR DESCRIPTION
Added missing mock method `RedisModule_RegisterNumericConfig` (A regression introduced in commit: 5e50c97e51f37a41021e766f70795fb4f53e86d8)

In addition, remove the `-S` from test binaries (to provide a better stack-traces when running under gdb)