### PR TITLE
Module-Config: fix a possibility of a double free

### DIFF
--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -321,12 +321,10 @@ class ConfigBuilder {
     return *this;
   }
 
-  std::shared_ptr<ConfigBase<ValkeyT>> Build() {
-    return std::shared_ptr<ConfigBase<ValkeyT>>{config_};
-  }
+  std::shared_ptr<ConfigBase<ValkeyT>> Build() { return config_; }
 
  private:
-  ConfigBase<ValkeyT> *config_ = nullptr;
+  std::shared_ptr<ConfigBase<ValkeyT>> config_;
 };
 
 /// Construct Configuration object of type `T`.


### PR DESCRIPTION
`ConfigBuilder`: keep `config_` as `shared_ptr` to make sure that the underlying pointer is free-ed once, in the unlikely event of `Build()` being called more than once.