### PR TITLE
fix compilation failure with DCMAKE_BUILD_TYPE=release option

### DIFF
--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -348,7 +348,7 @@ ConfigBuilder<ValkeyT> Builder(Args &&...args) {
     // Boolean
     return ConfigBuilder<int>(new Enum(std::forward<Args>(args)...));
   } else {
-    static_assert(false, "Unreachable");
+    static_assert(!std::is_same_v<ValkeyT, ValkeyT>, "Unreachable");
   }
 }
 


### PR DESCRIPTION
build fails with DCMAKE_BUILD_TYPE=release on latest main branch as below.

```
[ 53%] Built target ft_create_parser
In file included from /home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/module_config.cc:29:
/home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/module_config.h: In function ‘vmsdk::config::ConfigBuilder<ValkeyT> vmsdk::config::Builder(Args&& ...)’:
/home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/module_config.h:351:19: error: static assertion failed: Unreachable
  351 |     static_assert(false, "Unreachable");
      |                   ^~~~~
In file included from /home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/thread_pool.cc:46:
/home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/module_config.h: In function ‘vmsdk::config::ConfigBuilder<ValkeyT> vmsdk::config::Builder(Args&& ...)’:
/home/ubuntu/shiv-vector-search/valkey-search/vmsdk/src/module_config.h:351:19: error: static assertion failed: Unreachable
  351 |     static_assert(false, "Unreachable");
      |                   ^~~~~
make[2]: *** [vmsdk/src/CMakeFiles/thread_pool.dir/build.make:76: vmsdk/src/CMakeFiles/thread_pool.dir/thread_pool.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1021: vmsdk/src/CMakeFiles/thread_pool.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [vmsdk/src/CMakeFiles/module.dir/build.make:90: vmsdk/src/CMakeFiles/module.dir/module_config.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1106: vmsdk/src/CMakeFiles/module.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
```

Release build seems have diffrent compiler optimization level and it finds the else statement is not dependant on template so triggres failure.