### PR TITLE
Dynamic thread pool

### DIFF
--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -33,6 +33,7 @@
 #include <cstddef>
 #include <memory>
 #include <numeric>
+#include <ranges>
 #include <string>
 #include <utility>
 
@@ -44,9 +45,24 @@
 #include "absl/synchronization/mutex.h"
 namespace {
 
+class ThreadRunContext {
+ public:
+  ThreadRunContext(vmsdk::ThreadPool *pool,
+                   std::shared_ptr<vmsdk::ThreadPool::Thread> data)
+      : pool_{pool}, thread_{data} {}
+
+  vmsdk::ThreadPool *GetPool() { return pool_; }
+  std::shared_ptr<vmsdk::ThreadPool::Thread> GetThread() { return thread_; }
+
+ private:
+  vmsdk::ThreadPool *pool_ = nullptr;
+  std::shared_ptr<vmsdk::ThreadPool::Thread> thread_ = nullptr;
+};
+
 void *RunWorkerThread(void *arg) {
-  vmsdk::ThreadPool *pool = static_cast<vmsdk::ThreadPool *>(arg);
-  pool->WorkerThread();
+  ThreadRunContext *ctx = static_cast<ThreadRunContext *>(arg);
+  ctx->GetPool()->WorkerThread(ctx->GetThread());
+  delete ctx;  // shallow delete
   return nullptr;
 }
 }  // namespace
@@ -54,19 +70,14 @@ void *RunWorkerThread(void *arg) {
 namespace vmsdk {
 
 ThreadPool::ThreadPool(const std::string &name_prefix, size_t num_threads)
-    : threads_(num_threads),
+    : initial_thread_count_(num_threads),
       priority_tasks_(static_cast<int>(ThreadPool::Priority::kMax) + 1),
       name_prefix_(name_prefix) {}
 
 void ThreadPool::StartWorkers() {
   CHECK(!started_);
   started_ = true;
-  for (size_t i = 0; i < threads_.size(); ++i) {
-    pthread_create(&threads_[i], nullptr, RunWorkerThread, this);
-#ifndef __APPLE__
-    pthread_setname_np(threads_[i], (name_prefix_ + std::to_string(i)).c_str());
-#endif
-  }
+  IncrThreadCountBy(initial_thread_count_);
 }
 
 bool ThreadPool::Schedule(absl::AnyInvocable<void()> task, Priority priority) {
@@ -106,13 +117,17 @@ void ThreadPool::JoinWorkers() {
     }
     suspend_workers_ = false;
   }
-  if (!started_) {
-    return;
-  }
-  for (auto thread : threads_) {
-    pthread_join(thread, nullptr);
-  }
+
+  threads_.ClearWithCallback(
+      [](auto thread) { pthread_join(thread->thread_id, nullptr); });
   started_ = false;
+
+  JoinTerminatedWorkers();
+}
+
+void ThreadPool::JoinTerminatedWorkers() {
+  pending_join_threads_.ClearWithCallback(
+      [](auto thread) { pthread_join(thread->thread_id, nullptr); });
 }
 
 absl::Status ThreadPool::SuspendWorkers() {
@@ -132,7 +147,7 @@ absl::Status ThreadPool::SuspendWorkers() {
     }
     suspend_workers_ = true;
     blocking_refcount_ =
-        std::make_unique<absl::BlockingCounter>(threads_.size());
+        std::make_unique<absl::BlockingCounter>(threads_.Size());
     condition_.SignalAll();
   }
   blocking_refcount_->Wait();
@@ -154,7 +169,7 @@ absl::Status ThreadPool::ResumeWorkers() {
     }
     suspend_workers_ = false;
     blocking_refcount_ =
-        std::make_unique<absl::BlockingCounter>(threads_.size());
+        std::make_unique<absl::BlockingCounter>(threads_.Size());
   }
 
   blocking_refcount_->Wait();
@@ -176,7 +191,7 @@ void ThreadPool::AwaitSuspensionCleared()
   }
 }
 
-void ThreadPool::WorkerThread() {
+void ThreadPool::WorkerThread(std::shared_ptr<Thread> thread) {
   while (true) {
     absl::AnyInvocable<void()> task;
     {
@@ -184,7 +199,17 @@ void ThreadPool::WorkerThread() {
       AwaitSuspensionCleared();
       auto condition = absl::Condition(this, &ThreadPool::QueueReady);
       while (!condition.Eval()) {
-        condition_.Wait(&queue_mutex_);
+        condition_.WaitWithTimeout(&queue_mutex_, absl::Seconds(1));
+        if (thread->IsShutdown()) {
+          thread->InvokeShutdownCallback();
+          // remove this thread from the threads list and place it in the
+          // pending join list
+          threads_.PopIf([thread](std::shared_ptr<Thread> t) {
+            return t->thread_id == thread->thread_id;
+          });
+          pending_join_threads_.Add(thread);
+          return;
+        }
       }
       if (stop_mode_.has_value() &&
           (stop_mode_.value() == StopMode::kAbrupt ||
@@ -195,11 +220,11 @@ void ThreadPool::WorkerThread() {
       if (suspend_workers_) {
         continue;
       }
-      for (auto it = priority_tasks_.rbegin(); it != priority_tasks_.rend();
-           ++it) {
-        if (!it->empty()) {
-          task = std::move(it->front());
-          it->pop();
+
+      for (auto &tasks : priority_tasks_ | std::views::reverse) {
+        if (!tasks.empty()) {
+          task = std::move(tasks.front());
+          tasks.pop();
           break;
         }
       }
@@ -215,4 +240,48 @@ size_t ThreadPool::QueueSize() const {
       [](size_t sum, const auto &tasks) { return sum + tasks.size(); });
 }
 
+void ThreadPool::IncrThreadCountBy(size_t count) {
+  for (size_t i = 0; i < count; ++i) {
+    std::shared_ptr<Thread> thread_ptr = std::make_shared<Thread>();
+    ThreadRunContext *context = new ThreadRunContext{this, thread_ptr};
+    pthread_create(&thread_ptr->thread_id, nullptr, RunWorkerThread, context);
+#ifndef __APPLE__
+    size_t thread_num = threads_.Size();
+    pthread_setname_np(thread_ptr->thread_id,
+                       (name_prefix_ + std::to_string(thread_num)).c_str());
+#endif
+    threads_.Add(thread_ptr);
+  }
+}
+
+void ThreadPool::DecrThreadCountBy(size_t count, bool sync) {
+  auto threads = threads_.PopBackMulti(count);
+  absl::BlockingCounter counter{static_cast<int>(threads.size())};
+  for (const auto &thread : threads) {
+    if (sync) {
+      thread->Shutdown([&counter]() {
+        counter.DecrementCount();
+      });  // signal the thread to exit
+    } else {
+      thread->Shutdown();
+    }
+  }
+
+  if (sync) {
+    counter.Wait();
+  }
+}
+
+void ThreadPool::Resize(size_t count, bool wait_for_resize) {
+  size_t current_size = Size();
+  if (count == current_size) {
+    return;
+  } else if (count > current_size) {
+    // We need to add more threads
+    IncrThreadCountBy(count - current_size);
+  } else {
+    // Shutdown "current_size - count" threads
+    DecrThreadCountBy(current_size - count, wait_for_resize);
+  }
+}
 }  // namespace vmsdk

--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -48,8 +48,8 @@ namespace {
 class ThreadRunContext {
  public:
   ThreadRunContext(vmsdk::ThreadPool *pool,
-                   std::shared_ptr<vmsdk::ThreadPool::Thread> data)
-      : pool_{pool}, thread_{data} {}
+                   std::shared_ptr<vmsdk::ThreadPool::Thread> thread)
+      : pool_{pool}, thread_{thread} {}
 
   vmsdk::ThreadPool *GetPool() { return pool_; }
   std::shared_ptr<vmsdk::ThreadPool::Thread> GetThread() { return thread_; }

--- a/vmsdk/src/thread_pool.h
+++ b/vmsdk/src/thread_pool.h
@@ -45,7 +45,7 @@
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/synchronization/mutex.h"
 #include "gtest/gtest_prod.h"
-#include "vector.h"
+#include "vmsdk/src/thread_safe_vector.h"
 
 namespace vmsdk {
 // Note google3/thread can't be used as it's not open source
@@ -133,8 +133,8 @@ class ThreadPool {
     return priority_tasks_[static_cast<int>(priority)];
   }
   size_t initial_thread_count_ = 0;
-  Vector<std::shared_ptr<Thread>> threads_;
-  Vector<std::shared_ptr<Thread>> pending_join_threads_;
+  ThreadSafeVector<std::shared_ptr<Thread>> threads_;
+  ThreadSafeVector<std::shared_ptr<Thread>> pending_join_threads_;
   mutable absl::Mutex queue_mutex_;
   absl::CondVar condition_ ABSL_GUARDED_BY(queue_mutex_);
   std::vector<std::queue<absl::AnyInvocable<void()>>> priority_tasks_

--- a/vmsdk/src/thread_pool.h
+++ b/vmsdk/src/thread_pool.h
@@ -44,6 +44,8 @@
 #include "absl/status/status.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/synchronization/mutex.h"
+#include "gtest/gtest_prod.h"
+#include "vector.h"
 
 namespace vmsdk {
 // Note google3/thread can't be used as it's not open source
@@ -56,7 +58,15 @@ class ThreadPool {
   enum class StopMode { kGraceful, kAbrupt };
 
   void StartWorkers();
+
+  /// Notify all active workers to terminate and join them. In addition, this
+  /// method will internally call `JoinTerminatedWorkers`
   void JoinWorkers();
+
+  /// Cleanup after threads that self terminated after pool resize operation and
+  /// were placed in the `pending_join_threads_` queue.
+  void JoinTerminatedWorkers();
+
   absl::Status MarkForStop(StopMode stop_mode);
   absl::Status SuspendWorkers();
   bool IsSuspended() const {
@@ -66,14 +76,48 @@ class ThreadPool {
   absl::Status ResumeWorkers();
   virtual ~ThreadPool();
 
-  size_t Size() const { return threads_.size(); }
+  size_t Size() const { return threads_.Size(); }
   size_t QueueSize() const ABSL_LOCKS_EXCLUDED(queue_mutex_);
   enum class Priority { kLow = 0, kHigh = 1, kMax = 2 };
   virtual bool Schedule(absl::AnyInvocable<void()> task, Priority priority)
       ABSL_LOCKS_EXCLUDED(queue_mutex_);
-  void WorkerThread() ABSL_LOCKS_EXCLUDED(queue_mutex_);
+
+  /// Resize the pool size to `count` threads. If `wait_for_resize` is `true`,
+  /// this method waits for resize operation to complete, otherwise, the resize
+  /// operation is done asynchronously.
+  void Resize(size_t count, bool wait_for_resize = false);
+
+  /// A struct representing a worker thread
+  struct Thread {
+    bool IsShutdown() const { return shutdown_flag.load(); }
+    void Shutdown(absl::AnyInvocable<void()> callback = nullptr) {
+      if (callback != nullptr) {
+        shutdown_callback = std::move(callback);
+      }
+      shutdown_flag.store(true);
+    }
+
+    /// If `shutdown_callback is` not null, call it
+    void InvokeShutdownCallback() {
+      if (shutdown_callback.has_value()) {
+        (*shutdown_callback)();
+      }
+    }
+
+    pthread_t thread_id = 0;
+    std::atomic_bool shutdown_flag = false;
+    /// If not null, the thread will call this callback when it exits via the
+    /// shutdown_flag
+    std::optional<absl::AnyInvocable<void()>> shutdown_callback = std::nullopt;
+  };
+
+  void WorkerThread(std::shared_ptr<Thread> thread)
+      ABSL_LOCKS_EXCLUDED(queue_mutex_);
 
  private:
+  void IncrThreadCountBy(size_t count);
+  void DecrThreadCountBy(size_t count, bool sync);
+
   inline void AwaitSuspensionCleared()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(queue_mutex_);
   inline bool QueueReady() const ABSL_EXCLUSIVE_LOCKS_REQUIRED(queue_mutex_) {
@@ -88,7 +132,9 @@ class ThreadPool {
       Priority priority) ABSL_EXCLUSIVE_LOCKS_REQUIRED(queue_mutex_) {
     return priority_tasks_[static_cast<int>(priority)];
   }
-  std::vector<pthread_t> threads_;
+  size_t initial_thread_count_ = 0;
+  Vector<std::shared_ptr<Thread>> threads_;
+  Vector<std::shared_ptr<Thread>> pending_join_threads_;
   mutable absl::Mutex queue_mutex_;
   absl::CondVar condition_ ABSL_GUARDED_BY(queue_mutex_);
   std::vector<std::queue<absl::AnyInvocable<void()>>> priority_tasks_
@@ -101,6 +147,7 @@ class ThreadPool {
 
   // Suspend and resume are mutually exclusive.
   mutable absl::Mutex suspend_resume_mutex_;
+  FRIEND_TEST(ThreadPoolTest, DynamicSizing);
 };
 
 }  // namespace vmsdk

--- a/vmsdk/src/thread_safe_vector.h
+++ b/vmsdk/src/thread_safe_vector.h
@@ -12,12 +12,12 @@
 /// A thread safe vector protected by a mutex
 namespace vmsdk {
 template <typename T>
-class Vector {
+class ThreadSafeVector {
  public:
   // This type is neither copyable nor assignable.
-  Vector(const Vector&) = delete;
-  Vector& operator=(const Vector&) = delete;
-  Vector() = default;
+  ThreadSafeVector(const ThreadSafeVector&) = delete;
+  ThreadSafeVector& operator=(const ThreadSafeVector&) = delete;
+  ThreadSafeVector() = default;
 
   size_t Size() const { return vec_.size(); }
   bool IsEmpty() const { return Size() == 0; }

--- a/vmsdk/src/vector.h
+++ b/vmsdk/src/vector.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <vector>
+
+#include "absl/algorithm/container.h"
+#include "absl/synchronization/mutex.h"
+
+/// A thread safe vector protected by a mutex
+namespace vmsdk {
+template <typename T>
+class Vector {
+ public:
+  // This type is neither copyable nor assignable.
+  Vector(const Vector&) = delete;
+  Vector& operator=(const Vector&) = delete;
+  Vector() = default;
+
+  size_t Size() const { return vec_.size(); }
+  bool IsEmpty() const { return Size() == 0; }
+
+  /// Pop the first item that matches the predicate (starting from the top of
+  /// the list)
+  std::optional<T> PopIf(std::function<bool(T)> predicate) {
+    absl::MutexLock lock{&mutex_};
+    if (vec_.empty()) {
+      return std::nullopt;
+    }
+    auto where = absl::c_find_if(vec_, predicate);
+    if (where == vec_.end()) {
+      return std::nullopt;
+    }
+    auto item = std::move(*where);
+    vec_.erase(where);
+    return item;
+  }
+
+  /// Remove up to `count` items from the end of the list and return them.
+  std::vector<T> PopBackMulti(size_t count) {
+    absl::MutexLock lock{&mutex_};
+    count = std::min(count, vec_.size());
+    if (count == 0) {
+      return {};
+    }
+
+    // Move the last "count" items to our result vector and resize the original
+    // vector
+    std::vector<T> items;
+    items.reserve(count);
+    std::move(vec_.end() - count, vec_.end(), std::back_inserter(items));
+    vec_.resize(vec_.size() - count);
+    return items;
+  }
+
+  /// Append `item` at the end of the vector
+  void Add(T item) {
+    absl::MutexLock lock{&mutex_};
+    vec_.push_back(std::move(item));
+  }
+
+  /// Clear the list. Before items are removed from the list, apply `callback`
+  /// for each item.
+  ///
+  /// `callback` can be `nullptr`.
+  void ClearWithCallback(std::function<void(T)> callback) {
+    absl::MutexLock lock{&mutex_};
+    if (callback != nullptr) {
+      for (auto& item : vec_) {
+        callback(item);
+      }
+    }
+    vec_.clear();
+  }
+
+  /// This is the same as calling `ClearWithCallback()` with `nullptr` as the
+  /// callback
+  void Clear() { ClearWithCallback(nullptr); }
+
+ private:
+  std::vector<T> vec_;
+  absl::Mutex mutex_;
+};
+}  // namespace vmsdk


### PR DESCRIPTION
Extended `ThreadPool` class with a "Resize" method
which allows the caller to increase or reduce the
thread count at runtime. In order to reduce the thread count,
the ThreadPool class associates a metadata per running thread `Thread`
the thread, within its "main" loop, checks if it was signaled to exit.

If it does, than the thread leaves its main loop while moving itself to
a "pending join" queue. The idea is that at given interval (using existing
timer events) the engine will periodically call `ThreadPool::JoinTerminatedWorkers`
to join threads that were exit. 

The default `ThreadPool::JoinWorkers` now internally also calls `ThreadPool::JoinTerminatedWorkers`

Fixed flaky ThreadPool.priority test

Added new `Vector<T>` class which is a thread-safe wrapper around `std::vector` and provides convenience methods such as `PopIf(predicate)`, `PopBackMulti(..)` and `ClearWithCallback(cb)`

Related issue: https://github.com/valkey-io/valkey-search/issues/39