### PR TITLE
Allow changing the reader/writer threads count

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,9 @@ set(SRCS_MODULE_LOADER ${CMAKE_CURRENT_LIST_DIR}/module_loader.cc)
 # This is the module target
 valkey_search_add_shared_library(libsearch ${SRCS_MODULE_LOADER})
 target_include_directories(libsearch PUBLIC ${CMAKE_CURRENT_LIST_DIR})
-target_link_options(libsearch PRIVATE "LINKER:--version-script=${CMAKE_SOURCE_DIR}/vmsdk/versionscript.lds")
+target_link_options(
+  libsearch PRIVATE
+  "LINKER:--version-script=${CMAKE_SOURCE_DIR}/vmsdk/versionscript.lds")
 
 target_link_libraries(libsearch PUBLIC keyspace_event_manager)
 target_link_libraries(libsearch PUBLIC valkey_search)
@@ -20,7 +22,8 @@ target_link_libraries(libsearch PUBLIC server_events)
 list(APPEND THIRD_PARTY_LIBS coordinator_grpc_proto)
 list(APPEND THIRD_PARTY_LIBS coordinator_cc_proto)
 
-valkey_search_create_proto_library("src/rdb_section.proto" "rdb_section_cc_proto")
+valkey_search_create_proto_library("src/rdb_section.proto"
+                                   "rdb_section_cc_proto")
 target_link_libraries(rdb_section_cc_proto PUBLIC index_schema_cc_proto)
 target_link_libraries(rdb_section_cc_proto PUBLIC coordinator_cc_proto)
 message(STATUS "Created proto library rdb_section_cc_proto")
@@ -39,8 +42,11 @@ endif()
 # Append -Wl,--end-group as the LAST argument
 target_link_libraries(libsearch PRIVATE lib_to_add_end_group_flag)
 
-set(SRCS_VALKEY_SEARCH ${CMAKE_CURRENT_LIST_DIR}/valkey_search.cc
-                       ${CMAKE_CURRENT_LIST_DIR}/valkey_search.h)
+set(SRCS_VALKEY_SEARCH
+    ${CMAKE_CURRENT_LIST_DIR}/valkey_search.cc
+    ${CMAKE_CURRENT_LIST_DIR}/valkey_search.h
+    ${CMAKE_CURRENT_LIST_DIR}/valkey_search_config.cc
+    ${CMAKE_CURRENT_LIST_DIR}/valkey_search_config.h)
 
 valkey_search_add_static_library(valkey_search "${SRCS_VALKEY_SEARCH}")
 target_include_directories(valkey_search PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/valkey_search_config.cc
+++ b/src/valkey_search_config.cc
@@ -1,0 +1,61 @@
+
+#include "valkey_search_config.h"
+
+#include "absl/log/check.h"
+#include "absl/strings/str_cat.h"
+#include "vmsdk/src/log.h"
+
+namespace valkey_search {
+
+absl::Status ValkeySearchConfig::RegisterNumericConfig(
+    RedisModuleCtx *ctx, std::string_view config_name, long long default_value,
+    long long min_value, long long max_value,
+    NumericConfigEntry::OnSetFunc &&set_func,
+    NumericConfigEntry::OnGetFunc &&get_func,
+    NumericConfigEntry::ValidateFunc &&value_validation_func) {
+  auto entry = std::make_unique<NumericConfigEntry>(
+      default_value, std::move(set_func), std::move(get_func),
+      std::move(value_validation_func));
+  numeric_entries_.push_back(std::move(entry));
+  auto &d = numeric_entries_.back();
+  if (RedisModule_RegisterNumericConfig(
+          ctx,
+          config_name.data(),          // Name
+          default_value,               // Default value
+          REDISMODULE_CONFIG_DEFAULT,  // Flags (mutable, can be changed via
+                                       // CONFIG SET)
+          min_value,                   // Minimum value
+          max_value,                   // Maximum value
+          ValkeySearchConfig::OnGetNumericConfig,  // Get callback
+          ValkeySearchConfig::OnSetNumericConfig,  // Set callback
+          nullptr,                                 // Apply callback (optional)
+          d.get()                                  // privdata
+          ) != REDISMODULE_OK) {
+    numeric_entries_.pop_back();  // remove the entry
+    return absl::InternalError(
+        absl::StrCat("Failed to register configuration entry: ", config_name));
+  }
+  return absl::OkStatus();
+}
+
+long long ValkeySearchConfig::OnGetNumericConfig(const char *config_name,
+                                                 void *priv_data) {
+  auto entry = reinterpret_cast<NumericConfigEntry *>(priv_data);
+  CHECK(entry) << "null private data for configuration entry: " << config_name;
+  return entry->GetValue();
+}
+
+int ValkeySearchConfig::OnSetNumericConfig(const char *config_name,
+                                           long long value, void *priv_data,
+                                           RedisModuleString **err) {
+  auto entry = reinterpret_cast<NumericConfigEntry *>(priv_data);
+  CHECK(entry) << "null private data for configuration entry: " << config_name;
+  if (!entry->Validate(value, err)) {
+    return REDISMODULE_ERR;
+  }
+  entry->SetValue(value);
+  VMSDK_LOG(NOTICE, nullptr)
+      << "configuration item: " << config_name << " is set to " << value;
+  return REDISMODULE_OK;
+}
+}  // namespace valkey_search

--- a/src/valkey_search_config.h
+++ b/src/valkey_search_config.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <atomic>
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+#include "absl/status/statusor.h"
+#include "vmsdk/src/valkey_module_api/valkey_module.h"
+
+namespace valkey_search {
+
+template <typename T>
+void DefaultSetFunc([[maybe_unused]] T val) {}
+
+template <typename T, T DefaultValue>
+T DefaultGetFunc() {
+  return DefaultValue;
+}
+
+template <typename T, T DefaultValue>
+class ConfigEntry {
+ public:
+  using OnSetFunc = std::function<void(T)>;
+  using OnGetFunc = std::function<T()>;
+  using ValidateFunc = std::function<bool(T, RedisModuleString **)>;
+  ConfigEntry(T value, OnSetFunc set_func, OnGetFunc get_func,
+              ValidateFunc func)
+      : set_func_(std::move(set_func)),
+        get_func_(std::move(get_func)),
+        validation_func_(std::move(func)) {}
+
+  bool Validate(long long new_value, RedisModuleString **err) const {
+    if (validation_func_ == nullptr) {
+      return true;
+    }
+    return validation_func_(new_value, err);
+  }
+
+  void SetValue(T val) const { set_func_(val); }
+  T GetValue() const { return get_func_(); }
+
+ private:
+  OnSetFunc set_func_ = DefaultSetFunc<T>;
+  OnGetFunc get_func_ = DefaultGetFunc<T, DefaultValue>;
+  ValidateFunc validation_func_ = nullptr;
+};
+
+using NumericConfigEntry = ConfigEntry<long long, -1>;
+
+class ValkeySearchConfig {
+ public:
+  /// Register numeric configuration entry within Valkey. If
+  /// `value_validation_func` is not `nullptr`, it is used to validate the value
+  /// before set when user calls `config set`.
+  absl::Status RegisterNumericConfig(
+      RedisModuleCtx *ctx, std::string_view config_name,
+      long long default_value, long long min_value, long long max_value,
+      NumericConfigEntry::OnSetFunc &&set_func,
+      NumericConfigEntry::OnGetFunc &&get_func,
+      NumericConfigEntry::ValidateFunc &&validation_func = nullptr);
+
+ private:
+  static long long OnGetNumericConfig(const char *config_name, void *priv_data);
+  static int OnSetNumericConfig(const char *config_name, long long value,
+                                void *priv_data, RedisModuleString **err);
+  std::vector<std::unique_ptr<NumericConfigEntry>> numeric_entries_;
+};
+}  // namespace valkey_search

--- a/testing/common.h
+++ b/testing/common.h
@@ -62,6 +62,7 @@
 #include "src/server_events.h"
 #include "src/utils/string_interning.h"
 #include "src/valkey_search.h"
+#include "src/valkey_search_config.h"
 #include "src/vector_externalizer.h"
 #include "third_party/hnswlib/iostream.h"
 #include "vmsdk/src/managed_pointers.h"

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -325,13 +325,7 @@ TEST_F(VectorIndexTest, ResizeHNSW) ABSL_NO_THREAD_SAFETY_ANALYSIS {
                                    kM, kEFConstruction, kEFRuntime),
         "attribute_identifier_1",
         data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH);
-    RedisModuleString* err = nullptr;
-    EXPECT_EQ(ValkeySearch::BlockSizeSetConfig(NULL, 1024, nullptr, &err),
-              REDISMODULE_OK);
-    if (err) {
-      RedisModule_FreeString(nullptr, err);
-      err = nullptr;
-    }
+    ValkeySearch::Instance().SetHNSWBlockSize(1024);
     uint32_t block_size = ValkeySearch::Instance().GetHNSWBlockSize();
     EXPECT_EQ(index.value()->GetCapacity(), initial_cap);
     auto vectors = DeterministicallyGenerateVectors(


### PR DESCRIPTION
With this PR, user can control the threads counts
using

```
config set search.reader-threads <value>
config get search.reader-threads

config set search.writer-threads <value>
config get search.writer-threads
```

In addition, added new helper class `ValkeySearchConfig` which provides a convenient methods for registering numeric configuration items

![threads](https://github.com/user-attachments/assets/dbb81a87-943b-483f-bffe-da88dfad9fc3)
