### PR TITLE
Fix bug resulting in no ingestion to indexes with the same prefix as a dropped index

### DIFF
--- a/src/utils/patricia_tree.h
+++ b/src/utils/patricia_tree.h
@@ -286,12 +286,15 @@ class PatriciaTree {
     for (auto it = node->children.begin(); it != node->children.end(); ++it) {
       absl::string_view common_prefix =
           GetCommonPrefix(key, it->first, case_sensitive_);
+      PatriciaNodeType *child_node = it->second.get();
       if (!common_prefix.empty() && common_prefix.size() == it->first.size()) {
-        bool found = RemoveHelper(it->second.get(),
-                                  key.substr(common_prefix.size()), value);
+        bool found =
+            RemoveHelper(child_node, key.substr(common_prefix.size()), value);
         if (found) {
           node->subtree_values_count--;
-          if (it->second.get()->children.empty()) {
+          if (child_node->children.empty() &&
+              (!child_node->value.has_value() ||
+               child_node->value.value().empty())) {
             node->children.erase(it);
           }
           return found;

--- a/testing/utils/patricia_tree_test.cc
+++ b/testing/utils/patricia_tree_test.cc
@@ -71,6 +71,18 @@ TEST_F(PatriciaTreeSetTest, SimpleAddRemoveModify) {
   EXPECT_FALSE(tree_->Remove("APp", 2));
 }
 
+TEST_F(PatriciaTreeSetTest, MultipleItemsWithSameKey) {
+  tree_->AddKeyValue("hash:", 0);
+  tree_->AddKeyValue("hash:", 1);
+  auto set = tree_->GetValue("hash:", true);
+  EXPECT_EQ(set->size(), 2);
+
+  EXPECT_TRUE(tree_->Remove("hash:", 1));
+  set = tree_->GetValue("hash:", true);
+  EXPECT_TRUE(set != nullptr);
+  EXPECT_EQ(set->size(), 1);
+}
+
 TEST_F(PatriciaTreeSetTest, SimpleAddRemoveModifyCaseSensitive) {
   tree_case_sensitive_->AddKeyValue("", 0);
   tree_case_sensitive_->AddKeyValue("apple", 1);


### PR DESCRIPTION
In case multiple indexes are created for the same prefix the first index that will dropped - all of the subscribers associated with that prefix will be dropped.
Effectively making all these indexes "frozen"

This PR fixes issue: https://github.com/valkey-io/valkey-search/issues/124