### PR TITLE
Refactored protobuf generation code (cmake)

### DIFF
--- a/cmake/Modules/protobuf_generate.cmake
+++ b/cmake/Modules/protobuf_generate.cmake
@@ -1,221 +1,133 @@
+message(
+  STATUS "Processing file ${CMAKE_CURRENT_LIST_DIR}/protobuf_generate.cmake")
+
 set(MODULE_BASE_DIR "${CMAKE_BINARY_DIR}/.deps")
 set(MODULES_BIN_DIR "${MODULE_BASE_DIR}/install/bin")
 
-function(protobuf_generate)
-  include(CMakeParseArguments)
-
-  if(NOT EXISTS "${protoc_EXE}")
-    message(FATAL_ERROR "Could not locate 'protoc' executable")
-  endif()
-
-  set(_options APPEND_PATH)
-  set(_singleargs
-      LANGUAGE
-      OUT_VAR
-      EXPORT_MACRO
-      PROTOC_OUT_DIR
-      PLUGIN
-      PLUGIN_OPTIONS
-      PROTOC_EXE)
-  if(COMMAND target_sources)
-    list(APPEND _singleargs TARGET)
-  endif()
-  set(_multiargs PROTOS IMPORT_DIRS GENERATE_EXTENSIONS PROTOC_OPTIONS
-                 DEPENDENCIES)
-
-  cmake_parse_arguments(protobuf_generate "${_options}" "${_singleargs}"
-                        "${_multiargs}" "${ARGN}")
-
-  if(NOT protobuf_generate_PROTOS AND NOT protobuf_generate_TARGET)
-    message(
-      SEND_ERROR
-        "Error: protobuf_generate called without any targets or source files")
-    return()
-  endif()
-
-  if(NOT protobuf_generate_OUT_VAR AND NOT protobuf_generate_TARGET)
-    message(
-      SEND_ERROR
-        "Error: protobuf_generate called without a target or output variable")
-    return()
-  endif()
-
-  if(NOT protobuf_generate_LANGUAGE)
-    set(protobuf_generate_LANGUAGE cpp)
-  endif()
-  string(TOLOWER ${protobuf_generate_LANGUAGE} protobuf_generate_LANGUAGE)
-
-  if(NOT protobuf_generate_PROTOC_OUT_DIR)
-    set(protobuf_generate_PROTOC_OUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
-  endif()
-
-  if(protobuf_generate_EXPORT_MACRO AND protobuf_generate_LANGUAGE STREQUAL cpp)
-    set(_dll_export_decl "dllexport_decl=${protobuf_generate_EXPORT_MACRO}")
-  endif()
-
-  foreach(_option ${_dll_export_decl} ${protobuf_generate_PLUGIN_OPTIONS})
-    # append comma - not using CMake lists and string replacement as users might
-    # have semicolons in options
-    if(_plugin_options)
-      set(_plugin_options "${_plugin_options},")
-    endif()
-    set(_plugin_options "${_plugin_options}${_option}")
-  endforeach()
-
-  if(protobuf_generate_PLUGIN)
-    set(_plugin "--plugin=${protobuf_generate_PLUGIN}")
-  endif()
-
-  if(NOT protobuf_generate_GENERATE_EXTENSIONS)
-    if(protobuf_generate_LANGUAGE STREQUAL cpp)
-      set(protobuf_generate_GENERATE_EXTENSIONS .pb.h .pb.cc)
-    elseif(protobuf_generate_LANGUAGE STREQUAL python)
-      set(protobuf_generate_GENERATE_EXTENSIONS _pb2.py)
-    else()
-      message(
-        SEND_ERROR
-          "Error: protobuf_generate given unknown Language ${LANGUAGE}, please provide a value for GENERATE_EXTENSIONS"
-      )
-      return()
-    endif()
-  endif()
-
-  if(protobuf_generate_TARGET)
-    get_target_property(_source_list ${protobuf_generate_TARGET} SOURCES)
-    foreach(_file ${_source_list})
-      if(_file MATCHES "proto$")
-        list(APPEND protobuf_generate_PROTOS ${_file})
-      endif()
-    endforeach()
-  endif()
-
-  if(NOT protobuf_generate_PROTOS)
-    message(
-      SEND_ERROR "Error: protobuf_generate could not find any .proto files")
-    return()
-  endif()
-
-  if(protobuf_generate_APPEND_PATH)
-    # Create an include path for each file specified
-    foreach(_file ${protobuf_generate_PROTOS})
-      get_filename_component(_abs_file ${_file} ABSOLUTE)
-      get_filename_component(_abs_dir ${_abs_file} DIRECTORY)
-      list(FIND _protobuf_include_path ${_abs_dir} _contains_already)
-      if(${_contains_already} EQUAL -1)
-        list(APPEND _protobuf_include_path -I ${_abs_dir})
-      endif()
-    endforeach()
-  endif()
-
-  foreach(DIR ${protobuf_generate_IMPORT_DIRS})
-    get_filename_component(ABS_PATH ${DIR} ABSOLUTE)
-    list(FIND _protobuf_include_path ${ABS_PATH} _contains_already)
-    if(${_contains_already} EQUAL -1)
-      list(APPEND _protobuf_include_path -I ${ABS_PATH})
-    endif()
-  endforeach()
-
-  if(NOT _protobuf_include_path)
-    set(_protobuf_include_path -I ${CMAKE_CURRENT_SOURCE_DIR})
-  endif()
-
-  set(_generated_srcs_all)
-  foreach(_proto ${protobuf_generate_PROTOS})
-    get_filename_component(_abs_file ${_proto} ABSOLUTE)
-    get_filename_component(_abs_dir ${_abs_file} DIRECTORY)
-
-    get_filename_component(_file_full_name ${_proto} NAME)
-    string(FIND "${_file_full_name}" "." _file_last_ext_pos REVERSE)
-    string(SUBSTRING "${_file_full_name}" 0 ${_file_last_ext_pos} _basename)
-
-    set(_suitable_include_found FALSE)
-    foreach(DIR ${_protobuf_include_path})
-      if(NOT DIR STREQUAL "-I")
-        file(RELATIVE_PATH _rel_dir ${DIR} ${_abs_dir})
-        if(_rel_dir STREQUAL _abs_dir)
-          # When there is no relative path from DIR to _abs_dir (e.g. due to
-          # different drive letters on Windows), _rel_dir is equal to _abs_dir.
-          # Therefore, DIR is not a suitable include path and must be skipped.
-          continue()
-        endif()
-        string(FIND "${_rel_dir}" "../" _is_in_parent_folder)
-        if(NOT ${_is_in_parent_folder} EQUAL 0)
-          set(_suitable_include_found TRUE)
-          break()
-        endif()
-      endif()
-    endforeach()
-
-    if(NOT _suitable_include_found)
-      message(
-        SEND_ERROR
-          "Error: protobuf_generate could not find any correct proto include directory."
-      )
-      return()
-    endif()
-
-    set(_generated_srcs)
-    foreach(_ext ${protobuf_generate_GENERATE_EXTENSIONS})
-      list(
-        APPEND _generated_srcs
-        "${protobuf_generate_PROTOC_OUT_DIR}/${_rel_dir}/${_basename}${_ext}")
-    endforeach()
-    list(APPEND _generated_srcs_all ${_generated_srcs})
-
-    set(_comment
-        "Running ${protobuf_generate_LANGUAGE} protocol buffer compiler on ${_proto}"
-    )
-    if(protobuf_generate_PROTOC_OPTIONS)
-      set(_comment
-          "${_comment}, protoc-options: ${protobuf_generate_PROTOC_OPTIONS}")
-    endif()
-    if(_plugin_options)
-      set(_comment "${_comment}, plugin-options: ${_plugin_options}")
-    endif()
-
-    message(
-      STATUS
-        "Running: ${protoc_EXE} ARGS ${protobuf_generate_PROTOC_OPTIONS} --${protobuf_generate_LANGUAGE}_out ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin} ${_protobuf_include_path} ${_abs_file}"
-    )
-    add_custom_command(
-      OUTPUT ${_generated_srcs}
-      COMMAND
-        ${protoc_EXE} ARGS ${protobuf_generate_PROTOC_OPTIONS}
-        --${protobuf_generate_LANGUAGE}_out
-        ${_plugin_options}:${protobuf_generate_PROTOC_OUT_DIR} ${_plugin}
-        ${_protobuf_include_path} ${_abs_file}
-      DEPENDS ${_abs_file} ${protobuf_PROTOC_EXE}
-              ${protobuf_generate_DEPENDENCIES}
-      COMMENT ${_comment}
-      VERBATIM)
-  endforeach()
-
-  set_source_files_properties(${_generated_srcs_all} PROPERTIES GENERATED TRUE)
-  if(protobuf_generate_OUT_VAR)
-    set(${protobuf_generate_OUT_VAR}
-        ${_generated_srcs_all}
+# Check (based on timestamp) if we need to re-generate protbuf files
+function(_valkey_search_is_proto_gen_required PROTO_PATH TARGET_PATH
+         GEN_REQUIRED)
+  if(NOT EXISTS "${TARGET_PATH}")
+    # If the genenrated file does not exist, create it
+    set(${GEN_REQUIRED}
+        ON
         PARENT_SCOPE)
+  else()
+    set(PROTO_PATH "${CMAKE_SOURCE_DIR}/${PROTO_PATH}")
+    file(TIMESTAMP "${PROTO_PATH}" PROTO_TS "%s")
+    math(EXPR proto_timestamp "${PROTO_TS}")
+
+    file(TIMESTAMP "${TARGET_PATH}" TARGET_TS "%s")
+    math(EXPR target_timestamp "${TARGET_TS}")
+
+    if(proto_timestamp GREATER target_timestamp)
+      set(${GEN_REQUIRED}
+          ON
+          PARENT_SCOPE)
+    else()
+      set(${GEN_REQUIRED}
+          OFF
+          PARENT_SCOPE)
+    endif()
   endif()
-  if(protobuf_generate_TARGET)
-    target_sources(${protobuf_generate_TARGET} PRIVATE ${_generated_srcs_all})
+endfunction()
+
+# Generate grpc files for C++ at output directory "${OUT_GEN_DIR}" and create a
+# static library target named ${TARGET_NAME} from the generated files
+function(valkey_search_create_proto_grpc_library PROTO_PATH TARGET_NAME)
+  set(PROTO_OUT_DIR ${CMAKE_BINARY_DIR})
+  get_filename_component(PROTO_FILE_DIR "${PROTO_PATH}" PATH)
+  get_filename_component(PROTO_FILE_BASE_NAME "${PROTO_PATH}" NAME_WE)
+
+  set(GEN_FILE_H
+      "${PROTO_OUT_DIR}/${PROTO_FILE_DIR}/${PROTO_FILE_BASE_NAME}.grpc.pb.h")
+  set(GEN_FILE_CC
+      "${PROTO_OUT_DIR}/${PROTO_FILE_DIR}/${PROTO_FILE_BASE_NAME}.grpc.pb.cc")
+  list(APPEND GEN_FILES "${GEN_FILE_H}")
+  list(APPEND GEN_FILES "${GEN_FILE_CC}")
+
+  # To avoid rebuilding everytime we run "cmake", check if regenrting is
+  # actually required
+  _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_H}
+                                       GEN_H_REQUIRED)
+  _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_CC}
+                                       GEN_CC_REQUIRED)
+  if(${GEN_CC_REQUIRED} OR ${GEN_FILE_H})
+    message(STATUS "Generating files from ${PROTO_PATH} (gRPC)")
+    execute_process(
+      COMMAND ${protoc_EXE} --grpc_out=${PROTO_OUT_DIR} -I${CMAKE_SOURCE_DIR}
+              --plugin=protoc-gen-grpc=${GRPC_CPP_PLUGIN_PATH} ${PROTO_PATH}
+      RESULT_VARIABLE protoc_grpc_RES
+      OUTPUT_VARIABLE protoc_grpc_STDOUT
+      ERROR_VARIABLE protoc_grpc_STDERR)
+
+    if(NOT protoc_grpc_RES EQUAL 0)
+      message(WARNING "Failed to generate gRPC files.")
+      message(WARNING "STDOUT: ${protoc_grpc_STDOUT}")
+      message(WARNING "STDERR: ${protoc_grpc_STDERR}")
+      message(FATAL_ERROR "Exiting")
+    endif()
+  else()
+    foreach(GENERATED_FILE ${GEN_FILES})
+      message(STATUS "Generated file: ${GENERATED_FILE} is up-to-date")
+    endforeach()
   endif()
 
+  add_library(${TARGET_NAME} STATIC ${GEN_FILES})
+  message(STATUS "Created protobuf (gRPC) target: ${TARGET_NAME}")
+  valkey_search_target_update_compile_flags(${TARGET_NAME})
+  target_link_libraries(${TARGET_NAME} PUBLIC ${Protobuf_LIBRARIES})
 endfunction()
 
 # Helper method: create static library from a single proto file. "PROTO_PATH"
 # contains the relative path to the proto file from top level source directory.
-# "OUT_LIBNAME" is the user provided target name to create
-function(valkey_search_create_proto_library PROTO_PATH OUT_LIBNAME)
+# "TARGET_NAME" is the user provided target name to create
+function(valkey_search_create_proto_library PROTO_PATH TARGET_NAME)
   get_filename_component(PROTO_DIR "${PROTO_PATH}" PATH)
   set(PROTO_OUT_DIR ${CMAKE_BINARY_DIR})
-  add_library(${OUT_LIBNAME} STATIC "${CMAKE_SOURCE_DIR}/${PROTO_PATH}")
-  protobuf_generate(TARGET ${OUT_LIBNAME} IMPORT_DIRS "${CMAKE_SOURCE_DIR}"
-                    PROTOC_OUT_DIR "${PROTO_OUT_DIR}")
-  message(STATUS "Creating target ${OUT_LIBNAME}")
-  valkey_search_target_update_compile_flags(${OUT_LIBNAME})
-  target_link_libraries(${OUT_LIBNAME} PUBLIC ${Protobuf_LIBRARIES})
-  target_include_directories(${OUT_LIBNAME} PUBLIC ${CMAKE_BINARY_DIR})
-  target_include_directories(${OUT_LIBNAME} PUBLIC ${PROTO_OUT_DIR})
-  target_include_directories(${OUT_LIBNAME} PUBLIC ${Protobuf_INCLUDE_DIRS})
+  get_filename_component(PROTO_FILE_DIR "${PROTO_PATH}" PATH)
+  get_filename_component(PROTO_FILE_BASE_NAME "${PROTO_PATH}" NAME_WE)
+
+  set(GEN_FILE_H
+      "${PROTO_OUT_DIR}/${PROTO_FILE_DIR}/${PROTO_FILE_BASE_NAME}.pb.h")
+  set(GEN_FILE_CC
+      "${PROTO_OUT_DIR}/${PROTO_FILE_DIR}/${PROTO_FILE_BASE_NAME}.pb.cc")
+  list(APPEND GEN_FILES "${GEN_FILE_H}")
+  list(APPEND GEN_FILES "${GEN_FILE_CC}")
+
+  # To avoid rebuilding everytime we run "cmake", check if regenrting is
+  # actually required
+  _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_H}
+                                       GEN_H_REQUIRED)
+  _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_CC}
+                                       GEN_CC_REQUIRED)
+  if(${GEN_CC_REQUIRED} OR ${GEN_FILE_H})
+    message(STATUS "Generating files from ${PROTO_PATH}")
+    execute_process(
+      COMMAND ${protoc_EXE} --cpp_out=${PROTO_OUT_DIR} -I${CMAKE_SOURCE_DIR}
+              ${PROTO_PATH}
+      RESULT_VARIABLE protoc_RES
+      OUTPUT_VARIABLE protoc_STDOUT
+      ERROR_VARIABLE protoc_STDERR)
+
+    if(NOT protoc_RES EQUAL 0)
+      message(WARNING "Failed to generate protobuf files.")
+      message(WARNING "STDOUT: ${protoc_STDOUT}")
+      message(WARNING "STDERR: ${protoc_STDERR}")
+      message(FATAL_ERROR "Exiting")
+    endif()
+  else()
+    foreach(GENERATED_FILE ${GEN_FILES})
+      message(STATUS "Generated file: ${GENERATED_FILE} is up-to-date")
+    endforeach()
+  endif()
+
+  add_library(${TARGET_NAME} STATIC ${GEN_FILES})
+  valkey_search_target_update_compile_flags(${TARGET_NAME})
+  target_link_libraries(${TARGET_NAME} PUBLIC ${Protobuf_LIBRARIES})
+  target_include_directories(${TARGET_NAME} PUBLIC ${CMAKE_BINARY_DIR})
+  target_include_directories(${TARGET_NAME} PUBLIC ${PROTO_OUT_DIR})
+  target_include_directories(${TARGET_NAME} PUBLIC ${Protobuf_INCLUDE_DIRS})
   unset(PROTO_OUT_DIR CACHE)
+  message(STATUS "Created protobuf target ${TARGET_NAME}")
 endfunction()

--- a/cmake/Modules/valkey_search.cmake
+++ b/cmake/Modules/valkey_search.cmake
@@ -148,7 +148,8 @@ endfunction()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-missing-requires")
 
-include(protobuf_generate)
+message(STATUS "Including file ${CMAKE_SOURCE_DIR}/cmake/Modules/protobuf_generate.cmake")
+include(${CMAKE_SOURCE_DIR}/cmake/Modules/protobuf_generate.cmake)
 include(linux_utils)
 
 # HACK: in order to force CMake to put "-Wl,--end-group" as the last argument we

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,7 +26,6 @@ valkey_search_create_proto_library("src/rdb_section.proto"
                                    "rdb_section_cc_proto")
 target_link_libraries(rdb_section_cc_proto PUBLIC index_schema_cc_proto)
 target_link_libraries(rdb_section_cc_proto PUBLIC coordinator_cc_proto)
-message(STATUS "Created proto library rdb_section_cc_proto")
 
 # Wrap ${THIRD_PARTY_LIBS} with "--start/--end group"
 target_link_options(libsearch PRIVATE -Wl,--start-group)

--- a/src/coordinator/CMakeLists.txt
+++ b/src/coordinator/CMakeLists.txt
@@ -1,22 +1,11 @@
-# Create a static library "coordinator_grpc_proto" with the proto files
-add_library(coordinator_grpc_proto STATIC
-            ${CMAKE_CURRENT_LIST_DIR}/coordinator.proto)
-protobuf_generate(
-  TARGET
-  coordinator_grpc_proto
-  LANGUAGE
-  grpc
-  GENERATE_EXTENSIONS
-  .grpc.pb.h
-  .grpc.pb.cc
-  PLUGIN
-  "protoc-gen-grpc=${GRPC_CPP_PLUGIN_PATH}")
+valkey_search_create_proto_grpc_library("src/coordinator/coordinator.proto"
+                                        coordinator_grpc_proto)
 
 # Create the proto code (no grpc)
 valkey_search_create_proto_library("src/coordinator/coordinator.proto"
-                                   "coordinator_cc_proto")
-target_link_libraries(coordinator_grpc_proto coordinator_cc_proto)
+                                   coordinator_cc_proto)
 
+target_link_libraries(coordinator_grpc_proto PUBLIC coordinator_cc_proto)
 set(SRCS_SERVER ${CMAKE_CURRENT_LIST_DIR}/server.cc
                 ${CMAKE_CURRENT_LIST_DIR}/server.h)
 

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -1,5 +1,5 @@
-valkey_search_create_proto_library("src/index_schema.proto" "index_schema_cc_proto")
-message(STATUS "Created proto library index_schema_cc_proto")
+valkey_search_create_proto_library("src/index_schema.proto"
+                                   "index_schema_cc_proto")
 
 add_library(index_base INTERFACE ${SRCS_INDEX_BASE})
 target_include_directories(index_base INTERFACE ${CMAKE_CURRENT_LIST_DIR})

--- a/third_party/hnswlib/CMakeLists.txt
+++ b/third_party/hnswlib/CMakeLists.txt
@@ -9,7 +9,6 @@ set(SRCS_HNSWLIB_VMSDK
 
 valkey_search_create_proto_library("third_party/hnswlib/index.proto"
                                    "index_cc_proto")
-message(STATUS "Created proto library index_cc_proto")
 
 add_library(hnswlib_vmsdk INTERFACE ${SRCS_HNSWLIB_VMSDK})
 target_include_directories(hnswlib_vmsdk INTERFACE ${CMAKE_CURRENT_LIST_DIR})


### PR DESCRIPTION
Invoke `protoc` directly and simplify the function
that generates `grpc` / `proto` files. This fixes the build issues on Linux Alpine on ARM