### PR TITLE
Make release build as default for manual cmake.

### DIFF
--- a/cmake/Modules/valkey_search.cmake
+++ b/cmake/Modules/valkey_search.cmake
@@ -1,12 +1,12 @@
 # Determine if we are building in Release or Debug mode
-if(CMAKE_BUILD_TYPE MATCHES Release)
-  set(VALKEY_SEARCH_DEBUG_BUILD 0)
-  set(VALKEY_SEARCH_RELEASE_BUILD 1)
-  message(STATUS "Building in release mode")
-else()
+if(CMAKE_BUILD_TYPE MATCHES Debug)
   set(VALKEY_SEARCH_DEBUG_BUILD 1)
   set(VALKEY_SEARCH_RELEASE_BUILD 0)
   message(STATUS "Building in debug mode")
+else()
+  set(VALKEY_SEARCH_DEBUG_BUILD 0)
+  set(VALKEY_SEARCH_RELEASE_BUILD 1)
+  message(STATUS "Building in release mode")
 endif()
 
 if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")


### PR DESCRIPTION
This PR does not modify any functional code. By default, the build.sh script generates a release build. However, when running CMake manually and building with cmake --build, it defaults to a debug build. Aligning the default CMake behavior with the script ensures consistency, so that manually generated builds also default to the release configuration.

Since debug builds use the -O0 optimization flag, they can significantly impact performance. Defaulting to a release build for manual builds would help ensure performance is more representative during testing.