### PR TITLE
Command registration permissions alignment with ACL prefix permissions

### DIFF
--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -30,7 +30,6 @@
 #ifndef VALKEYSEARCH_SRC_COMMANDS_COMMANDS_H_
 #define VALKEYSEARCH_SRC_COMMANDS_COMMANDS_H_
 
-#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
@@ -51,6 +50,7 @@ constexpr absl::string_view kReadCategory{"@read"};
 constexpr absl::string_view kWriteCategory{"@write"};
 constexpr absl::string_view kFastCategory{"@fast"};
 constexpr absl::string_view kSlowCategory{"@slow"};
+constexpr absl::string_view kAdminCategory{"@admin"};
 
 constexpr absl::string_view kCreateCommand{"FT.CREATE"};
 constexpr absl::string_view kDropIndexCommand{"FT.DROPINDEX"};
@@ -58,17 +58,27 @@ constexpr absl::string_view kInfoCommand{"FT.INFO"};
 constexpr absl::string_view kListCommand{"FT._LIST"};
 constexpr absl::string_view kSearchCommand{"FT.SEARCH"};
 
-const absl::flat_hash_map<FTCommand,
-                          const absl::flat_hash_set<absl::string_view>>
-    kCommandCategories = {
-        {kCreate,
-         {kSearchCategory, kWriteCategory, kFastCategory, kCreateCommand}},
-        {kDropIndex,
-         {kSearchCategory, kWriteCategory, kFastCategory, kDropIndexCommand}},
-        {kInfo, {kSearchCategory, kReadCategory, kFastCategory, kInfoCommand}},
-        {kSearch,
-         {kSearchCategory, kReadCategory, kSlowCategory, kSearchCommand}},
-};
+const absl::flat_hash_set<absl::string_view> kCreateCmdPermissions{
+    kSearchCategory, kWriteCategory, kFastCategory};
+const absl::flat_hash_set<absl::string_view> kDropIndexCmdPermissions{
+    kSearchCategory, kWriteCategory, kFastCategory};
+const absl::flat_hash_set<absl::string_view> kSearchCmdPermissions{
+    kSearchCategory, kReadCategory, kSlowCategory};
+const absl::flat_hash_set<absl::string_view> kInfoCmdPermissions{
+    kSearchCategory, kReadCategory, kFastCategory};
+const absl::flat_hash_set<absl::string_view> kLISTCmdPermissions{
+    kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
+
+inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
+    const absl::flat_hash_set<absl::string_view> &cmd_permissions,
+    absl::string_view command) {
+  absl::flat_hash_set<absl::string_view> ret;
+  for (const auto &permission : cmd_permissions) {
+    ret.insert(permission);
+  }
+  ret.insert(command);
+  return ret;
+}
 
 absl::Status FTCreateCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
                          int argc);

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -72,10 +72,7 @@ const absl::flat_hash_set<absl::string_view> kLISTCmdPermissions{
 inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions,
     absl::string_view command) {
-  absl::flat_hash_set<absl::string_view> ret;
-  for (const auto &permission : cmd_permissions) {
-    ret.insert(permission);
-  }
+  absl::flat_hash_set<absl::string_view> ret = cmd_permissions;
   ret.insert(command);
   return ret;
 }

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -66,7 +66,7 @@ const absl::flat_hash_set<absl::string_view> kSearchCmdPermissions{
     kSearchCategory, kReadCategory, kSlowCategory};
 const absl::flat_hash_set<absl::string_view> kInfoCmdPermissions{
     kSearchCategory, kReadCategory, kFastCategory};
-const absl::flat_hash_set<absl::string_view> kLISTCmdPermissions{
+const absl::flat_hash_set<absl::string_view> kListCmdPermissions{
     kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
 
 inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(

--- a/src/commands/ft._list.json
+++ b/src/commands/ft._list.json
@@ -1,7 +1,8 @@
 {
   "FT._LIST": {
     "acl_categories": [
-      "FAST",
+      "ADMIN",
+      "SLOW",
       "READ",
       "SEARCH"
     ],

--- a/src/commands/ft_create.cc
+++ b/src/commands/ft_create.cc
@@ -42,8 +42,9 @@ absl::Status FTCreateCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
   VMSDK_ASSIGN_OR_RETURN(auto index_schema_proto,
                          ParseFTCreateArgs(ctx, argv + 1, argc - 1));
   index_schema_proto.set_db_num(RedisModule_GetSelectedDb(ctx));
-  VMSDK_RETURN_IF_ERROR(
-      AclPrefixCheck(ctx, kCommandCategories.at(kCreate), index_schema_proto));
+  static const auto permissions =
+      PrefixACLPermissions(kCreateCmdPermissions, kCreateCommand);
+  VMSDK_RETURN_IF_ERROR(AclPrefixCheck(ctx, permissions, index_schema_proto));
   VMSDK_RETURN_IF_ERROR(
       SchemaManager::Instance().CreateIndexSchema(ctx, index_schema_proto));
 

--- a/src/commands/ft_dropindex.cc
+++ b/src/commands/ft_dropindex.cc
@@ -50,8 +50,10 @@ absl::Status FTDropIndexCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
       auto index_schema,
       SchemaManager::Instance().GetIndexSchema(RedisModule_GetSelectedDb(ctx),
                                                index_schema_name));
-  VMSDK_RETURN_IF_ERROR(AclPrefixCheck(ctx, kCommandCategories.at(kDropIndex),
-                                       index_schema->GetKeyPrefixes()));
+  static const auto permissions =
+      PrefixACLPermissions(kDropIndexCmdPermissions, kDropIndexCommand);
+  VMSDK_RETURN_IF_ERROR(
+      AclPrefixCheck(ctx, permissions, index_schema->GetKeyPrefixes()));
 
   VMSDK_RETURN_IF_ERROR(SchemaManager::Instance().RemoveIndexSchema(
       RedisModule_GetSelectedDb(ctx), index_schema_name));

--- a/src/commands/ft_info.cc
+++ b/src/commands/ft_info.cc
@@ -55,9 +55,10 @@ absl::Status FTInfoCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
       auto index_schema,
       SchemaManager::Instance().GetIndexSchema(RedisModule_GetSelectedDb(ctx),
                                                index_schema_name));
-
-  VMSDK_RETURN_IF_ERROR(AclPrefixCheck(ctx, kCommandCategories.at(kInfo),
-                                       index_schema->GetKeyPrefixes()));
+  static const auto permissions =
+      PrefixACLPermissions(kInfoCmdPermissions, kInfoCommand);
+  VMSDK_RETURN_IF_ERROR(
+      AclPrefixCheck(ctx, permissions, index_schema->GetKeyPrefixes()));
   index_schema->RespondWithInfo(ctx);
 
   return absl::OkStatus();

--- a/src/commands/ft_search.cc
+++ b/src/commands/ft_search.cc
@@ -229,9 +229,11 @@ absl::Status FTSearchCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
         auto parameters,
         ParseVectorSearchParameters(ctx, argv + 1, argc - 1, schema_manager));
 
-    VMSDK_RETURN_IF_ERROR(
-        AclPrefixCheck(ctx, kCommandCategories.at(kSearch),
-                       parameters->index_schema->GetKeyPrefixes()));
+    static const auto permissions =
+        PrefixACLPermissions(kSearchCmdPermissions, kSearchCommand);
+    VMSDK_RETURN_IF_ERROR(AclPrefixCheck(
+        ctx, permissions, parameters->index_schema->GetKeyPrefixes()));
+
     parameters->index_schema->ProcessMultiQueue();
 
     const bool inside_multi_exec = vmsdk::MultiOrLua(ctx);

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -68,7 +68,7 @@ vmsdk::module::Options options = {
             },
             {
                 .cmd_name = valkey_search::kListCommand,
-                .permissions = "readonly",
+                .permissions = "readonly @search @read @fast",
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTListCmd>,
             },
             {
@@ -76,7 +76,8 @@ vmsdk::module::Options options = {
                 .permissions = "readonly",
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTSearchCmd>,
             },
-        },
+        }  // namespace
+    ,
     .on_load =
         [](RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
            [[maybe_unused]] const vmsdk::module::Options &options) {

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -45,15 +45,8 @@
 
 namespace {
 
-// Format the input permission to prefix ACL format by:
-// 1. Split the input string into words using space as a delimiter,
-//    skipping any empty words that might result from multiple spaces.
-// 2. Iterate through each 'word' (represented as an absl::string_view):
-//    a. If the 'word' is exactly "readonly", add "read" to the list of
-//    processed words. b. Otherwise, add "@" followed by the 'word' to the list
-//    of processed words.
-// 3. Join all collected processed words back into a single string, separated by
-// spaces.
+// Strip the '@' prefix from command categories (e.g., @read)
+// to format them for Valkey Search's prefix ACL rules (e.g., read).
 inline std::string ACLPermissionFormatter(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions) {
   std::vector<absl::string_view> permissions;

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -98,7 +98,6 @@ vmsdk::module::Options options = {
                 .permissions = ACLPermissionFormatter(
                     valkey_search::kSearchCmdPermissions),
                 .deny_oom = true,
-
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTSearchCmd>,
             },
         }  // namespace

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -54,7 +54,7 @@ namespace {
 //    of processed words.
 // 3. Join all collected processed words back into a single string, separated by
 // spaces.
-inline std::string ACLPermissionFormater(
+inline std::string ACLPermissionFormatter(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions) {
   std::vector<absl::string_view> permissions;
   for (auto permission : cmd_permissions) {
@@ -76,14 +76,14 @@ vmsdk::module::Options options = {
         {
             {
                 .cmd_name = valkey_search::kCreateCommand,
-                .permissions =
-                    ACLPermissionFormater(valkey_search::kCreateCmdPermissions),
+                .permissions = ACLPermissionFormatter(
+                    valkey_search::kCreateCmdPermissions),
                 .deny_oom = true,
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTCreateCmd>,
             },
             {
                 .cmd_name = valkey_search::kDropIndexCommand,
-                .permissions = ACLPermissionFormater(
+                .permissions = ACLPermissionFormatter(
                     valkey_search::kDropIndexCmdPermissions),
                 .cmd_func =
                     &vmsdk::CreateCommand<valkey_search::FTDropIndexCmd>,
@@ -91,19 +91,19 @@ vmsdk::module::Options options = {
             {
                 .cmd_name = valkey_search::kInfoCommand,
                 .permissions =
-                    ACLPermissionFormater(valkey_search::kInfoCmdPermissions),
+                    ACLPermissionFormatter(valkey_search::kInfoCmdPermissions),
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTInfoCmd>,
             },
             {
                 .cmd_name = valkey_search::kListCommand,
                 .permissions =
-                    ACLPermissionFormater(valkey_search::kLISTCmdPermissions),
+                    ACLPermissionFormatter(valkey_search::kLISTCmdPermissions),
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTListCmd>,
             },
             {
                 .cmd_name = valkey_search::kSearchCommand,
-                .permissions =
-                    ACLPermissionFormater(valkey_search::kSearchCmdPermissions),
+                .permissions = ACLPermissionFormatter(
+                    valkey_search::kSearchCmdPermissions),
                 .deny_oom = true,
 
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTSearchCmd>,

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -70,8 +70,8 @@ absl::Status RegisterCommands(RedisModuleCtx *ctx,
 
 int OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
            const Options &options) {
-  if (RedisModule_Init(ctx, options.name.c_str(), options.version, REDISMODULE_APIVER_1) ==
-      REDISMODULE_ERR) {
+  if (RedisModule_Init(ctx, options.name.c_str(), options.version,
+                       REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
     RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING, "Failed to init module");
     return REDISMODULE_ERR;
   }

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -72,6 +72,7 @@ namespace module {
 struct CommandOptions {
   absl::string_view cmd_name;
   std::string permissions;
+  bool deny_oom{false};
   RedisModuleCmdFunc cmd_func{nullptr};
   // By default - assume no keys.
   int first_key{0};
@@ -81,6 +82,7 @@ struct CommandOptions {
 
 struct Options {
   std::string name;
+  std::list<std::string> acl_categories;
   int version;
   RedisModuleInfoFunc info{nullptr};
   std::list<CommandOptions> commands;

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -69,10 +69,12 @@
 namespace vmsdk {
 namespace module {
 
+constexpr absl::string_view kDenyOOMFlag{"deny-oom"};
+
 struct CommandOptions {
   absl::string_view cmd_name;
-  std::string permissions;
-  bool deny_oom{false};
+  std::list<absl::string_view> permissions;
+  std::list<absl::string_view> flags;
   RedisModuleCmdFunc cmd_func{nullptr};
   // By default - assume no keys.
   int first_key{0};
@@ -82,7 +84,7 @@ struct CommandOptions {
 
 struct Options {
   std::string name;
-  std::list<std::string> acl_categories;
+  std::list<absl::string_view> acl_categories;
   int version;
   RedisModuleInfoFunc info{nullptr};
   std::list<CommandOptions> commands;

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -1055,6 +1055,10 @@ REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx,
                                                  const char *strflags,
                                                  int firstkey, int lastkey,
                                                  int keystep) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_AddACLCategory)(
+    RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
+REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(
+    RedisModuleCommand *command, const char *aclflags) REDISMODULE_ATTR;
 REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(
     RedisModuleCtx *ctx, const char *name)REDISMODULE_ATTR;
 REDISMODULE_API int (*RedisModule_CreateSubcommand)(
@@ -2068,6 +2072,10 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
   REDISMODULE_GET_API(DictCompare);
   REDISMODULE_GET_API(DictCompareC);
   REDISMODULE_GET_API(RegisterInfoFunc);
+  REDISMODULE_GET_API(AddACLCategory);
+  REDISMODULE_GET_API(SetCommandACLCategories);
+
+  REDISMODULE_GET_API(SetCommandACLCategories);
   REDISMODULE_GET_API(RegisterAuthCallback);
   REDISMODULE_GET_API(InfoAddSection);
   REDISMODULE_GET_API(InfoBeginDictField);

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -2074,7 +2074,6 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
   REDISMODULE_GET_API(RegisterInfoFunc);
   REDISMODULE_GET_API(AddACLCategory);
   REDISMODULE_GET_API(SetCommandACLCategories);
-
   REDISMODULE_GET_API(SetCommandACLCategories);
   REDISMODULE_GET_API(RegisterAuthCallback);
   REDISMODULE_GET_API(InfoAddSection);


### PR DESCRIPTION
While the ACL enhancement introduced in valkey-search allows command filtering based on prefixes, the engine enforces ACL checks on incoming commands independently. Currently, there's a misalignment between the permissions used during command registration and the permissions evaluated by valkey-search’s prefix-based ACL. This mismatch can result in the engine blocking legitimate commands. For example, if a user is allowed to execute only slow commands, an FT.SEARCH invocation may be blocked by the engine because it wasn't registered with the slow ACL category.

I manually verified this PR and integration tests should be added in the future.

In addition, this PR sets `admin` permission to FT._LIST, [similarly](https://redis.io/docs/latest/commands/ft._list/) to RediSearch. This is needed to be captured under the Valkey documentation.