### PR TITLE
Method `GetPhysicalCPUCoresCount` is broken for `Linux / aarch64`

### DIFF
--- a/vmsdk/src/concurrency.cc
+++ b/vmsdk/src/concurrency.cc
@@ -34,7 +34,11 @@
 
 #include "absl/algorithm/container.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
+#include "absl/strings/match.h"
+#include "absl/strings/str_cat.h"
+#include "absl/strings/str_split.h"
 #include "vmsdk/src/log.h"
 
 namespace vmsdk {
@@ -88,21 +92,81 @@ size_t ParseCPUInfo(std::istream& cpuinfo) {
   return total_physical_cores;
 }
 
+/// Execute `command` and return its output
+absl::StatusOr<std::string> ExecuteCommand(const std::string& command) {
+  errno = 0;
+  auto fp = ::popen(command.c_str(), "r");
+  if (fp == nullptr) {
+    return absl::ErrnoToStatus(
+        errno, absl::StrCat("Could not execute command: ", command));
+  }
+  constexpr size_t LINE_SIZE = 1024;
+  char line[LINE_SIZE];
+  std::stringstream ss;
+  while (std::fgets(line, LINE_SIZE, fp) != nullptr) {
+    ss << line;
+  }
+  ::fclose(fp);
+  return ss.str();
+}
+
+/// Return the number of physical cores by parsing the output of `lscpu` command
+size_t ParseLscpuOutput(const std::string& lscpu_output) {
+  constexpr absl::string_view CORES_PER_SOCKET = "Core(s) per socket";
+  constexpr absl::string_view SOCKETS = "Socket(s)";
+
+  std::vector<absl::string_view> lines = absl::StrSplit(lscpu_output, '\n');
+  int cores_per_socket = -1;
+  int sockets_count = -1;
+  for (auto line : lines) {
+    if (cores_per_socket == -1 && absl::StrContains(line, CORES_PER_SOCKET)) {
+      cores_per_socket = ExtractInteger(std::string{line});
+    } else if (sockets_count == -1 && absl::StrContains(line, SOCKETS)) {
+      sockets_count = ExtractInteger(std::string{line});
+    }
+
+    if (sockets_count != -1 && cores_per_socket != -1) {
+      break;
+    }
+  }
+
+  if (sockets_count < 0 || cores_per_socket < 0) {
+    VMSDK_LOG(NOTICE, nullptr) << "Error while parsing 'lscpu' output:\n"
+                               << lscpu_output << "\n"
+                               << ". Returning value from "
+                                  "std::thread::hardware_concurrency()";
+    return std::thread::hardware_concurrency();
+  }
+  return sockets_count * cores_per_socket;
+}
+
 }  // namespace helper
 
 size_t GetPhysicalCPUCoresCount() {
-#ifdef __linux__
+  // Default
+  size_t cpu_cores = std::thread::hardware_concurrency();
+#if defined(__linux__) && defined(__aarch64__)
+  auto res = helper::ExecuteCommand("/usr/bin/lscpu");
+  if (!res.ok()) {
+    VMSDK_LOG(WARNING, nullptr) << res.status().message()
+                                << ". Returning value from "
+                                   "std::thread::hardware_concurrency()";
+  } else {
+    const auto& lscpu_output = res.value();
+    cpu_cores = helper::ParseLscpuOutput(lscpu_output);
+  }
+#elif defined(__linux__)
   std::ifstream cpuinfo("/proc/cpuinfo");
   if (!cpuinfo.is_open()) {
     VMSDK_LOG(NOTICE, nullptr)
         << "Could not read /proc/cpuinfo. Returning value from "
            "std::thread::hardware_concurrency()";
-    return std::thread::hardware_concurrency();
+  } else {
+    cpu_cores = helper::ParseCPUInfo(cpuinfo);
   }
-  return helper::ParseCPUInfo(cpuinfo);
-#else
-  return std::thread::hardware_concurrency();
 #endif
+  VMSDK_LOG(NOTICE, nullptr) << "Cores count is set to:" << cpu_cores;
+  return cpu_cores;
 }
 
 }  // namespace vmsdk

--- a/vmsdk/src/concurrency.h
+++ b/vmsdk/src/concurrency.h
@@ -44,11 +44,14 @@ namespace helper {
 // Parses /proc/cpuinfo content and extracts the number of physical cores.
 size_t ParseCPUInfo(std::istream& cpuinfo);
 
+// Parses the output of the command `lscpu` and return the number of physical
+// cores.
+size_t ParseLscpuOutput(const std::string& lscpu_output);
+
 // Extracts an integer value from a formatted key-value string.
 int ExtractInteger(const std::string& line);
 
 }  // namespace helper
-
 }  // namespace vmsdk
 
 #endif  // VMSDK_SRC_CONCURRENCY_H_

--- a/vmsdk/testing/concurrency_test.cc
+++ b/vmsdk/testing/concurrency_test.cc
@@ -32,6 +32,7 @@
 #include <gtest/gtest.h>
 
 #include <sstream>
+#include <string>
 
 namespace vmsdk {
 namespace helper {
@@ -42,6 +43,14 @@ class ParseCPUInfoTest : public ::testing::Test {
   size_t CallParseCPUInfo(const std::string& cpuinfo_content) {
     std::istringstream stream(cpuinfo_content);
     return ParseCPUInfo(stream);
+  }
+};
+
+// Test fixture for ParseLscpuOutput
+class ParseLscpuTestTest : public ::testing::Test {
+ protected:
+  size_t CallParseLscpuOutput(const std::string& lscpu_output) {
+    return ParseLscpuOutput(lscpu_output);
   }
 };
 
@@ -155,6 +164,64 @@ TEST_F(ParseCPUInfoTest, MixedValidInvalidData) {
       "cpu cores   : 6\n";
 
   EXPECT_EQ(CallParseCPUInfo(cpuinfo), 10);  // Only 4 + 6 should count
+}
+
+// Test parsing lscpu output with valid output
+TEST_F(ParseLscpuTestTest, StandardLscpuOutput) {
+  std::string output =
+      R"#(
+Core(s) per socket:  8
+Socket(s):           1
+NUMA node(s):        1
+Vendor ID:           ARM
+Model:               1
+Stepping:            r1p1
+BogoMIPS:            2100.00
+)#";
+  EXPECT_EQ(CallParseLscpuOutput(output), 8);  // 8 cores * 1 socket
+}
+
+// Test parsing lscpu output with missing "Cores" entry
+TEST_F(ParseLscpuTestTest, MissingCoresEntry) {
+  auto default_value = std::thread::hardware_concurrency();
+  std::string output = R"#(
+Socket(s):           1
+NUMA node(s):        1
+Vendor ID:           ARM
+Model:               1
+Stepping:            r1p1
+BogoMIPS:            2100.00
+)#";
+  EXPECT_EQ(CallParseLscpuOutput(output), default_value);
+}
+
+// Test parsing lscpu output with missing "Socket" entry
+TEST_F(ParseLscpuTestTest, MissingSocketEntry) {
+  auto default_value = std::thread::hardware_concurrency();
+  std::string output =
+      R"#(
+Core(s) per socket:  8
+NUMA node(s):        1
+Vendor ID:           ARM
+Model:               1
+Stepping:            r1p1
+BogoMIPS:            2100.00
+)#";
+  EXPECT_EQ(CallParseLscpuOutput(output), default_value);
+}
+
+// Test parsing lscpu output with missing both socket & cores entries
+TEST_F(ParseLscpuTestTest, MissingBothEntries) {
+  auto default_value = std::thread::hardware_concurrency();
+  std::string output =
+      R"#(
+NUMA node(s):        1
+Vendor ID:           ARM
+Model:               1
+Stepping:            r1p1
+BogoMIPS:            2100.00
+)#";
+  EXPECT_EQ(CallParseLscpuOutput(output), default_value);
 }
 
 }  // namespace helper


### PR DESCRIPTION
On aarch64, `cpuinfo` output is different than the one generated by `amd64` machines. This fix uses `lscpu` to get the number of physical cores by parsing `lscpu` output and multiplying the number of sockets by the number of cores-per-socket. In case of an error, it will return the default from `std::thread::hardware_concurrency`.

Tests were added to `concurrency_test` binary