### PR TITLE
Search trigger for Valkey Extension Automation

### DIFF
--- a/.github/trigger-search-release.yml
+++ b/.github/trigger-search-release.yml
@@ -1,0 +1,39 @@
+name: Trigger Extension Update - Search
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Version of Valkey Search module that was released
+        required: true
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine version
+        id: determine-vars
+        run: |
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            echo "Triggered by a release event."
+            VERSION=${{ github.event.release.tag_name }}
+          else
+            echo "Triggered manually."
+            VERSION=${{ inputs.version }}
+          fi
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Trigger extension update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.EXTENSION_PAT }}
+          repository: ${{ github.repository_owner }}/valkey-extensions
+          event-type: search-release
+          client-payload: >
+            {
+              "version": "${{ steps.determine-vars.outputs.version }}",
+              "module": "search"
+            }


### PR DESCRIPTION
This will be used to trigger the workflows in the Valkey-Extensions repository. A secret will also need to added to this repository called EXTENSION_PAT.