### PR TITLE
Use background context rather than IO context during Aux save.

### DIFF
--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -520,13 +520,13 @@ absl::Status MetadataManager::SaveMetadata(RedisModuleCtx *ctx, SafeRDB *rdb,
   if (!DoesGlobalMetadataContainEntry(metadata_.Get())) {
     // Auxsave2 will ensure nothing is written to the aux section if we write
     // nothing.
-    VMSDK_LOG(NOTICE, detached_ctx_.get())
+    VMSDK_LOG(NOTICE, ctx)
         << "Skipping aux metadata for MetadataManager since there is no "
            "content";
     return absl::OkStatus();
   }
 
-  VMSDK_LOG(NOTICE, detached_ctx_.get())
+  VMSDK_LOG(NOTICE, ctx)
       << "Saving aux metadata for MetadataManager to aux RDB";
   data_model::RDBSection section;
   std::string serialized_metadata;

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -40,6 +40,7 @@
 #include "absl/strings/string_view.h"
 #include "src/metrics.h"
 #include "src/rdb_section.pb.h"
+#include "src/valkey_search.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/status/status_macros.h"
@@ -282,8 +283,8 @@ absl::Status PerformRDBSave(RedisModuleCtx *ctx, SafeRDB *rdb, int when) {
 }
 
 void AuxSaveCallback(RedisModuleIO *rdb, int when) {
-  auto ctx = RedisModule_GetContextFromIO(rdb);
   SafeRDB safe_rdb(rdb);
+  auto ctx = ValkeySearch::Instance().GetBackgroundCtx();
   auto result = PerformRDBSave(ctx, &safe_rdb, when);
   if (result.ok()) {
     Metrics::GetStats().rdb_save_success_cnt++;

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -521,13 +521,13 @@ absl::Status SchemaManager::SaveIndexes(RedisModuleCtx *ctx, SafeRDB *rdb,
   if (db_to_index_schemas_.empty()) {
     // Auxsave2 will ensure nothing is written to the aux section if we
     // write nothing.
-    RedisModule_Log(detached_ctx_.get(), REDISMODULE_LOGLEVEL_NOTICE,
+    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_NOTICE,
                     "Skipping aux metadata for SchemaManager since there "
                     "is no content");
     return absl::OkStatus();
   }
 
-  RedisModule_Log(detached_ctx_.get(), REDISMODULE_LOGLEVEL_NOTICE,
+  RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_NOTICE,
                   "Saving aux metadata for SchemaManager to aux RDB");
   for (const auto &[db_num, inner_map] : db_to_index_schemas_) {
     for (const auto &[name, schema] : inner_map) {


### PR DESCRIPTION
Due to https://github.com/valkey-io/valkey/issues/2125 the IO context will not be freed which can trigger later assertions. We don't rely on it during saving so instead we now just use the background context for things like logging.

Fixes #142