### PR TITLE
Fixing empty vector query clause ft.search cmd parsing

### DIFF
--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -182,6 +182,9 @@ absl::StatusOr<FilterParseResults> ParsePreFilter(
 
 absl::Status ParseKNN(query::VectorSearchParameters &parameters,
                       absl::string_view filter_str) {
+  if (filter_str.empty()) {
+    return absl::InvalidArgumentError("Vector query clause is missing");
+  }
   VMSDK_ASSIGN_OR_RETURN(auto close_position,
                          FindCloseSquareBracket(filter_str));
   size_t position = 0;


### PR DESCRIPTION
Empty vector query clause leads to [accessing](https://github.com/valkey-io/valkey-search/blob/5001de38f1a39b1c10bf371a9746b5529ba901f1/src/commands/ft_search_parser.cc#L171) out of bounds memory