### PR TITLE
Rebranding module to use Valkey instead of Redis

### DIFF
--- a/src/acl.h
+++ b/src/acl.h
@@ -29,12 +29,12 @@ Check if
     * according to the ACL rules defined in the server.
 */
 absl::Status AclPrefixCheck(
-    RedisModuleCtx *ctx,
+    ValkeyModuleCtx *ctx,
     const absl::flat_hash_set<absl::string_view> &module_allowed_cmds,
     const std::vector<std::string> &module_prefixes);
 
 absl::Status AclPrefixCheck(
-    RedisModuleCtx *ctx,
+    ValkeyModuleCtx *ctx,
     const absl::flat_hash_set<absl::string_view> &module_allowed_cmds,
     const data_model::IndexSchema &index_schema_proto);
 

--- a/src/attribute.h
+++ b/src/attribute.h
@@ -57,23 +57,23 @@ class Attribute {
     attribute_proto->set_allocated_index(index_->ToProto().release());
     return attribute_proto;
   }
-  inline int RespondWithInfo(RedisModuleCtx* ctx) const {
-    RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
-    RedisModule_ReplyWithSimpleString(ctx, "identifier");
-    RedisModule_ReplyWithSimpleString(ctx, GetIdentifier().c_str());
-    RedisModule_ReplyWithSimpleString(ctx, "attribute");
-    RedisModule_ReplyWithSimpleString(ctx, GetAlias().c_str());
+  inline int RespondWithInfo(ValkeyModuleCtx* ctx) const {
+    ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_LEN);
+    ValkeyModule_ReplyWithSimpleString(ctx, "identifier");
+    ValkeyModule_ReplyWithSimpleString(ctx, GetIdentifier().c_str());
+    ValkeyModule_ReplyWithSimpleString(ctx, "attribute");
+    ValkeyModule_ReplyWithSimpleString(ctx, GetAlias().c_str());
     int added_fields = index_->RespondWithInfo(ctx);
-    RedisModule_ReplySetArrayLength(ctx, added_fields + 4);
+    ValkeyModule_ReplySetArrayLength(ctx, added_fields + 4);
     return 1;
   }
 
-  inline vmsdk::UniqueRedisString DefaultReplyScoreAs() const {
+  inline vmsdk::UniqueValkeyString DefaultReplyScoreAs() const {
     if (!cached_score_as_) {
       cached_score_as_ =
-          vmsdk::MakeUniqueRedisString(absl::StrCat("__", alias_, "_score"));
+          vmsdk::MakeUniqueValkeyString(absl::StrCat("__", alias_, "_score"));
     }
-    return vmsdk::RetainUniqueRedisString(cached_score_as_.get());
+    return vmsdk::RetainUniqueValkeyString(cached_score_as_.get());
   }
 
  private:
@@ -81,7 +81,7 @@ class Attribute {
   std::string identifier_;
   std::shared_ptr<indexes::IndexBase> index_;
   // Maintaining a cached version
-  mutable vmsdk::UniqueRedisString cached_score_as_;
+  mutable vmsdk::UniqueValkeyString cached_score_as_;
 };
 
 }  // namespace valkey_search

--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -45,18 +45,18 @@
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search {
-absl::StatusOr<vmsdk::UniqueRedisString> HashAttributeDataType::GetRecord(
-    [[maybe_unused]] RedisModuleCtx *ctx, RedisModuleKey *open_key,
+absl::StatusOr<vmsdk::UniqueValkeyString> HashAttributeDataType::GetRecord(
+    [[maybe_unused]] ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
     [[maybe_unused]] absl::string_view key,
     absl::string_view identifier) const {
   vmsdk::VerifyMainThread();
-  RedisModuleString *record{nullptr};
-  RedisModule_HashGet(open_key, REDISMODULE_HASH_CFIELDS, identifier.data(),
-                      &record, nullptr);
+  ValkeyModuleString *record{nullptr};
+  ValkeyModule_HashGet(open_key, VALKEYMODULE_HASH_CFIELDS, identifier.data(),
+                       &record, nullptr);
   if (!record) {
     return absl::NotFoundError("No such record with identifier");
   }
-  return vmsdk::UniqueRedisString(record);
+  return vmsdk::UniqueValkeyString(record);
 }
 
 struct HashScanCallbackData {
@@ -64,8 +64,8 @@ struct HashScanCallbackData {
   RecordsMap key_value_content;
 };
 
-void HashScanCallback(RedisModuleKey *key, RedisModuleString *field,
-                      RedisModuleString *value, void *privdata) {
+void HashScanCallback(ValkeyModuleKey *key, ValkeyModuleString *field,
+                      ValkeyModuleString *value, void *privdata) {
   vmsdk::VerifyMainThread();
   if (!field || !value) {
     return;
@@ -78,26 +78,27 @@ void HashScanCallback(RedisModuleKey *key, RedisModuleString *field,
   if (callback_data->identifiers.empty() ||
       callback_data->identifiers.contains(field_str)) {
     callback_data->key_value_content.emplace(
-        field_str, RecordsMapValue(vmsdk::RetainUniqueRedisString(field),
-                                   vmsdk::RetainUniqueRedisString(value)));
+        field_str, RecordsMapValue(vmsdk::RetainUniqueValkeyString(field),
+                                   vmsdk::RetainUniqueValkeyString(value)));
   }
 }
 
-bool HashHasRecord(RedisModuleKey *key, absl::string_view identifier) {
+bool HashHasRecord(ValkeyModuleKey *key, absl::string_view identifier) {
   int exists;
-  RedisModule_HashGet(key, REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXISTS,
-                      identifier.data(), &exists, nullptr);
+  ValkeyModule_HashGet(key,
+                       VALKEYMODULE_HASH_CFIELDS | VALKEYMODULE_HASH_EXISTS,
+                       identifier.data(), &exists, nullptr);
   return exists;
 }
 
 absl::StatusOr<RecordsMap> HashAttributeDataType::FetchAllRecords(
-    RedisModuleCtx *ctx, const std::string &vector_identifier,
+    ValkeyModuleCtx *ctx, const std::string &vector_identifier,
     absl::string_view key,
     const absl::flat_hash_set<absl::string_view> &identifiers) const {
   vmsdk::VerifyMainThread();
-  auto key_str = vmsdk::MakeUniqueRedisString(key);
+  auto key_str = vmsdk::MakeUniqueValkeyString(key);
   auto key_obj =
-      vmsdk::MakeUniqueRedisOpenKey(ctx, key_str.get(), REDISMODULE_READ);
+      vmsdk::MakeUniqueValkeyOpenKey(ctx, key_str.get(), VALKEYMODULE_READ);
   if (!key_obj) {
     return absl::NotFoundError(
         absl::StrCat("No such record with key: `", vector_identifier, "`"));
@@ -106,10 +107,10 @@ absl::StatusOr<RecordsMap> HashAttributeDataType::FetchAllRecords(
     return absl::NotFoundError(absl::StrCat("No such record with identifier: `",
                                             vector_identifier, "`"));
   }
-  vmsdk::UniqueRedisScanCursor cursor = vmsdk::MakeUniqueRedisScanCursor();
+  vmsdk::UniqueValkeyScanCursor cursor = vmsdk::MakeUniqueValkeyScanCursor();
   HashScanCallbackData callback_data{identifiers};
-  while (RedisModule_ScanKey(key_obj.get(), cursor.get(), HashScanCallback,
-                             &callback_data)) {
+  while (ValkeyModule_ScanKey(key_obj.get(), cursor.get(), HashScanCallback,
+                              &callback_data)) {
   }
   return std::move(callback_data.key_value_content);
 }
@@ -121,7 +122,7 @@ absl::string_view TrimBrackets(absl::string_view record) {
   return record;
 }
 
-absl::StatusOr<vmsdk::UniqueRedisString> NormalizeJsonRecord(
+absl::StatusOr<vmsdk::UniqueValkeyString> NormalizeJsonRecord(
     absl::string_view record) {
   if (!record.empty() && record[0] != '[') {
     return absl::NotFoundError("Invalid record");
@@ -135,40 +136,40 @@ absl::StatusOr<vmsdk::UniqueRedisString> NormalizeJsonRecord(
   if (record.empty()) {
     return absl::NotFoundError("Empty record");
   }
-  return vmsdk::MakeUniqueRedisString(record);
+  return vmsdk::MakeUniqueValkeyString(record);
 }
 
-absl::StatusOr<vmsdk::UniqueRedisString> JsonAttributeDataType::GetRecord(
-    RedisModuleCtx *ctx, [[maybe_unused]] RedisModuleKey *open_key,
+absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetRecord(
+    ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleKey *open_key,
     absl::string_view key, absl::string_view identifier) const {
   vmsdk::VerifyMainThread();
 
-  auto reply = vmsdk::UniquePtrRedisCallReply(RedisModule_Call(
+  auto reply = vmsdk::UniquePtrValkeyCallReply(ValkeyModule_Call(
       ctx, kJsonCmd.data(), "cc", key.data(), identifier.data()));
   if (reply == nullptr) {
     return absl::NotFoundError(
         absl::StrCat("No such record with identifier: `", identifier, "`"));
   }
-  auto reply_type = RedisModule_CallReplyType(reply.get());
-  if (reply_type == REDISMODULE_REPLY_STRING) {
-    auto reply_str = vmsdk::UniqueRedisString(
-        RedisModule_CreateStringFromCallReply(reply.get()));
+  auto reply_type = ValkeyModule_CallReplyType(reply.get());
+  if (reply_type == VALKEYMODULE_REPLY_STRING) {
+    auto reply_str = vmsdk::UniqueValkeyString(
+        ValkeyModule_CreateStringFromCallReply(reply.get()));
     return NormalizeJsonRecord(vmsdk::ToStringView(reply_str.get()));
   }
   return absl::NotFoundError("Json.get returned a non string value");
 }
 
 absl::StatusOr<RecordsMap> JsonAttributeDataType::FetchAllRecords(
-    RedisModuleCtx *ctx, const std::string &vector_identifier,
+    ValkeyModuleCtx *ctx, const std::string &vector_identifier,
     absl::string_view key,
     const absl::flat_hash_set<absl::string_view> &identifiers) const {
   vmsdk::VerifyMainThread();
   // Validating that a JSON object with the key exists with the vector
   // identifier
-  auto reply = vmsdk::UniquePtrRedisCallReply(RedisModule_Call(
+  auto reply = vmsdk::UniquePtrValkeyCallReply(ValkeyModule_Call(
       ctx, kJsonCmd.data(), "cc", key.data(), vector_identifier.c_str()));
   if (reply == nullptr ||
-      RedisModule_CallReplyType(reply.get()) != REDISMODULE_REPLY_STRING) {
+      ValkeyModule_CallReplyType(reply.get()) != VALKEYMODULE_REPLY_STRING) {
     return absl::NotFoundError(absl::StrCat("No such record with identifier: `",
                                             vector_identifier, "`"));
   }
@@ -179,13 +180,13 @@ absl::StatusOr<RecordsMap> JsonAttributeDataType::FetchAllRecords(
       continue;
     }
     key_value_content.emplace(
-        identifier, RecordsMapValue(vmsdk::MakeUniqueRedisString(identifier),
+        identifier, RecordsMapValue(vmsdk::MakeUniqueValkeyString(identifier),
                                     std::move(str.value())));
   }
   return key_value_content;
 }
 
-bool IsJsonModuleLoaded(RedisModuleCtx *ctx) {
+bool IsJsonModuleLoaded(ValkeyModuleCtx *ctx) {
   return vmsdk::IsModuleLoaded(ctx, "json");
 }
 }  // namespace valkey_search

--- a/src/attribute_data_type.h
+++ b/src/attribute_data_type.h
@@ -43,25 +43,26 @@
 
 namespace valkey_search {
 
-bool HashHasRecord(RedisModuleKey *key, absl::string_view identifier);
+bool HashHasRecord(ValkeyModuleKey *key, absl::string_view identifier);
 
 class RecordsMapValue {
  public:
-  RecordsMapValue(vmsdk::UniqueRedisString identifier,
-                  vmsdk::UniqueRedisString value)
+  RecordsMapValue(vmsdk::UniqueValkeyString identifier,
+                  vmsdk::UniqueValkeyString value)
       : value(std::move(value)), identifier_(std::move(identifier)) {}
-  RecordsMapValue(RedisModuleString *identifier, vmsdk::UniqueRedisString value)
+  RecordsMapValue(ValkeyModuleString *identifier,
+                  vmsdk::UniqueValkeyString value)
       : value(std::move(value)), identifier_(identifier) {}
-  vmsdk::UniqueRedisString value;
-  RedisModuleString *GetIdentifier() const {
-    if (absl::holds_alternative<vmsdk::UniqueRedisString>(identifier_)) {
-      return absl::get<vmsdk::UniqueRedisString>(identifier_).get();
+  vmsdk::UniqueValkeyString value;
+  ValkeyModuleString *GetIdentifier() const {
+    if (absl::holds_alternative<vmsdk::UniqueValkeyString>(identifier_)) {
+      return absl::get<vmsdk::UniqueValkeyString>(identifier_).get();
     }
-    return absl::get<RedisModuleString *>(identifier_);
+    return absl::get<ValkeyModuleString *>(identifier_);
   }
 
  private:
-  absl::variant<RedisModuleString *, vmsdk::UniqueRedisString> identifier_;
+  absl::variant<ValkeyModuleString *, vmsdk::UniqueValkeyString> identifier_;
 };
 
 using RecordsMap = absl::flat_hash_map<absl::string_view, RecordsMapValue>;
@@ -69,20 +70,20 @@ using RecordsMap = absl::flat_hash_map<absl::string_view, RecordsMapValue>;
 class AttributeDataType {
  public:
   virtual ~AttributeDataType() = default;
-  virtual absl::StatusOr<vmsdk::UniqueRedisString> GetRecord(
-      RedisModuleCtx *ctx, RedisModuleKey *open_key, absl::string_view key,
+  virtual absl::StatusOr<vmsdk::UniqueValkeyString> GetRecord(
+      ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
       absl::string_view identifier) const = 0;
-  virtual int GetRedisEventTypes() const {
-    return REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_EXPIRED |
-           REDISMODULE_NOTIFY_EVICTED;
+  virtual int GetValkeyEventTypes() const {
+    return VALKEYMODULE_NOTIFY_GENERIC | VALKEYMODULE_NOTIFY_EXPIRED |
+           VALKEYMODULE_NOTIFY_EVICTED;
   };
   virtual absl::StatusOr<RecordsMap> FetchAllRecords(
-      RedisModuleCtx *ctx, const std::string &vector_identifier,
+      ValkeyModuleCtx *ctx, const std::string &vector_identifier,
       absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const = 0;
   virtual data_model::AttributeDataType ToProto() const = 0;
   virtual std::string ToString() const = 0;
-  virtual bool IsProperType(RedisModuleKey *key) const = 0;
+  virtual bool IsProperType(ValkeyModuleKey *key) const = 0;
   // This provides indication whether the fetched content need special
   // normalization.
   virtual bool RecordsProvidedAsString() const = 0;
@@ -90,11 +91,11 @@ class AttributeDataType {
 
 class HashAttributeDataType : public AttributeDataType {
  public:
-  absl::StatusOr<vmsdk::UniqueRedisString> GetRecord(
-      RedisModuleCtx *ctx, RedisModuleKey *open_key, absl::string_view key,
+  absl::StatusOr<vmsdk::UniqueValkeyString> GetRecord(
+      ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
       absl::string_view identifier) const override;
-  inline int GetRedisEventTypes() const override {
-    return REDISMODULE_NOTIFY_HASH | AttributeDataType::GetRedisEventTypes();
+  inline int GetValkeyEventTypes() const override {
+    return VALKEYMODULE_NOTIFY_HASH | AttributeDataType::GetValkeyEventTypes();
   }
 
   inline data_model::AttributeDataType ToProto() const override {
@@ -102,11 +103,11 @@ class HashAttributeDataType : public AttributeDataType {
   }
   inline std::string ToString() const override { return "HASH"; }
   absl::StatusOr<RecordsMap> FetchAllRecords(
-      RedisModuleCtx *ctx, const std::string &vector_identifier,
+      ValkeyModuleCtx *ctx, const std::string &vector_identifier,
       absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const override;
-  bool IsProperType(RedisModuleKey *key) const override {
-    return RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_HASH;
+  bool IsProperType(ValkeyModuleKey *key) const override {
+    return ValkeyModule_KeyType(key) == VALKEYMODULE_KEYTYPE_HASH;
   }
   bool RecordsProvidedAsString() const override { return false; }
 };
@@ -116,27 +117,27 @@ inline constexpr absl::string_view kJsonRootElementQuery = "$";
 
 class JsonAttributeDataType : public AttributeDataType {
  public:
-  absl::StatusOr<vmsdk::UniqueRedisString> GetRecord(
-      RedisModuleCtx *ctx, RedisModuleKey *open_key, absl::string_view key,
+  absl::StatusOr<vmsdk::UniqueValkeyString> GetRecord(
+      ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
       absl::string_view identifier) const override;
-  inline int GetRedisEventTypes() const override {
-    return REDISMODULE_NOTIFY_MODULE | AttributeDataType::GetRedisEventTypes();
+  inline int GetValkeyEventTypes() const override {
+    return VALKEYMODULE_NOTIFY_MODULE | AttributeDataType::GetValkeyEventTypes();
   }
   inline data_model::AttributeDataType ToProto() const override {
     return data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON;
   }
   inline std::string ToString() const override { return "JSON"; }
   absl::StatusOr<RecordsMap> FetchAllRecords(
-      RedisModuleCtx *ctx, const std::string &vector_identifier,
+      ValkeyModuleCtx *ctx, const std::string &vector_identifier,
       absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const override;
-  bool IsProperType(RedisModuleKey *key) const override {
-    return RedisModule_KeyType(key) == REDISMODULE_KEYTYPE_MODULE;
+  bool IsProperType(ValkeyModuleKey *key) const override {
+    return ValkeyModule_KeyType(key) == VALKEYMODULE_KEYTYPE_MODULE;
   }
   bool RecordsProvidedAsString() const override { return true; }
 };
 
-bool IsJsonModuleLoaded(RedisModuleCtx *ctx);
+bool IsJsonModuleLoaded(ValkeyModuleCtx *ctx);
 absl::string_view TrimBrackets(absl::string_view record);
 }  // namespace valkey_search
 #endif  // VALKEYSEARCH_SRC_ATTRIBUTE_DATA_TYPE_H_

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -77,13 +77,15 @@ inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
   return ret;
 }
 
-absl::Status FTCreateCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTCreateCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                          int argc);
-absl::Status FTDropIndexCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTDropIndexCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                             int argc);
-absl::Status FTInfoCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-absl::Status FTListCmd(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-absl::Status FTSearchCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTInfoCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                       int argc);
+absl::Status FTListCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                       int argc);
+absl::Status FTSearchCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                          int argc);
 }  // namespace valkey_search
 

--- a/src/commands/ft_create.cc
+++ b/src/commands/ft_create.cc
@@ -37,19 +37,19 @@
 
 namespace valkey_search {
 
-absl::Status FTCreateCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTCreateCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                          int argc) {
   VMSDK_ASSIGN_OR_RETURN(auto index_schema_proto,
                          ParseFTCreateArgs(ctx, argv + 1, argc - 1));
-  index_schema_proto.set_db_num(RedisModule_GetSelectedDb(ctx));
+  index_schema_proto.set_db_num(ValkeyModule_GetSelectedDb(ctx));
   static const auto permissions =
       PrefixACLPermissions(kCreateCmdPermissions, kCreateCommand);
   VMSDK_RETURN_IF_ERROR(AclPrefixCheck(ctx, permissions, index_schema_proto));
   VMSDK_RETURN_IF_ERROR(
       SchemaManager::Instance().CreateIndexSchema(ctx, index_schema_proto));
 
-  RedisModule_ReplyWithSimpleString(ctx, "OK");
-  RedisModule_ReplicateVerbatim(ctx);
+  ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+  ValkeyModule_ReplicateVerbatim(ctx);
   return absl::OkStatus();
 }
 }  // namespace valkey_search

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -303,7 +303,7 @@ bool HasVectorIndex(const data_model::IndexSchema &index_schema_proto) {
 
 }  // namespace
 absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
-    RedisModuleCtx *ctx, RedisModuleString **argv, int argc) {
+    ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
   data_model::IndexSchema index_schema_proto;
   vmsdk::ArgsIterator itr{argv, argc};
   VMSDK_RETURN_IF_ERROR(

--- a/src/commands/ft_create_parser.h
+++ b/src/commands/ft_create_parser.h
@@ -84,6 +84,6 @@ struct FlatParameters : public FTCreateVectorParameters {
 };
 
 absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
-    RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
+    ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc);
 }  // namespace valkey_search
 #endif  // VALKEYSEARCH_SRC_COMMANDS_FT_CREATE_PARSER_H_

--- a/src/commands/ft_dropindex.cc
+++ b/src/commands/ft_dropindex.cc
@@ -39,7 +39,7 @@
 
 namespace valkey_search {
 
-absl::Status FTDropIndexCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTDropIndexCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                             int argc) {
   if (argc != 2) {
     return absl::InvalidArgumentError(vmsdk::WrongArity(kDropIndexCommand));
@@ -48,7 +48,7 @@ absl::Status FTDropIndexCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   VMSDK_ASSIGN_OR_RETURN(
       auto index_schema,
-      SchemaManager::Instance().GetIndexSchema(RedisModule_GetSelectedDb(ctx),
+      SchemaManager::Instance().GetIndexSchema(ValkeyModule_GetSelectedDb(ctx),
                                                index_schema_name));
   static const auto permissions =
       PrefixACLPermissions(kDropIndexCmdPermissions, kDropIndexCommand);
@@ -56,9 +56,9 @@ absl::Status FTDropIndexCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
       AclPrefixCheck(ctx, permissions, index_schema->GetKeyPrefixes()));
 
   VMSDK_RETURN_IF_ERROR(SchemaManager::Instance().RemoveIndexSchema(
-      RedisModule_GetSelectedDb(ctx), index_schema_name));
-  RedisModule_ReplyWithSimpleString(ctx, "OK");
-  RedisModule_ReplicateVerbatim(ctx);
+      ValkeyModule_GetSelectedDb(ctx), index_schema_name));
+  ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+  ValkeyModule_ReplicateVerbatim(ctx);
   return absl::OkStatus();
 }
 }  // namespace valkey_search

--- a/src/commands/ft_info.cc
+++ b/src/commands/ft_info.cc
@@ -40,7 +40,7 @@
 
 namespace valkey_search {
 
-absl::Status FTInfoCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTInfoCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                        int argc) {
   if (argc < 2) {
     return absl::InvalidArgumentError(vmsdk::WrongArity(kInfoCommand));
@@ -53,7 +53,7 @@ absl::Status FTInfoCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
 
   VMSDK_ASSIGN_OR_RETURN(
       auto index_schema,
-      SchemaManager::Instance().GetIndexSchema(RedisModule_GetSelectedDb(ctx),
+      SchemaManager::Instance().GetIndexSchema(ValkeyModule_GetSelectedDb(ctx),
                                                index_schema_name));
   static const auto permissions =
       PrefixACLPermissions(kInfoCmdPermissions, kInfoCommand);

--- a/src/commands/ft_list.cc
+++ b/src/commands/ft_list.cc
@@ -39,17 +39,17 @@
 
 namespace valkey_search {
 
-absl::Status FTListCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTListCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                        int argc) {
   if (argc > 1) {
     return absl::InvalidArgumentError(vmsdk::WrongArity(kListCommand));
   }
   absl::flat_hash_set<std::string> names =
       SchemaManager::Instance().GetIndexSchemasInDB(
-          RedisModule_GetSelectedDb(ctx));
-  RedisModule_ReplyWithArray(ctx, names.size());
+          ValkeyModule_GetSelectedDb(ctx));
+  ValkeyModule_ReplyWithArray(ctx, names.size());
   for (const auto &name : names) {
-    RedisModule_ReplyWithSimpleString(ctx, name.c_str());
+    ValkeyModule_ReplyWithSimpleString(ctx, name.c_str());
   }
   return absl::OkStatus();
 }

--- a/src/commands/ft_search.cc
+++ b/src/commands/ft_search.cc
@@ -67,10 +67,10 @@ namespace valkey_search {
 namespace {
 // FT.SEARCH idx "*=>[KNN 10 @vec $BLOB AS score]" PARAMS 2 BLOB
 // "\x12\xa9\xf5\x6c" DIALECT 2
-void ReplyAvailNeighbors(RedisModuleCtx *ctx,
+void ReplyAvailNeighbors(ValkeyModuleCtx *ctx,
                          const std::deque<indexes::Neighbor> &neighbors,
                          const query::VectorSearchParameters &parameters) {
-  RedisModule_ReplyWithLongLong(
+  ValkeyModule_ReplyWithLongLong(
       ctx, std::min(neighbors.size(), static_cast<size_t>(parameters.k)));
 }
 
@@ -90,50 +90,50 @@ size_t CalcStartIndex(const std::deque<indexes::Neighbor> &neighbors,
   return parameters.limit.first_index;
 }
 
-void SendReplyNoContent(RedisModuleCtx *ctx,
+void SendReplyNoContent(ValkeyModuleCtx *ctx,
                         const std::deque<indexes::Neighbor> &neighbors,
                         const query::VectorSearchParameters &parameters) {
   const size_t start_index = CalcStartIndex(neighbors, parameters);
   const size_t end_index = start_index + CalcEndIndex(neighbors, parameters);
-  RedisModule_ReplyWithArray(ctx, end_index - start_index + 1);
+  ValkeyModule_ReplyWithArray(ctx, end_index - start_index + 1);
   ReplyAvailNeighbors(ctx, neighbors, parameters);
   for (auto i = start_index; i < end_index; ++i) {
-    RedisModule_ReplyWithString(
-        ctx, vmsdk::MakeUniqueRedisString(*neighbors[i].external_id).get());
+    ValkeyModule_ReplyWithString(
+        ctx, vmsdk::MakeUniqueValkeyString(*neighbors[i].external_id).get());
   }
 }
 
-void ReplyScore(RedisModuleCtx *ctx, RedisModuleString &score_as,
+void ReplyScore(ValkeyModuleCtx *ctx, ValkeyModuleString &score_as,
                 const indexes::Neighbor &neighbor) {
-  RedisModule_ReplyWithString(ctx, &score_as);
+  ValkeyModule_ReplyWithString(ctx, &score_as);
   auto score_value = absl::StrFormat("%.12g", neighbor.distance);
-  RedisModule_ReplyWithString(ctx,
-                              vmsdk::MakeUniqueRedisString(score_value).get());
+  ValkeyModule_ReplyWithString(ctx,
+                               vmsdk::MakeUniqueValkeyString(score_value).get());
 }
 
-void SerializeNeighbors(RedisModuleCtx *ctx,
+void SerializeNeighbors(ValkeyModuleCtx *ctx,
                         const std::deque<indexes::Neighbor> &neighbors,
                         const query::VectorSearchParameters &parameters) {
   CHECK_GT(static_cast<size_t>(parameters.k), parameters.limit.first_index);
   const size_t start_index = CalcStartIndex(neighbors, parameters);
   const size_t end_index = start_index + CalcEndIndex(neighbors, parameters);
-  RedisModule_ReplyWithArray(ctx, 2 * (end_index - start_index) + 1);
+  ValkeyModule_ReplyWithArray(ctx, 2 * (end_index - start_index) + 1);
   ReplyAvailNeighbors(ctx, neighbors, parameters);
 
   for (auto i = start_index; i < end_index; ++i) {
-    RedisModule_ReplyWithString(
-        ctx, vmsdk::MakeUniqueRedisString(*neighbors[i].external_id).get());
+    ValkeyModule_ReplyWithString(
+        ctx, vmsdk::MakeUniqueValkeyString(*neighbors[i].external_id).get());
     if (parameters.return_attributes.empty()) {
-      RedisModule_ReplyWithArray(
+      ValkeyModule_ReplyWithArray(
           ctx, 2 * neighbors[i].attribute_contents.value().size() + 2);
       ReplyScore(ctx, *parameters.score_as, neighbors[i]);
       for (auto &attribute_content : neighbors[i].attribute_contents.value()) {
-        RedisModule_ReplyWithString(ctx,
-                                    attribute_content.second.GetIdentifier());
-        RedisModule_ReplyWithString(ctx, attribute_content.second.value.get());
+        ValkeyModule_ReplyWithString(ctx,
+                                     attribute_content.second.GetIdentifier());
+        ValkeyModule_ReplyWithString(ctx, attribute_content.second.value.get());
       }
     } else {
-      RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_LEN);
+      ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_LEN);
       size_t cnt = 0;
       for (const auto &return_attribute : parameters.return_attributes) {
         if (vmsdk::ToStringView(parameters.score_as.get()) ==
@@ -145,12 +145,12 @@ void SerializeNeighbors(RedisModuleCtx *ctx,
         auto it = neighbors[i].attribute_contents.value().find(
             vmsdk::ToStringView(return_attribute.identifier.get()));
         if (it != neighbors[i].attribute_contents.value().end()) {
-          RedisModule_ReplyWithString(ctx, return_attribute.alias.get());
-          RedisModule_ReplyWithString(ctx, it->second.value.get());
+          ValkeyModule_ReplyWithString(ctx, return_attribute.alias.get());
+          ValkeyModule_ReplyWithString(ctx, it->second.value.get());
           ++cnt;
         }
       }
-      RedisModule_ReplySetArrayLength(ctx, 2 * cnt);
+      ValkeyModule_ReplySetArrayLength(ctx, 2 * cnt);
     }
   }
 }
@@ -165,15 +165,15 @@ void SerializeNeighbors(RedisModuleCtx *ctx,
 //      2. Distance value
 //      3. Attribute name
 //      4. The vector value
-// SendReply respects the Limit, see https://redis.io/commands/ft.search/
-void SendReply(RedisModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
+// SendReply respects the Limit, see https://valkey.io/commands/ft.search/
+void SendReply(ValkeyModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
                const query::VectorSearchParameters &parameters) {
   // Increment success counter.
   ++Metrics::GetStats().query_successful_requests_cnt;
   if (parameters.limit.first_index >= static_cast<uint64_t>(parameters.k) ||
       parameters.limit.number == 0) {
-    RedisModule_ReplyWithArray(ctx, 1);
-    RedisModule_ReplyWithLongLong(ctx, neighbors.size());
+    ValkeyModule_ReplyWithArray(ctx, 1);
+    ValkeyModule_ReplyWithLongLong(ctx, neighbors.size());
     return;
   }
   if (parameters.no_content) {
@@ -184,7 +184,7 @@ void SendReply(RedisModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
       parameters.index_schema->GetIdentifier(parameters.attribute_alias);
   if (!identifier.ok()) {
     ++Metrics::GetStats().query_failed_requests_cnt;
-    RedisModule_ReplyWithError(ctx, identifier.status().message().data());
+    ValkeyModule_ReplyWithError(ctx, identifier.status().message().data());
     return;
   }
   query::ProcessNeighborsForReply(
@@ -196,33 +196,33 @@ void SendReply(RedisModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
 
 namespace async {
 
-int Reply(RedisModuleCtx *ctx, [[maybe_unused]] RedisModuleString **argv,
+int Reply(ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleString **argv,
           [[maybe_unused]] int argc) {
   auto *res =
-      static_cast<Result *>(RedisModule_GetBlockedClientPrivateData(ctx));
+      static_cast<Result *>(ValkeyModule_GetBlockedClientPrivateData(ctx));
   CHECK(res != nullptr);
   if (!res->neighbors.ok()) {
     ++Metrics::GetStats().query_failed_requests_cnt;
-    return RedisModule_ReplyWithError(ctx,
-                                      res->neighbors.status().message().data());
+    return ValkeyModule_ReplyWithError(
+        ctx, res->neighbors.status().message().data());
   }
   SendReply(ctx, res->neighbors.value(), *res->parameters);
-  return REDISMODULE_OK;
+  return VALKEYMODULE_OK;
 }
 
-void Free([[maybe_unused]] RedisModuleCtx *ctx, void *privdata) {
+void Free([[maybe_unused]] ValkeyModuleCtx *ctx, void *privdata) {
   auto *result = static_cast<Result *>(privdata);
   delete result;
 }
 
-int Timeout(RedisModuleCtx *ctx, [[maybe_unused]] RedisModuleString **argv,
+int Timeout(ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleString **argv,
             [[maybe_unused]] int argc) {
-  return RedisModule_ReplyWithSimpleString(ctx, "Request timed out");
+  return ValkeyModule_ReplyWithSimpleString(ctx, "Request timed out");
 }
 
 }  // namespace async
 
-absl::Status FTSearchCmd(RedisModuleCtx *ctx, RedisModuleString **argv,
+absl::Status FTSearchCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                          int argc) {
   auto status = [&]() -> absl::Status {
     auto &schema_manager = SchemaManager::Instance();

--- a/src/commands/ft_search.h
+++ b/src/commands/ft_search.h
@@ -42,7 +42,7 @@
 namespace valkey_search {
 class ValkeySearch;
 // Declared here to support testing
-void SendReply(RedisModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
+void SendReply(ValkeyModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
                const query::VectorSearchParameters &parameters);
 namespace async {
 
@@ -51,10 +51,10 @@ struct Result {
   std::unique_ptr<query::VectorSearchParameters> parameters;
 };
 
-int Reply(RedisModuleCtx *ctx, [[maybe_unused]] RedisModuleString **argv,
+int Reply(ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleString **argv,
           [[maybe_unused]] int argc);
 
-void Free(RedisModuleCtx * /*ctx*/, void *privdata);
+void Free(ValkeyModuleCtx * /*ctx*/, void *privdata);
 
 }  // namespace async
 

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -287,9 +287,9 @@ ConstructReturnParser() {
           return absl::OkStatus();
         }
         for (uint32_t i = 0; i < cnt; ++i) {
-          vmsdk::UniqueRedisString identifier;
+          vmsdk::UniqueValkeyString identifier;
           VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, identifier));
-          auto as_property = vmsdk::RetainUniqueRedisString(identifier.get());
+          auto as_property = vmsdk::RetainUniqueValkeyString(identifier.get());
           VMSDK_ASSIGN_OR_RETURN(
               auto res, vmsdk::ParseParam(kAsParam, false, itr, as_property));
           if (res) {
@@ -300,10 +300,10 @@ ConstructReturnParser() {
           }
           auto schema_identifier = parameters.index_schema->GetIdentifier(
               vmsdk::ToStringView(identifier.get()));
-          vmsdk::UniqueRedisString attribute_alias;
+          vmsdk::UniqueValkeyString attribute_alias;
           if (schema_identifier.ok()) {
-            attribute_alias = vmsdk::RetainUniqueRedisString(identifier.get());
-            identifier = vmsdk::MakeUniqueRedisString(*schema_identifier);
+            attribute_alias = vmsdk::RetainUniqueValkeyString(identifier.get());
+            identifier = vmsdk::MakeUniqueValkeyString(*schema_identifier);
           }
           parameters.return_attributes.emplace_back(query::ReturnAttribute{
               std::move(identifier), std::move(attribute_alias),
@@ -375,14 +375,14 @@ absl::Status ParseQueryString(query::VectorSearchParameters &parameters) {
                                parameters.attribute_alias));
   } else {
     parameters.score_as =
-        vmsdk::MakeUniqueRedisString(parameters.parse_vars.score_as_string);
+        vmsdk::MakeUniqueValkeyString(parameters.parse_vars.score_as_string);
   }
   return absl::OkStatus();
 }
 }  // namespace
 
 absl::StatusOr<std::unique_ptr<query::VectorSearchParameters>>
-ParseVectorSearchParameters(RedisModuleCtx *ctx, RedisModuleString **argv,
+ParseVectorSearchParameters(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                             int argc, const SchemaManager &schema_manager) {
   vmsdk::ArgsIterator itr{argv, argc};
   auto parameters = std::make_unique<query::VectorSearchParameters>();
@@ -390,7 +390,7 @@ ParseVectorSearchParameters(RedisModuleCtx *ctx, RedisModuleString **argv,
       vmsdk::ParseParamValue(itr, parameters->index_schema_name));
   VMSDK_ASSIGN_OR_RETURN(
       parameters->index_schema,
-      SchemaManager::Instance().GetIndexSchema(RedisModule_GetSelectedDb(ctx),
+      SchemaManager::Instance().GetIndexSchema(ValkeyModule_GetSelectedDb(ctx),
                                                parameters->index_schema_name));
   VMSDK_RETURN_IF_ERROR(
       vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));

--- a/src/commands/ft_search_parser.h
+++ b/src/commands/ft_search_parser.h
@@ -50,7 +50,7 @@ struct LimitParameter {
 };
 
 absl::StatusOr<std::unique_ptr<query::VectorSearchParameters>>
-ParseVectorSearchParameters(RedisModuleCtx *ctx, RedisModuleString **argv,
+ParseVectorSearchParameters(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                             int argc, const SchemaManager &schema_manager);
 
 }  // namespace valkey_search

--- a/src/coordinator/client.cc
+++ b/src/coordinator/client.cc
@@ -88,7 +88,7 @@ grpc::ChannelArguments& GetChannelArgs() {
 }
 
 std::shared_ptr<Client> ClientImpl::MakeInsecureClient(
-    vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx,
+    vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
     absl::string_view address) {
   std::shared_ptr<grpc::ChannelCredentials> creds =
       grpc::InsecureChannelCredentials();
@@ -98,7 +98,7 @@ std::shared_ptr<Client> ClientImpl::MakeInsecureClient(
                                       Coordinator::NewStub(channel));
 }
 
-ClientImpl::ClientImpl(vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx,
+ClientImpl::ClientImpl(vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
                        absl::string_view address,
                        std::unique_ptr<Coordinator::Stub> stub)
     : detached_ctx_(std::move(detached_ctx)),

--- a/src/coordinator/client.h
+++ b/src/coordinator/client.h
@@ -58,11 +58,11 @@ class Client {
 
 class ClientImpl : public Client {
  public:
-  ClientImpl(vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx,
+  ClientImpl(vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
              absl::string_view address,
              std::unique_ptr<Coordinator::Stub> stub);
   static std::shared_ptr<Client> MakeInsecureClient(
-      vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx,
+      vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
       absl::string_view address);
 
   ClientImpl(const ClientImpl&) = delete;
@@ -74,7 +74,7 @@ class ClientImpl : public Client {
       SearchIndexPartitionCallback done) override;
 
  private:
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   std::string address_;
   std::unique_ptr<Coordinator::Stub> stub_;
 };

--- a/src/coordinator/client_pool.h
+++ b/src/coordinator/client_pool.h
@@ -45,7 +45,7 @@ namespace valkey_search::coordinator {
 
 class ClientPool {
  public:
-  ClientPool(vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx)
+  ClientPool(vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx)
       : detached_ctx_(std::move(detached_ctx)) {}
   virtual ~ClientPool() = default;
 
@@ -54,7 +54,7 @@ class ClientPool {
     auto itr = client_pool_.find(address);
     if (itr == client_pool_.end()) {
       auto client = ClientImpl::MakeInsecureClient(
-          vmsdk::MakeUniqueRedisDetachedThreadSafeContext(detached_ctx_.get()),
+          vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(detached_ctx_.get()),
           address);
       client_pool_[address] = std::move(client);
     }
@@ -62,7 +62,7 @@ class ClientPool {
   }
 
  private:
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   absl::Mutex client_pool_mutex_;
   absl::flat_hash_map<std::string, std::shared_ptr<Client>> client_pool_
       ABSL_GUARDED_BY(client_pool_mutex_);

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -271,12 +271,12 @@ void MetadataManager::RegisterType(absl::string_view type_name,
   DCHECK(insert_result.second);
 }
 
-void MetadataManager::BroadcastMetadata(RedisModuleCtx *ctx) {
+void MetadataManager::BroadcastMetadata(ValkeyModuleCtx *ctx) {
   BroadcastMetadata(ctx, metadata_.Get().version_header());
 }
 
 void MetadataManager::BroadcastMetadata(
-    RedisModuleCtx *ctx, const GlobalMetadataVersionHeader &version_header) {
+    ValkeyModuleCtx *ctx, const GlobalMetadataVersionHeader &version_header) {
   if (is_loading_.Get()) {
     VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
         << "Skipping send of metadata header due to loading";
@@ -285,12 +285,12 @@ void MetadataManager::BroadcastMetadata(
   std::string payload;
   version_header.SerializeToString(&payload);
   // Nullptr for target means broadcast to all.
-  RedisModule_SendClusterMessage(ctx, /* target= */ nullptr,
-                                 kMetadataBroadcastClusterMessageReceiverId,
-                                 payload.c_str(), payload.size());
+  ValkeyModule_SendClusterMessage(ctx, /* target= */ nullptr,
+                                  kMetadataBroadcastClusterMessageReceiverId,
+                                  payload.c_str(), payload.size());
 }
 
-void MetadataManager::HandleClusterMessage(RedisModuleCtx *ctx,
+void MetadataManager::HandleClusterMessage(ValkeyModuleCtx *ctx,
                                            const char *sender_id, uint8_t type,
                                            const unsigned char *payload,
                                            uint32_t len) {
@@ -306,7 +306,7 @@ void MetadataManager::HandleClusterMessage(RedisModuleCtx *ctx,
 }
 
 void MetadataManager::HandleBroadcastedMetadata(
-    RedisModuleCtx *ctx, const char *sender_id,
+    ValkeyModuleCtx *ctx, const char *sender_id,
     std::unique_ptr<GlobalMetadataVersionHeader> header) {
   if (is_loading_.Get()) {
     VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 10)
@@ -320,7 +320,7 @@ void MetadataManager::HandleBroadcastedMetadata(
   if (header->top_level_version() < top_level_version) {
     return;
   }
-  std::string sender_id_str(sender_id, REDISMODULE_NODE_ID_LEN);
+  std::string sender_id_str(sender_id, VALKEYMODULE_NODE_ID_LEN);
   if (header->top_level_version() == top_level_version) {
     if (header->top_level_fingerprint() == top_level_fingerprint) {
       return;
@@ -342,11 +342,11 @@ void MetadataManager::HandleBroadcastedMetadata(
   }
   // sender_id isn't NULL terminated, so we copy to a std::string to make sure
   // it is properly NULL terminated
-  char node_ip[REDISMODULE_NODE_ID_LEN];
+  char node_ip[VALKEYMODULE_NODE_ID_LEN];
   int node_port;
-  if (RedisModule_GetClusterNodeInfo(ctx, sender_id_str.c_str(), node_ip,
-                                     nullptr, &node_port,
-                                     nullptr) != REDISMODULE_OK) {
+  if (ValkeyModule_GetClusterNodeInfo(ctx, sender_id_str.c_str(), node_ip,
+                                      nullptr, &node_port,
+                                      nullptr) != VALKEYMODULE_OK) {
     VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
         << "Failed to get cluster node info for node " << sender_id
         << " broadcasting "
@@ -511,9 +511,9 @@ int MetadataManager::GetSectionsCount() const {
   return DoesGlobalMetadataContainEntry(metadata_.Get()) ? 1 : 0;
 }
 
-absl::Status MetadataManager::SaveMetadata(RedisModuleCtx *ctx, SafeRDB *rdb,
+absl::Status MetadataManager::SaveMetadata(ValkeyModuleCtx *ctx, SafeRDB *rdb,
                                            int when) {
-  if (when == REDISMODULE_AUX_BEFORE_RDB) {
+  if (when == VALKEYMODULE_AUX_BEFORE_RDB) {
     return absl::OkStatus();
   }
 
@@ -540,7 +540,7 @@ absl::Status MetadataManager::SaveMetadata(RedisModuleCtx *ctx, SafeRDB *rdb,
 }
 
 absl::Status MetadataManager::LoadMetadata(
-    RedisModuleCtx *ctx, std::unique_ptr<data_model::RDBSection> section,
+    ValkeyModuleCtx *ctx, std::unique_ptr<data_model::RDBSection> section,
     SupplementalContentIter &&supplemental_iter) {
   if (section->type() != data_model::RDB_SECTION_GLOBAL_METADATA) {
     return absl::InternalError(
@@ -560,7 +560,7 @@ absl::Status MetadataManager::LoadMetadata(
   return absl::OkStatus();
 }
 
-void MetadataManagerOnClusterMessageCallback(RedisModuleCtx *ctx,
+void MetadataManagerOnClusterMessageCallback(ValkeyModuleCtx *ctx,
                                              const char *sender_id,
                                              uint8_t type,
                                              const unsigned char *payload,
@@ -575,16 +575,16 @@ mstime_t GetIntervalWithJitter(mstime_t interval, float jitter_ratio) {
   return interval + interval * jitter;
 }
 
-void MetadataManagerSendMetadataBroadcast(RedisModuleCtx *ctx, void *data) {
-  RedisModule_CreateTimer(ctx,
-                          GetIntervalWithJitter(kMetadataBroadcastIntervalMs,
-                                                kMetadataBroadcastJitterRatio),
-                          &MetadataManagerSendMetadataBroadcast, nullptr);
+void MetadataManagerSendMetadataBroadcast(ValkeyModuleCtx *ctx, void *data) {
+  ValkeyModule_CreateTimer(ctx,
+                           GetIntervalWithJitter(kMetadataBroadcastIntervalMs,
+                                                 kMetadataBroadcastJitterRatio),
+                           &MetadataManagerSendMetadataBroadcast, nullptr);
   MetadataManager::Instance().BroadcastMetadata(ctx);
 }
 
 void MetadataManager::OnServerCronCallback(
-    RedisModuleCtx *ctx, [[maybe_unused]] RedisModuleEvent eid,
+    ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleEvent eid,
     [[maybe_unused]] uint64_t subevent, [[maybe_unused]] void *data) {
   static bool timer_started = false;
   if (!timer_started) {
@@ -593,7 +593,7 @@ void MetadataManager::OnServerCronCallback(
     // because timers cannot be safely created in background threads (the GIL
     // does not protect event loop code which uses the timers).
     timer_started = true;
-    RedisModule_CreateTimer(
+    ValkeyModule_CreateTimer(
         ctx,
         GetIntervalWithJitter(kMetadataBroadcastIntervalMs,
                               kMetadataBroadcastJitterRatio),
@@ -601,7 +601,7 @@ void MetadataManager::OnServerCronCallback(
   }
 }
 
-void MetadataManager::OnLoadingEnded(RedisModuleCtx *ctx) {
+void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
   // Only on loading ended do we apply the staged changes.
   if (staging_metadata_due_to_repl_load_.Get()) {
     VMSDK_LOG(NOTICE, ctx)
@@ -623,38 +623,38 @@ void MetadataManager::OnLoadingEnded(RedisModuleCtx *ctx) {
   is_loading_ = false;
 }
 
-void MetadataManager::OnReplicationLoadStart(RedisModuleCtx *ctx) {
+void MetadataManager::OnReplicationLoadStart(ValkeyModuleCtx *ctx) {
   VMSDK_LOG(NOTICE, ctx) << "Staging metadata during RDB load due to "
                             "replication, will apply on loading finished";
   staging_metadata_due_to_repl_load_ = true;
 }
 
-void MetadataManager::OnLoadingStarted(RedisModuleCtx *ctx) {
+void MetadataManager::OnLoadingStarted(ValkeyModuleCtx *ctx) {
   VMSDK_LOG(NOTICE, ctx)
       << "Loading started, stopping incoming metadata updates";
   is_loading_ = true;
 }
 
-void MetadataManager::OnLoadingCallback(RedisModuleCtx *ctx,
-                                        [[maybe_unused]] RedisModuleEvent eid,
+void MetadataManager::OnLoadingCallback(ValkeyModuleCtx *ctx,
+                                        [[maybe_unused]] ValkeyModuleEvent eid,
                                         uint64_t subevent,
                                         [[maybe_unused]] void *data) {
-  if (subevent == REDISMODULE_SUBEVENT_LOADING_ENDED) {
+  if (subevent == VALKEYMODULE_SUBEVENT_LOADING_ENDED) {
     MetadataManager::Instance().OnLoadingEnded(ctx);
     return;
   }
-  if (subevent == REDISMODULE_SUBEVENT_LOADING_REPL_START) {
+  if (subevent == VALKEYMODULE_SUBEVENT_LOADING_REPL_START) {
     MetadataManager::Instance().OnReplicationLoadStart(ctx);
   }
-  if (subevent == REDISMODULE_SUBEVENT_LOADING_AOF_START ||
-      subevent == REDISMODULE_SUBEVENT_LOADING_RDB_START ||
-      subevent == REDISMODULE_SUBEVENT_LOADING_REPL_START) {
+  if (subevent == VALKEYMODULE_SUBEVENT_LOADING_AOF_START ||
+      subevent == VALKEYMODULE_SUBEVENT_LOADING_RDB_START ||
+      subevent == VALKEYMODULE_SUBEVENT_LOADING_REPL_START) {
     MetadataManager::Instance().OnLoadingStarted(ctx);
   }
 }
 
-void MetadataManager::RegisterForClusterMessages(RedisModuleCtx *ctx) {
-  RedisModule_RegisterClusterMessageReceiver(
+void MetadataManager::RegisterForClusterMessages(ValkeyModuleCtx *ctx) {
+  ValkeyModule_RegisterClusterMessageReceiver(
       ctx, coordinator::kMetadataBroadcastClusterMessageReceiverId,
       MetadataManagerOnClusterMessageCallback);
 }

--- a/src/coordinator/search_converter.cc
+++ b/src/coordinator/search_converter.cc
@@ -145,7 +145,7 @@ GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request) {
       parameters->index_schema,
       SchemaManager::Instance().GetIndexSchema(0, request.index_schema_name()));
   if (request.has_score_as()) {
-    parameters->score_as = vmsdk::MakeUniqueRedisString(request.score_as());
+    parameters->score_as = vmsdk::MakeUniqueValkeyString(request.score_as());
   } else {
     VMSDK_ASSIGN_OR_RETURN(parameters->score_as,
                            parameters->index_schema->DefaultReplyScoreAs(
@@ -168,8 +168,8 @@ GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request) {
   }
   for (auto& return_parameter : request.return_parameters()) {
     parameters->return_attributes.emplace_back(query::ReturnAttribute(
-        vmsdk::MakeUniqueRedisString(return_parameter.identifier()),
-        vmsdk::MakeUniqueRedisString(return_parameter.alias())));
+        vmsdk::MakeUniqueValkeyString(return_parameter.identifier()),
+        vmsdk::MakeUniqueValkeyString(return_parameter.alias())));
   }
   return parameters;
 }

--- a/src/coordinator/server.cc
+++ b/src/coordinator/server.cc
@@ -161,7 +161,7 @@ grpc::ServerUnaryReactor* Service::SearchIndexPartition(
                neighbors = std::move(neighbors.value())]() mutable {
                 const auto& attribute_data_type =
                     parameters->index_schema->GetAttributeDataType();
-                auto ctx = vmsdk::MakeUniqueRedisThreadSafeContext(nullptr);
+                auto ctx = vmsdk::MakeUniqueValkeyThreadSafeContext(nullptr);
                 auto vector_identifier =
                     parameters->index_schema
                         ->GetIdentifier(parameters->attribute_alias)
@@ -193,13 +193,14 @@ ServerImpl::ServerImpl(std::unique_ptr<Service> coordinator_service,
       port_(port) {}
 
 std::unique_ptr<Server> ServerImpl::Create(
-    RedisModuleCtx* ctx, vmsdk::ThreadPool* reader_thread_pool, uint16_t port) {
+    ValkeyModuleCtx* ctx, vmsdk::ThreadPool* reader_thread_pool,
+    uint16_t port) {
   std::string server_address = absl::StrCat("[::]:", port);
   grpc::EnableDefaultHealthCheckService(true);
   std::shared_ptr<grpc::ServerCredentials> creds =
       grpc::InsecureServerCredentials();
   auto coordinator_service = std::make_unique<Service>(
-      vmsdk::MakeUniqueRedisDetachedThreadSafeContext(ctx), reader_thread_pool);
+      vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(ctx), reader_thread_pool);
   grpc::ServerBuilder builder;
   builder.AddListeningPort(server_address, creds);
   builder.RegisterService(coordinator_service.get());

--- a/src/coordinator/server.h
+++ b/src/coordinator/server.h
@@ -48,7 +48,7 @@ namespace valkey_search::coordinator {
 
 class Service final : public Coordinator::CallbackService {
  public:
-  Service(vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx,
+  Service(vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
           vmsdk::ThreadPool* reader_thread_pool)
       : detached_ctx_(std::move(detached_ctx)),
         reader_thread_pool_(reader_thread_pool) {}
@@ -68,7 +68,7 @@ class Service final : public Coordinator::CallbackService {
       SearchIndexPartitionResponse* response) override;
 
  private:
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   vmsdk::ThreadPool* reader_thread_pool_;
 };
 
@@ -80,7 +80,7 @@ class Server {
 
 class ServerImpl final : public Server {
  public:
-  static std::unique_ptr<Server> Create(RedisModuleCtx* ctx,
+  static std::unique_ptr<Server> Create(ValkeyModuleCtx* ctx,
                                         vmsdk::ThreadPool* reader_thread_pool,
                                         uint16_t port);
   ServerImpl(const ServerImpl&) = delete;

--- a/src/coordinator/util.h
+++ b/src/coordinator/util.h
@@ -45,16 +45,16 @@ inline grpc::Status ToGrpcStatus(const absl::Status& status) {
           std::string(status.message())};
 }
 namespace coordinator {
-// This offset results in 26673 for Redis default port 6379 - which is COORD
+// This offset results in 26673 for Valkey default port 6379 - which is COORD
 // on a telephone keypad.
 static constexpr int kCoordinatorPortOffset = 20294;
 
-inline int GetCoordinatorPort(int redis_port) {
+inline int GetCoordinatorPort(int valkey_port) {
   // TODO Make handling of TLS more robust
-  if (redis_port == 6378) {
-    return redis_port + kCoordinatorPortOffset + 1;
+  if (valkey_port == 6378) {
+    return valkey_port + kCoordinatorPortOffset + 1;
   }
-  return redis_port + kCoordinatorPortOffset;
+  return valkey_port + kCoordinatorPortOffset;
 }
 }  // namespace coordinator
 

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -79,18 +79,18 @@ namespace valkey_search {
 
 LogLevel GetLogSeverity(bool ok) { return ok ? DEBUG : WARNING; }
 
-IndexSchema::BackfillJob::BackfillJob(RedisModuleCtx *ctx,
+IndexSchema::BackfillJob::BackfillJob(ValkeyModuleCtx *ctx,
                                       absl::string_view name, int db_num)
-    : cursor(vmsdk::MakeUniqueRedisScanCursor()) {
-  scan_ctx = vmsdk::MakeUniqueRedisDetachedThreadSafeContext(ctx);
-  RedisModule_SelectDb(scan_ctx.get(), db_num);
-  db_size = RedisModule_DbSize(scan_ctx.get());
+    : cursor(vmsdk::MakeUniqueValkeyScanCursor()) {
+  scan_ctx = vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(ctx);
+  ValkeyModule_SelectDb(scan_ctx.get(), db_num);
+  db_size = ValkeyModule_DbSize(scan_ctx.get());
   VMSDK_LOG(NOTICE, ctx) << "Starting backfill for index schema in DB "
                          << db_num << ": " << name;
 }
 
 absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
-    RedisModuleCtx *ctx, IndexSchema *index_schema,
+    ValkeyModuleCtx *ctx, IndexSchema *index_schema,
     const data_model::Attribute &attribute,
     std::optional<SupplementalContentChunkIter> iter) {
   const auto &index = attribute.index();
@@ -164,7 +164,7 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
 }
 
 absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::Create(
-    RedisModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto,
+    ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto,
     vmsdk::ThreadPool *mutations_thread_pool, bool skip_attributes) {
   std::unique_ptr<AttributeDataType> attribute_data_type;
   switch (index_schema_proto.attribute_data_type()) {
@@ -206,18 +206,18 @@ vmsdk::MRMWMutexOptions CreateMrmwMutexOptions() {
   return options;
 }
 
-IndexSchema::IndexSchema(RedisModuleCtx *ctx,
+IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
                          const data_model::IndexSchema &index_schema_proto,
                          std::unique_ptr<AttributeDataType> attribute_data_type,
                          vmsdk::ThreadPool *mutations_thread_pool)
-    : detached_ctx_(vmsdk::MakeUniqueRedisDetachedThreadSafeContext(ctx)),
+    : detached_ctx_(vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(ctx)),
       keyspace_event_manager_(&KeyspaceEventManager::Instance()),
       attribute_data_type_(std::move(attribute_data_type)),
       name_(std::string(index_schema_proto.name())),
       db_num_(index_schema_proto.db_num()),
       mutations_thread_pool_(mutations_thread_pool),
       time_sliced_mutex_(CreateMrmwMutexOptions()) {
-  RedisModule_SelectDb(detached_ctx_.get(), db_num_);
+  ValkeyModule_SelectDb(detached_ctx_.get(), db_num_);
   if (index_schema_proto.subscribed_key_prefixes().empty()) {
     subscribed_key_prefixes_.push_back("");
     return;
@@ -232,7 +232,7 @@ IndexSchema::IndexSchema(RedisModuleCtx *ctx,
   stats_.document_cnt = index_schema_proto.stats().documents_count();
 }
 
-absl::Status IndexSchema::Init(RedisModuleCtx *ctx) {
+absl::Status IndexSchema::Init(ValkeyModuleCtx *ctx) {
   VMSDK_RETURN_IF_ERROR(keyspace_event_manager_->InsertSubscription(ctx, this));
   backfill_job_ = std::make_optional<BackfillJob>(ctx, name_, db_num_);
   return absl::OkStatus();
@@ -269,7 +269,7 @@ absl::StatusOr<std::string> IndexSchema::GetIdentifier(
   return itr->second.GetIdentifier();
 }
 
-absl::StatusOr<vmsdk::UniqueRedisString> IndexSchema::DefaultReplyScoreAs(
+absl::StatusOr<vmsdk::UniqueValkeyString> IndexSchema::DefaultReplyScoreAs(
     absl::string_view attribute_alias) const {
   auto itr = attributes_.find(std::string{attribute_alias});
   if (ABSL_PREDICT_FALSE(itr == attributes_.end())) {
@@ -292,7 +292,7 @@ absl::Status IndexSchema::AddIndex(absl::string_view attribute_alias,
 }
 
 void TrackResults(
-    RedisModuleCtx *ctx, const absl::StatusOr<bool> &status,
+    ValkeyModuleCtx *ctx, const absl::StatusOr<bool> &status,
     const char *operation_str,
     IndexSchema::Stats::ResultCnt<std::atomic<uint64_t>> &counter) {
   if (ABSL_PREDICT_FALSE(!status.ok())) {
@@ -314,9 +314,9 @@ void TrackResults(
   }
 }
 
-void IndexSchema::OnKeyspaceNotification(RedisModuleCtx *ctx, int type,
+void IndexSchema::OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
                                          const char *event,
-                                         RedisModuleString *key) {
+                                         ValkeyModuleString *key) {
   if (ABSL_PREDICT_FALSE(!IsInCurrentDB(ctx))) {
     return;
   }
@@ -326,7 +326,7 @@ void IndexSchema::OnKeyspaceNotification(RedisModuleCtx *ctx, int type,
 bool AddAttributeData(IndexSchema::MutatedAttributes &mutated_attributes,
                       const Attribute &attribute,
                       AttributeDataType &attribute_data_type,
-                      vmsdk::UniqueRedisString record) {
+                      vmsdk::UniqueValkeyString record) {
   if (record) {
     if (attribute_data_type.RecordsProvidedAsString()) {
       auto normalized_record =
@@ -345,15 +345,15 @@ bool AddAttributeData(IndexSchema::MutatedAttributes &mutated_attributes,
   return true;
 }
 
-void IndexSchema::ProcessKeyspaceNotification(RedisModuleCtx *ctx,
-                                              RedisModuleString *key,
+void IndexSchema::ProcessKeyspaceNotification(ValkeyModuleCtx *ctx,
+                                              ValkeyModuleString *key,
                                               bool from_backfill) {
   auto key_cstr = vmsdk::ToStringView(key);
   if (key_cstr.empty()) {
     return;
   }
-  auto key_obj = vmsdk::MakeUniqueRedisOpenKey(
-      ctx, key, REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_READ);
+  auto key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+      ctx, key, VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
   // Fail fast if the key type does not match the data type.
   if (key_obj && !GetAttributeDataType().IsProperType(key_obj.get())) {
     return;
@@ -370,7 +370,7 @@ void IndexSchema::ProcessKeyspaceNotification(RedisModuleCtx *ctx,
       continue;
     }
     bool is_module_owned;
-    vmsdk::UniqueRedisString record = VectorExternalizer::Instance().GetRecord(
+    vmsdk::UniqueValkeyString record = VectorExternalizer::Instance().GetRecord(
         ctx, attribute_data_type_.get(), key_obj.get(), key_cstr,
         attribute.GetIdentifier(), is_module_owned);
     if (!is_module_owned) {
@@ -395,7 +395,7 @@ bool IndexSchema::IsTrackedByAnyIndex(const InternedStringPtr &key) const {
                      });
 }
 
-void IndexSchema::SyncProcessMutation(RedisModuleCtx *ctx,
+void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
                                       MutatedAttributes &mutated_attributes,
                                       const InternedStringPtr &key) {
   vmsdk::WriterMutexLock lock(&time_sliced_mutex_);
@@ -411,8 +411,8 @@ void IndexSchema::SyncProcessMutation(RedisModuleCtx *ctx,
 }
 
 void IndexSchema::ProcessAttributeMutation(
-    RedisModuleCtx *ctx, const Attribute &attribute,
-    const InternedStringPtr &key, vmsdk::UniqueRedisString data,
+    ValkeyModuleCtx *ctx, const Attribute &attribute,
+    const InternedStringPtr &key, vmsdk::UniqueValkeyString data,
     indexes::DeletionType deletion_type) {
   auto index = attribute.GetIndex();
   if (data) {
@@ -525,12 +525,12 @@ void IndexSchema::ScheduleMutation(bool from_backfill,
       priority);
 }
 
-bool ShouldBlockClient(RedisModuleCtx *ctx, bool inside_multi_exec,
+bool ShouldBlockClient(ValkeyModuleCtx *ctx, bool inside_multi_exec,
                        bool from_backfill) {
   return !inside_multi_exec && !from_backfill && vmsdk::IsRealUserClient(ctx);
 }
 
-void IndexSchema::ProcessMutation(RedisModuleCtx *ctx,
+void IndexSchema::ProcessMutation(ValkeyModuleCtx *ctx,
                                   MutatedAttributes &mutated_attributes,
                                   const InternedStringPtr &interned_key,
                                   bool from_backfill) {
@@ -559,7 +559,7 @@ void IndexSchema::ProcessMutation(RedisModuleCtx *ctx,
   ScheduleMutation(from_backfill, interned_key, priority, nullptr);
 }
 
-void IndexSchema::ProcessSingleMutationAsync(RedisModuleCtx *ctx,
+void IndexSchema::ProcessSingleMutationAsync(ValkeyModuleCtx *ctx,
                                              bool from_backfill,
                                              const InternedStringPtr &key,
                                              vmsdk::StopWatch *delay_capturer) {
@@ -582,9 +582,9 @@ void IndexSchema::ProcessSingleMutationAsync(RedisModuleCtx *ctx,
   }
 }
 
-void IndexSchema::BackfillScanCallback(RedisModuleCtx *ctx,
-                                       RedisModuleString *keyname,
-                                       RedisModuleKey *key, void *privdata) {
+void IndexSchema::BackfillScanCallback(ValkeyModuleCtx *ctx,
+                                       ValkeyModuleString *keyname,
+                                       ValkeyModuleKey *key, void *privdata) {
   IndexSchema *index_schema = reinterpret_cast<IndexSchema *>(privdata);
   index_schema->backfill_job_.Get()->scanned_key_count++;
   auto key_prefixes = index_schema->GetKeyPrefixes();
@@ -597,7 +597,7 @@ void IndexSchema::BackfillScanCallback(RedisModuleCtx *ctx,
   }
 }
 
-uint32_t IndexSchema::PerformBackfill(RedisModuleCtx *ctx,
+uint32_t IndexSchema::PerformBackfill(ValkeyModuleCtx *ctx,
                                       uint32_t batch_size) {
   auto &backfill_job = backfill_job_.Get();
   if (!backfill_job.has_value() || backfill_job->IsScanDone()) {
@@ -610,13 +610,13 @@ uint32_t IndexSchema::PerformBackfill(RedisModuleCtx *ctx,
   // change during the backfill, in which case we may show incorrect progress.
   backfill_job->db_size =
       std::max(backfill_job->db_size,
-               (uint64_t)RedisModule_DbSize(backfill_job->scan_ctx.get()));
+               (uint64_t)ValkeyModule_DbSize(backfill_job->scan_ctx.get()));
 
   uint64_t start_scan_count = backfill_job->scanned_key_count;
   uint64_t &current_scan_count = backfill_job->scanned_key_count;
   while (current_scan_count - start_scan_count < batch_size) {
-    auto ctx_flags = RedisModule_GetContextFlags(ctx);
-    if (ctx_flags & REDISMODULE_CTX_FLAGS_OOM) {
+    auto ctx_flags = ValkeyModule_GetContextFlags(ctx);
+    if (ctx_flags & VALKEYMODULE_CTX_FLAGS_OOM) {
       backfill_job->paused_by_oom = true;
       return 0;
     }
@@ -626,9 +626,9 @@ uint32_t IndexSchema::PerformBackfill(RedisModuleCtx *ctx,
     // end of the current iteration. Because of this, we use the scanned key
     // count to know how many keys we have scanned in total (either zero or
     // one).
-    if (!RedisModule_Scan(backfill_job->scan_ctx.get(),
-                          backfill_job->cursor.get(), BackfillScanCallback,
-                          (void *)this)) {
+    if (!ValkeyModule_Scan(backfill_job->scan_ctx.get(),
+                           backfill_job->cursor.get(), BackfillScanCallback,
+                           (void *)this)) {
       VMSDK_LOG(NOTICE, ctx)
           << "Index schema " << name_ << " finished backfill. Scanned "
           << backfill_job->scanned_key_count << " keys in "
@@ -682,67 +682,67 @@ uint64_t IndexSchema::CountRecords() const {
   return record_cnt;
 }
 
-void IndexSchema::RespondWithInfo(RedisModuleCtx *ctx) const {
-  RedisModule_ReplyWithArray(ctx, 26);
-  RedisModule_ReplyWithSimpleString(ctx, "index_name");
-  RedisModule_ReplyWithSimpleString(ctx, name_.data());
-  RedisModule_ReplyWithSimpleString(ctx, "index_options");
-  RedisModule_ReplyWithArray(ctx, 0);
+void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
+  ValkeyModule_ReplyWithArray(ctx, 26);
+  ValkeyModule_ReplyWithSimpleString(ctx, "index_name");
+  ValkeyModule_ReplyWithSimpleString(ctx, name_.data());
+  ValkeyModule_ReplyWithSimpleString(ctx, "index_options");
+  ValkeyModule_ReplyWithArray(ctx, 0);
 
-  RedisModule_ReplyWithSimpleString(ctx, "index_definition");
-  RedisModule_ReplyWithArray(ctx, 6);
-  RedisModule_ReplyWithSimpleString(ctx, "key_type");
-  RedisModule_ReplyWithSimpleString(ctx,
-                                    attribute_data_type_->ToString().c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "prefixes");
-  RedisModule_ReplyWithArray(ctx, subscribed_key_prefixes_.size());
+  ValkeyModule_ReplyWithSimpleString(ctx, "index_definition");
+  ValkeyModule_ReplyWithArray(ctx, 6);
+  ValkeyModule_ReplyWithSimpleString(ctx, "key_type");
+  ValkeyModule_ReplyWithSimpleString(ctx,
+                                     attribute_data_type_->ToString().c_str());
+  ValkeyModule_ReplyWithSimpleString(ctx, "prefixes");
+  ValkeyModule_ReplyWithArray(ctx, subscribed_key_prefixes_.size());
   for (const auto &prefix : subscribed_key_prefixes_) {
-    RedisModule_ReplyWithSimpleString(ctx, prefix.c_str());
+    ValkeyModule_ReplyWithSimpleString(ctx, prefix.c_str());
   }
   // hard-code default score of 1 as it's the only value we currently
   // supported.
-  RedisModule_ReplyWithSimpleString(ctx, "default_score");
-  RedisModule_ReplyWithCString(ctx, "1");
+  ValkeyModule_ReplyWithSimpleString(ctx, "default_score");
+  ValkeyModule_ReplyWithCString(ctx, "1");
 
-  RedisModule_ReplyWithSimpleString(ctx, "attributes");
-  RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
+  ValkeyModule_ReplyWithSimpleString(ctx, "attributes");
+  ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_ARRAY_LEN);
   int attribute_array_len = 0;
   for (const auto &attribute : attributes_) {
     attribute_array_len += attribute.second.RespondWithInfo(ctx);
   }
-  RedisModule_ReplySetArrayLength(ctx, attribute_array_len);
+  ValkeyModule_ReplySetArrayLength(ctx, attribute_array_len);
 
-  RedisModule_ReplyWithSimpleString(ctx, "num_docs");
-  RedisModule_ReplyWithCString(ctx,
-                               std::to_string(stats_.document_cnt).c_str());
+  ValkeyModule_ReplyWithSimpleString(ctx, "num_docs");
+  ValkeyModule_ReplyWithCString(ctx,
+                                std::to_string(stats_.document_cnt).c_str());
   // hard-code num_terms to 0 as it's related to fulltext indexes:
-  RedisModule_ReplyWithSimpleString(ctx, "num_terms");
-  RedisModule_ReplyWithCString(ctx, "0");
-  RedisModule_ReplyWithSimpleString(ctx, "num_records");
-  RedisModule_ReplyWithCString(ctx, std::to_string(CountRecords()).c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "hash_indexing_failures");
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "num_terms");
+  ValkeyModule_ReplyWithCString(ctx, "0");
+  ValkeyModule_ReplyWithSimpleString(ctx, "num_records");
+  ValkeyModule_ReplyWithCString(ctx, std::to_string(CountRecords()).c_str());
+  ValkeyModule_ReplyWithSimpleString(ctx, "hash_indexing_failures");
+  ValkeyModule_ReplyWithCString(
       ctx, absl::StrFormat("%lu", stats_.subscription_add.skipped_cnt).c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "backfill_in_progress");
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "backfill_in_progress");
+  ValkeyModule_ReplyWithCString(
       ctx, absl::StrFormat("%d", IsBackfillInProgress() ? 1 : 0).c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "backfill_complete_percent");
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "backfill_complete_percent");
+  ValkeyModule_ReplyWithCString(
       ctx, absl::StrFormat("%f", GetBackfillPercent()).c_str());
 
   absl::MutexLock lock(&stats_.mutex_);
-  RedisModule_ReplyWithSimpleString(ctx, "mutation_queue_size");
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "mutation_queue_size");
+  ValkeyModule_ReplyWithCString(
       ctx, absl::StrFormat("%lu", stats_.mutation_queue_size_).c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "recent_mutations_queue_delay");
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "recent_mutations_queue_delay");
+  ValkeyModule_ReplyWithCString(
       ctx, absl::StrFormat("%lu sec", (stats_.mutation_queue_size_ > 0
                                            ? stats_.mutations_queue_delay_ /
                                                  absl::Seconds(1)
                                            : 0))
                .c_str());
-  RedisModule_ReplyWithSimpleString(ctx, "state");
-  RedisModule_ReplyWithSimpleString(ctx, GetStateForInfo().data());
+  ValkeyModule_ReplyWithSimpleString(ctx, "state");
+  ValkeyModule_ReplyWithSimpleString(ctx, GetStateForInfo().data());
 }
 
 bool IsVectorIndex(std::shared_ptr<indexes::IndexBase> index) {
@@ -838,7 +838,7 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
 }
 
 absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
-    RedisModuleCtx *ctx, vmsdk::ThreadPool *mutations_thread_pool,
+    ValkeyModuleCtx *ctx, vmsdk::ThreadPool *mutations_thread_pool,
     std::unique_ptr<data_model::IndexSchema> index_schema_proto,
     SupplementalContentIter &&supplemental_iter) {
   // Attributes will be loaded from supplemental content.
@@ -889,11 +889,11 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
   return index_schema;
 }
 
-bool IndexSchema::IsInCurrentDB(RedisModuleCtx *ctx) const {
-  return RedisModule_GetSelectedDb(ctx) == db_num_;
+bool IndexSchema::IsInCurrentDB(ValkeyModuleCtx *ctx) const {
+  return ValkeyModule_GetSelectedDb(ctx) == db_num_;
 }
 
-void IndexSchema::OnSwapDB(RedisModuleSwapDbInfo *swap_db_info) {
+void IndexSchema::OnSwapDB(ValkeyModuleSwapDbInfo *swap_db_info) {
   uint32_t curr_db = db_num_;
   uint32_t db_to_swap_to;
   if (curr_db == swap_db_info->dbnum_first) {
@@ -906,15 +906,15 @@ void IndexSchema::OnSwapDB(RedisModuleSwapDbInfo *swap_db_info) {
   db_num_ = db_to_swap_to;
   auto &backfill_job = backfill_job_.Get();
   if (IsBackfillInProgress() && !backfill_job->IsScanDone()) {
-    RedisModule_SelectDb(backfill_job->scan_ctx.get(), db_to_swap_to);
+    ValkeyModule_SelectDb(backfill_job->scan_ctx.get(), db_to_swap_to);
   }
 }
 
-void IndexSchema::OnLoadingEnded(RedisModuleCtx *ctx) {
+void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
   // Clean up any potentially stale index entries that can arise from pending
   // record deletions being lost during RDB save.
   vmsdk::StopWatch stop_watch;
-  RedisModule_SelectDb(ctx, db_num_);  // Make sure we are in the right DB.
+  ValkeyModule_SelectDb(ctx, db_num_);  // Make sure we are in the right DB.
   absl::flat_hash_map<std::string, MutatedAttributes> deletion_attributes;
   for (const auto &attribute : attributes_) {
     const auto &index = attribute.second.GetIndex();
@@ -923,8 +923,8 @@ void IndexSchema::OnLoadingEnded(RedisModuleCtx *ctx) {
     uint64_t stale_entries = 0;
     index->ForEachTrackedKey([ctx, &deletion_attributes, &key_size, &attribute,
                               &stale_entries](const InternedStringPtr &key) {
-      auto r_str = vmsdk::MakeUniqueRedisString(*key);
-      if (!RedisModule_KeyExists(ctx, r_str.get())) {
+      auto r_str = vmsdk::MakeUniqueValkeyString(*key);
+      if (!ValkeyModule_KeyExists(ctx, r_str.get())) {
         deletion_attributes[std::string(*key)][attribute.second.GetAlias()] = {
             nullptr, indexes::DeletionType::kRecord};
         stale_entries++;
@@ -949,7 +949,7 @@ void IndexSchema::OnLoadingEnded(RedisModuleCtx *ctx) {
 }
 
 // Returns true if the inserted key not exists otherwise false
-bool IndexSchema::TrackMutatedRecord(RedisModuleCtx *ctx,
+bool IndexSchema::TrackMutatedRecord(ValkeyModuleCtx *ctx,
                                      const InternedStringPtr &key,
                                      MutatedAttributes &&mutated_attributes,
                                      bool from_backfill, bool block_client) {
@@ -1035,7 +1035,7 @@ void IndexSchema::SubscribeToVectorExternalizer(
 
 void IndexSchema::VectorExternalizer(const InternedStringPtr &key,
                                      absl::string_view attribute_identifier,
-                                     vmsdk::UniqueRedisString &record) {
+                                     vmsdk::UniqueValkeyString &record) {
   auto it = vector_externalizer_subscriptions_.find(attribute_identifier);
   if (it == vector_externalizer_subscriptions_.end()) {
     return;

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -64,10 +64,10 @@
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search {
-bool ShouldBlockClient(RedisModuleCtx *ctx, bool inside_multi_exec,
+bool ShouldBlockClient(ValkeyModuleCtx *ctx, bool inside_multi_exec,
                        bool from_backfill);
 
-using RDBLoadFunc = void *(*)(RedisModuleIO *, int);
+using RDBLoadFunc = void *(*)(ValkeyModuleIO *, int);
 using FreeFunc = void (*)(void *);
 
 class IndexSchema : public KeyspaceEventSubscription,
@@ -93,20 +93,20 @@ class IndexSchema : public KeyspaceEventSubscription,
   std::weak_ptr<IndexSchema> GetWeakPtr() { return weak_from_this(); }
 
   static absl::StatusOr<std::shared_ptr<IndexSchema>> Create(
-      RedisModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto,
+      ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto,
       vmsdk::ThreadPool *mutations_thread_pool, bool skip_attributes = false);
   ~IndexSchema() override;
   absl::StatusOr<std::shared_ptr<indexes::IndexBase>> GetIndex(
       absl::string_view attribute_alias) const;
   virtual absl::StatusOr<std::string> GetIdentifier(
       absl::string_view attribute_alias) const;
-  absl::StatusOr<vmsdk::UniqueRedisString> DefaultReplyScoreAs(
+  absl::StatusOr<vmsdk::UniqueValkeyString> DefaultReplyScoreAs(
       absl::string_view attribute_alias) const;
   absl::Status AddIndex(absl::string_view attribute_alias,
                         absl::string_view identifier,
                         std::shared_ptr<indexes::IndexBase> index);
 
-  void RespondWithInfo(RedisModuleCtx *ctx) const;
+  void RespondWithInfo(ValkeyModuleCtx *ctx) const;
 
   inline const AttributeDataType &GetAttributeDataType() const override {
     return *attribute_data_type_;
@@ -119,10 +119,10 @@ class IndexSchema : public KeyspaceEventSubscription,
   inline const std::string &GetName() const { return name_; }
   inline std::uint32_t GetDBNum() const { return db_num_; }
 
-  void OnKeyspaceNotification(RedisModuleCtx *ctx, int type, const char *event,
-                              RedisModuleString *key) override;
+  void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type, const char *event,
+                              ValkeyModuleString *key) override;
 
-  uint32_t PerformBackfill(RedisModuleCtx *ctx, uint32_t batch_size);
+  uint32_t PerformBackfill(ValkeyModuleCtx *ctx, uint32_t batch_size);
 
   bool IsBackfillInProgress() const {
     auto &backfill_job = backfill_job_.Get();
@@ -139,23 +139,23 @@ class IndexSchema : public KeyspaceEventSubscription,
   virtual absl::Status RDBSave(SafeRDB *rdb) const;
 
   static absl::StatusOr<std::shared_ptr<IndexSchema>> LoadFromRDB(
-      RedisModuleCtx *ctx, vmsdk::ThreadPool *mutations_thread_pool,
+      ValkeyModuleCtx *ctx, vmsdk::ThreadPool *mutations_thread_pool,
       std::unique_ptr<data_model::IndexSchema> index_schema_proto,
       SupplementalContentIter &&supplemental_iter);
 
-  bool IsInCurrentDB(RedisModuleCtx *ctx) const;
+  bool IsInCurrentDB(ValkeyModuleCtx *ctx) const;
 
-  virtual void OnSwapDB(RedisModuleSwapDbInfo *swap_db_info);
-  virtual void OnLoadingEnded(RedisModuleCtx *ctx);
+  virtual void OnSwapDB(ValkeyModuleSwapDbInfo *swap_db_info);
+  virtual void OnLoadingEnded(ValkeyModuleCtx *ctx);
 
   inline const Stats &GetStats() const { return stats_; }
-  void ProcessSingleMutationAsync(RedisModuleCtx *ctx, bool from_backfill,
+  void ProcessSingleMutationAsync(ValkeyModuleCtx *ctx, bool from_backfill,
                                   const InternedStringPtr &key,
                                   vmsdk::StopWatch *delay_capturer);
   std::unique_ptr<data_model::IndexSchema> ToProto() const;
   struct DocumentMutation {
     struct AttributeData {
-      vmsdk::UniqueRedisString data;
+      vmsdk::UniqueValkeyString data;
       indexes::DeletionType deletion_type{indexes::DeletionType::kNone};
     };
     std::optional<absl::flat_hash_map<std::string, AttributeData>> attributes;
@@ -174,14 +174,14 @@ class IndexSchema : public KeyspaceEventSubscription,
                                      indexes::VectorBase *vector_index);
 
  protected:
-  IndexSchema(RedisModuleCtx *ctx,
+  IndexSchema(ValkeyModuleCtx *ctx,
               const data_model::IndexSchema &index_schema_proto,
               std::unique_ptr<AttributeDataType> attribute_data_type,
               vmsdk::ThreadPool *mutations_thread_pool);
-  absl::Status Init(RedisModuleCtx *ctx);
+  absl::Status Init(ValkeyModuleCtx *ctx);
 
  private:
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   absl::flat_hash_map<std::string, Attribute> attributes_;
   KeyspaceEventManager *keyspace_event_manager_;
   std::vector<std::string> subscribed_key_prefixes_;
@@ -197,14 +197,14 @@ class IndexSchema : public KeyspaceEventSubscription,
 
   struct BackfillJob {
     BackfillJob() = delete;
-    BackfillJob(RedisModuleCtx *ctx, absl::string_view name, int db_num);
+    BackfillJob(ValkeyModuleCtx *ctx, absl::string_view name, int db_num);
     bool IsScanDone() const { return scan_ctx.get() == nullptr; }
     void MarkScanAsDone() {
       scan_ctx.reset();
       cursor.reset();
     }
-    vmsdk::UniqueRedisDetachedThreadSafeContext scan_ctx;
-    vmsdk::UniqueRedisScanCursor cursor;
+    vmsdk::UniqueValkeyDetachedThreadSafeContext scan_ctx;
+    vmsdk::UniqueValkeyScanCursor cursor;
     uint64_t scanned_key_count{0};
     uint64_t db_size;
     vmsdk::StopWatch stopwatch;
@@ -216,14 +216,14 @@ class IndexSchema : public KeyspaceEventSubscription,
       vector_externalizer_subscriptions_;
   void VectorExternalizer(const InternedStringPtr &key,
                           absl::string_view attribute_identifier,
-                          vmsdk::UniqueRedisString &record);
+                          vmsdk::UniqueValkeyString &record);
 
   mutable Stats stats_;
 
-  void ProcessKeyspaceNotification(RedisModuleCtx *ctx, RedisModuleString *key,
-                                   bool from_backfill);
+  void ProcessKeyspaceNotification(ValkeyModuleCtx *ctx,
+                                   ValkeyModuleString *key, bool from_backfill);
 
-  void ProcessMutation(RedisModuleCtx *ctx,
+  void ProcessMutation(ValkeyModuleCtx *ctx,
                        MutatedAttributes &mutated_attributes,
                        const InternedStringPtr &interned_key,
                        bool from_backfill);
@@ -233,20 +233,21 @@ class IndexSchema : public KeyspaceEventSubscription,
   void EnqueueMultiMutation(const InternedStringPtr &key);
 
   bool IsTrackedByAnyIndex(const InternedStringPtr &key) const;
-  void SyncProcessMutation(RedisModuleCtx *ctx,
+  void SyncProcessMutation(ValkeyModuleCtx *ctx,
                            MutatedAttributes &mutated_attributes,
                            const InternedStringPtr &key);
-  void ProcessAttributeMutation(RedisModuleCtx *ctx, const Attribute &attribute,
+  void ProcessAttributeMutation(ValkeyModuleCtx *ctx,
+                                const Attribute &attribute,
                                 const InternedStringPtr &key,
-                                vmsdk::UniqueRedisString data,
+                                vmsdk::UniqueValkeyString data,
                                 indexes::DeletionType deletion_type);
-  static void BackfillScanCallback(RedisModuleCtx *ctx,
-                                   RedisModuleString *keyname,
-                                   RedisModuleKey *key, void *privdata);
-  bool DeleteIfNotInRedisDict(RedisModuleCtx *ctx, RedisModuleString *key,
+  static void BackfillScanCallback(ValkeyModuleCtx *ctx,
+                                   ValkeyModuleString *keyname,
+                                   ValkeyModuleKey *key, void *privdata);
+  bool DeleteIfNotInValkeyDict(ValkeyModuleCtx *ctx, ValkeyModuleString *key,
                               const Attribute &attribute);
 
-  bool TrackMutatedRecord(RedisModuleCtx *ctx, const InternedStringPtr &key,
+  bool TrackMutatedRecord(ValkeyModuleCtx *ctx, const InternedStringPtr &key,
                           MutatedAttributes &&mutated_attributes,
                           bool from_backfill, bool block_client)
       ABSL_LOCKS_EXCLUDED(mutated_records_mutex_);

--- a/src/indexes/index_base.h
+++ b/src/indexes/index_base.h
@@ -74,7 +74,7 @@ class IndexBase {
                                             DeletionType deletion_type) = 0;
   virtual absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                             absl::string_view data) = 0;
-  virtual int RespondWithInfo(RedisModuleCtx* ctx) const = 0;
+  virtual int RespondWithInfo(ValkeyModuleCtx* ctx) const = 0;
   virtual bool IsTracked(const InternedStringPtr& key) const = 0;
   IndexerType GetIndexerType() const { return indexer_type_; }
   virtual absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const = 0;
@@ -83,8 +83,8 @@ class IndexBase {
   virtual void ForEachTrackedKey(
       absl::AnyInvocable<void(const InternedStringPtr&)> fn) const {}
 
-  virtual vmsdk::UniqueRedisString NormalizeStringRecord(
-      vmsdk::UniqueRedisString input) const {
+  virtual vmsdk::UniqueValkeyString NormalizeStringRecord(
+      vmsdk::UniqueValkeyString input) const {
     return input;
   }
   virtual uint64_t GetRecordCount() const = 0;

--- a/src/indexes/numeric.cc
+++ b/src/indexes/numeric.cc
@@ -123,13 +123,13 @@ absl::StatusOr<bool> Numeric::RemoveRecord(const InternedStringPtr& key,
   return true;
 }
 
-int Numeric::RespondWithInfo(RedisModuleCtx* ctx) const {
-  RedisModule_ReplyWithSimpleString(ctx, "type");
-  RedisModule_ReplyWithSimpleString(ctx, "NUMERIC");
-  RedisModule_ReplyWithSimpleString(ctx, "size");
+int Numeric::RespondWithInfo(ValkeyModuleCtx* ctx) const {
+  ValkeyModule_ReplyWithSimpleString(ctx, "type");
+  ValkeyModule_ReplyWithSimpleString(ctx, "NUMERIC");
+  ValkeyModule_ReplyWithSimpleString(ctx, "size");
   absl::MutexLock lock(&index_mutex_);
-  RedisModule_ReplyWithCString(ctx,
-                               std::to_string(tracked_keys_.size()).c_str());
+  ValkeyModule_ReplyWithCString(ctx,
+                                std::to_string(tracked_keys_.size()).c_str());
   return 4;
 }
 

--- a/src/indexes/numeric.h
+++ b/src/indexes/numeric.h
@@ -114,7 +114,7 @@ class Numeric : public IndexBase {
   absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(RedisModuleCtx* ctx) const override;
+  int RespondWithInfo(ValkeyModuleCtx* ctx) const override;
   bool IsTracked(const InternedStringPtr& key) const override;
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -188,20 +188,20 @@ absl::StatusOr<bool> Tag::RemoveRecord(const InternedStringPtr& key,
   return true;
 }
 
-int Tag::RespondWithInfo(RedisModuleCtx* ctx) const {
+int Tag::RespondWithInfo(ValkeyModuleCtx* ctx) const {
   auto num_replies = 6;
-  RedisModule_ReplyWithSimpleString(ctx, "type");
-  RedisModule_ReplyWithSimpleString(ctx, "TAG");
-  RedisModule_ReplyWithSimpleString(ctx, "SEPARATOR");
-  RedisModule_ReplyWithSimpleString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "type");
+  ValkeyModule_ReplyWithSimpleString(ctx, "TAG");
+  ValkeyModule_ReplyWithSimpleString(ctx, "SEPARATOR");
+  ValkeyModule_ReplyWithSimpleString(
       ctx, std::string(&separator_, sizeof(char)).c_str());
   if (case_sensitive_) {
     num_replies++;
-    RedisModule_ReplyWithSimpleString(ctx, "CASESENSITIVE");
+    ValkeyModule_ReplyWithSimpleString(ctx, "CASESENSITIVE");
   }
-  RedisModule_ReplyWithSimpleString(ctx, "size");
+  ValkeyModule_ReplyWithSimpleString(ctx, "size");
   absl::MutexLock lock(&index_mutex_);
-  RedisModule_ReplyWithCString(
+  ValkeyModule_ReplyWithCString(
       ctx, std::to_string(tracked_tags_by_keys_.size()).c_str());
   return num_replies;
 }

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -64,7 +64,7 @@ class Tag : public IndexBase {
   absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(RedisModuleCtx* ctx) const override;
+  int RespondWithInfo(ValkeyModuleCtx* ctx) const override;
   bool IsTracked(const InternedStringPtr& key) const override;
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
@@ -123,7 +123,7 @@ class Tag : public IndexBase {
           size_(size),
           entries_(entries),
           negate_(negate),
-          untracked_keys_(untracked_keys){};
+          untracked_keys_(untracked_keys) {};
     size_t Size() const override;
     std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
 

--- a/src/indexes/vector_base.cc
+++ b/src/indexes/vector_base.cc
@@ -392,28 +392,28 @@ absl::StatusOr<bool> VectorBase::UpdateMetadata(
   return true;
 }
 
-int VectorBase::RespondWithInfo(RedisModuleCtx *ctx) const {
-  RedisModule_ReplyWithSimpleString(ctx, "type");
-  RedisModule_ReplyWithSimpleString(ctx, "VECTOR");
-  RedisModule_ReplyWithSimpleString(ctx, "index");
+int VectorBase::RespondWithInfo(ValkeyModuleCtx *ctx) const {
+  ValkeyModule_ReplyWithSimpleString(ctx, "type");
+  ValkeyModule_ReplyWithSimpleString(ctx, "VECTOR");
+  ValkeyModule_ReplyWithSimpleString(ctx, "index");
 
-  RedisModule_ReplyWithArray(ctx, REDISMODULE_POSTPONED_ARRAY_LEN);
-  RedisModule_ReplyWithSimpleString(ctx, "capacity");
-  RedisModule_ReplyWithLongLong(ctx, GetCapacity());
-  RedisModule_ReplyWithSimpleString(ctx, "dimensions");
-  RedisModule_ReplyWithLongLong(ctx, dimensions_);
-  RedisModule_ReplyWithSimpleString(ctx, "distance_metric");
-  RedisModule_ReplyWithSimpleString(
+  ValkeyModule_ReplyWithArray(ctx, VALKEYMODULE_POSTPONED_ARRAY_LEN);
+  ValkeyModule_ReplyWithSimpleString(ctx, "capacity");
+  ValkeyModule_ReplyWithLongLong(ctx, GetCapacity());
+  ValkeyModule_ReplyWithSimpleString(ctx, "dimensions");
+  ValkeyModule_ReplyWithLongLong(ctx, dimensions_);
+  ValkeyModule_ReplyWithSimpleString(ctx, "distance_metric");
+  ValkeyModule_ReplyWithSimpleString(
       ctx, LookupKeyByValue(*kDistanceMetricByStr, distance_metric_).data());
-  RedisModule_ReplyWithSimpleString(ctx, "size");
+  ValkeyModule_ReplyWithSimpleString(ctx, "size");
   {
     absl::MutexLock lock(&key_to_metadata_mutex_);
-    RedisModule_ReplyWithCString(
+    ValkeyModule_ReplyWithCString(
         ctx, std::to_string(key_by_internal_id_.size()).c_str());
   }
   int array_len = 8;
   array_len += RespondWithInfoImpl(ctx);
-  RedisModule_ReplySetArrayLength(ctx, array_len);
+  ValkeyModule_ReplySetArrayLength(ctx, array_len);
 
   return 4;
 }
@@ -439,18 +439,18 @@ absl::Status VectorBase::SaveTrackedKeys(
   return absl::OkStatus();
 }
 
-void VectorBase::ExternalizeVector(RedisModuleCtx *ctx,
+void VectorBase::ExternalizeVector(ValkeyModuleCtx *ctx,
                                    const AttributeDataType *attribute_data_type,
                                    absl::string_view key_cstr,
                                    absl::string_view attribute_identifier) {
-  auto key_obj = vmsdk::MakeUniqueRedisOpenKey(
-      ctx, vmsdk::MakeUniqueRedisString(key_cstr).get(),
-      REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_READ);
+  auto key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+      ctx, vmsdk::MakeUniqueValkeyString(key_cstr).get(),
+      VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
   if (!key_obj || !attribute_data_type->IsProperType(key_obj.get())) {
     return;
   }
   bool is_module_owned;
-  vmsdk::UniqueRedisString record = VectorExternalizer::Instance().GetRecord(
+  vmsdk::UniqueValkeyString record = VectorExternalizer::Instance().GetRecord(
       ctx, attribute_data_type, key_obj.get(), key_cstr, attribute_identifier,
       is_module_owned);
   CHECK(!is_module_owned);
@@ -466,7 +466,7 @@ void VectorBase::ExternalizeVector(RedisModuleCtx *ctx,
 }
 
 absl::Status VectorBase::LoadTrackedKeys(
-    RedisModuleCtx *ctx, const AttributeDataType *attribute_data_type,
+    ValkeyModuleCtx *ctx, const AttributeDataType *attribute_data_type,
     SupplementalContentChunkIter &&iter) {
   absl::WriterMutexLock lock(&key_to_metadata_mutex_);
   while (iter.HasNext()) {
@@ -532,8 +532,8 @@ void VectorBase::AddPrefilteredKey(
   }
 }
 
-vmsdk::UniqueRedisString VectorBase::NormalizeStringRecord(
-    vmsdk::UniqueRedisString record) const {
+vmsdk::UniqueValkeyString VectorBase::NormalizeStringRecord(
+    vmsdk::UniqueValkeyString record) const {
   CHECK_EQ(GetDataTypeSize(), sizeof(float));
   auto record_str = vmsdk::ToStringView(record.get());
   if (absl::ConsumePrefix(&record_str, "[")) {
@@ -550,7 +550,7 @@ vmsdk::UniqueRedisString VectorBase::NormalizeStringRecord(
     }
     binary_string += std::string((char *)&value, sizeof(float));
   }
-  return vmsdk::MakeUniqueRedisString(binary_string);
+  return vmsdk::MakeUniqueValkeyString(binary_string);
 }
 
 uint64_t VectorBase::GetRecordCount() const {

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -140,7 +140,7 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override;
   absl::Status SaveTrackedKeys(RDBChunkOutputStream chunked_out) const
       ABSL_LOCKS_EXCLUDED(key_to_metadata_mutex_);
-  absl::Status LoadTrackedKeys(RedisModuleCtx* ctx,
+  absl::Status LoadTrackedKeys(ValkeyModuleCtx* ctx,
                                const AttributeDataType* attribute_data_type,
                                SupplementalContentChunkIter&& iter);
   void ForEachTrackedKey(
@@ -156,8 +156,8 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
       absl::string_view query, uint64_t count, const InternedStringPtr& key,
       std::priority_queue<std::pair<float, hnswlib::labeltype>>& results,
       absl::flat_hash_set<hnswlib::labeltype>& top_keys) const;
-  vmsdk::UniqueRedisString NormalizeStringRecord(
-      vmsdk::UniqueRedisString record) const override;
+  vmsdk::UniqueValkeyString NormalizeStringRecord(
+      vmsdk::UniqueValkeyString record) const override;
   uint64_t GetRecordCount() const override;
   template <typename T>
   absl::StatusOr<std::deque<Neighbor>> CreateReply(
@@ -190,7 +190,7 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
     int32_t dim = record.size() / GetDataTypeSize();
     return dim == dimensions_ && (record.size() % data_type_size == 0);
   }
-  int RespondWithInfo(RedisModuleCtx* ctx) const override;
+  int RespondWithInfo(ValkeyModuleCtx* ctx) const override;
   template <typename T>
   void Init(int dimensions, data_model::DistanceMetric distance_metric,
             std::unique_ptr<hnswlib::SpaceInterface<T>>& space);
@@ -200,14 +200,14 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
   virtual absl::Status RemoveRecordImpl(uint64_t internal_id) = 0;
   virtual absl::Status ModifyRecordImpl(uint64_t internal_id,
                                         absl::string_view record) = 0;
-  virtual int RespondWithInfoImpl(RedisModuleCtx* ctx) const = 0;
+  virtual int RespondWithInfoImpl(ValkeyModuleCtx* ctx) const = 0;
 
   virtual size_t GetDataTypeSize() const = 0;
   virtual void ToProtoImpl(
       data_model::VectorIndex* vector_index_proto) const = 0;
   virtual absl::Status SaveIndexImpl(
       RDBChunkOutputStream chunked_out) const = 0;
-  void ExternalizeVector(RedisModuleCtx* ctx,
+  void ExternalizeVector(ValkeyModuleCtx* ctx,
                          const AttributeDataType* attribute_data_type,
                          absl::string_view key_cstr,
                          absl::string_view attribute_identifier);

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -119,7 +119,7 @@ void VectorFlat<T>::UnTrackVector(uint64_t internal_id) {
 
 template <typename T>
 absl::StatusOr<std::shared_ptr<VectorFlat<T>>> VectorFlat<T>::LoadFromRDB(
-    RedisModuleCtx *ctx, const AttributeDataType *attribute_data_type,
+    ValkeyModuleCtx *ctx, const AttributeDataType *attribute_data_type,
     const data_model::VectorIndex &vector_index_proto,
     absl::string_view attribute_identifier,
     SupplementalContentChunkIter &&iter) {
@@ -298,27 +298,27 @@ void VectorFlat<T>::ToProtoImpl(
 }
 
 template <typename T>
-int VectorFlat<T>::RespondWithInfoImpl(RedisModuleCtx *ctx) const {
-  RedisModule_ReplyWithSimpleString(ctx, "data_type");
+int VectorFlat<T>::RespondWithInfoImpl(ValkeyModuleCtx *ctx) const {
+  ValkeyModule_ReplyWithSimpleString(ctx, "data_type");
   if constexpr (std::is_same_v<T, float>) {
-    RedisModule_ReplyWithSimpleString(
+    ValkeyModule_ReplyWithSimpleString(
         ctx,
         LookupKeyByValue(*kVectorDataTypeByStr,
                          data_model::VectorDataType::VECTOR_DATA_TYPE_FLOAT32)
             .data());
   } else {
-    RedisModule_ReplyWithSimpleString(ctx, "UNKNOWN");
+    ValkeyModule_ReplyWithSimpleString(ctx, "UNKNOWN");
   }
-  RedisModule_ReplyWithSimpleString(ctx, "algorithm");
-  RedisModule_ReplyWithArray(ctx, 4);
-  RedisModule_ReplyWithSimpleString(ctx, "name");
-  RedisModule_ReplyWithSimpleString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "algorithm");
+  ValkeyModule_ReplyWithArray(ctx, 4);
+  ValkeyModule_ReplyWithSimpleString(ctx, "name");
+  ValkeyModule_ReplyWithSimpleString(
       ctx,
       LookupKeyByValue(*kVectorAlgoByStr,
                        data_model::VectorIndex::AlgorithmCase::kFlatAlgorithm)
           .data());
-  RedisModule_ReplyWithSimpleString(ctx, "block_size");
-  RedisModule_ReplyWithLongLong(ctx, block_size_);
+  ValkeyModule_ReplyWithSimpleString(ctx, "block_size");
+  ValkeyModule_ReplyWithLongLong(ctx, block_size_);
 
   return 4;
 }

--- a/src/indexes/vector_flat.h
+++ b/src/indexes/vector_flat.h
@@ -61,7 +61,7 @@ class VectorFlat : public VectorBase {
       data_model::AttributeDataType attribute_data_type)
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
   static absl::StatusOr<std::shared_ptr<VectorFlat<T>>> LoadFromRDB(
-      RedisModuleCtx* ctx, const AttributeDataType* attribute_data_type,
+      ValkeyModuleCtx* ctx, const AttributeDataType* attribute_data_type,
       const data_model::VectorIndex& vector_index_proto,
       absl::string_view attribute_identifier,
       SupplementalContentChunkIter&& iter) ABSL_NO_THREAD_SAFETY_ANALYSIS;
@@ -93,7 +93,7 @@ class VectorFlat : public VectorBase {
   absl::Status ModifyRecordImpl(uint64_t internal_id,
                                 absl::string_view record) override;
   void ToProtoImpl(data_model::VectorIndex* vector_index_proto) const override;
-  int RespondWithInfoImpl(RedisModuleCtx* ctx) const override;
+  int RespondWithInfoImpl(ValkeyModuleCtx* ctx) const override;
   absl::Status SaveIndexImpl(RDBChunkOutputStream chunked_out) const override;
   absl::StatusOr<std::pair<float, hnswlib::labeltype>>
   ComputeDistanceFromRecordImpl(uint64_t internal_id,

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -159,7 +159,7 @@ void VectorHNSW<T>::UnTrackVector(uint64_t internal_id) {}
 
 template <typename T>
 absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> VectorHNSW<T>::LoadFromRDB(
-    RedisModuleCtx *ctx, const AttributeDataType *attribute_data_type,
+    ValkeyModuleCtx *ctx, const AttributeDataType *attribute_data_type,
     const data_model::VectorIndex &vector_index_proto,
     absl::string_view attribute_identifier,
     SupplementalContentChunkIter &&iter) {
@@ -225,32 +225,32 @@ absl::Status VectorHNSW<T>::AddRecordImpl(uint64_t internal_id,
 }
 
 template <typename T>
-int VectorHNSW<T>::RespondWithInfoImpl(RedisModuleCtx *ctx) const {
-  RedisModule_ReplyWithSimpleString(ctx, "data_type");
+int VectorHNSW<T>::RespondWithInfoImpl(ValkeyModuleCtx *ctx) const {
+  ValkeyModule_ReplyWithSimpleString(ctx, "data_type");
   if constexpr (std::is_same_v<T, float>) {
-    RedisModule_ReplyWithSimpleString(
+    ValkeyModule_ReplyWithSimpleString(
         ctx,
         LookupKeyByValue(*kVectorDataTypeByStr,
                          data_model::VectorDataType::VECTOR_DATA_TYPE_FLOAT32)
             .data());
   } else {
-    RedisModule_ReplyWithSimpleString(ctx, "UNKNOWN");
+    ValkeyModule_ReplyWithSimpleString(ctx, "UNKNOWN");
   }
-  RedisModule_ReplyWithSimpleString(ctx, "algorithm");
-  RedisModule_ReplyWithArray(ctx, 8);
-  RedisModule_ReplyWithSimpleString(ctx, "name");
-  RedisModule_ReplyWithSimpleString(
+  ValkeyModule_ReplyWithSimpleString(ctx, "algorithm");
+  ValkeyModule_ReplyWithArray(ctx, 8);
+  ValkeyModule_ReplyWithSimpleString(ctx, "name");
+  ValkeyModule_ReplyWithSimpleString(
       ctx,
       LookupKeyByValue(*kVectorAlgoByStr,
                        data_model::VectorIndex::AlgorithmCase::kHnswAlgorithm)
           .data());
-  RedisModule_ReplyWithSimpleString(ctx, "m");
+  ValkeyModule_ReplyWithSimpleString(ctx, "m");
   absl::ReaderMutexLock lock(&resize_mutex_);
-  RedisModule_ReplyWithLongLong(ctx, GetM());
-  RedisModule_ReplyWithSimpleString(ctx, "ef_construction");
-  RedisModule_ReplyWithLongLong(ctx, GetEfConstruction());
-  RedisModule_ReplyWithSimpleString(ctx, "ef_runtime");
-  RedisModule_ReplyWithLongLong(ctx, GetEfRuntime());
+  ValkeyModule_ReplyWithLongLong(ctx, GetM());
+  ValkeyModule_ReplyWithSimpleString(ctx, "ef_construction");
+  ValkeyModule_ReplyWithLongLong(ctx, GetEfConstruction());
+  ValkeyModule_ReplyWithSimpleString(ctx, "ef_runtime");
+  ValkeyModule_ReplyWithLongLong(ctx, GetEfRuntime());
   return 4;
 }
 

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -60,7 +60,7 @@ class VectorHNSW : public VectorBase {
       data_model::AttributeDataType attribute_data_type)
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
   static absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> LoadFromRDB(
-      RedisModuleCtx* ctx, const AttributeDataType* attribute_data_type,
+      ValkeyModuleCtx* ctx, const AttributeDataType* attribute_data_type,
       const data_model::VectorIndex& vector_index_proto,
       absl::string_view attribute_identifier,
       SupplementalContentChunkIter&& iter) ABSL_NO_THREAD_SAFETY_ANALYSIS;
@@ -104,7 +104,7 @@ class VectorHNSW : public VectorBase {
                                 absl::string_view record) override
       ABSL_LOCKS_EXCLUDED(resize_mutex_);
   void ToProtoImpl(data_model::VectorIndex* vector_index_proto) const override;
-  int RespondWithInfoImpl(RedisModuleCtx* ctx) const override;
+  int RespondWithInfoImpl(ValkeyModuleCtx* ctx) const override;
   absl::Status SaveIndexImpl(RDBChunkOutputStream chunked_out) const override;
   absl::StatusOr<std::pair<float, hnswlib::labeltype>>
   ComputeDistanceFromRecordImpl(uint64_t internal_id, absl::string_view query)

--- a/src/keyspace_event_manager.h
+++ b/src/keyspace_event_manager.h
@@ -43,7 +43,7 @@
 
 namespace valkey_search {
 using StartSubscriptionFunction =
-    std::function<absl::Status(RedisModuleCtx *, int)>;
+    std::function<absl::Status(ValkeyModuleCtx *, int)>;
 
 // KeyspaceEventSubscription is an interface for classes that want to subscribe
 // to keyspace events.
@@ -63,18 +63,18 @@ class KeyspaceEventSubscription {
   // completely prefixed by B. Otherwise, duplicate events may fire.
   virtual const std::vector<std::string> &GetKeyPrefixes() const = 0;
 
-  virtual void OnKeyspaceNotification(RedisModuleCtx *ctx, int type,
+  virtual void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
                                       const char *event,
-                                      RedisModuleString *key) = 0;
+                                      ValkeyModuleString *key) = 0;
 };
 
 class KeyspaceEventManager {
  public:
   KeyspaceEventManager() = default;
-  void NotifySubscribers(RedisModuleCtx *ctx, int type, const char *event,
-                         RedisModuleString *key);
+  void NotifySubscribers(ValkeyModuleCtx *ctx, int type, const char *event,
+                         ValkeyModuleString *key);
 
-  absl::Status InsertSubscription(RedisModuleCtx *ctx,
+  absl::Status InsertSubscription(ValkeyModuleCtx *ctx,
                                   KeyspaceEventSubscription *subscription);
 
   absl::Status RemoveSubscription(KeyspaceEventSubscription *subscription);
@@ -86,13 +86,13 @@ class KeyspaceEventManager {
   static KeyspaceEventManager &Instance();
 
  private:
-  absl::Status StartRedisSubscriptionIfNeeded(RedisModuleCtx *ctx, int types);
+  absl::Status StartValkeySubscriptionIfNeeded(ValkeyModuleCtx *ctx, int types);
 
-  static inline int OnRedisKeyspaceNotification(RedisModuleCtx *ctx, int type,
+  static inline int OnValkeyKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
                                                 const char *event,
-                                                RedisModuleString *key) {
+                                                ValkeyModuleString *key) {
     Instance().NotifySubscribers(ctx, type, event, key);
-    return REDISMODULE_OK;
+    return VALKEYMODULE_OK;
   }
 
   vmsdk::MainThreadAccessGuard<absl::flat_hash_set<KeyspaceEventSubscription *>>

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -36,7 +36,7 @@
 #include "absl/time/time.h"
 #include "vmsdk/src/latency_sampler.h"
 
-// 2 is the value used by Redis and correlates to ~40KiB and ~1% precision.
+// 2 is the value used by Valkey and correlates to ~40KiB and ~1% precision.
 #define LATENCY_PRECISION 2
 
 namespace valkey_search {

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -101,7 +101,7 @@ vmsdk::module::Options options = {
         }  // namespace
     ,
     .on_load =
-        [](RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+        [](ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
            [[maybe_unused]] const vmsdk::module::Options &options) {
           valkey_search::KeyspaceEventManager::InitInstance(
               std::make_unique<valkey_search::KeyspaceEventManager>());
@@ -112,7 +112,7 @@ vmsdk::module::Options options = {
                                                                 argc);
         },
     .on_unload =
-        [](RedisModuleCtx *ctx,
+        [](ValkeyModuleCtx *ctx,
            [[maybe_unused]] const vmsdk::module::Options &options) {
           valkey_search::ValkeySearch::Instance().OnUnload(ctx);
         },

--- a/src/query/fanout.h
+++ b/src/query/fanout.h
@@ -67,12 +67,12 @@ struct FanoutSearchTarget {
 };
 
 absl::Status PerformSearchFanoutAsync(
-    RedisModuleCtx* ctx, std::vector<FanoutSearchTarget>& search_targets,
+    ValkeyModuleCtx* ctx, std::vector<FanoutSearchTarget>& search_targets,
     coordinator::ClientPool* coordinator_client_pool,
     std::unique_ptr<query::VectorSearchParameters> parameters,
     vmsdk::ThreadPool* thread_pool, query::SearchResponseCallback callback);
 
-std::vector<FanoutSearchTarget> GetSearchTargetsForFanout(RedisModuleCtx* ctx);
+std::vector<FanoutSearchTarget> GetSearchTargetsForFanout(ValkeyModuleCtx* ctx);
 
 }  // namespace valkey_search::query::fanout
 

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -53,7 +53,7 @@ NumericPredicate::NumericPredicate(const indexes::Numeric* index,
                                    bool is_inclusive_end)
     : Predicate(PredicateType::kNumeric),
       index_(index),
-      identifier_(vmsdk::MakeUniqueRedisString(identifier)),
+      identifier_(vmsdk::MakeUniqueValkeyString(identifier)),
       start_(start),
       is_inclusive_start_(is_inclusive_start),
       end_(end),
@@ -78,7 +78,7 @@ TagPredicate::TagPredicate(const indexes::Tag* index,
                            const absl::flat_hash_set<absl::string_view>& tags)
     : Predicate(PredicateType::kTag),
       index_(index),
-      identifier_(vmsdk::MakeUniqueRedisString(identifier)),
+      identifier_(vmsdk::MakeUniqueValkeyString(identifier)),
       raw_tag_string_(raw_tag_string),
       tags_(tags.begin(), tags.end()) {}
 

--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -102,8 +102,8 @@ class NumericPredicate : public Predicate {
   absl::string_view GetIdentifier() const {
     return vmsdk::ToStringView(identifier_.get());
   }
-  vmsdk::UniqueRedisString GetRetainedIdentifier() const {
-    return vmsdk::RetainUniqueRedisString(identifier_.get());
+  vmsdk::UniqueValkeyString GetRetainedIdentifier() const {
+    return vmsdk::RetainUniqueValkeyString(identifier_.get());
   }
   double GetStart() const { return start_; }
   bool IsStartInclusive() const { return is_inclusive_start_; }
@@ -114,7 +114,7 @@ class NumericPredicate : public Predicate {
 
  private:
   const indexes::Numeric* index_;
-  vmsdk::UniqueRedisString identifier_;
+  vmsdk::UniqueValkeyString identifier_;
   double start_;
   bool is_inclusive_start_;
   double end_;
@@ -133,15 +133,15 @@ class TagPredicate : public Predicate {
   absl::string_view GetIdentifier() const {
     return vmsdk::ToStringView(identifier_.get());
   }
-  vmsdk::UniqueRedisString GetRetainedIdentifier() const {
-    return vmsdk::RetainUniqueRedisString(identifier_.get());
+  vmsdk::UniqueValkeyString GetRetainedIdentifier() const {
+    return vmsdk::RetainUniqueValkeyString(identifier_.get());
   }
   const std::string& GetTagString() const { return raw_tag_string_; }
   const absl::flat_hash_set<std::string>& GetTags() const { return tags_; }
 
  private:
   const indexes::Tag* index_;
-  vmsdk::UniqueRedisString identifier_;
+  vmsdk::UniqueValkeyString identifier_;
   std::string raw_tag_string_;
   absl::flat_hash_set<std::string> tags_;
 };

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -99,7 +99,7 @@ bool VerifyFilter(const query::Predicate *predicate,
 }
 
 absl::StatusOr<RecordsMap> GetContentNoReturnJson(
-    RedisModuleCtx *ctx, const AttributeDataType &attribute_data_type,
+    ValkeyModuleCtx *ctx, const AttributeDataType &attribute_data_type,
     const query::VectorSearchParameters &parameters, absl::string_view key,
     const std::string &vector_identifier) {
   absl::flat_hash_set<absl::string_view> identifiers;
@@ -119,8 +119,8 @@ absl::StatusOr<RecordsMap> GetContentNoReturnJson(
     return absl::NotFoundError("Verify filter failed");
   }
   RecordsMap return_content;
-  static const vmsdk::UniqueRedisString kJsonRootElementQueryPtr =
-      vmsdk::MakeUniqueRedisString(kJsonRootElementQuery);
+  static const vmsdk::UniqueValkeyString kJsonRootElementQueryPtr =
+      vmsdk::MakeUniqueValkeyString(kJsonRootElementQuery);
   return_content.emplace(
       kJsonRootElementQuery,
       RecordsMapValue(
@@ -130,7 +130,7 @@ absl::StatusOr<RecordsMap> GetContentNoReturnJson(
 }
 
 absl::StatusOr<RecordsMap> GetContent(
-    RedisModuleCtx *ctx, const AttributeDataType &attribute_data_type,
+    ValkeyModuleCtx *ctx, const AttributeDataType &attribute_data_type,
     const query::VectorSearchParameters &parameters, absl::string_view key,
     const std::string &vector_identifier) {
   if (attribute_data_type.ToProto() ==
@@ -173,7 +173,7 @@ absl::StatusOr<RecordsMap> GetContent(
         vmsdk::ToStringView(return_attribute.identifier.get()),
         RecordsMapValue(
             return_attribute.identifier.get(),
-            vmsdk::RetainUniqueRedisString(itr->second.value.get())));
+            vmsdk::RetainUniqueValkeyString(itr->second.value.get())));
   }
   return return_content;
 }
@@ -181,7 +181,7 @@ absl::StatusOr<RecordsMap> GetContent(
 //
 // Any neighbors already contained in the attribute content map will be skipped.
 // Any data not found locally will be skipped.
-void ProcessNeighborsForReply(RedisModuleCtx *ctx,
+void ProcessNeighborsForReply(ValkeyModuleCtx *ctx,
                               const AttributeDataType &attribute_data_type,
                               std::deque<indexes::Neighbor> &neighbors,
                               const query::VectorSearchParameters &parameters,

--- a/src/query/response_generator.h
+++ b/src/query/response_generator.h
@@ -46,7 +46,7 @@ namespace valkey_search::query {
 // Neighbor already contained in the attribute content map.
 // Neighbor without any attribute content.
 // Neighbor not comply to the pre-filter expression.
-void ProcessNeighborsForReply(RedisModuleCtx *ctx,
+void ProcessNeighborsForReply(ValkeyModuleCtx *ctx,
                               const AttributeDataType &attribute_data_type,
                               std::deque<indexes::Neighbor> &neighbors,
                               const query::VectorSearchParameters &parameters,

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -276,13 +276,13 @@ absl::StatusOr<std::deque<indexes::Neighbor>> MaybeAddIndexedContent(
     neighbor.attribute_contents = RecordsMap();
     bool any_value_missing = false;
     for (auto &attribute_info : attributes) {
-      vmsdk::UniqueRedisString attribute_value = nullptr;
+      vmsdk::UniqueValkeyString attribute_value = nullptr;
       switch (attribute_info.index->GetIndexerType()) {
         case indexes::IndexerType::kTag: {
           auto tag_index = dynamic_cast<indexes::Tag *>(attribute_info.index);
           auto tag_value_ptr = tag_index->GetRawValue(neighbor.external_id);
           if (tag_value_ptr != nullptr) {
-            attribute_value = vmsdk::MakeUniqueRedisString(*tag_value_ptr);
+            attribute_value = vmsdk::MakeUniqueValkeyString(*tag_value_ptr);
           }
           break;
         }
@@ -292,7 +292,7 @@ absl::StatusOr<std::deque<indexes::Neighbor>> MaybeAddIndexedContent(
           auto numeric = numeric_index->GetValue(neighbor.external_id);
           if (numeric != nullptr) {
             attribute_value =
-                vmsdk::MakeUniqueRedisString(absl::StrCat(*numeric));
+                vmsdk::MakeUniqueValkeyString(absl::StrCat(*numeric));
           }
           break;
         }
@@ -305,11 +305,11 @@ absl::StatusOr<std::deque<indexes::Neighbor>> MaybeAddIndexedContent(
           if (vector.ok()) {
             if (parameters.index_schema->GetAttributeDataType().ToProto() ==
                 data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON) {
-              attribute_value = vmsdk::MakeUniqueRedisString(
+              attribute_value = vmsdk::MakeUniqueValkeyString(
                   StringFormatVector(vector.value()));
             } else {
               attribute_value =
-                  vmsdk::UniqueRedisString(RedisModule_CreateString(
+                  vmsdk::UniqueValkeyString(ValkeyModule_CreateString(
                       nullptr, vector->data(), vector->size()));
             }
           } else {
@@ -326,7 +326,7 @@ absl::StatusOr<std::deque<indexes::Neighbor>> MaybeAddIndexedContent(
       }
 
       if (attribute_value != nullptr) {
-        auto identifier = vmsdk::MakeUniqueRedisString(
+        auto identifier = vmsdk::MakeUniqueValkeyString(
             vmsdk::ToStringView(attribute_info.attribute->identifier.get()));
         auto identifier_view = vmsdk::ToStringView(identifier.get());
         neighbor.attribute_contents->emplace(

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -64,16 +64,16 @@ struct LimitParameter {
 };
 
 struct ReturnAttribute {
-  vmsdk::UniqueRedisString identifier;
-  vmsdk::UniqueRedisString attribute_alias;
-  vmsdk::UniqueRedisString alias;
+  vmsdk::UniqueValkeyString identifier;
+  vmsdk::UniqueValkeyString attribute_alias;
+  vmsdk::UniqueValkeyString alias;
 };
 
 struct VectorSearchParameters {
   std::shared_ptr<IndexSchema> index_schema;
   std::string index_schema_name;
   std::string attribute_alias;
-  vmsdk::UniqueRedisString score_as;
+  vmsdk::UniqueValkeyString score_as;
   std::string query;
   uint32_t dialect{2};
   bool local_only{false};

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -160,7 +160,7 @@ void RegisterRDBCallback(data_model::RDBSectionType type,
 }
 void ClearRDBCallbacks() { kRegisteredRDBSectionCallbacks.clear(); }
 
-absl::Status PerformRDBLoad(RedisModuleCtx *ctx, SafeRDB *rdb, int encver) {
+absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
   // Parse the header
   if (encver != kCurrentEncVer) {
     return absl::InternalError(absl::StrFormat(
@@ -211,36 +211,36 @@ absl::Status PerformRDBLoad(RedisModuleCtx *ctx, SafeRDB *rdb, int encver) {
   return absl::OkStatus();
 }
 
-absl::StatusOr<vmsdk::UniqueRedisDetachedThreadSafeContext>
-CreateRDBDetachedContext(RedisModuleIO *rdb) {
+absl::StatusOr<vmsdk::UniqueValkeyDetachedThreadSafeContext>
+CreateRDBDetachedContext(ValkeyModuleIO *rdb) {
   /* Wrap the RDB context in a detached context to ensure we have a client. */
-  auto ctx = RedisModule_GetContextFromIO(rdb);
-  return vmsdk::MakeUniqueRedisDetachedThreadSafeContext(
-      RedisModule_GetDetachedThreadSafeContext(ctx));
+  auto ctx = ValkeyModule_GetContextFromIO(rdb);
+  return vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(
+      ValkeyModule_GetDetachedThreadSafeContext(ctx));
 }
 
-int AuxLoadCallback(RedisModuleIO *rdb, int encver, int when) {
+int AuxLoadCallback(ValkeyModuleIO *rdb, int encver, int when) {
   auto ctx = CreateRDBDetachedContext(rdb);
   if (!ctx.ok()) {
     VMSDK_LOG(WARNING, nullptr)
         << "Could not create RDB load context: " << ctx.status().message();
-    return REDISMODULE_ERR;
+    return VALKEYMODULE_ERR;
   }
   SafeRDB safe_rdb(rdb);
   auto result = PerformRDBLoad(ctx.value().get(), &safe_rdb, encver);
   if (result.ok()) {
     Metrics::GetStats().rdb_load_success_cnt++;
 
-    return REDISMODULE_OK;
+    return VALKEYMODULE_OK;
   }
   Metrics::GetStats().rdb_load_failure_cnt++;
   VMSDK_LOG_EVERY_N_SEC(WARNING, ctx.value().get(), 0.1)
       << "Failed to load ValkeySearch aux section from RDB: "
       << result.message();
-  return REDISMODULE_ERR;
+  return VALKEYMODULE_ERR;
 }
 
-absl::Status PerformRDBSave(RedisModuleCtx *ctx, SafeRDB *rdb, int when) {
+absl::Status PerformRDBSave(ValkeyModuleCtx *ctx, SafeRDB *rdb, int when) {
   // Aggregate header information from save callbacks first
   int rdb_section_count = 0;
   int min_semantic_version = 0;  // 0.0.0 by default
@@ -282,7 +282,7 @@ absl::Status PerformRDBSave(RedisModuleCtx *ctx, SafeRDB *rdb, int when) {
   return absl::OkStatus();
 }
 
-void AuxSaveCallback(RedisModuleIO *rdb, int when) {
+void AuxSaveCallback(ValkeyModuleIO *rdb, int when) {
   SafeRDB safe_rdb(rdb);
   auto ctx = ValkeySearch::Instance().GetBackgroundCtx();
   auto result = PerformRDBSave(ctx, &safe_rdb, when);
@@ -296,19 +296,19 @@ void AuxSaveCallback(RedisModuleIO *rdb, int when) {
 }
 
 // This module type is used purely to get aux callbacks.
-absl::Status RegisterModuleType(RedisModuleCtx *ctx) {
-  static RedisModuleTypeMethods tm = {
-      .version = REDISMODULE_TYPE_METHOD_VERSION,
-      .rdb_load = [](RedisModuleIO *io, int encver) -> void * {
+absl::Status RegisterModuleType(ValkeyModuleCtx *ctx) {
+  static ValkeyModuleTypeMethods tm = {
+      .version = VALKEYMODULE_TYPE_METHOD_VERSION,
+      .rdb_load = [](ValkeyModuleIO *io, int encver) -> void * {
         DCHECK(false) << "Attempt to load ValkeySearch module type from RDB";
         return nullptr;
       },
       .rdb_save =
-          [](RedisModuleIO *io, void *value) {
+          [](ValkeyModuleIO *io, void *value) {
             DCHECK(false) << "Attempt to save ValkeySearch module type to RDB";
           },
       .aof_rewrite =
-          [](RedisModuleIO *aof, RedisModuleString *key, void *value) {
+          [](ValkeyModuleIO *aof, ValkeyModuleString *key, void *value) {
             DCHECK(false)
                 << "Attempt to rewrite ValkeySearch module type to AOF";
           },
@@ -317,12 +317,12 @@ absl::Status RegisterModuleType(RedisModuleCtx *ctx) {
             DCHECK(false) << "Attempt to free ValkeySearch module type object";
           },
       .aux_load = AuxLoadCallback,
-      .aux_save_triggers = REDISMODULE_AUX_AFTER_RDB,
+      .aux_save_triggers = VALKEYMODULE_AUX_AFTER_RDB,
       .aux_save2 = AuxSaveCallback,
   };
 
-  static RedisModuleType *kValkeySearchModuleType = nullptr;
-  kValkeySearchModuleType = RedisModule_CreateDataType(
+  static ValkeyModuleType *kValkeySearchModuleType = nullptr;
+  kValkeySearchModuleType = ValkeyModule_CreateDataType(
       ctx, kValkeySearchModuleTypeName.data(), kCurrentEncVer, &tm);
   if (!kValkeySearchModuleType) {
     return absl::InternalError(absl::StrCat(

--- a/src/rdb_serialization.h
+++ b/src/rdb_serialization.h
@@ -60,19 +60,19 @@ class RDBSectionIter;
 // if the load fails. Supplemental content iterator must be fully iterated (and
 // any chunks within it iterated as well) or loading will not succeed.
 using RDBSectionLoadCallback = absl::AnyInvocable<absl::Status(
-    RedisModuleCtx *ctx, std::unique_ptr<data_model::RDBSection> section,
+    ValkeyModuleCtx *ctx, std::unique_ptr<data_model::RDBSection> section,
     SupplementalContentIter &&supplemental_iter)>;
 
 // Callback to save an arbitrary count of RDBSections to RDB on aux save events.
 // Return value is an error status or the count of written RDBSections.
 using RDBSectionSaveCallback = absl::AnyInvocable<absl::Status(
-    RedisModuleCtx *ctx, SafeRDB *rdb, int when)>;
+    ValkeyModuleCtx *ctx, SafeRDB *rdb, int when)>;
 
 using RDBSectionCountCallback =
-    absl::AnyInvocable<int(RedisModuleCtx *ctx, int when)>;
+    absl::AnyInvocable<int(ValkeyModuleCtx *ctx, int when)>;
 
 using RDBSectionMinSemVerCallback =
-    absl::AnyInvocable<int(RedisModuleCtx *ctx, int when)>;
+    absl::AnyInvocable<int(ValkeyModuleCtx *ctx, int when)>;
 
 using RDBSectionCallbacks = struct RDBSectionCallbacks {
   RDBSectionLoadCallback load;
@@ -91,89 +91,89 @@ inline std::string HumanReadableSemanticVersion(uint64_t semantic_version) {
                          semantic_version & 0xFF);
 }
 
-/* SafeRDB wraps a RedisModuleIO object and performs IO error checking,
+/* SafeRDB wraps a ValkeyModuleIO object and performs IO error checking,
  * returning absl::StatusOr to force error handling on the caller side. */
 class SafeRDB {
  public:
-  explicit SafeRDB(RedisModuleIO *rdb) : rdb_(rdb) {}
+  explicit SafeRDB(ValkeyModuleIO *rdb) : rdb_(rdb) {}
 
   virtual absl::StatusOr<size_t> LoadSizeT() {
-    auto val = RedisModule_LoadUnsigned(rdb_);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_LoadUnsigned failed");
+    auto val = ValkeyModule_LoadUnsigned(rdb_);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_LoadUnsigned failed");
     }
     return val;
   }
 
   virtual absl::StatusOr<unsigned int> LoadUnsigned() {
-    auto val = RedisModule_LoadUnsigned(rdb_);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_LoadUnsigned failed");
+    auto val = ValkeyModule_LoadUnsigned(rdb_);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_LoadUnsigned failed");
     }
     return val;
   }
 
   virtual absl::StatusOr<int> LoadSigned() {
-    auto val = RedisModule_LoadSigned(rdb_);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_LoadSigned failed");
+    auto val = ValkeyModule_LoadSigned(rdb_);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_LoadSigned failed");
     }
     return val;
   }
 
   virtual absl::StatusOr<double> LoadDouble() {
-    auto val = RedisModule_LoadDouble(rdb_);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_LoadDouble failed");
+    auto val = ValkeyModule_LoadDouble(rdb_);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_LoadDouble failed");
     }
     return val;
   }
 
-  virtual absl::StatusOr<vmsdk::UniqueRedisString> LoadString() {
-    auto str = vmsdk::UniqueRedisString(RedisModule_LoadString(rdb_));
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_LoadString failed");
+  virtual absl::StatusOr<vmsdk::UniqueValkeyString> LoadString() {
+    auto str = vmsdk::UniqueValkeyString(ValkeyModule_LoadString(rdb_));
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_LoadString failed");
     }
     return str;
   }
   bool operator==(const SafeRDB &other) const { return rdb_ == other.rdb_; }
 
   virtual absl::Status SaveSizeT(size_t val) {
-    RedisModule_SaveUnsigned(rdb_, val);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_SaveUnsigned failed");
+    ValkeyModule_SaveUnsigned(rdb_, val);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_SaveUnsigned failed");
     }
     return absl::OkStatus();
   }
 
   virtual absl::Status SaveUnsigned(unsigned int val) {
-    RedisModule_SaveUnsigned(rdb_, val);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_SaveUnsigned failed");
+    ValkeyModule_SaveUnsigned(rdb_, val);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_SaveUnsigned failed");
     }
     return absl::OkStatus();
   }
 
   virtual absl::Status SaveSigned(int val) {
-    RedisModule_SaveSigned(rdb_, val);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_SaveSigned failed");
+    ValkeyModule_SaveSigned(rdb_, val);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_SaveSigned failed");
     }
     return absl::OkStatus();
   }
 
   virtual absl::Status SaveDouble(double val) {
-    RedisModule_SaveDouble(rdb_, val);
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_SaveDouble failed");
+    ValkeyModule_SaveDouble(rdb_, val);
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_SaveDouble failed");
     }
     return absl::OkStatus();
   }
 
   virtual absl::Status SaveStringBuffer(absl::string_view buf) {
-    RedisModule_SaveStringBuffer(rdb_, buf.data(), buf.size());
-    if (RedisModule_IsIOError(rdb_)) {
-      return absl::InternalError("RedisModule_SaveStringBuffer failed");
+    ValkeyModule_SaveStringBuffer(rdb_, buf.data(), buf.size());
+    if (ValkeyModule_IsIOError(rdb_)) {
+      return absl::InternalError("ValkeyModule_SaveStringBuffer failed");
     }
     return absl::OkStatus();
   }
@@ -182,7 +182,7 @@ class SafeRDB {
   SafeRDB() = default;
 
  private:
-  RedisModuleIO *rdb_;
+  ValkeyModuleIO *rdb_;
 };
 
 /* SupplementalContentChunkIter is an iterator over chunks of a supplemental
@@ -373,11 +373,11 @@ class RDBChunkOutputStream : public hnswlib::OutputStream {
 void RegisterRDBCallback(data_model::RDBSectionType type,
                          RDBSectionCallbacks callbacks);
 void ClearRDBCallbacks();
-absl::Status PerformRDBLoad(RedisModuleCtx *ctx, SafeRDB *rdb, int encver);
-int AuxLoadCallback(RedisModuleIO *rdb, int encver, int when);
-absl::Status PerformRDBSave(RedisModuleCtx *ctx, SafeRDB *rdb, int when);
-void AuxSaveCallback(RedisModuleIO *rdb, int when);
-absl::Status RegisterModuleType(RedisModuleCtx *ctx);
+absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver);
+int AuxLoadCallback(ValkeyModuleIO *rdb, int encver, int when);
+absl::Status PerformRDBSave(ValkeyModuleCtx *ctx, SafeRDB *rdb, int when);
+void AuxSaveCallback(ValkeyModuleIO *rdb, int when);
+absl::Status RegisterModuleType(ValkeyModuleCtx *ctx);
 
 }  // namespace valkey_search
 

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -58,7 +58,7 @@ constexpr uint32_t kMetadataEncodingVersion = 1;
 
 class SchemaManager {
  public:
-  SchemaManager(RedisModuleCtx *ctx,
+  SchemaManager(ValkeyModuleCtx *ctx,
                 absl::AnyInvocable<void()> server_events_subscriber_callback,
                 vmsdk::ThreadPool *mutations_thread_pool,
                 bool coordinator_enabled);
@@ -67,7 +67,7 @@ class SchemaManager {
   SchemaManager &operator=(const SchemaManager &) = delete;
 
   absl::Status CreateIndexSchema(
-      RedisModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto)
+      ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto)
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
   absl::Status ImportIndexSchema(std::shared_ptr<IndexSchema> index_schema)
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
@@ -88,33 +88,33 @@ class SchemaManager {
           std::atomic<uint64_t>> &(const IndexSchema::Stats &) const>
           get_result_cnt_func) const;
 
-  void OnFlushDBEnded(RedisModuleCtx *ctx);
-  void OnSwapDB(RedisModuleSwapDbInfo *swap_db_info);
+  void OnFlushDBEnded(ValkeyModuleCtx *ctx);
+  void OnSwapDB(ValkeyModuleSwapDbInfo *swap_db_info);
 
-  void OnLoadingEnded(RedisModuleCtx *ctx)
+  void OnLoadingEnded(ValkeyModuleCtx *ctx)
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
-  void OnReplicationLoadStart(RedisModuleCtx *ctx);
+  void OnReplicationLoadStart(ValkeyModuleCtx *ctx);
 
-  void PerformBackfill(RedisModuleCtx *ctx, uint32_t batch_size)
+  void PerformBackfill(ValkeyModuleCtx *ctx, uint32_t batch_size)
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
 
-  void OnFlushDBCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+  void OnFlushDBCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                          uint64_t subevent, void *data)
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
 
-  void OnLoadingCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+  void OnLoadingCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                          uint64_t subevent, void *data);
 
-  void OnServerCronCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+  void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                             uint64_t subevent, void *data);
 
   static void InitInstance(std::unique_ptr<SchemaManager> instance);
   static SchemaManager &Instance();
 
-  absl::Status LoadIndex(RedisModuleCtx *ctx,
+  absl::Status LoadIndex(ValkeyModuleCtx *ctx,
                          std::unique_ptr<data_model::RDBSection> section,
                          SupplementalContentIter &&supplemental_iter);
-  absl::Status SaveIndexes(RedisModuleCtx *ctx, SafeRDB *rdb, int when);
+  absl::Status SaveIndexes(ValkeyModuleCtx *ctx, SafeRDB *rdb, int when);
 
  private:
   absl::Status RemoveAll()
@@ -122,7 +122,7 @@ class SchemaManager {
   absl::AnyInvocable<void()> server_events_subscriber_callback_;
   bool is_subscribed_to_server_events_ = false;
   vmsdk::ThreadPool *mutations_thread_pool_;
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
 
   static absl::StatusOr<uint64_t> ComputeFingerprint(
       const google::protobuf::Any &metadata);
@@ -131,7 +131,7 @@ class SchemaManager {
       ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
 
   absl::Status CreateIndexSchemaInternal(
-      RedisModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto)
+      ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto)
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(db_to_index_schemas_mutex_);
   absl::StatusOr<std::shared_ptr<IndexSchema>> RemoveIndexSchemaInternal(
       uint32_t db_num, absl::string_view name)

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -38,17 +38,17 @@
 
 namespace valkey_search::server_events {
 
-void OnForkChildCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+void OnForkChildCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                          uint64_t subevent, void *data) {
   ValkeySearch::Instance().OnForkChildCallback(ctx, eid, subevent, data);
 }
 
-void OnFlushDBCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+void OnFlushDBCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                        uint64_t subevent, void *data) {
   SchemaManager::Instance().OnFlushDBCallback(ctx, eid, subevent, data);
 }
 
-void OnLoadingCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+void OnLoadingCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                        uint64_t subevent, void *data) {
   SchemaManager::Instance().OnLoadingCallback(ctx, eid, subevent, data);
   if (coordinator::MetadataManager::IsInitialized()) {
@@ -57,12 +57,12 @@ void OnLoadingCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
   }
 }
 
-void OnSwapDBCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+void OnSwapDBCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                       uint64_t subevent, void *data) {
-  SchemaManager::Instance().OnSwapDB((RedisModuleSwapDbInfo *)data);
+  SchemaManager::Instance().OnSwapDB((ValkeyModuleSwapDbInfo *)data);
 }
 
-void OnServerCronCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                           uint64_t subevent, void *data) {
   ValkeySearch::Instance().OnServerCronCallback(ctx, eid, subevent, data);
   SchemaManager::Instance().OnServerCronCallback(ctx, eid, subevent, data);
@@ -82,18 +82,18 @@ void SubscribeToServerEvents() {
   // prevent unexpected behavior. If multiple events are subscribed to in
   // different places, the engine will only call the callback for the first
   // subscriber and the other will silently be ignored.
-  RedisModuleCtx *ctx = ValkeySearch::Instance().GetBackgroundCtx();
-  RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_CronLoop,
-                                     &OnServerCronCallback);
+  ValkeyModuleCtx *ctx = ValkeySearch::Instance().GetBackgroundCtx();
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_CronLoop,
+                                      &OnServerCronCallback);
   pthread_atfork(AtForkPrepare, AfterForkParent, nullptr);
-  RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_ForkChild,
-                                     &OnForkChildCallback);
-  RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_Loading,
-                                     &OnLoadingCallback);
-  RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_SwapDB,
-                                     &OnSwapDBCallback);
-  RedisModule_SubscribeToServerEvent(ctx, RedisModuleEvent_FlushDB,
-                                     &OnFlushDBCallback);
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_ForkChild,
+                                      &OnForkChildCallback);
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_Loading,
+                                      &OnLoadingCallback);
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_SwapDB,
+                                      &OnSwapDBCallback);
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_FlushDB,
+                                      &OnFlushDBCallback);
 }
 
 }  // namespace valkey_search::server_events

--- a/src/utils/lru.h
+++ b/src/utils/lru.h
@@ -38,7 +38,7 @@ namespace valkey_search {
 template <typename T>
 class LRU {
  public:
-  explicit LRU(size_t capacity) : capacity_(capacity){};
+  explicit LRU(size_t capacity) : capacity_(capacity) {};
   T *InsertAtTop(T *node);
   void Promote(T *node);
   void Remove(T *node);

--- a/src/utils/string_interning.h
+++ b/src/utils/string_interning.h
@@ -83,7 +83,7 @@ class InternedString {
   // It is intended for cases where an API requires a `StringIntern` object
   // but interning is unnecessary or inefficient. For example, this applies
   // when fetching data from remote nodes.
-  InternedString(absl::string_view str) : InternedString(str, false){};
+  InternedString(absl::string_view str) : InternedString(str, false) {};
 
   ~InternedString();
 

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -102,17 +102,17 @@ static std::string ConvertToMB(double bytes_value) {
   return absl::StrCat(converted_mb, "M");
 }
 
-void ModuleInfo(RedisModuleInfoCtx *ctx, int for_crash_report) {
+void ModuleInfo(ValkeyModuleInfoCtx *ctx, int for_crash_report) {
   ValkeySearch::Instance().Info(ctx, for_crash_report);
 }
 
-void AddLatencyStat(RedisModuleInfoCtx *ctx, absl::string_view stat_name,
+void AddLatencyStat(ValkeyModuleInfoCtx *ctx, absl::string_view stat_name,
                     vmsdk::LatencySampler &sampler) {
   // Latency stats are excluded unless they have values, following Valkey engine
   // logic.
   if (sampler.HasSamples()) {
-    RedisModule_InfoAddFieldCString(ctx, stat_name.data(),
-                                    sampler.GetStatsString().c_str());
+    ValkeyModule_InfoAddFieldCString(ctx, stat_name.data(),
+                                     sampler.GetStatsString().c_str());
   }
 }
 /* Note: ValkeySearch::Info may be invoked during a crashdump by the engine.
@@ -122,69 +122,69 @@ void AddLatencyStat(RedisModuleInfoCtx *ctx, absl::string_view stat_name,
  *   2. Performing heap allocations
  *   3. Requiring execution on the main thread
  */
-void ValkeySearch::Info(RedisModuleInfoCtx *ctx, bool for_crash_report) const {
-  RedisModule_InfoAddSection(ctx, "memory");
-  RedisModule_InfoAddFieldLongLong(ctx, "used_memory_bytes",
-                                   vmsdk::GetUsedMemoryCnt());
-  RedisModule_InfoAddFieldCString(
+void ValkeySearch::Info(ValkeyModuleInfoCtx *ctx, bool for_crash_report) const {
+  ValkeyModule_InfoAddSection(ctx, "memory");
+  ValkeyModule_InfoAddFieldLongLong(ctx, "used_memory_bytes",
+                                    vmsdk::GetUsedMemoryCnt());
+  ValkeyModule_InfoAddFieldCString(
       ctx, "used_memory_human", ConvertToMB(vmsdk::GetUsedMemoryCnt()).c_str());
   if (!for_crash_report) {
-    RedisModule_InfoAddSection(ctx, "index_stats");
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddSection(ctx, "index_stats");
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "number_of_indexes",
         SchemaManager::Instance().GetNumberOfIndexSchemas());
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "number_of_attributes",
         SchemaManager::Instance().GetNumberOfAttributes());
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "total_indexed_documents",
         SchemaManager::Instance().GetTotalIndexedDocuments());
 
-    RedisModule_InfoAddSection(ctx, "ingestion");
-    RedisModule_InfoAddFieldCString(
+    ValkeyModule_InfoAddSection(ctx, "ingestion");
+    ValkeyModule_InfoAddFieldCString(
         ctx, "background_indexing_status",
         SchemaManager::Instance().IsIndexingInProgress() ? "IN_PROGRESS"
                                                          : "NO_ACTIVITY");
   }
-  RedisModule_InfoAddSection(ctx, "thread-pool");
-  RedisModule_InfoAddFieldLongLong(ctx, "query_queue_size",
-                                   reader_thread_pool_->QueueSize());
-  RedisModule_InfoAddFieldLongLong(ctx, "writer_queue_size",
-                                   writer_thread_pool_->QueueSize());
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddSection(ctx, "thread-pool");
+  ValkeyModule_InfoAddFieldLongLong(ctx, "query_queue_size",
+                                    reader_thread_pool_->QueueSize());
+  ValkeyModule_InfoAddFieldLongLong(ctx, "writer_queue_size",
+                                    writer_thread_pool_->QueueSize());
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "worker_pool_suspend_cnt",
       Metrics::GetStats().worker_thread_pool_suspend_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "writer_resumed_cnt",
       Metrics::GetStats().writer_worker_thread_pool_resumed_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "reader_resumed_cnt",
       Metrics::GetStats().reader_worker_thread_pool_resumed_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "writer_suspension_expired_cnt",
       Metrics::GetStats().writer_worker_thread_pool_suspension_expired_cnt);
 
-  RedisModule_InfoAddSection(ctx, "rdb");
-  RedisModule_InfoAddFieldLongLong(ctx, "rdb_load_success_cnt",
-                                   Metrics::GetStats().rdb_load_success_cnt);
-  RedisModule_InfoAddFieldLongLong(ctx, "rdb_load_failure_cnt",
-                                   Metrics::GetStats().rdb_load_failure_cnt);
-  RedisModule_InfoAddFieldLongLong(ctx, "rdb_save_success_cnt",
-                                   Metrics::GetStats().rdb_save_success_cnt);
-  RedisModule_InfoAddFieldLongLong(ctx, "rdb_save_failure_cnt",
-                                   Metrics::GetStats().rdb_save_failure_cnt);
+  ValkeyModule_InfoAddSection(ctx, "rdb");
+  ValkeyModule_InfoAddFieldLongLong(ctx, "rdb_load_success_cnt",
+                                    Metrics::GetStats().rdb_load_success_cnt);
+  ValkeyModule_InfoAddFieldLongLong(ctx, "rdb_load_failure_cnt",
+                                    Metrics::GetStats().rdb_load_failure_cnt);
+  ValkeyModule_InfoAddFieldLongLong(ctx, "rdb_save_success_cnt",
+                                    Metrics::GetStats().rdb_save_success_cnt);
+  ValkeyModule_InfoAddFieldLongLong(ctx, "rdb_save_failure_cnt",
+                                    Metrics::GetStats().rdb_save_failure_cnt);
 
-  RedisModule_InfoAddSection(ctx, "query");
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddSection(ctx, "query");
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "successful_requests_count",
       Metrics::GetStats().query_successful_requests_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "failure_requests_count",
       Metrics::GetStats().query_failed_requests_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "hybrid_requests_count",
       Metrics::GetStats().query_hybrid_requests_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "inline_filtering_requests_count",
       Metrics::GetStats().query_inline_filtering_requests_cnt);
 
@@ -198,15 +198,15 @@ void ValkeySearch::Info(RedisModuleInfoCtx *ctx, bool for_crash_report) const {
       std::string skipped_count_str =
           section_name + "_" + std::string("skipped_count");
 
-      RedisModule_InfoAddFieldLongLong(ctx, successful_count_str.c_str(),
-                                       stat.success_cnt);
-      RedisModule_InfoAddFieldLongLong(ctx, failure_count_str.c_str(),
-                                       stat.failure_cnt);
-      RedisModule_InfoAddFieldLongLong(ctx, skipped_count_str.c_str(),
-                                       stat.skipped_cnt);
+      ValkeyModule_InfoAddFieldLongLong(ctx, successful_count_str.c_str(),
+                                        stat.success_cnt);
+      ValkeyModule_InfoAddFieldLongLong(ctx, failure_count_str.c_str(),
+                                        stat.failure_cnt);
+      ValkeyModule_InfoAddFieldLongLong(ctx, skipped_count_str.c_str(),
+                                        stat.skipped_cnt);
     };
 #ifdef DEBUG_INFO
-    RedisModule_InfoAddSection(ctx, "subscription");
+    ValkeyModule_InfoAddSection(ctx, "subscription");
     InfoResultCnt(
         SchemaManager::Instance().AccumulateIndexSchemaResults(
             [](const IndexSchema::Stats &stats)
@@ -227,58 +227,58 @@ void ValkeySearch::Info(RedisModuleInfoCtx *ctx, bool for_crash_report) const {
         "remove_subscription");
 #endif
   }
-  RedisModule_InfoAddSection(ctx, "hnswlib");
-  RedisModule_InfoAddFieldLongLong(ctx, "hnsw_add_exceptions_count",
-                                   Metrics::GetStats().hnsw_add_exceptions_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddSection(ctx, "hnswlib");
+  ValkeyModule_InfoAddFieldLongLong(
+      ctx, "hnsw_add_exceptions_count",
+      Metrics::GetStats().hnsw_add_exceptions_cnt);
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "hnsw_remove_exceptions_count",
       Metrics::GetStats().hnsw_remove_exceptions_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "hnsw_modify_exceptions_count",
       Metrics::GetStats().hnsw_modify_exceptions_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "hnsw_search_exceptions_count",
       Metrics::GetStats().hnsw_search_exceptions_cnt);
-  RedisModule_InfoAddFieldLongLong(
+  ValkeyModule_InfoAddFieldLongLong(
       ctx, "hnsw_create_exceptions_count",
       Metrics::GetStats().hnsw_create_exceptions_cnt);
 
-  RedisModule_InfoAddSection(ctx, "latency");
+  ValkeyModule_InfoAddSection(ctx, "latency");
   AddLatencyStat(ctx, "hnsw_vector_index_search_latency_usec",
                  Metrics::GetStats().hnsw_vector_index_search_latency);
   AddLatencyStat(ctx, "flat_vector_index_search_latency_usec",
                  Metrics::GetStats().flat_vector_index_search_latency);
 
   if (UsingCoordinator()) {
-    RedisModule_InfoAddSection(ctx, "coordinator");
-    RedisModule_InfoAddFieldLongLong(
-        ctx, "coordinator_server_listening_port",
-        GetCoordinatorServer()->GetPort());
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddSection(ctx, "coordinator");
+    ValkeyModule_InfoAddFieldLongLong(ctx, "coordinator_server_listening_port",
+                                      GetCoordinatorServer()->GetPort());
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_server_get_global_metadata_success_count",
         Metrics::GetStats().coordinator_server_get_global_metadata_success_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_server_get_global_metadata_failure_count",
         Metrics::GetStats().coordinator_server_get_global_metadata_failure_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_server_search_index_partition_success_count",
         Metrics::GetStats()
             .coordinator_server_search_index_partition_success_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_server_search_index_partition_failure_count",
         Metrics::GetStats()
             .coordinator_server_search_index_partition_failure_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_client_get_global_metadata_success_count",
         Metrics::GetStats().coordinator_client_get_global_metadata_success_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_client_get_global_metadata_failure_count",
         Metrics::GetStats().coordinator_client_get_global_metadata_failure_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_client_search_index_partition_success_count",
         Metrics::GetStats()
             .coordinator_client_search_index_partition_success_cnt);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "coordinator_client_search_index_partition_failure_count",
         Metrics::GetStats()
             .coordinator_client_search_index_partition_failure_cnt);
@@ -316,25 +316,27 @@ void ValkeySearch::Info(RedisModuleInfoCtx *ctx, bool for_crash_report) const {
             .coordinator_server_search_index_partition_failure_latency);
   }
   if (!for_crash_report) {
-    RedisModule_InfoAddSection(ctx, "string_interning");
-    RedisModule_InfoAddFieldLongLong(ctx, "string_interning_store_size",
-                                     StringInternStore::Instance().Size());
+    ValkeyModule_InfoAddSection(ctx, "string_interning");
+    ValkeyModule_InfoAddFieldLongLong(ctx, "string_interning_store_size",
+                                      StringInternStore::Instance().Size());
 
-    RedisModule_InfoAddSection(ctx, "vector_externing");
+    ValkeyModule_InfoAddSection(ctx, "vector_externing");
     auto vector_externing_stats = VectorExternalizer::Instance().GetStats();
-    RedisModule_InfoAddFieldLongLong(ctx, "vector_externing_entry_count",
-                                     vector_externing_stats.entry_cnt);
-    RedisModule_InfoAddFieldLongLong(ctx, "vector_externing_hash_extern_errors",
-                                     vector_externing_stats.hash_extern_errors);
-    RedisModule_InfoAddFieldLongLong(
+    ValkeyModule_InfoAddFieldLongLong(ctx, "vector_externing_entry_count",
+                                      vector_externing_stats.entry_cnt);
+    ValkeyModule_InfoAddFieldLongLong(
+        ctx, "vector_externing_hash_extern_errors",
+        vector_externing_stats.hash_extern_errors);
+    ValkeyModule_InfoAddFieldLongLong(
         ctx, "vector_externing_generated_value_cnt",
         vector_externing_stats.generated_value_cnt);
-    RedisModule_InfoAddFieldLongLong(ctx, "vector_externing_num_lru_entries",
-                                     vector_externing_stats.num_lru_entries);
-    RedisModule_InfoAddFieldLongLong(ctx, "vector_externing_lru_promote_cnt",
-                                     vector_externing_stats.lru_promote_cnt);
-    RedisModule_InfoAddFieldLongLong(ctx, "vector_externing_deferred_entry_cnt",
-                                     vector_externing_stats.deferred_entry_cnt);
+    ValkeyModule_InfoAddFieldLongLong(ctx, "vector_externing_num_lru_entries",
+                                      vector_externing_stats.num_lru_entries);
+    ValkeyModule_InfoAddFieldLongLong(ctx, "vector_externing_lru_promote_cnt",
+                                      vector_externing_stats.lru_promote_cnt);
+    ValkeyModule_InfoAddFieldLongLong(
+        ctx, "vector_externing_deferred_entry_cnt",
+        vector_externing_stats.deferred_entry_cnt);
   }
 }
 
@@ -387,8 +389,8 @@ void ValkeySearch::AfterForkParent() {
                               << status.message();
 }
 
-void ValkeySearch::OnServerCronCallback(RedisModuleCtx *ctx,
-                                        [[maybe_unused]] RedisModuleEvent eid,
+void ValkeySearch::OnServerCronCallback(ValkeyModuleCtx *ctx,
+                                        [[maybe_unused]] ValkeyModuleEvent eid,
                                         [[maybe_unused]] uint64_t subevent,
                                         [[maybe_unused]] void *data) {
   // Clean-up after threads that exited without being "joined"
@@ -407,58 +409,59 @@ void ValkeySearch::OnServerCronCallback(RedisModuleCtx *ctx,
   }
 }
 
-void ValkeySearch::OnForkChildCallback(RedisModuleCtx *ctx,
-                                       [[maybe_unused]] RedisModuleEvent eid,
+void ValkeySearch::OnForkChildCallback(ValkeyModuleCtx *ctx,
+                                       [[maybe_unused]] ValkeyModuleEvent eid,
                                        uint64_t subevent,
                                        [[maybe_unused]] void *data) {
-  if (subevent & REDISMODULE_SUBEVENT_FORK_CHILD_DIED) {
+  if (subevent & VALKEYMODULE_SUBEVENT_FORK_CHILD_DIED) {
     ResumeWriterThreadPool(ctx, /*is_expired=*/false);
   }
 }
 
-absl::StatusOr<std::string> GetConfigGetReply(RedisModuleCtx *ctx, const char *config) {
-  auto reply = vmsdk::UniquePtrRedisCallReply(
-    RedisModule_Call(ctx, "CONFIG", "cc", "GET", config));
+absl::StatusOr<std::string> GetConfigGetReply(ValkeyModuleCtx *ctx,
+                                              const char *config) {
+  auto reply = vmsdk::UniquePtrValkeyCallReply(
+      ValkeyModule_Call(ctx, "CONFIG", "cc", "GET", config));
   if (reply == nullptr) {
     return absl::InternalError(
-      absl::StrFormat("Failed to get config: %s", config));
+        absl::StrFormat("Failed to get config: %s", config));
   }
-  RedisModuleCallReply *config_reply =
-    RedisModule_CallReplyArrayElement(reply.get(), 1);
+  ValkeyModuleCallReply *config_reply =
+      ValkeyModule_CallReplyArrayElement(reply.get(), 1);
 
   size_t reply_len;
-  const char *reply_str = RedisModule_CallReplyStringPtr(config_reply, &reply_len);
+  const char *reply_str =
+      ValkeyModule_CallReplyStringPtr(config_reply, &reply_len);
   return std::string(reply_str, reply_len);
 }
 
-
-absl::StatusOr<int> GetRedisLocalPort(RedisModuleCtx *ctx) {
+absl::StatusOr<int> GetValkeyLocalPort(ValkeyModuleCtx *ctx) {
   int port = -1;
   VMSDK_ASSIGN_OR_RETURN(auto tls_port_str, GetConfigGetReply(ctx, "tls-port"));
   if (!absl::SimpleAtoi(tls_port_str, &port)) {
     return absl::InternalError(
-      absl::StrFormat("Failed to parse port: %s", tls_port_str));
+        absl::StrFormat("Failed to parse port: %s", tls_port_str));
   }
   if (port == 0) {
     VMSDK_ASSIGN_OR_RETURN(auto port_str, GetConfigGetReply(ctx, "port"));
     if (!absl::SimpleAtoi(port_str, &port)) {
       return absl::InternalError(
-        absl::StrFormat("Failed to parse port: %s", port_str));
+          absl::StrFormat("Failed to parse port: %s", port_str));
     }
   }
 
   if (port < 0) {
-    return absl::InternalError("Redis port is negative");
+    return absl::InternalError("Valkey port is negative");
   }
   if (coordinator::GetCoordinatorPort(port) > 65535) {
     return absl::FailedPreconditionError(
-        "Coordinator port is too large, Redis port must be less than or equal "
+        "Coordinator port is too large, Valkey port must be less than or equal "
         "to 45241 (max port of 65535 minus coordinator offset of 20294).");
   }
   return port;
 }
 
-absl::Status ValkeySearch::Startup(RedisModuleCtx *ctx) {
+absl::Status ValkeySearch::Startup(ValkeyModuleCtx *ctx) {
   reader_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
       "read-worker-", options::GetReaderThreadCount().GetValue());
   reader_thread_pool_->StartWorkers();
@@ -477,7 +480,7 @@ absl::Status ValkeySearch::Startup(RedisModuleCtx *ctx) {
 
   if (options::GetUseCoordinator().GetValue() && IsCluster()) {
     client_pool_ = std::make_unique<coordinator::ClientPool>(
-        vmsdk::MakeUniqueRedisDetachedThreadSafeContext(ctx));
+        vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(ctx));
     coordinator::MetadataManager::InitInstance(
         std::make_unique<coordinator::MetadataManager>(ctx, *client_pool_));
     coordinator::MetadataManager::Instance().RegisterForClusterMessages(ctx);
@@ -486,8 +489,8 @@ absl::Status ValkeySearch::Startup(RedisModuleCtx *ctx) {
       ctx, server_events::SubscribeToServerEvents, writer_thread_pool_.get(),
       options::GetUseCoordinator().GetValue() && IsCluster()));
   if (options::GetUseCoordinator().GetValue()) {
-    VMSDK_ASSIGN_OR_RETURN(auto redis_port, GetRedisLocalPort(ctx));
-    auto coordinator_port = coordinator::GetCoordinatorPort(redis_port);
+    VMSDK_ASSIGN_OR_RETURN(auto valkey_port, GetValkeyLocalPort(ctx));
+    auto coordinator_port = coordinator::GetCoordinatorPort(valkey_port);
     coordinator_ = coordinator::ServerImpl::Create(
         ctx, reader_thread_pool_.get(), coordinator_port);
     if (coordinator_ == nullptr) {
@@ -497,7 +500,7 @@ absl::Status ValkeySearch::Startup(RedisModuleCtx *ctx) {
   return absl::OkStatus();
 }
 
-void ValkeySearch::ResumeWriterThreadPool(RedisModuleCtx *ctx,
+void ValkeySearch::ResumeWriterThreadPool(ValkeyModuleCtx *ctx,
                                           bool is_expired) {
   auto status = writer_thread_pool_->ResumeWorkers();
   auto msg =
@@ -520,9 +523,9 @@ void ValkeySearch::ResumeWriterThreadPool(RedisModuleCtx *ctx,
   writer_thread_pool_suspend_watch_ = std::nullopt;
 }
 
-absl::Status ValkeySearch::OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                  int argc) {
-  ctx_ = RedisModule_GetDetachedThreadSafeContext(ctx);
+absl::Status ValkeySearch::OnLoad(ValkeyModuleCtx *ctx,
+                                  ValkeyModuleString **argv, int argc) {
+  ctx_ = ValkeyModule_GetDetachedThreadSafeContext(ctx);
 
   // Register a single module type for Aux load/save callbacks.
   VMSDK_RETURN_IF_ERROR(RegisterModuleType(ctx));
@@ -531,7 +534,7 @@ absl::Status ValkeySearch::OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
   VMSDK_RETURN_IF_ERROR(ModuleConfigManager::Instance().Init(ctx));
 
   // Load configurations to initialize registered configs
-  if (RedisModule_LoadConfigs(ctx) != REDISMODULE_OK) {
+  if (ValkeyModule_LoadConfigs(ctx) != VALKEYMODULE_OK) {
     return absl::InternalError("Failed to load configurations");
   }
 
@@ -539,10 +542,10 @@ absl::Status ValkeySearch::OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
   VMSDK_RETURN_IF_ERROR(LoadAndParseArgv(ctx, argv, argc));
   VMSDK_RETURN_IF_ERROR(Startup(ctx));
 
-  RedisModule_SetModuleOptions(
-      ctx, REDISMODULE_OPTIONS_HANDLE_IO_ERRORS |
-               REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
-               REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED);
+  ValkeyModule_SetModuleOptions(
+      ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS |
+               VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
+               VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED);
   VMSDK_LOG(NOTICE, ctx) << "Json module is "
                          << (IsJsonModuleLoaded(ctx) ? "" : "not ")
                          << "loaded!";
@@ -551,8 +554,8 @@ absl::Status ValkeySearch::OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv,
   return absl::OkStatus();
 }
 
-absl::Status ValkeySearch::LoadAndParseArgv(RedisModuleCtx *ctx,
-                                            RedisModuleString **argv,
+absl::Status ValkeySearch::LoadAndParseArgv(ValkeyModuleCtx *ctx,
+                                            ValkeyModuleString **argv,
                                             int argc) {
   VMSDK_RETURN_IF_ERROR(
       vmsdk::config::ModuleConfigManager::Instance().ParseAndLoadArgv(ctx, argv,
@@ -571,12 +574,12 @@ absl::Status ValkeySearch::LoadAndParseArgv(RedisModuleCtx *ctx,
 }
 
 bool ValkeySearch::IsChildProcess() {
-  const auto flags = RedisModule_GetContextFlags(nullptr);
-  return flags & REDISMODULE_CTX_FLAGS_IS_CHILD;
+  const auto flags = ValkeyModule_GetContextFlags(nullptr);
+  return flags & VALKEYMODULE_CTX_FLAGS_IS_CHILD;
 }
 
-void ValkeySearch::OnUnload(RedisModuleCtx *ctx) {
-  RedisModule_FreeThreadSafeContext(ctx_);
+void ValkeySearch::OnUnload(ValkeyModuleCtx *ctx) {
+  ValkeyModule_FreeThreadSafeContext(ctx_);
   reader_thread_pool_ = nullptr;
 }
 

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -68,20 +68,20 @@ class ValkeySearch {
   vmsdk::ThreadPool *GetWriterThreadPool() const {
     return writer_thread_pool_.get();
   }
-  void Info(RedisModuleInfoCtx *ctx, bool for_crash_report) const;
+  void Info(ValkeyModuleInfoCtx *ctx, bool for_crash_report) const;
 
   IndexSchema::Stats::ResultCnt<uint64_t> AccumulateIndexSchemaResults(
       absl::AnyInvocable<const IndexSchema::Stats::ResultCnt<
           std::atomic<uint64_t>> &(const IndexSchema::Stats &) const>
           get_result_cnt_func) const;
-  void OnServerCronCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+  void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                             uint64_t subevent, void *data);
-  void OnForkChildCallback(RedisModuleCtx *ctx, RedisModuleEvent eid,
+  void OnForkChildCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                            uint64_t subevent, void *data);
-  void OnClusterMessageCallback(RedisModuleCtx *ctx, const char *sender_id,
+  void OnClusterMessageCallback(ValkeyModuleCtx *ctx, const char *sender_id,
                                 uint8_t type, const unsigned char *payload,
                                 uint32_t len);
-  void SendMetadataBroadcast(RedisModuleCtx *ctx, void *data);
+  void SendMetadataBroadcast(ValkeyModuleCtx *ctx, void *data);
   void AtForkPrepare();
   void AfterForkParent();
   static ValkeySearch &Instance();
@@ -90,14 +90,15 @@ class ValkeySearch {
   uint32_t GetHNSWBlockSize() const;
   void SetHNSWBlockSize(uint32_t block_size);
 
-  absl::Status OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc);
-  void OnUnload(RedisModuleCtx *ctx);
+  absl::Status OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
+                      int argc);
+  void OnUnload(ValkeyModuleCtx *ctx);
   friend absl::NoDestructor<ValkeySearch>;
 
   bool UsingCoordinator() const { return coordinator_ != nullptr; }
   bool IsCluster() const {
-    return RedisModule_GetContextFlags(GetBackgroundCtx()) &
-           REDISMODULE_CTX_FLAGS_CLUSTER;
+    return ValkeyModule_GetContextFlags(GetBackgroundCtx()) &
+           VALKEYMODULE_CTX_FLAGS_CLUSTER;
   }
 
   coordinator::ClientPool *GetCoordinatorClientPool() const {
@@ -113,10 +114,10 @@ class ValkeySearch {
   void SetCoordinatorServer(std::unique_ptr<coordinator::Server> server) {
     coordinator_ = std::move(server);
   }
-  // GetBackgroundCtx returns a RedisModuleCtx that is valid for the scope of
+  // GetBackgroundCtx returns a ValkeyModuleCtx that is valid for the scope of
   // the module lifetime. Getting this context should be safe for the duration
   // of the program.
-  RedisModuleCtx *GetBackgroundCtx() const { return ctx_; }
+  ValkeyModuleCtx *GetBackgroundCtx() const { return ctx_; }
 
  protected:
   std::unique_ptr<vmsdk::ThreadPool> reader_thread_pool_;
@@ -124,25 +125,26 @@ class ValkeySearch {
   virtual size_t GetMaxWorkerThreadPoolSuspensionSec() const;
 
  private:
-  absl::Status Startup(RedisModuleCtx *ctx);
-  absl::Status LoadAndParseArgv(RedisModuleCtx *ctx, RedisModuleString **argv,
+  absl::Status Startup(ValkeyModuleCtx *ctx);
+  absl::Status LoadAndParseArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                                 int argc);
 
-  static void *RDBLoad(RedisModuleIO *rdb, int encoding_version);
+  static void *RDBLoad(ValkeyModuleIO *rdb, int encoding_version);
   static void FreeIndexSchema(void *value);
   static bool IsChildProcess();
-  void ProcessIndexSchemaBackfill(RedisModuleCtx *ctx, uint32_t batch_size);
-  void ResumeWriterThreadPool(RedisModuleCtx *ctx, bool is_expired);
-  absl::StatusOr<std::string> GetConfigGetReply(RedisModuleCtx *ctx, const char* config);
+  void ProcessIndexSchemaBackfill(ValkeyModuleCtx *ctx, uint32_t batch_size);
+  void ResumeWriterThreadPool(ValkeyModuleCtx *ctx, bool is_expired);
+  absl::StatusOr<std::string> GetConfigGetReply(ValkeyModuleCtx *ctx,
+                                                const char *config);
 
   uint64_t inc_id_{0};
-  RedisModuleCtx *ctx_{nullptr};
+  ValkeyModuleCtx *ctx_{nullptr};
   std::optional<vmsdk::StopWatch> writer_thread_pool_suspend_watch_;
 
   std::unique_ptr<coordinator::Server> coordinator_;
   std::unique_ptr<coordinator::ClientPool> client_pool_;
 };
-void ModuleInfo(RedisModuleInfoCtx *ctx, int for_crash_report);
+void ModuleInfo(ValkeyModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search
 
 #endif  // VALKEYSEARCH_SRC_VALKEY_SEARCH_H_

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -85,10 +85,10 @@ namespace config = vmsdk::config;
 
 // Register an enumerator for the log level
 static const std::vector<std::string_view> kLogLevelNames = {
-    REDISMODULE_LOGLEVEL_WARNING,
-    REDISMODULE_LOGLEVEL_NOTICE,
-    REDISMODULE_LOGLEVEL_VERBOSE,
-    REDISMODULE_LOGLEVEL_DEBUG,
+    VALKEYMODULE_LOGLEVEL_WARNING,
+    VALKEYMODULE_LOGLEVEL_NOTICE,
+    VALKEYMODULE_LOGLEVEL_VERBOSE,
+    VALKEYMODULE_LOGLEVEL_DEBUG,
 };
 
 static const std::vector<int> kLogLevelValues = {
@@ -132,8 +132,8 @@ static auto writer_threads_count =
 /// Should this instance use coordinator?
 static auto use_coordinator =
     config::BooleanBuilder(kUseCoordinator, false)
-        .WithFlags(REDISMODULE_CONFIG_HIDDEN)  // can only be set during
-                                               // start-up
+        .WithFlags(VALKEYMODULE_CONFIG_HIDDEN)  // can only be set during
+                                                // start-up
         .Build();
 
 /// Control the modules log level verbosity

--- a/src/vector_externalizer.h
+++ b/src/vector_externalizer.h
@@ -104,14 +104,14 @@ class VectorExternalizer {
   void LRUPromote(LRUCacheEntry* entry);
   LRUCacheEntry* LRUAdd(LRUCacheEntry* entry);
   void LRURemove(LRUCacheEntry* entry);
-  void Init(RedisModuleCtx* ctx);
-  RedisModuleCtx* GetCtx() const {
+  void Init(ValkeyModuleCtx* ctx);
+  ValkeyModuleCtx* GetCtx() const {
     CHECK(ctx_.Get());
     return ctx_.Get().get();
   }
-  vmsdk::UniqueRedisString GetRecord(
-      RedisModuleCtx* ctx, const AttributeDataType* attribute_data_type,
-      RedisModuleKey* key_obj, absl::string_view key_cstr,
+  vmsdk::UniqueValkeyString GetRecord(
+      ValkeyModuleCtx* ctx, const AttributeDataType* attribute_data_type,
+      ValkeyModuleKey* key_obj, absl::string_view key_cstr,
       absl::string_view attribute_identifier, bool& is_module_owned);
 
   // Used for testing.
@@ -128,7 +128,7 @@ class VectorExternalizer {
       deferred_shared_vectors_;
   vmsdk::MainThreadAccessGuard<std::unique_ptr<LRU<LRUCacheEntry>>> lru_cache_;
   vmsdk::MainThreadAccessGuard<Stats> stats_;
-  vmsdk::MainThreadAccessGuard<vmsdk::UniqueRedisDetachedThreadSafeContext>
+  vmsdk::MainThreadAccessGuard<vmsdk::UniqueValkeyDetachedThreadSafeContext>
       ctx_;
   size_t EntriesCnt() const;
   size_t PendingEntriesCnt() const;

--- a/testing/attribute_data_type_test.cc
+++ b/testing/attribute_data_type_test.cc
@@ -68,15 +68,15 @@ class HashAttributeDataTypeTest
   void SetUp() override {
     ValkeySearchTestWithParam<
         ::testing::tuple<bool, bool, FetchAllRecordsTestCase>>::SetUp();
-    exists_key = vmsdk::MakeUniqueRedisString(std::string("exists_key"));
+    exists_key = vmsdk::MakeUniqueValkeyString(std::string("exists_key"));
     not_exists_key =
-        vmsdk::MakeUniqueRedisString(std::string("not_exists_key"));
-    EXPECT_CALL(*kMockRedisModule, OpenKey(&fake_ctx, testing::_, testing::_))
-        .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
+        vmsdk::MakeUniqueValkeyString(std::string("not_exists_key"));
+    EXPECT_CALL(*kMockValkeyModule, OpenKey(&fake_ctx, testing::_, testing::_))
+        .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
     opened_exists_key =
-        vmsdk::MakeUniqueRedisOpenKey(&fake_ctx, exists_key.get(), 0);
+        vmsdk::MakeUniqueValkeyOpenKey(&fake_ctx, exists_key.get(), 0);
     opened_not_exists_key =
-        vmsdk::MakeUniqueRedisOpenKey(&fake_ctx, not_exists_key.get(), 0);
+        vmsdk::MakeUniqueValkeyOpenKey(&fake_ctx, not_exists_key.get(), 0);
   }
   void TearDown() override {
     exists_key = nullptr;
@@ -86,20 +86,20 @@ class HashAttributeDataTypeTest
     ValkeySearchTestWithParam<
         ::testing::tuple<bool, bool, FetchAllRecordsTestCase>>::TearDown();
   }
-  RedisModuleCtx fake_ctx;
-  vmsdk::UniqueRedisString exists_key;
-  vmsdk::UniqueRedisString not_exists_key;
-  vmsdk::UniqueRedisOpenKey opened_exists_key;
-  vmsdk::UniqueRedisOpenKey opened_not_exists_key;
+  ValkeyModuleCtx fake_ctx;
+  vmsdk::UniqueValkeyString exists_key;
+  vmsdk::UniqueValkeyString not_exists_key;
+  vmsdk::UniqueValkeyOpenKey opened_exists_key;
+  vmsdk::UniqueValkeyOpenKey opened_not_exists_key;
   absl::string_view exists_identifier{"exists_identifier"};
   absl::string_view not_exists_identifier{"not_exists_identifier"};
   HashAttributeDataType hash_attribute_data_type;
 };
 
 TEST_F(HashAttributeDataTypeTest, HashBasic) {
-  EXPECT_EQ(hash_attribute_data_type.GetRedisEventTypes(),
-            REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_GENERIC |
-                REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED);
+  EXPECT_EQ(hash_attribute_data_type.GetValkeyEventTypes(),
+            VALKEYMODULE_NOTIFY_HASH | VALKEYMODULE_NOTIFY_GENERIC |
+                VALKEYMODULE_NOTIFY_EXPIRED | VALKEYMODULE_NOTIFY_EVICTED);
 
   EXPECT_EQ(hash_attribute_data_type.ToProto(),
             data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH);
@@ -112,15 +112,15 @@ TEST_F(HashAttributeDataTypeTest, HashHasRecord) {
     for (auto expect_exists_identifier : {true, false}) {
       absl::string_view identifier =
           expect_exists_identifier ? exists_identifier : not_exists_identifier;
-      EXPECT_CALL(*kMockRedisModule,
+      EXPECT_CALL(*kMockValkeyModule,
                   HashGet(testing::_,
-                          REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXISTS,
+                          VALKEYMODULE_HASH_CFIELDS | VALKEYMODULE_HASH_EXISTS,
                           testing::_, An<int *>(), TypedEq<void *>(nullptr)))
-          .WillOnce([&](RedisModuleKey *key, int flags, const char *identifier,
+          .WillOnce([&](ValkeyModuleKey *key, int flags, const char *identifier,
                         int *exists_out, void *terminating_null) {
             *exists_out = opened_exists_key.get() == key &&
                           absl::string_view(identifier) == exists_identifier;
-            return REDISMODULE_OK;
+            return VALKEYMODULE_OK;
           });
 
       EXPECT_EQ(HashHasRecord(key, identifier),
@@ -131,18 +131,18 @@ TEST_F(HashAttributeDataTypeTest, HashHasRecord) {
 
 TEST_F(HashAttributeDataTypeTest, HashGetRecord) {
   for (auto expect_found_record : {true, false}) {
-    RedisModuleString *found_record =
+    ValkeyModuleString *found_record =
         expect_found_record
-            ? TestRedisModule_CreateStringPrintf(nullptr, "found_record")
+            ? TestValkeyModule_CreateStringPrintf(nullptr, "found_record")
             : nullptr;
-    EXPECT_CALL(*kMockRedisModule,
-                HashGet(testing::_, REDISMODULE_HASH_CFIELDS, testing::_,
-                        An<RedisModuleString **>(), TypedEq<void *>(nullptr)))
+    EXPECT_CALL(*kMockValkeyModule,
+                HashGet(testing::_, VALKEYMODULE_HASH_CFIELDS, testing::_,
+                        An<ValkeyModuleString **>(), TypedEq<void *>(nullptr)))
         .WillOnce([found_record](
-                      RedisModuleKey *key, int flags, const char *field,
-                      RedisModuleString **value_out, void *terminating_null) {
+                      ValkeyModuleKey *key, int flags, const char *field,
+                      ValkeyModuleString **value_out, void *terminating_null) {
           *value_out = found_record;
-          return REDISMODULE_OK;
+          return VALKEYMODULE_OK;
         });
     auto record = hash_attribute_data_type.GetRecord(
         &fake_ctx, opened_exists_key.get(),
@@ -186,37 +186,38 @@ TEST_P(HashAttributeDataTypeTest, HashFetchAllRecords) {
   auto expect_exists_identifier = std::get<1>(params);
   const FetchAllRecordsTestCase &test_case = std::get<2>(params);
   auto key = expect_exists_key ? exists_key.get() : not_exists_key.get();
-  EXPECT_CALL(*kMockRedisModule, OpenKey(&fake_ctx, testing::_, testing::_))
-      .WillOnce([&](RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(&fake_ctx, testing::_, testing::_))
+      .WillOnce([&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
         return vmsdk::ToStringView(key) == vmsdk::ToStringView(exists_key.get())
-                   ? TestRedisModule_OpenKeyDefaultImpl(&fake_ctx,
-                                                        exists_key.get(), 0)
+                   ? TestValkeyModule_OpenKeyDefaultImpl(&fake_ctx,
+                                                         exists_key.get(), 0)
                    : nullptr;
       });
   absl::string_view identifier =
       expect_exists_identifier ? exists_identifier : not_exists_identifier;
   // Needed to make sure that the mocked fields/values generated by ScanKey
   // outlive the lifetime of the returned RecordMap
-  std::list<vmsdk::UniqueRedisString> values;
-  std::list<vmsdk::UniqueRedisString> fields;
+  std::list<vmsdk::UniqueValkeyString> values;
+  std::list<vmsdk::UniqueValkeyString> fields;
   auto itr = test_case.expected_records_map.begin();
   if (expect_exists_key) {
-    EXPECT_CALL(
-        *kMockRedisModule,
-        HashGet(testing::_, REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXISTS,
-                testing::_, An<int *>(), TypedEq<void *>(nullptr)))
-        .WillOnce([&](RedisModuleKey *key, int flags, const char *identifier,
+    EXPECT_CALL(*kMockValkeyModule,
+                HashGet(testing::_,
+                        VALKEYMODULE_HASH_CFIELDS | VALKEYMODULE_HASH_EXISTS,
+                        testing::_, An<int *>(), TypedEq<void *>(nullptr)))
+        .WillOnce([&](ValkeyModuleKey *key, int flags, const char *identifier,
                       int *exists_out, void *terminating_null) {
           *exists_out = absl::string_view(identifier) == exists_identifier;
-          return REDISMODULE_OK;
+          return VALKEYMODULE_OK;
         });
     if (expect_exists_identifier) {
-      EXPECT_CALL(*kMockRedisModule,
-                  ScanKey(An<RedisModuleKey *>(), An<RedisModuleScanCursor *>(),
-                          An<RedisModuleScanKeyCB>(), An<void *>()))
-          .WillRepeatedly([&](RedisModuleKey *key,
-                              RedisModuleScanCursor *scan_cursor,
-                              RedisModuleScanKeyCB fn, void *privdata) {
+      EXPECT_CALL(
+          *kMockValkeyModule,
+          ScanKey(An<ValkeyModuleKey *>(), An<ValkeyModuleScanCursor *>(),
+                  An<ValkeyModuleScanKeyCB>(), An<void *>()))
+          .WillRepeatedly([&](ValkeyModuleKey *key,
+                              ValkeyModuleScanCursor *scan_cursor,
+                              ValkeyModuleScanKeyCB fn, void *privdata) {
             if (itr == test_case.expected_records_map.end()) {
               return 0;
             }
@@ -224,8 +225,8 @@ TEST_P(HashAttributeDataTypeTest, HashFetchAllRecords) {
             if (itr->first == identifier) {
               value = HexStringToBinary(itr->second);
             }
-            fields.push_back(vmsdk::MakeUniqueRedisString(itr->first));
-            values.push_back(vmsdk::MakeUniqueRedisString(value));
+            fields.push_back(vmsdk::MakeUniqueValkeyString(itr->first));
+            values.push_back(vmsdk::MakeUniqueValkeyString(value));
             fn(key, fields.back().get(), values.back().get(), privdata);
             itr++;
             return 1;
@@ -295,45 +296,45 @@ class JsonAttributeDataTypeTest
     : public ValkeySearchTestWithParam<
           ::testing::tuple<bool, FetchAllRecordsTestCase>> {
  protected:
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   JsonAttributeDataType json_attribute_data_type;
 };
 
 TEST_F(JsonAttributeDataTypeTest, JsonBasic) {
-  EXPECT_EQ(json_attribute_data_type.GetRedisEventTypes(),
-            REDISMODULE_NOTIFY_MODULE | REDISMODULE_NOTIFY_GENERIC |
-                REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED);
+  EXPECT_EQ(json_attribute_data_type.GetValkeyEventTypes(),
+            VALKEYMODULE_NOTIFY_MODULE | VALKEYMODULE_NOTIFY_GENERIC |
+                VALKEYMODULE_NOTIFY_EXPIRED | VALKEYMODULE_NOTIFY_EVICTED);
 
   EXPECT_EQ(json_attribute_data_type.ToProto(),
             data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON);
 }
 
 void CheckJsonGetRecord(
-    RedisModuleCtx &fake_ctx, absl::string_view identifier,
+    ValkeyModuleCtx &fake_ctx, absl::string_view identifier,
     int module_reply_type,
     const absl::flat_hash_map<std::string, std::string> &json_path_results) {
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               Call(&fake_ctx, testing::StrEq(kJsonCmd), testing::StrEq("cc"),
                    testing::_, testing::StrEq(identifier)))
       .WillOnce([identifier, json_path_results, module_reply_type](
-                    RedisModuleCtx *ctx, const char *cmd, const char *fmt,
+                    ValkeyModuleCtx *ctx, const char *cmd, const char *fmt,
                     const char *arg1,
-                    const char *arg2) -> RedisModuleCallReply * {
+                    const char *arg2) -> ValkeyModuleCallReply * {
         if (!json_path_results.contains(identifier)) {
           return nullptr;
         }
-        auto reply = new RedisModuleCallReply;
+        auto reply = new ValkeyModuleCallReply;
         reply->msg = json_path_results.at(identifier);
-        EXPECT_CALL(*kMockRedisModule, FreeCallReply(reply))
-            .WillOnce([](RedisModuleCallReply *reply) { delete reply; });
-        EXPECT_CALL(*kMockRedisModule, CallReplyType(reply))
-            .WillOnce([module_reply_type](RedisModuleCallReply *reply) {
+        EXPECT_CALL(*kMockValkeyModule, FreeCallReply(reply))
+            .WillOnce([](ValkeyModuleCallReply *reply) { delete reply; });
+        EXPECT_CALL(*kMockValkeyModule, CallReplyType(reply))
+            .WillOnce([module_reply_type](ValkeyModuleCallReply *reply) {
               return module_reply_type;
             });
-        if (module_reply_type == REDISMODULE_REPLY_STRING) {
-          EXPECT_CALL(*kMockRedisModule, CreateStringFromCallReply(reply))
-              .WillOnce([](RedisModuleCallReply *reply) {
-                return vmsdk::MakeUniqueRedisString(
+        if (module_reply_type == VALKEYMODULE_REPLY_STRING) {
+          EXPECT_CALL(*kMockValkeyModule, CreateStringFromCallReply(reply))
+              .WillOnce([](ValkeyModuleCallReply *reply) {
+                return vmsdk::MakeUniqueValkeyString(
                            absl::string_view(reply->msg))
                     .release();
               });
@@ -349,8 +350,8 @@ TEST_F(JsonAttributeDataTypeTest, JsonGetRecord) {
       {"json_path_results2", "res2"}};
   absl::flat_hash_set<std::string> identifiers{"$", "false"};
   for (const auto &identifier : identifiers) {
-    for (int module_reply_type = REDISMODULE_REPLY_UNKNOWN;
-         module_reply_type < REDISMODULE_REPLY_ATTRIBUTE * 2;
+    for (int module_reply_type = VALKEYMODULE_REPLY_UNKNOWN;
+         module_reply_type < VALKEYMODULE_REPLY_ATTRIBUTE * 2;
          module_reply_type++) {
       CheckJsonGetRecord(fake_ctx, identifier, module_reply_type,
                          json_path_results);
@@ -358,12 +359,12 @@ TEST_F(JsonAttributeDataTypeTest, JsonGetRecord) {
                                                        "key", identifier);
       if (record.ok()) {
         EXPECT_TRUE(json_path_results.contains(identifier));
-        EXPECT_EQ(module_reply_type, REDISMODULE_REPLY_STRING);
+        EXPECT_EQ(module_reply_type, VALKEYMODULE_REPLY_STRING);
         EXPECT_EQ(vmsdk::ToStringView(record.value().get()),
                   TrimBrackets(json_path_results[identifier]));
       } else {
         EXPECT_FALSE(json_path_results.contains(identifier) &&
-                     module_reply_type == REDISMODULE_REPLY_STRING);
+                     module_reply_type == VALKEYMODULE_REPLY_STRING);
         EXPECT_EQ(record.status().code(), absl::StatusCode::kNotFound);
       }
     }
@@ -375,33 +376,33 @@ TEST_P(JsonAttributeDataTypeTest, JsonFetchAllRecords) {
       {"$", "[res0]"},
       {"json_path_results1", "[res1]"},
       {"json_path_results2", "[res2]"}};
-  RedisModuleCallReply reply;
+  ValkeyModuleCallReply reply;
   auto &params = GetParam();
   auto expect_exists_key = std::get<0>(params);
   const FetchAllRecordsTestCase &test_case = std::get<1>(params);
   std::string query_attribute_name = "vector_json_path";
-  for (int module_reply_type = REDISMODULE_REPLY_UNKNOWN;
-       module_reply_type < REDISMODULE_REPLY_ATTRIBUTE * 2;
+  for (int module_reply_type = VALKEYMODULE_REPLY_UNKNOWN;
+       module_reply_type < VALKEYMODULE_REPLY_ATTRIBUTE * 2;
        module_reply_type++) {
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         Call(&fake_ctx, testing::StrEq(kJsonCmd), testing::StrEq("cc"),
              testing::StrEq("key"), testing::StrEq(query_attribute_name)))
-        .WillOnce([&](RedisModuleCtx *ctx, const char *cmd, const char *fmt,
+        .WillOnce([&](ValkeyModuleCtx *ctx, const char *cmd, const char *fmt,
                       const char *arg1,
-                      const char *arg2) -> RedisModuleCallReply * {
+                      const char *arg2) -> ValkeyModuleCallReply * {
           if (!expect_exists_key) {
             return nullptr;
           }
-          EXPECT_CALL(*kMockRedisModule, FreeCallReply(&reply))
-              .WillOnce([](RedisModuleCallReply *reply) {});
+          EXPECT_CALL(*kMockValkeyModule, FreeCallReply(&reply))
+              .WillOnce([](ValkeyModuleCallReply *reply) {});
           return &reply;
         });
     if (expect_exists_key) {
-      EXPECT_CALL(*kMockRedisModule, CallReplyType(&reply))
+      EXPECT_CALL(*kMockValkeyModule, CallReplyType(&reply))
           .WillOnce(
-              [&](RedisModuleCallReply *reply) { return module_reply_type; });
-      if (module_reply_type == REDISMODULE_REPLY_STRING) {
+              [&](ValkeyModuleCallReply *reply) { return module_reply_type; });
+      if (module_reply_type == VALKEYMODULE_REPLY_STRING) {
         if (test_case.identifiers.empty()) {
           CheckJsonGetRecord(fake_ctx, kJsonRootElementQuery, module_reply_type,
                              json_path_results);
@@ -417,11 +418,11 @@ TEST_P(JsonAttributeDataTypeTest, JsonFetchAllRecords) {
     auto records = json_attribute_data_type.FetchAllRecords(
         &fake_ctx, query_attribute_name, "key", identifiers);
     if (records.ok()) {
-      EXPECT_EQ(module_reply_type, REDISMODULE_REPLY_STRING);
+      EXPECT_EQ(module_reply_type, VALKEYMODULE_REPLY_STRING);
       EXPECT_EQ(ToStringMap(records.value()), test_case.expected_records_map);
     } else {
       EXPECT_FALSE(expect_exists_key &&
-                   module_reply_type == REDISMODULE_REPLY_STRING);
+                   module_reply_type == VALKEYMODULE_REPLY_STRING);
       EXPECT_EQ(records.status().code(), absl::StatusCode::kNotFound);
     }
   }

--- a/testing/common.cc
+++ b/testing/common.cc
@@ -89,7 +89,7 @@ void TestableValkeySearch::InitThreadPools(std::optional<size_t> readers,
 }
 
 absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateVectorHNSWSchema(
-    std::string index_schema_key, RedisModuleCtx *fake_ctx,
+    std::string index_schema_key, ValkeyModuleCtx *fake_ctx,
     vmsdk::ThreadPool *writer_thread_pool,
     const std::vector<absl::string_view> *key_prefixes,
     int32_t index_schema_db_num) {
@@ -110,11 +110,11 @@ absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateVectorHNSWSchema(
 }
 
 absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateIndexSchema(
-    std::string index_schema_key, RedisModuleCtx *fake_ctx,
+    std::string index_schema_key, ValkeyModuleCtx *fake_ctx,
     vmsdk::ThreadPool *writer_thread_pool,
     const std::vector<absl::string_view> *key_prefixes,
     int32_t index_schema_db_num) {
-  RedisModuleCtx local_fake_ctx;
+  ValkeyModuleCtx local_fake_ctx;
   if (fake_ctx == nullptr) {
     fake_ctx = &local_fake_ctx;
   }
@@ -122,9 +122,9 @@ absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateIndexSchema(
   if (key_prefixes == nullptr) {
     key_prefixes = &local_key_prefixes;
   }
-  ON_CALL(*kMockRedisModule, GetSelectedDb(fake_ctx))
+  ON_CALL(*kMockValkeyModule, GetSelectedDb(fake_ctx))
       .WillByDefault(testing::Return(index_schema_db_num));
-  EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(testing::_))
+  EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
       .WillRepeatedly(testing::Return(fake_ctx));
   VMSDK_ASSIGN_OR_RETURN(
       auto test_index_schema,
@@ -176,12 +176,12 @@ indexes::Neighbor ToIndexesNeighbor(const NeighborTest &neighbor_test) {
     for (const auto &attribute_contents :
          neighbor_test.attribute_contents.value()) {
       auto attribute_alias =
-          vmsdk::MakeUniqueRedisString(attribute_contents.first);
+          vmsdk::MakeUniqueValkeyString(attribute_contents.first);
       neighbor.attribute_contents.value().emplace(
           vmsdk::ToStringView(attribute_alias.get()),
           RecordsMapValue(
               std::move(attribute_alias),
-              vmsdk::MakeUniqueRedisString(attribute_contents.second)));
+              vmsdk::MakeUniqueValkeyString(attribute_contents.second)));
     }
   }
   return neighbor;
@@ -206,8 +206,8 @@ query::ReturnAttribute ToReturnAttribute(
     const TestReturnAttribute &test_return_attribute) {
   return query::ReturnAttribute{
       .identifier =
-          vmsdk::MakeUniqueRedisString(test_return_attribute.identifier),
-      .alias = vmsdk::MakeUniqueRedisString(test_return_attribute.alias)};
+          vmsdk::MakeUniqueValkeyString(test_return_attribute.identifier),
+      .alias = vmsdk::MakeUniqueValkeyString(test_return_attribute.alias)};
 }
 
 std::unordered_map<std::string, std::string> ToStringMap(

--- a/testing/coordinator/metadata_manager_test.cc
+++ b/testing/coordinator/metadata_manager_test.cc
@@ -101,19 +101,19 @@ struct EntryOperationTestParam {
 class EntryOperationTest
     : public ValkeySearchTestWithParam<EntryOperationTestParam> {
  public:
-  RedisModuleCtx* fake_ctx = reinterpret_cast<RedisModuleCtx*>(0xBADF00D0);
+  ValkeyModuleCtx* fake_ctx = reinterpret_cast<ValkeyModuleCtx*>(0xBADF00D0);
   std::unique_ptr<MetadataManager> test_metadata_manager_;
   std::unique_ptr<ClientPool> test_client_pool_;
 
  protected:
   void SetUp() override {
     ValkeySearchTestWithParam::SetUp();
-    ON_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
         .WillByDefault(testing::Return(fake_ctx));
-    ON_CALL(*kMockRedisModule, FreeThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, FreeThreadSafeContext(testing::_))
         .WillByDefault(testing::Return());
     test_client_pool_ = std::make_unique<ClientPool>(
-        vmsdk::UniqueRedisDetachedThreadSafeContext(fake_ctx));
+        vmsdk::UniqueValkeyDetachedThreadSafeContext(fake_ctx));
     test_metadata_manager_ =
         std::make_unique<MetadataManager>(fake_ctx, *test_client_pool_);
   }
@@ -144,15 +144,15 @@ TEST_P(EntryOperationTest, TestEntryOperations) {
         });
   }
   if (test_case.expect_num_broadcasts > 0) {
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 SendClusterMessage(
                     fake_ctx, nullptr,
                     coordinator::kMetadataBroadcastClusterMessageReceiverId,
                     testing::_, testing::_))
         .Times(test_case.expect_num_broadcasts)
-        .WillRepeatedly(testing::Return(REDISMODULE_OK));
+        .WillRepeatedly(testing::Return(VALKEYMODULE_OK));
   } else {
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 SendClusterMessage(
                     fake_ctx, nullptr,
                     coordinator::kMetadataBroadcastClusterMessageReceiverId,
@@ -497,9 +497,9 @@ class MetadataManagerReconciliationTest
   void SetUp() override {
     ValkeySearchTestWithParam::SetUp();
     mock_client_pool_ = std::make_unique<MockClientPool>();
-    ON_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
         .WillByDefault(testing::Return(&fake_ctx_));
-    ON_CALL(*kMockRedisModule, FreeThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, FreeThreadSafeContext(testing::_))
         .WillByDefault(testing::Return());
     auto test_metadata_manager =
         std::make_unique<MetadataManager>(&fake_ctx_, *mock_client_pool_);
@@ -565,14 +565,14 @@ TEST_P(MetadataManagerReconciliationTest, TestReconciliation) {
   }
 
   if (test_case.expect_broadcast) {
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 SendClusterMessage(
                     &fake_ctx_, nullptr,
                     coordinator::kMetadataBroadcastClusterMessageReceiverId,
                     testing::_, testing::_))
-        .WillOnce(testing::Return(REDISMODULE_OK));
+        .WillOnce(testing::Return(VALKEYMODULE_OK));
   } else {
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 SendClusterMessage(
                     &fake_ctx_, nullptr,
                     coordinator::kMetadataBroadcastClusterMessageReceiverId,
@@ -582,7 +582,7 @@ TEST_P(MetadataManagerReconciliationTest, TestReconciliation) {
 
   std::string sender_id = "fake_sender";
   // Pad the sender id to meet to expected node id length
-  sender_id += std::string(REDISMODULE_NODE_ID_LEN - sender_id.length(), 'a');
+  sender_id += std::string(VALKEYMODULE_NODE_ID_LEN - sender_id.length(), 'a');
   std::string sender_ip = "127.0.0.1";
   int sender_port = 1234;
   int sender_coordinator_port = sender_port + 20294;
@@ -590,21 +590,21 @@ TEST_P(MetadataManagerReconciliationTest, TestReconciliation) {
       absl::StrCat(sender_ip, ":", sender_coordinator_port);
   if (test_case.expect_get_cluster_node_info) {
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         GetClusterNodeInfo(&fake_ctx_, testing::StrEq(sender_id), testing::_,
                            testing::_, testing::_, testing::_))
-        .WillOnce([&](RedisModuleCtx* ctx, const char* sender_id, char* ip,
+        .WillOnce([&](ValkeyModuleCtx* ctx, const char* sender_id, char* ip,
                       char* master_id, int* port, int* flags) {
           if (test_case.fail_get_cluster_node_info) {
-            return REDISMODULE_ERR;
+            return VALKEYMODULE_ERR;
           }
           memcpy(ip, sender_ip.c_str(), sender_ip.length() + 1);
           *port = sender_port;
-          return REDISMODULE_OK;
+          return VALKEYMODULE_OK;
         });
   } else {
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         GetClusterNodeInfo(&fake_ctx_, testing::StrEq(sender_id), testing::_,
                            testing::_, testing::_, testing::_))
         .Times(0);
@@ -1575,19 +1575,19 @@ INSTANTIATE_TEST_SUITE_P(
       return info.param.test_name;
     });
 
-class MetadataManagerTest : public vmsdk::RedisTest {
+class MetadataManagerTest : public vmsdk::ValkeyTest {
  public:
-  RedisModuleCtx* fake_ctx = reinterpret_cast<RedisModuleCtx*>(0xBADF00D0);
+  ValkeyModuleCtx* fake_ctx = reinterpret_cast<ValkeyModuleCtx*>(0xBADF00D0);
   std::unique_ptr<MetadataManager> test_metadata_manager_;
   std::unique_ptr<MockClientPool> mock_client_pool_;
 
  protected:
   void SetUp() override {
-    vmsdk::RedisTest::SetUp();
+    vmsdk::ValkeyTest::SetUp();
     mock_client_pool_ = std::make_unique<MockClientPool>();
-    ON_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
         .WillByDefault(testing::Return(fake_ctx));
-    ON_CALL(*kMockRedisModule, FreeThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, FreeThreadSafeContext(testing::_))
         .WillByDefault(testing::Return());
     test_metadata_manager_ =
         std::make_unique<MetadataManager>(fake_ctx, *mock_client_pool_);
@@ -1595,7 +1595,7 @@ class MetadataManagerTest : public vmsdk::RedisTest {
   void TearDown() override {
     test_metadata_manager_.reset();
     mock_client_pool_.reset();
-    vmsdk::RedisTest::TearDown();
+    vmsdk::ValkeyTest::TearDown();
   }
 };
 
@@ -1620,12 +1620,12 @@ TEST_F(MetadataManagerTest, TestBroadcastMetadata) {
   std::string version_header_str =
       existing_metadata.version_header().SerializeAsString();
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SendClusterMessage(
           fake_ctx, nullptr,
           coordinator::kMetadataBroadcastClusterMessageReceiverId,
           testing::StrEq(version_header_str), version_header_str.size()))
-      .WillOnce(testing::Return(REDISMODULE_OK));
+      .WillOnce(testing::Return(VALKEYMODULE_OK));
 
   test_metadata_manager_->BroadcastMetadata(fake_ctx);
 }
@@ -1779,7 +1779,7 @@ TEST_F(MetadataManagerTest, TestSave) {
       MetadataManager::ComputeTopLevelFingerprint(
           existing_metadata.type_namespace_map()));
 
-  auto fake_rdb_io = reinterpret_cast<RedisModuleIO*>(0xBADF00D1);
+  auto fake_rdb_io = reinterpret_cast<ValkeyModuleIO*>(0xBADF00D1);
   SafeRDB fake_rdb(fake_rdb_io);
   auto section = std::make_unique<data_model::RDBSection>();
   section->set_type(data_model::RDB_SECTION_GLOBAL_METADATA);
@@ -1792,24 +1792,24 @@ TEST_F(MetadataManagerTest, TestSave) {
   test_metadata_manager_->OnLoadingEnded(fake_ctx);
 
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SaveStringBuffer(fake_rdb_io,
                        testing::StrEq(expected_section.SerializeAsString()),
                        expected_section.SerializeAsString().size()))
       .Times(1);
   VMSDK_EXPECT_OK(test_metadata_manager_->SaveMetadata(
-      fake_ctx, &fake_rdb, REDISMODULE_AUX_AFTER_RDB));
+      fake_ctx, &fake_rdb, VALKEYMODULE_AUX_AFTER_RDB));
 }
 
 TEST_F(MetadataManagerTest, TestSaveWrongTimeIsNoOp) {
-  auto fake_rdb_io = reinterpret_cast<RedisModuleIO*>(0xBADF00D1);
-  EXPECT_CALL(*kMockRedisModule,
+  auto fake_rdb_io = reinterpret_cast<ValkeyModuleIO*>(0xBADF00D1);
+  EXPECT_CALL(*kMockValkeyModule,
               SaveStringBuffer(fake_rdb_io, testing::_, testing::_))
       .Times(0);
   SafeRDB fake_rdb(fake_rdb_io);
 
   VMSDK_EXPECT_OK(test_metadata_manager_->SaveMetadata(
-      fake_ctx, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      fake_ctx, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
 }
 
 }  // namespace valkey_search::coordinator

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -81,7 +81,7 @@ struct FTCreateParserTestCase {
 };
 
 class FTCreateParserTest
-    : public vmsdk::RedisTestWithParam<FTCreateParserTestCase> {};
+    : public vmsdk::ValkeyTestWithParam<FTCreateParserTestCase> {};
 
 void VerifyVectorParams(const data_model::VectorIndex &vector_index_proto,
                         const FTCreateVectorParameters *expected_params) {
@@ -103,7 +103,7 @@ TEST_P(FTCreateParserTest, ParseParams) {
                       "DISTANCE_METRIC IP ");
     }
   }
-  auto args = vmsdk::ToRedisStringVector(command_str);
+  auto args = vmsdk::ToValkeyStringVector(command_str);
   auto index_schema_proto =
       ParseFTCreateArgs(nullptr, args.data(), args.size());
   EXPECT_EQ(index_schema_proto.ok(), test_case.success);
@@ -198,7 +198,7 @@ TEST_P(FTCreateParserTest, ParseParams) {
               << "\n";
   }
   for (const auto &arg : args) {
-    TestRedisModule_FreeString(nullptr, arg);
+    TestValkeyModule_FreeString(nullptr, arg);
   }
 }
 

--- a/testing/ft_create_test.cc
+++ b/testing/ft_create_test.cc
@@ -68,14 +68,14 @@ class FTCreateTest : public ValkeySearchTestWithParam<FTCreateTestCase> {};
 TEST_P(FTCreateTest, FTCreateTests) {
   const FTCreateTestCase& test_case = GetParam();
   int db_num = 1;
-  ON_CALL(*kMockRedisModule, GetSelectedDb(&fake_ctx_))
+  ON_CALL(*kMockValkeyModule, GetSelectedDb(&fake_ctx_))
       .WillByDefault(testing::Return(db_num));
 
-  std::vector<RedisModuleString*> cmd_argv;
+  std::vector<ValkeyModuleString*> cmd_argv;
   std::transform(test_case.argv.begin(), test_case.argv.end(),
                  std::back_inserter(cmd_argv), [&](std::string val) {
-                   return TestRedisModule_CreateStringPrintf(&fake_ctx_, "%s",
-                                                             val.data());
+                   return TestValkeyModule_CreateStringPrintf(&fake_ctx_, "%s",
+                                                              val.data());
                  });
   EXPECT_EQ(vmsdk::CreateCommand<FTCreateCmd>(&fake_ctx_, cmd_argv.data(),
                                               cmd_argv.size()),
@@ -93,7 +93,7 @@ TEST_P(FTCreateTest, FTCreateTests) {
   VMSDK_EXPECT_OK(SchemaManager::Instance().RemoveIndexSchema(
       db_num, test_case.index_schema_name));
   for (auto cmd_arg : cmd_argv) {
-    TestRedisModule_FreeString(&fake_ctx_, cmd_arg);
+    TestValkeyModule_FreeString(&fake_ctx_, cmd_arg);
   }
 }
 
@@ -107,7 +107,7 @@ INSTANTIATE_TEST_SUITE_P(
                      "DIM", "100", "DISTANCE_METRIC", "IP", "EF_CONSTRUCTION",
                      "40", "INITIAL_CAP", "15000"},
             .index_schema_name = "test_index_schema",
-            .expected_run_return = REDISMODULE_OK,
+            .expected_run_return = VALKEYMODULE_OK,
             .expected_reply_message = "+OK\r\n",
             .expected_indexes =
                 {
@@ -131,7 +131,7 @@ INSTANTIATE_TEST_SUITE_P(
                      "40",        "INITIAL_CAP",
                      "15000"},
             .index_schema_name = "test_index_schema",
-            .expected_run_return = REDISMODULE_OK,
+            .expected_run_return = VALKEYMODULE_OK,
             .expected_reply_message = "+OK\r\n",
             .expected_indexes =
                 {
@@ -151,7 +151,7 @@ INSTANTIATE_TEST_SUITE_P(
                      "vector", "Flat", "8", "TYPE", "FLOAT32", "DIM", "100",
                      "DISTANCE_METRIC", "IP", "INITIAL_CAP", "15000"},
             .index_schema_name = "test_index_schema",
-            .expected_run_return = REDISMODULE_OK,
+            .expected_run_return = VALKEYMODULE_OK,
             .expected_reply_message = "+OK\r\n",
             .expected_indexes =
                 {
@@ -168,7 +168,7 @@ INSTANTIATE_TEST_SUITE_P(
                      "DISTANCE_METRIC", "IP", "INITIAL_CAP", "15000", "field1",
                      "tag", "separator", "|"},
             .index_schema_name = "test_index_schema",
-            .expected_run_return = REDISMODULE_OK,
+            .expected_run_return = VALKEYMODULE_OK,
             .expected_reply_message = "+OK\r\n",
             .expected_indexes =
                 {

--- a/testing/ft_dropindex_test.cc
+++ b/testing/ft_dropindex_test.cc
@@ -74,7 +74,7 @@ TEST_P(FTDropIndexTest, FTDropIndexTests) {
   for (bool use_thread_pool : {true, false}) {
     for (const auto& test_case : test_cases.test_cases) {
       // Set up the data structures for the test case.
-      RedisModuleCtx fake_ctx;
+      ValkeyModuleCtx fake_ctx;
       vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 5);
       SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
           &fake_ctx_, []() {},
@@ -95,11 +95,11 @@ TEST_P(FTDropIndexTest, FTDropIndexTests) {
       }
 
       // Run the command.
-      std::vector<RedisModuleString*> cmd_argv;
+      std::vector<ValkeyModuleString*> cmd_argv;
       std::transform(test_case.argv.begin(), test_case.argv.end(),
                      std::back_inserter(cmd_argv),
                      [&fake_ctx](std::string val) {
-                       return TestRedisModule_CreateStringPrintf(
+                       return TestValkeyModule_CreateStringPrintf(
                            &fake_ctx, "%s", val.data());
                      });
 
@@ -131,7 +131,7 @@ TEST_P(FTDropIndexTest, FTDropIndexTests) {
 
       // Clean up
       for (auto cmd_arg : cmd_argv) {
-        TestRedisModule_FreeString(&fake_ctx, cmd_arg);
+        TestValkeyModule_FreeString(&fake_ctx, cmd_arg);
       }
     }
   }

--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -75,7 +75,7 @@ TEST_P(FTInfoTest, FTInfoTests) {
 
   for (bool use_thread_pool : {true, false}) {
     for (const auto& test_case : test_cases.test_cases) {
-      fake_ctx_ = RedisModuleCtx{};
+      fake_ctx_ = ValkeyModuleCtx{};
       // Set up the data structures for the test case.
       vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 5);
       SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
@@ -91,20 +91,20 @@ TEST_P(FTInfoTest, FTInfoTests) {
       }
 
       if (test_case.expect_return_failure) {
-        EXPECT_CALL(*kMockRedisModule, ReplyWithError(&fake_ctx_, _))
-            .WillOnce(Return(REDISMODULE_OK));
+        EXPECT_CALL(*kMockValkeyModule, ReplyWithError(&fake_ctx_, _))
+            .WillOnce(Return(VALKEYMODULE_OK));
       }
 
       // Run the command.
-      std::vector<RedisModuleString*> cmd_argv;
+      std::vector<ValkeyModuleString*> cmd_argv;
       std::transform(test_case.argv.begin(), test_case.argv.end(),
                      std::back_inserter(cmd_argv), [&](std::string val) {
-                       return TestRedisModule_CreateStringPrintf(
+                       return TestValkeyModule_CreateStringPrintf(
                            &fake_ctx_, "%s", val.data());
                      });
       EXPECT_EQ(vmsdk::CreateCommand<FTInfoCmd>(&fake_ctx_, cmd_argv.data(),
                                                 cmd_argv.size()),
-                REDISMODULE_OK);
+                VALKEYMODULE_OK);
       EXPECT_EQ(fake_ctx_.reply_capture.GetReply(), test_case.expected_output);
 
       if (test_case.index_schema_pbtxt.has_value()) {
@@ -115,7 +115,7 @@ TEST_P(FTInfoTest, FTInfoTests) {
 
       // Clean up
       for (auto cmd_arg : cmd_argv) {
-        TestRedisModule_FreeString(&fake_ctx_, cmd_arg);
+        TestValkeyModule_FreeString(&fake_ctx_, cmd_arg);
       }
     }
   }

--- a/testing/ft_list_test.cc
+++ b/testing/ft_list_test.cc
@@ -52,7 +52,7 @@ class FTListTest : public ValkeySearchTest {};
 TEST_F(FTListTest, basic) {
   // Set up the data structures for the test case.
   for (bool use_thread_pool : {true, false}) {
-    RedisModuleCtx fake_ctx;
+    ValkeyModuleCtx fake_ctx;
     vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 5);
     SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
         &fake_ctx_, []() {}, use_thread_pool ? &mutations_thread_pool : nullptr,
@@ -103,7 +103,7 @@ TEST_F(FTListTest, basic) {
     VMSDK_EXPECT_OK(SchemaManager::Instance().CreateIndexSchema(
         &fake_ctx, different_db_index_schema));
 
-    EXPECT_CALL(*kMockRedisModule, GetSelectedDb(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetSelectedDb(&fake_ctx))
         .WillRepeatedly(testing::Return(0));
     VMSDK_EXPECT_OK(FTListCmd(&fake_ctx, nullptr, 0));
     EXPECT_THAT(fake_ctx.reply_capture.GetReply(),
@@ -119,7 +119,7 @@ TEST_F(FTListTest, basic) {
   }
 }
 TEST_F(FTListTest, no_indexes) {
-  EXPECT_CALL(*kMockRedisModule, ReplyWithArray(&fake_ctx_, 0));
+  EXPECT_CALL(*kMockValkeyModule, ReplyWithArray(&fake_ctx_, 0));
   VMSDK_EXPECT_OK(FTListCmd(&fake_ctx_, nullptr, 0));
 }
 

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -94,15 +94,15 @@ struct FTSearchParserTestCase {
 class FTSearchParserTest
     : public ValkeySearchTestWithParam<FTSearchParserTestCase> {};
 
-std::vector<RedisModuleString *> FloatToRedisStringVector(
+std::vector<ValkeyModuleString *> FloatToValkeyStringVector(
     const std::vector<float> &floats) {
-  std::vector<RedisModuleString *> ret;
+  std::vector<ValkeyModuleString *> ret;
   const absl::string_view blob_str = "BLOB";
   ret.push_back(
-      RedisModule_CreateString(nullptr, blob_str.data(), blob_str.size()));
+      ValkeyModule_CreateString(nullptr, blob_str.data(), blob_str.size()));
   std::string vector_str((char *)(&floats[0]), floats.size() * sizeof(float));
-  ret.push_back(
-      RedisModule_CreateString(nullptr, vector_str.c_str(), vector_str.size()));
+  ret.push_back(ValkeyModule_CreateString(nullptr, vector_str.c_str(),
+                                          vector_str.size()));
   return ret;
 }
 
@@ -121,16 +121,16 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   std::cerr << ", no_content: " << no_content << "\n";
 
   std::vector<float> floats = {0.1, 0.2, 0.3};
-  std::vector<RedisModuleString *> args;
+  std::vector<ValkeyModuleString *> args;
   const std::string key_str = "my_schema_name";
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   SchemaManager::InitInstance(
       std::make_unique<TestableSchemaManager>(&fake_ctx));
   auto index_schema = CreateIndexSchema(key_str, &fake_ctx).value();
   EXPECT_CALL(
-      *kMockRedisModule,
-      OpenKey(testing::_, testing::An<RedisModuleString *>(), testing::_))
-      .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
+      *kMockValkeyModule,
+      OpenKey(testing::_, testing::An<ValkeyModuleString *>(), testing::_))
+      .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
   data_model::VectorIndex vector_index_proto;
   vector_index_proto.set_dimension_count(3);
   vector_index_proto.set_initial_cap(100);
@@ -147,24 +147,24 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   VMSDK_EXPECT_OK(
       index_schema->AddIndex(test_case.attribute_alias, "id1", index));
   args.push_back(
-      RedisModule_CreateString(nullptr, key_str.data(), key_str.size()));
-  args.push_back(RedisModule_CreateString(nullptr, test_case.filter_str.data(),
-                                          test_case.filter_str.size()));
+      ValkeyModule_CreateString(nullptr, key_str.data(), key_str.size()));
+  args.push_back(ValkeyModule_CreateString(nullptr, test_case.filter_str.data(),
+                                           test_case.filter_str.size()));
   if (no_content) {
     const absl::string_view kNoContentParam = "NoContent";
-    args.push_back(RedisModule_CreateString(nullptr, kNoContentParam.data(),
-                                            kNoContentParam.size()));
+    args.push_back(ValkeyModule_CreateString(nullptr, kNoContentParam.data(),
+                                             kNoContentParam.size()));
   }
-  auto return_vec = vmsdk::ToRedisStringVector(test_case.return_str);
+  auto return_vec = vmsdk::ToValkeyStringVector(test_case.return_str);
   args.insert(args.end(), return_vec.begin(), return_vec.end());
   bool timeout_expected_success = true;
   if (timeout_ms.has_value()) {
     const absl::string_view kTimeoutParam = "Timeout";
-    args.push_back(RedisModule_CreateString(nullptr, kTimeoutParam.data(),
-                                            kTimeoutParam.size()));
+    args.push_back(ValkeyModule_CreateString(nullptr, kTimeoutParam.data(),
+                                             kTimeoutParam.size()));
     auto timeout_str = std::to_string(timeout_ms.value());
-    args.push_back(RedisModule_CreateString(nullptr, timeout_str.data(),
-                                            timeout_str.size()));
+    args.push_back(ValkeyModule_CreateString(nullptr, timeout_str.data(),
+                                             timeout_str.size()));
     if (timeout_ms.value() >= kMaxTimeoutMs + 1) {
       timeout_expected_success = false;
     }
@@ -172,30 +172,30 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   bool limit_expected_success = true;
   if (!kLimitOptions[limit_itr].second.empty()) {
     auto limit_vec =
-        vmsdk::ToRedisStringVector(kLimitOptions[limit_itr].second);
+        vmsdk::ToValkeyStringVector(kLimitOptions[limit_itr].second);
     args.insert(args.end(), limit_vec.begin(), limit_vec.end());
     limit_expected_success = kLimitOptions[limit_itr].first;
   }
-  auto params_vec = vmsdk::ToRedisStringVector(test_case.params_str);
+  auto params_vec = vmsdk::ToValkeyStringVector(test_case.params_str);
   args.insert(args.end(), params_vec.begin(), params_vec.end());
-  auto floats_vec = FloatToRedisStringVector(floats);
+  auto floats_vec = FloatToValkeyStringVector(floats);
   bool dialect_expected_success = true;
   args.insert(args.end(), floats_vec.begin(), floats_vec.end());
 
   auto search_parameters_vec =
-      vmsdk::ToRedisStringVector(test_case.search_parameters_str);
+      vmsdk::ToValkeyStringVector(test_case.search_parameters_str);
   args.insert(args.end(), search_parameters_vec.begin(),
               search_parameters_vec.end());
 
   if (!kDialectOptions[dialect_itr].second.empty()) {
     auto dialect_vec =
-        vmsdk::ToRedisStringVector(kDialectOptions[dialect_itr].second);
+        vmsdk::ToValkeyStringVector(kDialectOptions[dialect_itr].second);
     args.insert(args.end(), dialect_vec.begin(), dialect_vec.end());
     dialect_expected_success = kDialectOptions[dialect_itr].first;
   }
   if (add_end_unexpected_param) {
     args.push_back(
-        RedisModule_CreateString(nullptr, "END_UNEXPECTED_PARAM", 0));
+        ValkeyModule_CreateString(nullptr, "END_UNEXPECTED_PARAM", 0));
   }
   auto &schema_manager = SchemaManager::Instance();
 
@@ -220,7 +220,7 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
     EXPECT_EQ(search_params.value()->query, vector_str.c_str());
     EXPECT_EQ(search_params.value()->k, test_case.k);
     EXPECT_EQ(search_params.value()->ef, test_case.ef);
-    auto score_as = vmsdk::MakeUniqueRedisString(test_case.score_as);
+    auto score_as = vmsdk::MakeUniqueValkeyString(test_case.score_as);
     if (test_case.score_as.empty()) {
       score_as =
           index_schema->DefaultReplyScoreAs(test_case.attribute_alias).value();
@@ -272,7 +272,7 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
     }
   }
   for (const auto &arg : args) {
-    TestRedisModule_FreeString(nullptr, arg);
+    TestValkeyModule_FreeString(nullptr, arg);
   }
 }
 

--- a/testing/ft_search_test.cc
+++ b/testing/ft_search_test.cc
@@ -109,16 +109,16 @@ void SendReplyTest::DoSendReplyTest(
     const std::set<std::string> &hash_get_exclude_ids,
     const std::set<std::string> &open_key_exclude_ids,
     vmsdk::ThreadPool *mutations_thread_pool) {
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
       &fake_ctx, []() {}, mutations_thread_pool, false));
 
   const std::string attribute_id = "attribute_id";
-  EXPECT_CALL(*kMockRedisModule,
-              HashGet(An<RedisModuleKey *>(),
-                      REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXISTS,
+  EXPECT_CALL(*kMockValkeyModule,
+              HashGet(An<ValkeyModuleKey *>(),
+                      VALKEYMODULE_HASH_CFIELDS | VALKEYMODULE_HASH_EXISTS,
                       An<const char *>(), An<int *>(), An<void *>()))
-      .WillRepeatedly([&](RedisModuleKey *module_key, int flags,
+      .WillRepeatedly([&](ValkeyModuleKey *module_key, int flags,
                           const char *field, int *exists,
                           void *terminating_null) {
         *exists = 1;
@@ -127,14 +127,14 @@ void SendReplyTest::DoSendReplyTest(
         if (hash_get_exclude_ids.find(key_str) != hash_get_exclude_ids.end()) {
           *exists = 0;
         }
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
-  EXPECT_CALL(*kMockRedisModule,
-              ScanKey(An<RedisModuleKey *>(), An<RedisModuleScanCursor *>(),
-                      An<RedisModuleScanKeyCB>(), An<void *>()))
-      .WillRepeatedly([&](RedisModuleKey *key,
-                          RedisModuleScanCursor *scan_cursor,
-                          RedisModuleScanKeyCB fn, void *privdata) {
+  EXPECT_CALL(*kMockValkeyModule,
+              ScanKey(An<ValkeyModuleKey *>(), An<ValkeyModuleScanCursor *>(),
+                      An<ValkeyModuleScanKeyCB>(), An<void *>()))
+      .WillRepeatedly([&](ValkeyModuleKey *key,
+                          ValkeyModuleScanCursor *scan_cursor,
+                          ValkeyModuleScanKeyCB fn, void *privdata) {
         ++scan_cursor->cursor;
         if ((scan_cursor->cursor % 5) == 0) {
           return 0;
@@ -142,36 +142,36 @@ void SendReplyTest::DoSendReplyTest(
         if ((scan_cursor->cursor % 5) == 1) {
           static const absl::string_view field_str = "field1";
           static const absl::string_view value_str = "value1";
-          auto field = vmsdk::MakeUniqueRedisString(field_str);
-          auto value = vmsdk::MakeUniqueRedisString(value_str);
+          auto field = vmsdk::MakeUniqueValkeyString(field_str);
+          auto value = vmsdk::MakeUniqueValkeyString(value_str);
           fn(key, field.get(), value.get(), privdata);
           return 1;
         }
         if ((scan_cursor->cursor % 5) == 2) {
           std::string value2_str = input.attribute_alias + "_hash_value";
-          auto field = vmsdk::MakeUniqueRedisString(input.attribute_alias);
-          auto value = vmsdk::MakeUniqueRedisString(value2_str);
+          auto field = vmsdk::MakeUniqueValkeyString(input.attribute_alias);
+          auto value = vmsdk::MakeUniqueValkeyString(value2_str);
           fn(key, field.get(), value.get(), privdata);
           return 1;
         }
         if ((scan_cursor->cursor % 5) == 3) {
           static const absl::string_view field_str = "";
           static const absl::string_view value_str = "value1";
-          auto field = vmsdk::MakeUniqueRedisString(field_str);
-          auto value = vmsdk::MakeUniqueRedisString(value_str);
+          auto field = vmsdk::MakeUniqueValkeyString(field_str);
+          auto value = vmsdk::MakeUniqueValkeyString(value_str);
           fn(key, field.get(), value.get(), privdata);
           return 1;
         }
         fn(key, nullptr, nullptr, privdata);
         return 1;
       });
-  EXPECT_CALL(*kMockRedisModule,
-              OpenKey(&fake_ctx, An<RedisModuleString *>(), testing::_))
-      .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
+  EXPECT_CALL(*kMockValkeyModule,
+              OpenKey(&fake_ctx, An<ValkeyModuleString *>(), testing::_))
+      .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
   for (const auto &key : open_key_exclude_ids) {
     EXPECT_CALL(
-        *kMockRedisModule,
-        OpenKey(&fake_ctx, vmsdk::RedisModuleStringValueEq(key), testing::_))
+        *kMockValkeyModule,
+        OpenKey(&fake_ctx, vmsdk::ValkeyModuleStringValueEq(key), testing::_))
         .WillRepeatedly(testing::Return(nullptr));
   }
 
@@ -197,7 +197,7 @@ void SendReplyTest::DoSendReplyTest(
   auto parameters = std::make_unique<query::VectorSearchParameters>();
   parameters->index_schema = test_index_schema;
   parameters->attribute_alias = attribute_alias;
-  parameters->score_as = vmsdk::MakeUniqueRedisString(score_as);
+  parameters->score_as = vmsdk::MakeUniqueValkeyString(score_as);
   parameters->k = 20;
   parameters->limit = input.limit;
   parameters->no_content = no_content;
@@ -479,7 +479,7 @@ class FTSearchTest : public ValkeySearchTestWithParam<
 };
 
 std::string GetNodeId(int i) {
-  return std::string(REDISMODULE_NODE_ID_LEN, 'a' + i);
+  return std::string(VALKEYMODULE_NODE_ID_LEN, 'a' + i);
 }
 
 TEST_P(FTSearchTest, FTSearchTests) {
@@ -502,20 +502,20 @@ TEST_P(FTSearchTest, FTSearchTests) {
     ValkeySearch::Instance().SetCoordinatorServer(std::move(mock_server));
     std::vector<std::string> node_ids = {GetNodeId(0), GetNodeId(1),
                                          GetNodeId(2)};
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 GetClusterNodesList(testing::_, testing::An<size_t *>()))
-        .WillRepeatedly([node_ids](RedisModuleCtx *ctx, size_t *numnodes) {
+        .WillRepeatedly([node_ids](ValkeyModuleCtx *ctx, size_t *numnodes) {
           *numnodes = node_ids.size();
           char **res = new char *[3];
-          res[0] = new char[REDISMODULE_NODE_ID_LEN];
-          res[1] = new char[REDISMODULE_NODE_ID_LEN];
-          res[2] = new char[REDISMODULE_NODE_ID_LEN];
-          memcpy(res[0], node_ids[0].c_str(), REDISMODULE_NODE_ID_LEN);
-          memcpy(res[1], node_ids[1].c_str(), REDISMODULE_NODE_ID_LEN);
-          memcpy(res[2], node_ids[2].c_str(), REDISMODULE_NODE_ID_LEN);
+          res[0] = new char[VALKEYMODULE_NODE_ID_LEN];
+          res[1] = new char[VALKEYMODULE_NODE_ID_LEN];
+          res[2] = new char[VALKEYMODULE_NODE_ID_LEN];
+          memcpy(res[0], node_ids[0].c_str(), VALKEYMODULE_NODE_ID_LEN);
+          memcpy(res[1], node_ids[1].c_str(), VALKEYMODULE_NODE_ID_LEN);
+          memcpy(res[2], node_ids[2].c_str(), VALKEYMODULE_NODE_ID_LEN);
           return res;
         });
-    EXPECT_CALL(*kMockRedisModule, FreeClusterNodesList(testing::_))
+    EXPECT_CALL(*kMockValkeyModule, FreeClusterNodesList(testing::_))
         .WillRepeatedly([](char **ids) {
           delete[] ids[0];
           delete[] ids[1];
@@ -525,20 +525,20 @@ TEST_P(FTSearchTest, FTSearchTests) {
     for (size_t i = 0; i < node_ids.size(); ++i) {
       auto node_id = node_ids[i];
       EXPECT_CALL(
-          *kMockRedisModule,
+          *kMockValkeyModule,
           GetClusterNodeInfo(testing::_, testing::StrEq(node_id), testing::_,
                              testing::_, testing::_, testing::_))
-          .WillRepeatedly([i](RedisModuleCtx *ctx, const char *node_id,
+          .WillRepeatedly([i](ValkeyModuleCtx *ctx, const char *node_id,
                               char *ip, char *master_id, int *port,
                               int *flags) {
             memcpy(ip, "127.0.0.1", 9);
             *port = i;
             if (i == 0) {
-              *flags = REDISMODULE_NODE_MYSELF;
+              *flags = VALKEYMODULE_NODE_MYSELF;
             } else {
-              *flags = REDISMODULE_NODE_MASTER;
+              *flags = VALKEYMODULE_NODE_MASTER;
             }
-            return REDISMODULE_OK;
+            return VALKEYMODULE_OK;
           });
       if (i != 0) {
         auto mock_client = std::make_shared<coordinator::MockClient>();
@@ -561,23 +561,23 @@ TEST_P(FTSearchTest, FTSearchTests) {
     }
   }
   const FTSearchTestCase &test_case = std::get<2>(params);
-  EXPECT_CALL(*kMockRedisModule,
-              HashGet(An<RedisModuleKey *>(),
-                      REDISMODULE_HASH_CFIELDS | REDISMODULE_HASH_EXISTS,
+  EXPECT_CALL(*kMockValkeyModule,
+              HashGet(An<ValkeyModuleKey *>(),
+                      VALKEYMODULE_HASH_CFIELDS | VALKEYMODULE_HASH_EXISTS,
                       An<const char *>(), An<int *>(), An<void *>()))
-      .WillRepeatedly([&](RedisModuleKey *module_key, int flags,
+      .WillRepeatedly([&](ValkeyModuleKey *module_key, int flags,
                           const char *field, int *exists,
                           void *terminating_null) {
         *exists = 1;
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               OpenKey(VectorExternalizer::Instance().GetCtx(),
-                      An<RedisModuleString *>(), testing::_))
-      .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
-  EXPECT_CALL(*kMockRedisModule,
-              OpenKey(&fake_ctx_, An<RedisModuleString *>(), testing::_))
-      .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
+                      An<ValkeyModuleString *>(), testing::_))
+      .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
+  EXPECT_CALL(*kMockValkeyModule,
+              OpenKey(&fake_ctx_, An<ValkeyModuleString *>(), testing::_))
+      .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
   auto index_schema = CreateVectorHNSWSchema(index_name, &fake_ctx_).value();
   auto vectors = DeterministicallyGenerateVectors(100, dimensions, 10.0);
   AddVectors(vectors);
@@ -585,33 +585,33 @@ TEST_P(FTSearchTest, FTSearchTests) {
   uint64_t i = 0;
   for (auto &vector : vectors) {
     ++i;
-    std::vector<RedisModuleString *> cmd_argv;
+    std::vector<ValkeyModuleString *> cmd_argv;
     std::transform(
         test_case.argv.begin(), test_case.argv.end(),
         std::back_inserter(cmd_argv), [&](std::string val) {
           if (val == "$index_name") {
-            return RedisModule_CreateString(&fake_ctx_, index_name.data(),
-                                            index_name.size());
+            return ValkeyModule_CreateString(&fake_ctx_, index_name.data(),
+                                             index_name.size());
           }
           if (val == "$embedding") {
-            return RedisModule_CreateString(&fake_ctx_, (char *)vector.data(),
-                                            vector.size() * sizeof(float));
+            return ValkeyModule_CreateString(&fake_ctx_, (char *)vector.data(),
+                                             vector.size() * sizeof(float));
           }
-          return RedisModule_CreateString(&fake_ctx_, val.data(), val.size());
+          return ValkeyModule_CreateString(&fake_ctx_, val.data(), val.size());
         });
     absl::Notification search_done;
     void *private_data_external = nullptr;
     if (use_thread_pool) {
-      EXPECT_CALL(*kMockRedisModule,
+      EXPECT_CALL(*kMockValkeyModule,
                   BlockClient(testing::_, testing::_, testing::_, testing::_,
                               testing::_))
-          .WillOnce(testing::Return((RedisModuleBlockedClient *)i));
-      EXPECT_CALL(*kMockRedisModule,
-                  UnblockClient((RedisModuleBlockedClient *)i, testing::_))
-          .WillOnce([&](RedisModuleBlockedClient *client, void *private_data) {
+          .WillOnce(testing::Return((ValkeyModuleBlockedClient *)i));
+      EXPECT_CALL(*kMockValkeyModule,
+                  UnblockClient((ValkeyModuleBlockedClient *)i, testing::_))
+          .WillOnce([&](ValkeyModuleBlockedClient *client, void *private_data) {
             private_data_external = private_data;
             search_done.Notify();
-            return REDISMODULE_OK;
+            return VALKEYMODULE_OK;
           });
     }
     EXPECT_EQ(vmsdk::CreateCommand<FTSearchCmd>(&fake_ctx_, cmd_argv.data(),
@@ -620,7 +620,7 @@ TEST_P(FTSearchTest, FTSearchTests) {
     if (use_thread_pool) {
       fake_ctx_.reply_capture.ClearReply();
       search_done.WaitForNotification();
-      EXPECT_CALL(*kMockRedisModule, GetBlockedClientPrivateData(&fake_ctx_))
+      EXPECT_CALL(*kMockValkeyModule, GetBlockedClientPrivateData(&fake_ctx_))
           .WillRepeatedly(testing::InvokeWithoutArgs(
               [&] { return private_data_external; }));
       async::Reply(&fake_ctx_, nullptr, 0);
@@ -631,7 +631,7 @@ TEST_P(FTSearchTest, FTSearchTests) {
     //      RE2::FullMatch(fake_ctx_.reply_capture.GetReply(), reply_regex));
     fake_ctx_.reply_capture.ClearReply();
     for (auto cmd_arg : cmd_argv) {
-      TestRedisModule_FreeString(&fake_ctx_, cmd_arg);
+      TestValkeyModule_FreeString(&fake_ctx_, cmd_arg);
     }
   }
 }
@@ -655,7 +655,7 @@ INSTANTIATE_TEST_SUITE_P(
                                      "DIALECT",
                                      "2",
                                  },
-                             .expected_run_return = REDISMODULE_OK,
+                             .expected_run_return = VALKEYMODULE_OK,
                          },
                      })),
     [](const TestParamInfo<::testing::tuple<bool, bool, FTSearchTestCase>>

--- a/testing/index_schema_test.cc
+++ b/testing/index_schema_test.cc
@@ -86,7 +86,7 @@ struct IndexSchemaSubscriptionTestCase {
   int open_key_type;
   bool expect_wrong_type;
   // Set to nullopt to have Redis return does not exist
-  absl::optional<std::pair<std::string, std::string>> redis_hash_data;
+  absl::optional<std::pair<std::string, std::string>> valkey_hash_data;
   bool is_tracked;
   // Set to nullopt to not expect a call to the given index method.
   absl::optional<absl::StatusOr<bool>> expect_index_add_w_result;
@@ -109,7 +109,7 @@ TEST_P(IndexSchemaSubscriptionTest, OnKeyspaceNotificationTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
   mutations_thread_pool.StartWorkers();
   for (bool use_thread_pool : {true, false}) {
-    RedisModuleCtx fake_ctx;
+    ValkeyModuleCtx fake_ctx;
     std::vector<absl::string_view> key_prefixes = {"prefix:"};
     std::string index_schema_name_str("index_schema_name");
     auto index_schema = MockIndexSchema::Create(
@@ -124,7 +124,7 @@ TEST_P(IndexSchemaSubscriptionTest, OnKeyspaceNotificationTest) {
                                            test_case.hash_field, mock_index));
 
     auto key = StringInternStore::Intern("key");
-    auto key_redis_str = vmsdk::MakeUniqueRedisString(key->Str().data());
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key->Str().data());
     EXPECT_CALL(*mock_index, IsTracked(key))
         .WillRepeatedly(Return(test_case.is_tracked));
     if (test_case.expect_index_add_w_result.has_value()) {
@@ -144,45 +144,49 @@ TEST_P(IndexSchemaSubscriptionTest, OnKeyspaceNotificationTest) {
     }
     if (test_case.open_key_fail) {
       // Keep the default behavior still for other keys (e.g. IndexSchema key).
-      EXPECT_CALL(*kMockRedisModule, OpenKey(&fake_ctx, testing::_, testing::_))
-          .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
-      EXPECT_CALL(*kMockRedisModule,
-                  OpenKey(&fake_ctx, key_redis_str.get(),
-                          REDISMODULE_OPEN_KEY_NOEFFECTS | REDISMODULE_READ))
+      EXPECT_CALL(*kMockValkeyModule,
+                  OpenKey(&fake_ctx, testing::_, testing::_))
+          .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
+      EXPECT_CALL(*kMockValkeyModule,
+                  OpenKey(&fake_ctx, key_valkey_str.get(),
+                          VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ))
           .WillOnce(Return(nullptr));
     } else {
-      EXPECT_CALL(*kMockRedisModule, KeyType(testing::_))
-          .WillRepeatedly(TestRedisModule_KeyTypeDefaultImpl);
-      EXPECT_CALL(*kMockRedisModule,
-                  KeyType(vmsdk::RedisModuleKeyIsForString(key->Str())))
+      EXPECT_CALL(*kMockValkeyModule, KeyType(testing::_))
+          .WillRepeatedly(TestValkeyModule_KeyTypeDefaultImpl);
+      EXPECT_CALL(*kMockValkeyModule,
+                  KeyType(vmsdk::ValkeyModuleKeyIsForString(key->Str())))
           .WillRepeatedly(Return(test_case.open_key_type));
     }
 
-    if (test_case.redis_hash_data.has_value()) {
-      const char *field = test_case.redis_hash_data.value().first.c_str();
-      const char *value = test_case.redis_hash_data.value().second.c_str();
-      RedisModuleString *value_redis_str =
-          TestRedisModule_CreateStringPrintf(nullptr, "%s", value);
+    if (test_case.valkey_hash_data.has_value()) {
+      const char *field = test_case.valkey_hash_data.value().first.c_str();
+      const char *value = test_case.valkey_hash_data.value().second.c_str();
+      ValkeyModuleString *value_valkey_str =
+          TestValkeyModule_CreateStringPrintf(nullptr, "%s", value);
 
-      EXPECT_CALL(*kMockRedisModule,
-                  HashGet(vmsdk::RedisModuleKeyIsForString(key->Str()),
-                          REDISMODULE_HASH_CFIELDS, StrEq(field),
-                          An<RedisModuleString **>(), TypedEq<void *>(nullptr)))
-          .WillOnce([value_redis_str](
-                        RedisModuleKey *key, int flags, const char *field,
-                        RedisModuleString **value_out, void *terminating_null) {
-            *value_out = value_redis_str;
-            return REDISMODULE_OK;
+      EXPECT_CALL(
+          *kMockValkeyModule,
+          HashGet(vmsdk::ValkeyModuleKeyIsForString(key->Str()),
+                  VALKEYMODULE_HASH_CFIELDS, StrEq(field),
+                  An<ValkeyModuleString **>(), TypedEq<void *>(nullptr)))
+          .WillOnce([value_valkey_str](ValkeyModuleKey *key, int flags,
+                                       const char *field,
+                                       ValkeyModuleString **value_out,
+                                       void *terminating_null) {
+            *value_out = value_valkey_str;
+            return VALKEYMODULE_OK;
           });
     } else if (!test_case.open_key_fail && !test_case.expect_wrong_type) {
-      EXPECT_CALL(*kMockRedisModule,
-                  HashGet(vmsdk::RedisModuleKeyIsForString(key->Str()),
-                          REDISMODULE_HASH_CFIELDS, StrEq(test_case.hash_field),
-                          An<RedisModuleString **>(), TypedEq<void *>(nullptr)))
-          .WillOnce([](RedisModuleKey *key, int flags, const char *field,
-                       RedisModuleString **value_out, void *terminating_null) {
+      EXPECT_CALL(
+          *kMockValkeyModule,
+          HashGet(vmsdk::ValkeyModuleKeyIsForString(key->Str()),
+                  VALKEYMODULE_HASH_CFIELDS, StrEq(test_case.hash_field),
+                  An<ValkeyModuleString **>(), TypedEq<void *>(nullptr)))
+          .WillOnce([](ValkeyModuleKey *key, int flags, const char *field,
+                       ValkeyModuleString **value_out, void *terminating_null) {
             *value_out = nullptr;
-            return REDISMODULE_OK;
+            return VALKEYMODULE_OK;
           });
     }
 
@@ -201,8 +205,8 @@ TEST_P(IndexSchemaSubscriptionTest, OnKeyspaceNotificationTest) {
         .skipped_cnt =
             index_schema->GetStats().subscription_modify.skipped_cnt};
     uint32_t document_cnt = index_schema->GetStats().document_cnt;
-    index_schema->OnKeyspaceNotification(&fake_ctx, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
+    index_schema->OnKeyspaceNotification(&fake_ctx, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
     if (use_thread_pool) {
       WaitWorkerTasksAreCompleted(mutations_thread_pool);
     }
@@ -237,8 +241,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "happy_path_add",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = false,
             .expect_index_add_w_result = true,
             .expected_vector_buffer = "vector_buffer",
@@ -252,8 +256,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "happy_path_remove_key",
             .hash_field = "vector",
             .open_key_fail = true,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = true,
             .expect_index_remove_w_result = true,
             .expected_vector_buffer = "vector_buffer",
@@ -267,8 +271,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "happy_path_remove_record",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = true,
             .expect_index_remove_w_result = true,
             .expected_vector_buffer = "vector_buffer",
@@ -281,8 +285,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "happy_path_modify",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = true,
             .expect_index_modify_w_result = true,
             .expected_vector_buffer = "vector_buffer",
@@ -295,8 +299,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "untracked_and_record_does_not_exist",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = false,
             .expect_index_remove_w_result = false,
             .expected_remove_cnt_delta =
@@ -308,8 +312,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "untracked_and_key_does_not_exist",
             .hash_field = "vector",
             .open_key_fail = true,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = false,
             .expect_index_remove_w_result = false,
             .expected_remove_cnt_delta =
@@ -322,8 +326,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "add_failure",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = false,
             .expect_index_add_w_result = absl::InternalError("error"),
             .expected_vector_buffer = "vector_buffer",
@@ -336,8 +340,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "modify_failure",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = true,
             .expect_index_modify_w_result = absl::InternalError("error"),
             .expected_vector_buffer = "vector_buffer",
@@ -350,8 +354,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "remove_failure",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = true,
             .expect_index_remove_w_result = absl::InternalError("error"),
             .expected_vector_buffer = "vector_buffer",
@@ -364,8 +368,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "add_skipped",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = false,
             .expect_index_add_w_result = false,
             .expected_vector_buffer = "vector_buffer",
@@ -378,15 +382,15 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "add_wrong_type",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_STRING,
+            .open_key_type = VALKEYMODULE_KEYTYPE_STRING,
             .expect_wrong_type = true,
         },
         {
             .test_name = "modify_skipped",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::make_pair("vector", "vector_buffer"),
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::make_pair("vector", "vector_buffer"),
             .is_tracked = true,
             .expect_index_modify_w_result = false,
             .expected_vector_buffer = "vector_buffer",
@@ -399,8 +403,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "remove_skipped",
             .hash_field = "vector",
             .open_key_fail = false,
-            .open_key_type = REDISMODULE_KEYTYPE_HASH,
-            .redis_hash_data = std::nullopt,
+            .open_key_type = VALKEYMODULE_KEYTYPE_HASH,
+            .valkey_hash_data = std::nullopt,
             .is_tracked = true,
             .expect_index_remove_w_result = false,
             .expected_vector_buffer = "vector_buffer",
@@ -439,42 +443,42 @@ TEST_P(IndexSchemaSubscriptionSimpleTest, DropIndexPrematurely) {
         index_schema->AddIndex("attribute_name", "vector", mock_index));
 
     auto key = StringInternStore::Intern("key");
-    auto key_redis_str = vmsdk::MakeUniqueRedisString(key->Str().data());
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key->Str().data());
     EXPECT_CALL(*mock_index, IsTracked(key)).WillRepeatedly(Return(false));
 
     EXPECT_CALL(*mock_index, AddRecord(key, testing::_)).Times(0);
 
-    EXPECT_CALL(*kMockRedisModule, KeyType(testing::_))
-        .WillRepeatedly(TestRedisModule_KeyTypeDefaultImpl);
-    EXPECT_CALL(*kMockRedisModule,
-                KeyType(vmsdk::RedisModuleKeyIsForString(key->Str())))
-        .WillRepeatedly(Return(REDISMODULE_KEYTYPE_HASH));
-    EXPECT_CALL(*kMockRedisModule, GetClientId(testing::_))
+    EXPECT_CALL(*kMockValkeyModule, KeyType(testing::_))
+        .WillRepeatedly(TestValkeyModule_KeyTypeDefaultImpl);
+    EXPECT_CALL(*kMockValkeyModule,
+                KeyType(vmsdk::ValkeyModuleKeyIsForString(key->Str())))
+        .WillRepeatedly(Return(VALKEYMODULE_KEYTYPE_HASH));
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(testing::_))
         .WillRepeatedly(testing::Return(1));
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         BlockClient(testing::_, testing::_, testing::_, testing::_, testing::_))
-        .WillOnce(Return((RedisModuleBlockedClient *)1));
+        .WillOnce(Return((ValkeyModuleBlockedClient *)1));
     const char *field = "vector";
     const char *value = "vector_buffer";
-    RedisModuleString *value_redis_str =
-        TestRedisModule_CreateStringPrintf(nullptr, "%s", value);
+    ValkeyModuleString *value_valkey_str =
+        TestValkeyModule_CreateStringPrintf(nullptr, "%s", value);
 
-    EXPECT_CALL(*kMockRedisModule,
-                HashGet(vmsdk::RedisModuleKeyIsForString(key->Str()),
-                        REDISMODULE_HASH_CFIELDS, StrEq(field),
-                        An<RedisModuleString **>(), TypedEq<void *>(nullptr)))
-        .WillOnce([value_redis_str](
-                      RedisModuleKey *key, int flags, const char *field,
-                      RedisModuleString **value_out, void *terminating_null) {
-          *value_out = value_redis_str;
-          return REDISMODULE_OK;
+    EXPECT_CALL(*kMockValkeyModule,
+                HashGet(vmsdk::ValkeyModuleKeyIsForString(key->Str()),
+                        VALKEYMODULE_HASH_CFIELDS, StrEq(field),
+                        An<ValkeyModuleString **>(), TypedEq<void *>(nullptr)))
+        .WillOnce([value_valkey_str](
+                      ValkeyModuleKey *key, int flags, const char *field,
+                      ValkeyModuleString **value_out, void *terminating_null) {
+          *value_out = value_valkey_str;
+          return VALKEYMODULE_OK;
         });
 
-    index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
-    EXPECT_CALL(*kMockRedisModule,
-                UnblockClient((RedisModuleBlockedClient *)1, nullptr))
+    index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
+    EXPECT_CALL(*kMockValkeyModule,
+                UnblockClient((ValkeyModuleBlockedClient *)1, nullptr))
         .WillOnce(Return(1));
   }
   EXPECT_EQ(mutations_thread_pool.QueueSize(), 1);
@@ -549,10 +553,11 @@ TEST_P(IndexSchemaSubscriptionSimpleTest, IndexSchemaInDifferentDBTest) {
 
   EXPECT_CALL(*mock_index, AddRecord(testing::_, testing::_)).Times(0);
   std::string key = "key";
-  auto key_redis_str = vmsdk::MakeUniqueRedisString(key.c_str());
-  RedisModuleCtx different_db_ctx;
-  index_schema->OnKeyspaceNotification(
-      &different_db_ctx, REDISMODULE_NOTIFY_HASH, "event", key_redis_str.get());
+  auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key.c_str());
+  ValkeyModuleCtx different_db_ctx;
+  index_schema->OnKeyspaceNotification(&different_db_ctx,
+                                       VALKEYMODULE_NOTIFY_HASH, "event",
+                                       key_valkey_str.get());
   if (use_thread_pool) {
     WaitWorkerTasksAreCompleted(mutations_thread_pool);
   }
@@ -576,14 +581,15 @@ TEST_P(IndexSchemaSubscriptionSimpleTest,
 
   EXPECT_CALL(*mock_index, AddRecord(testing::_, testing::_)).Times(0);
   std::string key = "key";
-  auto key_redis_str = vmsdk::MakeUniqueRedisString(key.c_str());
-  RedisModuleCtx different_db_ctx;
+  auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key.c_str());
+  ValkeyModuleCtx different_db_ctx;
   auto match_key =
-      vmsdk::MakeUniqueRedisOpenKey(&different_db_ctx, key_redis_str.get(), 0);
-  TestRedisModule_ModuleTypeSetValueDefaultImpl(
-      match_key.get(), (RedisModuleType *)0x1, nullptr);
-  index_schema->OnKeyspaceNotification(
-      &different_db_ctx, REDISMODULE_NOTIFY_HASH, "event", key_redis_str.get());
+      vmsdk::MakeUniqueValkeyOpenKey(&different_db_ctx, key_valkey_str.get(), 0);
+  TestValkeyModule_ModuleTypeSetValueDefaultImpl(
+      match_key.get(), (ValkeyModuleType *)0x1, nullptr);
+  index_schema->OnKeyspaceNotification(&different_db_ctx,
+                                       VALKEYMODULE_NOTIFY_HASH, "event",
+                                       key_valkey_str.get());
   if (use_thread_pool) {
     WaitWorkerTasksAreCompleted(mutations_thread_pool);
   }
@@ -603,9 +609,9 @@ TEST_P(IndexSchemaSubscriptionSimpleTest, KeyspaceNotificationWithNullptrTest) {
   auto mock_index = std::make_shared<MockIndex>();
   VMSDK_EXPECT_OK(
       index_schema->AddIndex("attribute_name", "test_identifier", mock_index));
-  EXPECT_CALL(*kMockRedisModule, OpenKey(&fake_ctx_, testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(&fake_ctx_, testing::_, testing::_))
       .Times(0);
-  index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
+  index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
                                        "event", nullptr);
   if (use_thread_pool) {
     WaitWorkerTasksAreCompleted(mutations_thread_pool);
@@ -641,9 +647,9 @@ TEST_P(IndexSchemaSubscriptionSimpleTest, GetEventTypesTest) {
                           use_thread_pool ? &mutations_thread_pool : nullptr)
                           .value();
 
-  EXPECT_EQ(index_schema->GetAttributeDataType().GetRedisEventTypes(),
-            REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_GENERIC |
-                REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED);
+  EXPECT_EQ(index_schema->GetAttributeDataType().GetValkeyEventTypes(),
+            VALKEYMODULE_NOTIFY_HASH | VALKEYMODULE_NOTIFY_GENERIC |
+                VALKEYMODULE_NOTIFY_EXPIRED | VALKEYMODULE_NOTIFY_EVICTED);
 }
 
 INSTANTIATE_TEST_SUITE_P(IndexSchemaSubscriptionSimpleTests,
@@ -684,16 +690,16 @@ TEST_P(IndexSchemaBackfillTest, PerformBackfillTest) {
                    return absl::string_view(key_prefix);
                  });
   std::string index_schema_name_str("index_schema_name");
-  EXPECT_CALL(*kMockRedisModule, DbSize(testing::_))
+  EXPECT_CALL(*kMockValkeyModule, DbSize(testing::_))
       .WillRepeatedly(Return(test_case.db_size));
 
-  RedisModuleCtx parent_ctx;
-  RedisModuleCtx scan_ctx;
-  EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&parent_ctx))
+  ValkeyModuleCtx parent_ctx;
+  ValkeyModuleCtx scan_ctx;
+  EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&parent_ctx))
       .WillRepeatedly(Return(&scan_ctx));
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(&parent_ctx))
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&parent_ctx))
       .WillRepeatedly(Return(test_case.context_flags));
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(&scan_ctx))
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&scan_ctx))
       .WillRepeatedly(Return(0));
   auto index_schema =
       MockIndexSchema::Create(&parent_ctx, index_schema_name_str, key_prefixes,
@@ -705,11 +711,11 @@ TEST_P(IndexSchemaBackfillTest, PerformBackfillTest) {
       index_schema->AddIndex("attribute_name", "test_identifier", mock_index));
 
   size_t i = 0;
-  EXPECT_CALL(*kMockRedisModule,
-              Scan(&scan_ctx, testing::An<RedisModuleScanCursor *>(),
-                   testing::An<RedisModuleScanCB>(), testing::An<void *>()))
-      .WillRepeatedly([&](RedisModuleCtx *ctx, RedisModuleScanCursor *cursor,
-                          RedisModuleScanCB fn, void *privdata) -> int {
+  EXPECT_CALL(*kMockValkeyModule,
+              Scan(&scan_ctx, testing::An<ValkeyModuleScanCursor *>(),
+                   testing::An<ValkeyModuleScanCB>(), testing::An<void *>()))
+      .WillRepeatedly([&](ValkeyModuleCtx *ctx, ValkeyModuleScanCursor *cursor,
+                          ValkeyModuleScanCB fn, void *privdata) -> int {
         if (i >= test_case.keys_to_return_in_scan.size()) {
           return 0;
         }
@@ -720,22 +726,22 @@ TEST_P(IndexSchemaBackfillTest, PerformBackfillTest) {
             test_case.expected_keys_processed.end();
 
         auto key_str = test_case.keys_to_return_in_scan[i];
-        auto key_r_str = vmsdk::MakeUniqueRedisString(key_str);
-        RedisModuleKey key = {.ctx = &scan_ctx, .key = key_str};
+        auto key_r_str = vmsdk::MakeUniqueValkeyString(key_str);
+        ValkeyModuleKey key = {.ctx = &scan_ctx, .key = key_str};
         if (expect_processed) {
-          RedisModuleString *value_redis_str =
-              TestRedisModule_CreateStringPrintf(nullptr, "arbitrary data");
+          ValkeyModuleString *value_valkey_str =
+              TestValkeyModule_CreateStringPrintf(nullptr, "arbitrary data");
           EXPECT_CALL(
-              *kMockRedisModule,
-              HashGet(vmsdk::RedisModuleKeyIsForString(key_str),
-                      REDISMODULE_HASH_CFIELDS, testing::_,
-                      An<RedisModuleString **>(), TypedEq<void *>(nullptr)))
-              .WillOnce([value_redis_str](RedisModuleKey *key, int flags,
-                                          const char *field,
-                                          RedisModuleString **value_out,
-                                          void *terminating_null) {
-                *value_out = value_redis_str;
-                return REDISMODULE_OK;
+              *kMockValkeyModule,
+              HashGet(vmsdk::ValkeyModuleKeyIsForString(key_str),
+                      VALKEYMODULE_HASH_CFIELDS, testing::_,
+                      An<ValkeyModuleString **>(), TypedEq<void *>(nullptr)))
+              .WillOnce([value_valkey_str](ValkeyModuleKey *key, int flags,
+                                           const char *field,
+                                           ValkeyModuleString **value_out,
+                                           void *terminating_null) {
+                *value_out = value_valkey_str;
+                return VALKEYMODULE_OK;
               });
           EXPECT_CALL(*mock_index,
                       IsTracked(testing::Pointee(testing::StrEq(key_str))))
@@ -748,23 +754,23 @@ TEST_P(IndexSchemaBackfillTest, PerformBackfillTest) {
             EXPECT_CALL(thread_pool,
                         Schedule(testing::_, vmsdk::ThreadPool::Priority::kLow))
                 .Times(1);
-            EXPECT_CALL(*kMockRedisModule,
+            EXPECT_CALL(*kMockValkeyModule,
                         BlockClient(testing::_, testing::_, testing::_,
                                     testing::_, testing::_))
                 .Times(0);
-            EXPECT_CALL(*kMockRedisModule,
+            EXPECT_CALL(*kMockValkeyModule,
                         UnblockClient(testing::_, testing::_))
                 .Times(0);
           }
         }
         if (test_case.return_wrong_types) {
-          EXPECT_CALL(*kMockRedisModule,
-                      KeyType(vmsdk::RedisModuleKeyIsForString(key_str)))
-              .WillRepeatedly(Return(REDISMODULE_KEYTYPE_STRING));
+          EXPECT_CALL(*kMockValkeyModule,
+                      KeyType(vmsdk::ValkeyModuleKeyIsForString(key_str)))
+              .WillRepeatedly(Return(VALKEYMODULE_KEYTYPE_STRING));
         } else {
-          EXPECT_CALL(*kMockRedisModule,
-                      KeyType(vmsdk::RedisModuleKeyIsForString(key_str)))
-              .WillRepeatedly(Return(REDISMODULE_KEYTYPE_HASH));
+          EXPECT_CALL(*kMockValkeyModule,
+                      KeyType(vmsdk::ValkeyModuleKeyIsForString(key_str)))
+              .WillRepeatedly(Return(VALKEYMODULE_KEYTYPE_HASH));
         }
         fn(ctx, key_r_str.get(), &key, privdata);
         if (use_thread_pool) {
@@ -798,9 +804,9 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_NoOngoingBackfillTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
   mutations_thread_pool.StartWorkers();
   for (bool use_thread_pool : {true, false}) {
-    RedisModuleCtx parent_ctx;
-    RedisModuleCtx scan_ctx;
-    EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&parent_ctx))
+    ValkeyModuleCtx parent_ctx;
+    ValkeyModuleCtx scan_ctx;
+    EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&parent_ctx))
         .WillRepeatedly(Return(&scan_ctx));
     auto index_schema = MockIndexSchema::Create(
                             &parent_ctx, index_schema_name_str, key_prefixes,
@@ -809,11 +815,11 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_NoOngoingBackfillTest) {
                             .value();
 
     // We only expect it to do the scan the first iteration.
-    EXPECT_CALL(*kMockRedisModule,
-                Scan(&scan_ctx, testing::An<RedisModuleScanCursor *>(),
-                     testing::An<RedisModuleScanCB>(), testing::An<void *>()))
-        .WillOnce([&](RedisModuleCtx *ctx, RedisModuleScanCursor *cursor,
-                      RedisModuleScanCB fn,
+    EXPECT_CALL(*kMockValkeyModule,
+                Scan(&scan_ctx, testing::An<ValkeyModuleScanCursor *>(),
+                     testing::An<ValkeyModuleScanCB>(), testing::An<void *>()))
+        .WillOnce([&](ValkeyModuleCtx *ctx, ValkeyModuleScanCursor *cursor,
+                      ValkeyModuleScanCB fn,
                       void *privdata) -> int { return 0; });
 
     for (size_t i = 0; i < 100; ++i) {
@@ -830,14 +836,14 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_SwapDB) {
   for (bool use_thread_pool : {true, false}) {
     int starting_db = 0;
     int db_to_swap = 1;
-    RedisModuleCtx parent_ctx;
-    RedisModuleCtx scan_ctx;
-    EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&parent_ctx))
+    ValkeyModuleCtx parent_ctx;
+    ValkeyModuleCtx scan_ctx;
+    EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&parent_ctx))
         .WillRepeatedly(Return(&scan_ctx));
-    EXPECT_CALL(*kMockRedisModule, GetSelectedDb(&parent_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetSelectedDb(&parent_ctx))
         .WillRepeatedly(Return(starting_db));
-    EXPECT_CALL(*kMockRedisModule, SelectDb(&scan_ctx, starting_db))
-        .WillRepeatedly(Return(REDISMODULE_OK));
+    EXPECT_CALL(*kMockValkeyModule, SelectDb(&scan_ctx, starting_db))
+        .WillRepeatedly(Return(VALKEYMODULE_OK));
     auto index_schema = MockIndexSchema::Create(
                             &parent_ctx, index_schema_name_str, key_prefixes,
                             std::make_unique<HashAttributeDataType>(),
@@ -845,17 +851,17 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_SwapDB) {
                             .value();
 
     // Validate swapping changes the db in the context
-    RedisModuleSwapDbInfo swap_db_info = {
+    ValkeyModuleSwapDbInfo swap_db_info = {
         .dbnum_first = starting_db,
         .dbnum_second = db_to_swap,
     };
-    EXPECT_CALL(*kMockRedisModule, SelectDb(&scan_ctx, db_to_swap))
-        .WillOnce(Return(REDISMODULE_OK));
+    EXPECT_CALL(*kMockValkeyModule, SelectDb(&scan_ctx, db_to_swap))
+        .WillOnce(Return(VALKEYMODULE_OK));
     index_schema->OnSwapDB(&swap_db_info);
 
     // Validate swapping again brings the db back to the original
-    EXPECT_CALL(*kMockRedisModule, SelectDb(&scan_ctx, starting_db))
-        .WillOnce(Return(REDISMODULE_OK));
+    EXPECT_CALL(*kMockValkeyModule, SelectDb(&scan_ctx, starting_db))
+        .WillOnce(Return(VALKEYMODULE_OK));
     index_schema->OnSwapDB(&swap_db_info);
   }
 }
@@ -965,7 +971,7 @@ INSTANTIATE_TEST_SUITE_P(
                     .key_prefixes = {"prefix1:"},
                     .db_size = 100,
                     .keys_to_return_in_scan = {},
-                    .context_flags = REDISMODULE_CTX_FLAGS_OOM,
+                    .context_flags = VALKEYMODULE_CTX_FLAGS_OOM,
                     .expected_keys_scanned = 0,
                     .expected_keys_processed = {},
                     .expected_backfill_percent = 0.0,
@@ -1014,8 +1020,8 @@ TEST_F(IndexSchemaRDBTest, SaveAndLoad) ABSL_NO_THREAD_SAFETY_ANALYSIS {
     EXPECT_FALSE(itr == index_schema->attributes_.end());
     auto vectors = DeterministicallyGenerateVectors(10, dimensions, 2);
     for (size_t i = 0; i < vectors.size(); ++i) {
-      vmsdk::UniqueRedisString data =
-          vmsdk::MakeUniqueRedisString(absl::string_view(
+      vmsdk::UniqueValkeyString data =
+          vmsdk::MakeUniqueValkeyString(absl::string_view(
               (char *)&vectors[i][0], dimensions * sizeof(float)));
       auto interned_key = StringInternStore::Intern("key" + std::to_string(i));
       index_schema->ProcessAttributeMutation(&fake_ctx_, itr->second,
@@ -1037,9 +1043,9 @@ TEST_F(IndexSchemaRDBTest, SaveAndLoad) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   }
 
   // Load the saved index schema and validate
-  RedisModuleCtx parent_ctx;
-  RedisModuleCtx scan_ctx;
-  EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&parent_ctx))
+  ValkeyModuleCtx parent_ctx;
+  ValkeyModuleCtx scan_ctx;
+  EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&parent_ctx))
       .WillRepeatedly(Return(&scan_ctx));
   RDBSectionIter iter(&rdb_stream, 1);
   auto section = iter.Next();
@@ -1111,17 +1117,18 @@ TEST_F(IndexSchemaRDBTest, LoadEndedDeletesOrphanedKeys) {
 
     VMSDK_EXPECT_OK(
         index_schema->AddIndex("attribute", "identifier", mock_index));
-    EXPECT_CALL(*kMockRedisModule, SelectDb(testing::_, testing::_))
+    EXPECT_CALL(*kMockValkeyModule, SelectDb(testing::_, testing::_))
         .WillRepeatedly(Return(1));  // So backfill job can be created.
-    EXPECT_CALL(*kMockRedisModule, SelectDb(&fake_ctx_, 0)).WillOnce(Return(1));
-    EXPECT_CALL(*kMockRedisModule,
-                KeyExists(&fake_ctx_, vmsdk::RedisModuleStringValueEq("key1")))
+    EXPECT_CALL(*kMockValkeyModule, SelectDb(&fake_ctx_, 0))
+        .WillOnce(Return(1));
+    EXPECT_CALL(*kMockValkeyModule,
+                KeyExists(&fake_ctx_, vmsdk::ValkeyModuleStringValueEq("key1")))
         .WillRepeatedly(Return(0));
-    EXPECT_CALL(*kMockRedisModule,
-                KeyExists(&fake_ctx_, vmsdk::RedisModuleStringValueEq("key2")))
+    EXPECT_CALL(*kMockValkeyModule,
+                KeyExists(&fake_ctx_, vmsdk::ValkeyModuleStringValueEq("key2")))
         .WillRepeatedly(Return(0));
-    EXPECT_CALL(*kMockRedisModule,
-                KeyExists(&fake_ctx_, vmsdk::RedisModuleStringValueEq("key3")))
+    EXPECT_CALL(*kMockValkeyModule,
+                KeyExists(&fake_ctx_, vmsdk::ValkeyModuleStringValueEq("key3")))
         .WillRepeatedly(Return(1));
 
     EXPECT_CALL(*mock_index,
@@ -1178,7 +1185,7 @@ class IndexSchemaFriendTest : public ValkeySearchTest {
   int m = 16;
   int ef_construction = 100;
   int ef_runtime = 5;
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   vmsdk::ThreadPool mutations_thread_pool{"writer-thread-pool-", 10};
   std::shared_ptr<IndexSchema> index_schema;
   std::shared_ptr<indexes::VectorHNSW<float>> hnsw_index;
@@ -1190,7 +1197,7 @@ IndexSchema::MutatedAttributes CreateMutatedAttributes(
     const std::string &attribute_identifier, absl::string_view data_ptr) {
   IndexSchema::MutatedAttributes mutated_attributes;
   mutated_attributes[attribute_identifier].data =
-      vmsdk::MakeUniqueRedisString(data_ptr);
+      vmsdk::MakeUniqueValkeyString(data_ptr);
   return mutated_attributes;
 }
 
@@ -1255,8 +1262,8 @@ TEST_F(IndexSchemaFriendTest, MutatedAttributes) {
     EXPECT_TRUE(consumed_data.has_value());
     auto data_view =
         vmsdk::ToStringView(consumed_data->begin()->second.data.get());
-    vmsdk::UniqueRedisString expected_data =
-        vmsdk::MakeUniqueRedisString(data_ptr);
+    vmsdk::UniqueValkeyString expected_data =
+        vmsdk::MakeUniqueValkeyString(data_ptr);
     VLOG(1) << "consumed_data size: " << consumed_data->size();
     auto expected_data_view = vmsdk::ToStringView(expected_data.get());
     EXPECT_EQ(data_view, expected_data_view);
@@ -1285,8 +1292,8 @@ TEST_F(IndexSchemaFriendTest, MutatedAttributes) {
       EXPECT_TRUE(consumed_data.has_value());
       auto data_view =
           vmsdk::ToStringView(consumed_data->begin()->second.data.get());
-      vmsdk::UniqueRedisString expected_data =
-          vmsdk::MakeUniqueRedisString(track_after_consumption_data_ptr);
+      vmsdk::UniqueValkeyString expected_data =
+          vmsdk::MakeUniqueValkeyString(track_after_consumption_data_ptr);
 
       auto expected_data_view = vmsdk::ToStringView(expected_data.get());
       EXPECT_EQ(data_view, expected_data_view);
@@ -1323,7 +1330,7 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
     // Verify that the mutations were processed asynchronous, by the writer
     // worker pool
     VMSDK_EXPECT_OK(mutations_thread_pool.SuspendWorkers());
-    vmsdk::UniqueRedisString data = vmsdk::MakeUniqueRedisString(
+    vmsdk::UniqueValkeyString data = vmsdk::MakeUniqueValkeyString(
         absl::string_view((char *)&vectors[0][0], dimensions * sizeof(float)));
     IndexSchema::MutatedAttributes mutated_attributes;
     mutated_attributes[itr->second.GetIdentifier()].data = std::move(data);
@@ -1338,8 +1345,8 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
   // Test delete consistency
   for (size_t j = 0; j < iterations; ++j) {
     for (size_t i = 0; i < vectors.size(); ++i) {
-      vmsdk::UniqueRedisString data =
-          vmsdk::MakeUniqueRedisString(absl::string_view(
+      vmsdk::UniqueValkeyString data =
+          vmsdk::MakeUniqueValkeyString(absl::string_view(
               (char *)&vectors[i][0], dimensions * sizeof(float)));
       IndexSchema::MutatedAttributes mutated_attributes;
       mutated_attributes[attribute_identifier].data = std::move(data);
@@ -1350,7 +1357,7 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
     }
   }
   for (size_t i = 0; i < vectors.size(); ++i) {
-    vmsdk::UniqueRedisString data;
+    vmsdk::UniqueValkeyString data;
     IndexSchema::MutatedAttributes mutated_attributes;
     mutated_attributes[attribute_identifier].data = std::move(data);
     auto key_interned =
@@ -1375,8 +1382,8 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
   // Test update consistency
   for (size_t j = 0; j < iterations; ++j) {
     for (size_t i = 0; i < vectors.size(); ++i) {
-      vmsdk::UniqueRedisString data =
-          vmsdk::MakeUniqueRedisString(absl::string_view(
+      vmsdk::UniqueValkeyString data =
+          vmsdk::MakeUniqueValkeyString(absl::string_view(
               (char *)&vectors[0][0], dimensions * sizeof(float)));
       IndexSchema::MutatedAttributes mutated_attributes;
       mutated_attributes[attribute_identifier].data = std::move(data);
@@ -1387,7 +1394,7 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
     }
   }
   for (size_t i = 0; i < vectors.size(); ++i) {
-    vmsdk::UniqueRedisString data = vmsdk::MakeUniqueRedisString(
+    vmsdk::UniqueValkeyString data = vmsdk::MakeUniqueValkeyString(
         absl::string_view((char *)&vectors[i][0], dimensions * sizeof(float)));
     IndexSchema::MutatedAttributes mutated_attributes;
     mutated_attributes[attribute_identifier].data = std::move(data);
@@ -1413,17 +1420,17 @@ TEST_F(IndexSchemaFriendTest, ConsistencyTest) {
   EXPECT_EQ(stats.subscription_modify.failure_cnt, 0);
 }
 
-class IndexSchemaTest : public vmsdk::RedisTest {};
+class IndexSchemaTest : public vmsdk::ValkeyTest {};
 
 TEST_F(IndexSchemaTest, ShouldBlockClient) {
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   {
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
         .WillOnce(testing::Return(1));
     EXPECT_TRUE(ShouldBlockClient(&fake_ctx, false, false));
   }
   {
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
         .WillOnce(testing::Return(0));
     EXPECT_FALSE(ShouldBlockClient(&fake_ctx, false, false));
   }

--- a/testing/integration/vector_search_integration_test.py
+++ b/testing/integration/vector_search_integration_test.py
@@ -372,15 +372,15 @@ class VectorSearchIntegrationTest(VSSTestCase):
         logging.basicConfig(level=logging.DEBUG)
 
         # Get the logger used by redis-py
-        redis_logger = logging.getLogger("redis")
-        redis_logger.setLevel(logging.DEBUG)
+        valkey_logger = logging.getLogger("redis")
+        valkey_logger.setLevel(logging.DEBUG)
 
         # Optional: Stream to stderr explicitly
         handler = logging.StreamHandler()
         handler.setLevel(logging.DEBUG)
         formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         handler.setFormatter(formatter)
-        redis_logger.addHandler(handler)
+        valkey_logger.addHandler(handler)
 
         valkey_server_stdout_dir = os.environ["TEST_UNDECLARED_OUTPUTS_DIR"]
         valkey_server_path = os.environ["VALKEY_SERVER_PATH"]

--- a/testing/keyspace_event_manager_test.cc
+++ b/testing/keyspace_event_manager_test.cc
@@ -98,14 +98,14 @@ TEST_P(KeyspaceEventManagerTest, SubscriptionAndNotificationTest) {
        test_case.subscriptions) {
     if (subscription.expected_type_subscriptions.has_value()) {
       EXPECT_CALL(
-          *kMockRedisModule,
+          *kMockValkeyModule,
           SubscribeToKeyspaceEvents(
               &fake_ctx_, subscription.expected_type_subscriptions.value(), _))
-          .WillOnce(Return(REDISMODULE_OK));
+          .WillOnce(Return(VALKEYMODULE_OK));
     }
     auto mock_subscription = std::make_unique<MockKeyspaceEventSubscription>();
     auto mock_attribute_data_type = std::make_unique<MockAttributeDataType>();
-    EXPECT_CALL(*mock_attribute_data_type, GetRedisEventTypes())
+    EXPECT_CALL(*mock_attribute_data_type, GetValkeyEventTypes())
         .WillRepeatedly(Return(subscription.types_to_subscribe));
     EXPECT_CALL(*mock_subscription, GetAttributeDataType())
         .WillRepeatedly(ReturnRef(*mock_attribute_data_type));
@@ -121,7 +121,7 @@ TEST_P(KeyspaceEventManagerTest, SubscriptionAndNotificationTest) {
 
   for (const KeyspaceEventNotificationTestCase &notification :
        test_case.notifications) {
-    RedisModuleString *key = TestRedisModule_CreateStringPrintf(
+    ValkeyModuleString *key = TestValkeyModule_CreateStringPrintf(
         &fake_ctx_, "%s", notification.notification_key.data());
     for (const std::string &subscription_id :
          notification.expected_subscriptions_with_notifications) {
@@ -133,7 +133,7 @@ TEST_P(KeyspaceEventManagerTest, SubscriptionAndNotificationTest) {
     }
     keyspace_event_manager->NotifySubscribers(
         &fake_ctx_, notification.notification_type, event_name.data(), key);
-    TestRedisModule_FreeString(nullptr, key);
+    TestValkeyModule_FreeString(nullptr, key);
   }
 
   for (const KeyspaceEventSubscriptionTestCase &subscription :
@@ -145,11 +145,11 @@ TEST_P(KeyspaceEventManagerTest, SubscriptionAndNotificationTest) {
   // Check everything is cleaned up. We should see no calls
   for (const KeyspaceEventNotificationTestCase &notification :
        test_case.notifications) {
-    RedisModuleString *key = TestRedisModule_CreateStringPrintf(
+    ValkeyModuleString *key = TestValkeyModule_CreateStringPrintf(
         &fake_ctx_, "%s", notification.notification_key.data());
     keyspace_event_manager->NotifySubscribers(
         &fake_ctx_, notification.notification_type, event_name.data(), key);
-    TestRedisModule_FreeString(nullptr, key);
+    TestValkeyModule_FreeString(nullptr, key);
   }
 }
 
@@ -169,12 +169,12 @@ INSTANTIATE_TEST_SUITE_P(
             .subscriptions = {{
                 .subscription_id = "subscription_id",
                 .key_prefixes_to_subscribe = {"prefix:"},
-                .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                .expected_type_subscriptions = REDISMODULE_NOTIFY_HASH,
+                .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
             }},
             .notifications = {{
                 .notification_key = "prefix:key",
-                .notification_type = REDISMODULE_NOTIFY_HASH,
+                .notification_type = VALKEYMODULE_NOTIFY_HASH,
                 .expected_subscriptions_with_notifications =
                     {"subscription_id"},
             }},
@@ -184,12 +184,12 @@ INSTANTIATE_TEST_SUITE_P(
             .subscriptions = {{
                 .subscription_id = "subscription_id",
                 .key_prefixes_to_subscribe = {"prefix1:"},
-                .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                .expected_type_subscriptions = REDISMODULE_NOTIFY_HASH,
+                .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
             }},
             .notifications = {{
                 .notification_key = "prefix:key",
-                .notification_type = REDISMODULE_NOTIFY_HASH,
+                .notification_type = VALKEYMODULE_NOTIFY_HASH,
                 .expected_subscriptions_with_notifications = {},
             }},
         },
@@ -198,12 +198,12 @@ INSTANTIATE_TEST_SUITE_P(
             .subscriptions = {{
                 .subscription_id = "subscription_id",
                 .key_prefixes_to_subscribe = {"prefix:"},
-                .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                .expected_type_subscriptions = REDISMODULE_NOTIFY_HASH,
+                .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
             }},
             .notifications = {{
                 .notification_key = "prefix:key",
-                .notification_type = REDISMODULE_NOTIFY_EVICTED,
+                .notification_type = VALKEYMODULE_NOTIFY_EVICTED,
                 .expected_subscriptions_with_notifications = {},
             }},
         },
@@ -212,40 +212,40 @@ INSTANTIATE_TEST_SUITE_P(
             .subscriptions = {{
                 .subscription_id = "subscription_id",
                 .key_prefixes_to_subscribe = {""},
-                .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                .expected_type_subscriptions = REDISMODULE_NOTIFY_HASH,
+                .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
             }},
             .notifications = {{
                                   .notification_key = "prefix:key",
-                                  .notification_type = REDISMODULE_NOTIFY_HASH,
+                                  .notification_type = VALKEYMODULE_NOTIFY_HASH,
                                   .expected_subscriptions_with_notifications =
                                       {"subscription_id"},
                               },
                               {
                                   .notification_key = "different:key",
-                                  .notification_type = REDISMODULE_NOTIFY_HASH,
+                                  .notification_type = VALKEYMODULE_NOTIFY_HASH,
                                   .expected_subscriptions_with_notifications =
                                       {"subscription_id"},
                               }},
         },
         {
             .test_name = "two_subscriptions_same_types",
-            .subscriptions = {{
-                                  .subscription_id = "subscription_id_0",
-                                  .key_prefixes_to_subscribe = {"prefix:"},
-                                  .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                                  .expected_type_subscriptions =
-                                      REDISMODULE_NOTIFY_HASH,
-                              },
-                              {
-                                  .subscription_id = "subscription_id_1",
-                                  .key_prefixes_to_subscribe = {"prefix:"},
-                                  .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                                  .expected_type_subscriptions = absl::nullopt,
-                              }},
+            .subscriptions =
+                {{
+                     .subscription_id = "subscription_id_0",
+                     .key_prefixes_to_subscribe = {"prefix:"},
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                     .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
+                 },
+                 {
+                     .subscription_id = "subscription_id_1",
+                     .key_prefixes_to_subscribe = {"prefix:"},
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                     .expected_type_subscriptions = absl::nullopt,
+                 }},
             .notifications = {{
                 .notification_key = "prefix:key",
-                .notification_type = REDISMODULE_NOTIFY_HASH,
+                .notification_type = VALKEYMODULE_NOTIFY_HASH,
                 .expected_subscriptions_with_notifications =
                     {"subscription_id_0", "subscription_id_1"},
             }},
@@ -256,63 +256,63 @@ INSTANTIATE_TEST_SUITE_P(
                 {{
                      .subscription_id = "subscription_id_0",
                      .key_prefixes_to_subscribe = {"prefix:"},
-                     .types_to_subscribe = REDISMODULE_NOTIFY_HASH |
-                                           REDISMODULE_NOTIFY_STREAM,
-                     .expected_type_subscriptions = REDISMODULE_NOTIFY_HASH |
-                                                    REDISMODULE_NOTIFY_STREAM,
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH |
+                                           VALKEYMODULE_NOTIFY_STREAM,
+                     .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH |
+                                                    VALKEYMODULE_NOTIFY_STREAM,
                  },
                  {
                      .subscription_id = "subscription_id_1",
                      .key_prefixes_to_subscribe = {"prefix:"},
-                     .types_to_subscribe = REDISMODULE_NOTIFY_HASH |
-                                           REDISMODULE_NOTIFY_ZSET,
-                     .expected_type_subscriptions = REDISMODULE_NOTIFY_ZSET,
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH |
+                                           VALKEYMODULE_NOTIFY_ZSET,
+                     .expected_type_subscriptions = VALKEYMODULE_NOTIFY_ZSET,
                  }},
             .notifications =
                 {{
                      .notification_key = "prefix:key",
-                     .notification_type = REDISMODULE_NOTIFY_HASH,
+                     .notification_type = VALKEYMODULE_NOTIFY_HASH,
                      .expected_subscriptions_with_notifications =
                          {"subscription_id_0", "subscription_id_1"},
                  },
                  {
                      .notification_key = "prefix:key",
-                     .notification_type = REDISMODULE_NOTIFY_ZSET,
+                     .notification_type = VALKEYMODULE_NOTIFY_ZSET,
                      .expected_subscriptions_with_notifications =
                          {"subscription_id_1"},
                  },
                  {
                      .notification_key = "prefix:key",
-                     .notification_type = REDISMODULE_NOTIFY_STREAM,
+                     .notification_type = VALKEYMODULE_NOTIFY_STREAM,
                      .expected_subscriptions_with_notifications =
                          {"subscription_id_0"},
                  }},
         },
         {
             .test_name = "two_subscriptions_prefix_partial_match",
-            .subscriptions = {{
-                                  .subscription_id = "subscription_id_0",
-                                  .key_prefixes_to_subscribe = {"prefix1"},
-                                  .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                                  .expected_type_subscriptions =
-                                      REDISMODULE_NOTIFY_HASH,
-                              },
-                              {
-                                  .subscription_id = "subscription_id_1",
-                                  .key_prefixes_to_subscribe = {"prefix11"},
-                                  .types_to_subscribe = REDISMODULE_NOTIFY_HASH,
-                                  .expected_type_subscriptions = absl::nullopt,
-                              }},
+            .subscriptions =
+                {{
+                     .subscription_id = "subscription_id_0",
+                     .key_prefixes_to_subscribe = {"prefix1"},
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                     .expected_type_subscriptions = VALKEYMODULE_NOTIFY_HASH,
+                 },
+                 {
+                     .subscription_id = "subscription_id_1",
+                     .key_prefixes_to_subscribe = {"prefix11"},
+                     .types_to_subscribe = VALKEYMODULE_NOTIFY_HASH,
+                     .expected_type_subscriptions = absl::nullopt,
+                 }},
             .notifications = {{
                                   .notification_key = "prefix11:key",
-                                  .notification_type = REDISMODULE_NOTIFY_HASH,
+                                  .notification_type = VALKEYMODULE_NOTIFY_HASH,
                                   .expected_subscriptions_with_notifications =
                                       {"subscription_id_0",
                                        "subscription_id_1"},
                               },
                               {
                                   .notification_key = "prefix1:key",
-                                  .notification_type = REDISMODULE_NOTIFY_HASH,
+                                  .notification_type = VALKEYMODULE_NOTIFY_HASH,
                                   .expected_subscriptions_with_notifications =
                                       {"subscription_id_0"},
                               }},

--- a/testing/multi_exec_test.cc
+++ b/testing/multi_exec_test.cc
@@ -70,27 +70,27 @@ class MultiExecTest : public ValkeySearchTest {
         index_schema->AddIndex("attribute_name", identifier, mock_index));
     EXPECT_CALL(*mock_index, IsTracked(testing::_))
         .WillRepeatedly(testing::Return(false));
-    EXPECT_CALL(*kMockRedisModule, KeyType(testing::_))
-        .WillRepeatedly(testing::Return(REDISMODULE_KEYTYPE_HASH));
+    EXPECT_CALL(*kMockValkeyModule, KeyType(testing::_))
+        .WillRepeatedly(testing::Return(VALKEYMODULE_KEYTYPE_HASH));
 
-    EXPECT_CALL(*kMockRedisModule,
-                HashGet(testing::_, REDISMODULE_HASH_CFIELDS, testing::_,
-                        testing::An<RedisModuleString **>(),
+    EXPECT_CALL(*kMockValkeyModule,
+                HashGet(testing::_, VALKEYMODULE_HASH_CFIELDS, testing::_,
+                        testing::An<ValkeyModuleString **>(),
                         testing::TypedEq<void *>(nullptr)))
-        .WillRepeatedly([this, identifier](RedisModuleKey *key, int flags,
+        .WillRepeatedly([this, identifier](ValkeyModuleKey *key, int flags,
                                            const char *field,
-                                           RedisModuleString **value_out,
+                                           ValkeyModuleString **value_out,
                                            void *terminating_null) {
-          RedisModuleString *value_redis_str =
-              TestRedisModule_CreateStringPrintf(nullptr, "%s%d", record_value_,
-                                                 record_index);
+          ValkeyModuleString *value_valkey_str =
+              TestValkeyModule_CreateStringPrintf(nullptr, "%s%d",
+                                                  record_value_, record_index);
           std::string field_str(field);
           std::string identifier_str(identifier);
           if (identifier_str == field_str) {
             record_index++;
           }
-          *value_out = value_redis_str;
-          return REDISMODULE_OK;
+          *value_out = value_valkey_str;
+          return VALKEYMODULE_OK;
         });
     EXPECT_CALL(*mock_index, AddRecord(testing::_, testing::_))
         .WillRepeatedly(
@@ -123,32 +123,33 @@ class MultiExecTest : public ValkeySearchTest {
 };
 
 TEST_F(MultiExecTest, Basic) {
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
-      .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_MULTI));
-  EXPECT_CALL(*kMockRedisModule, EventLoopAddOneShot(testing::_, testing::_))
-      .WillOnce([this](RedisModuleEventLoopOneShotFunc func, void *data) {
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_MULTI));
+  EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
+      .WillOnce([this](ValkeyModuleEventLoopOneShotFunc func, void *data) {
         cb_data = data;
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
   std::vector<std::string> expected_keys;
   expected_keys.reserve(max_keys + 1);
   for (int i = 0; i < max_keys; ++i) {
     expected_keys.push_back(key_prefix + std::to_string(i));
   }
-  EXPECT_CALL(*kMockRedisModule, BlockClient(testing::_, testing::_, testing::_,
-                                             testing::_, testing::_))
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      BlockClient(testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(0);
-  EXPECT_CALL(*kMockRedisModule,
-              UnblockClient((RedisModuleBlockedClient *)1, testing::_))
+  EXPECT_CALL(*kMockValkeyModule,
+              UnblockClient((ValkeyModuleBlockedClient *)1, testing::_))
       .Times(0);
   {
     absl::MutexLock lock(&mutex);
     EXPECT_TRUE(added_keys.empty());
   }
   for (const auto &expected_key : expected_keys) {
-    auto key_redis_str = vmsdk::MakeUniqueRedisString(expected_key);
-    index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString(expected_key);
+    index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
   }
   {
     absl::MutexLock lock(&mutex);
@@ -170,20 +171,20 @@ TEST_F(MultiExecTest, Basic) {
     EXPECT_THAT(expected_keys, testing::UnorderedElementsAreArray(added_keys));
     added_keys.clear();
 
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
         .WillRepeatedly(testing::Return(0));
-    auto key_redis_str = vmsdk::MakeUniqueRedisString("key3");
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx_))
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString("key3");
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx_))
         .WillRepeatedly(testing::Return(1));
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         BlockClient(testing::_, testing::_, testing::_, testing::_, testing::_))
-        .WillOnce(testing::Return((RedisModuleBlockedClient *)1));
-    EXPECT_CALL(*kMockRedisModule,
-                UnblockClient((RedisModuleBlockedClient *)1, testing::_))
-        .WillOnce(testing::Return(REDISMODULE_OK));
-    index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
+        .WillOnce(testing::Return((ValkeyModuleBlockedClient *)1));
+    EXPECT_CALL(*kMockValkeyModule,
+                UnblockClient((ValkeyModuleBlockedClient *)1, testing::_))
+        .WillOnce(testing::Return(VALKEYMODULE_OK));
+    index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
   }
   WaitWorkerTasksAreCompleted(*mutations_thread_pool);
   {
@@ -196,31 +197,32 @@ TEST_F(MultiExecTest, Basic) {
 
 TEST_F(MultiExecTest, TrackMutationOverride) {
   VMSDK_EXPECT_OK(mutations_thread_pool->SuspendWorkers());
-  EXPECT_CALL(*kMockRedisModule, EventLoopAddOneShot(testing::_, testing::_))
-      .WillOnce([this](RedisModuleEventLoopOneShotFunc func, void *data) {
+  EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
+      .WillOnce([this](ValkeyModuleEventLoopOneShotFunc func, void *data) {
         cb_data = data;
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
       .WillRepeatedly(testing::Return(0));
-  EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx_))
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx_))
       .WillRepeatedly(testing::Return(1));
-  EXPECT_CALL(*kMockRedisModule, BlockClient(testing::_, testing::_, testing::_,
-                                             testing::_, testing::_))
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      BlockClient(testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(1)
-      .WillRepeatedly(testing::Return((RedisModuleBlockedClient *)1));
+      .WillRepeatedly(testing::Return((ValkeyModuleBlockedClient *)1));
 
-  EXPECT_CALL(*kMockRedisModule,
-              UnblockClient((RedisModuleBlockedClient *)1, testing::_))
+  EXPECT_CALL(*kMockValkeyModule,
+              UnblockClient((ValkeyModuleBlockedClient *)1, testing::_))
       .Times(1)
-      .WillRepeatedly(testing::Return(REDISMODULE_OK));
-  auto key_redis_str = vmsdk::MakeUniqueRedisString(key_prefix + "0");
-  index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                       "event", key_redis_str.get());
+      .WillRepeatedly(testing::Return(VALKEYMODULE_OK));
+  auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key_prefix + "0");
+  index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                       "event", key_valkey_str.get());
   EXPECT_EQ(mutations_thread_pool->QueueSize(), 1);
 
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
-      .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_MULTI));
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_MULTI));
 
   std::vector<std::string> expected_keys;
   expected_keys.reserve(max_keys + 1);
@@ -228,9 +230,9 @@ TEST_F(MultiExecTest, TrackMutationOverride) {
     expected_keys.push_back(key_prefix + std::to_string(i));
   }
   for (const auto &key : expected_keys) {
-    auto key_redis_str = vmsdk::MakeUniqueRedisString(key);
-    index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key);
+    index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
   }
 
   EXPECT_EQ(mutations_thread_pool->QueueSize(), 1);
@@ -238,14 +240,14 @@ TEST_F(MultiExecTest, TrackMutationOverride) {
     absl::MutexLock lock(&mutex);
     EXPECT_TRUE(added_keys.empty());
   }
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
       .WillRepeatedly(testing::Return(0));
-  EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx_))
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx_))
       .WillRepeatedly(testing::Return(1));
-  key_redis_str = vmsdk::MakeUniqueRedisString(key_prefix + "1");
+  key_valkey_str = vmsdk::MakeUniqueValkeyString(key_prefix + "1");
   VMSDK_EXPECT_OK(mutations_thread_pool->ResumeWorkers());
-  index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                       "event", key_redis_str.get());
+  index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                       "event", key_valkey_str.get());
   absl::AnyInvocable<void()> *fn = (absl::AnyInvocable<void()> *)cb_data;
   (*fn)();
   delete fn;
@@ -263,32 +265,33 @@ TEST_F(MultiExecTest, TrackMutationOverride) {
 }
 
 TEST_F(MultiExecTest, FtSearchMulti) {
-  EXPECT_CALL(*kMockRedisModule, EventLoopAddOneShot(testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
       .Times(0);
   VMSDK_EXPECT_OK(
       ValkeySearch::Instance().GetReaderThreadPool()->SuspendWorkers());
   EXPECT_CALL(
-      *kMockRedisModule,
-      OpenKey(&fake_ctx_, testing::An<RedisModuleString *>(), testing::_))
-      .WillRepeatedly(TestRedisModule_OpenKeyDefaultImpl);
+      *kMockValkeyModule,
+      OpenKey(&fake_ctx_, testing::An<ValkeyModuleString *>(), testing::_))
+      .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
 
-  EXPECT_CALL(*kMockRedisModule, GetContextFlags(testing::_))
-      .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_MULTI));
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(testing::_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_MULTI));
   std::vector<std::string> expected_keys;
   expected_keys.reserve(max_keys);
   for (size_t i = 0; i < mutations_thread_pool->Size() - 1; ++i) {
     expected_keys.push_back(key_prefix + std::to_string(i));
   }
-  EXPECT_CALL(*kMockRedisModule, BlockClient(testing::_, testing::_, testing::_,
-                                             testing::_, testing::_))
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      BlockClient(testing::_, testing::_, testing::_, testing::_, testing::_))
       .Times(0);
-  EXPECT_CALL(*kMockRedisModule,
-              UnblockClient((RedisModuleBlockedClient *)1, testing::_))
+  EXPECT_CALL(*kMockValkeyModule,
+              UnblockClient((ValkeyModuleBlockedClient *)1, testing::_))
       .Times(0);
   for (const auto &key : expected_keys) {
-    auto key_redis_str = vmsdk::MakeUniqueRedisString(key);
-    index_schema->OnKeyspaceNotification(&fake_ctx_, REDISMODULE_NOTIFY_HASH,
-                                         "event", key_redis_str.get());
+    auto key_valkey_str = vmsdk::MakeUniqueValkeyString(key);
+    index_schema->OnKeyspaceNotification(&fake_ctx_, VALKEYMODULE_NOTIFY_HASH,
+                                         "event", key_valkey_str.get());
   }
 
   std::vector<std::string> argv = {
@@ -304,15 +307,16 @@ TEST_F(MultiExecTest, FtSearchMulti) {
       "2",
   };
   auto vectors = DeterministicallyGenerateVectors(1, 100, 10.0);
-  std::vector<RedisModuleString *> cmd_argv;
+  std::vector<ValkeyModuleString *> cmd_argv;
   std::transform(
       argv.begin(), argv.end(), std::back_inserter(cmd_argv),
       [&](std::string val) {
         if (val == "$embedding") {
-          return RedisModule_CreateString(&fake_ctx_, (char *)vectors[0].data(),
-                                          vectors[0].size() * sizeof(float));
+          return ValkeyModule_CreateString(&fake_ctx_,
+                                           (char *)vectors[0].data(),
+                                           vectors[0].size() * sizeof(float));
         }
-        return RedisModule_CreateString(&fake_ctx_, val.data(), val.size());
+        return ValkeyModule_CreateString(&fake_ctx_, val.data(), val.size());
       });
   EXPECT_FALSE(cb_data);
   VMSDK_EXPECT_OK(FTSearchCmd(&fake_ctx_, cmd_argv.data(), cmd_argv.size()));
@@ -321,7 +325,7 @@ TEST_F(MultiExecTest, FtSearchMulti) {
     EXPECT_THAT(expected_keys, testing::UnorderedElementsAreArray(added_keys));
   }
   for (auto cmd_arg : cmd_argv) {
-    TestRedisModule_FreeString(&fake_ctx_, cmd_arg);
+    TestValkeyModule_FreeString(&fake_ctx_, cmd_arg);
   }
   index_schema = nullptr;
 }

--- a/testing/numeric_index_test.cc
+++ b/testing/numeric_index_test.cc
@@ -45,7 +45,7 @@ namespace valkey_search::indexes {
 
 namespace {
 
-class NumericIndexTest : public vmsdk::RedisTest {
+class NumericIndexTest : public vmsdk::ValkeyTest {
  protected:
   data_model::NumericIndex numeric_index_proto;
   IndexTeser<Numeric, data_model::NumericIndex> index{numeric_index_proto};

--- a/testing/query/response_generator_test.cc
+++ b/testing/query/response_generator_test.cc
@@ -88,15 +88,15 @@ RecordsMap ToRecordsMap(
   RecordsMap records_map;
   for (const auto &[key, value] : record_map) {
     records_map.emplace(key,
-                        RecordsMapValue(vmsdk::MakeUniqueRedisString(key),
-                                        vmsdk::MakeUniqueRedisString(value)));
+                        RecordsMapValue(vmsdk::MakeUniqueValkeyString(key),
+                                        vmsdk::MakeUniqueValkeyString(value)));
   }
   return records_map;
 }
 
 TEST_P(ResponseGeneratorTest, ProcessNeighborsForReply) {
   auto &params = GetParam();
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
 
   std::deque<indexes::Neighbor> expected_neighbors;
   for (const auto &external_id : params.external_id_neighbors) {
@@ -113,8 +113,8 @@ TEST_P(ResponseGeneratorTest, ProcessNeighborsForReply) {
   for (const auto &return_attribute : params.return_attributes) {
     parameters.return_attributes.push_back(
         {.identifier =
-             vmsdk::MakeUniqueRedisString(return_attribute.identifier),
-         .alias = vmsdk::MakeUniqueRedisString(return_attribute.alias)});
+             vmsdk::MakeUniqueValkeyString(return_attribute.identifier),
+         .alias = vmsdk::MakeUniqueValkeyString(return_attribute.alias)});
   }
   parameters.filter_parse_results.filter_identifiers =
       params.filter_identifiers;
@@ -148,7 +148,7 @@ TEST_P(ResponseGeneratorTest, ProcessNeighborsForReply) {
                                 absl::string_view(*neighbor.external_id),
                                 expected_fetched_identifiers))
         .WillOnce([&params](
-                      RedisModuleCtx *ctx,
+                      ValkeyModuleCtx *ctx,
                       const std::string &query_attribute_alias,
                       absl::string_view key,
                       const absl::flat_hash_set<absl::string_view> &identifiers)

--- a/testing/rdb_serialization_test.cc
+++ b/testing/rdb_serialization_test.cc
@@ -46,17 +46,17 @@ namespace {
 
 class SafeRDBTest : public ValkeySearchTest {
  protected:
-  void SetUp() override { TestRedisModule_Init(); }
-  RedisModuleIO* fake_redis_module_io_ = (RedisModuleIO*)0xBADF00D1;
+  void SetUp() override { TestValkeyModule_Init(); }
+  ValkeyModuleIO* fake_valkey_module_io_ = (ValkeyModuleIO*)0xBADF00D1;
 };
 
 TEST_F(SafeRDBTest, LoadSizeTSuccess) {
   size_t expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadUnsigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadUnsigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   auto res = rdb_stream.LoadSizeT();
   VMSDK_EXPECT_OK(res);
   EXPECT_EQ(res.value(), expected_value);
@@ -64,22 +64,22 @@ TEST_F(SafeRDBTest, LoadSizeTSuccess) {
 
 TEST_F(SafeRDBTest, LoadSizeTFailure) {
   size_t expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadUnsigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadUnsigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.LoadSizeT().status().code(),
             absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, LoadUnsignedSuccess) {
   unsigned int expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadUnsigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadUnsigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   auto res = rdb_stream.LoadUnsigned();
   VMSDK_EXPECT_OK(res);
   EXPECT_EQ(res.value(), expected_value);
@@ -88,22 +88,22 @@ TEST_F(SafeRDBTest, LoadUnsignedSuccess) {
 TEST_F(SafeRDBTest, LoadUnsignedFailure) {
   unsigned int actual_value;
   unsigned int expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadUnsigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadUnsigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.LoadUnsigned().status().code(),
             absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, LoadSignedSuccess) {
   int expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadSigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadSigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   auto res = rdb_stream.LoadSigned();
   VMSDK_EXPECT_OK(res);
   EXPECT_EQ(res.value(), expected_value);
@@ -111,11 +111,11 @@ TEST_F(SafeRDBTest, LoadSignedSuccess) {
 
 TEST_F(SafeRDBTest, LoadSignedFailure) {
   int expected_value = 34;
-  EXPECT_CALL(*kMockRedisModule, LoadSigned(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadSigned(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.LoadSigned().status().code(),
             absl::StatusCode::kInternal);
 }
@@ -123,11 +123,11 @@ TEST_F(SafeRDBTest, LoadSignedFailure) {
 TEST_F(SafeRDBTest, LoadDoubleSuccess) {
   double actual_value;
   double expected_value = 34.5;
-  EXPECT_CALL(*kMockRedisModule, LoadDouble(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadDouble(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   auto res = rdb_stream.LoadDouble();
   VMSDK_EXPECT_OK(res);
   EXPECT_EQ(res.value(), expected_value);
@@ -135,129 +135,129 @@ TEST_F(SafeRDBTest, LoadDoubleSuccess) {
 
 TEST_F(SafeRDBTest, LoadDoubleFailure) {
   double expected_value = 34.5;
-  EXPECT_CALL(*kMockRedisModule, LoadDouble(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, LoadDouble(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.LoadDouble().status().code(),
             absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, LoadStringSuccess) {
-  RedisModuleString* expected_value =
-      TestRedisModule_CreateStringPrintf(nullptr, "test");
-  EXPECT_CALL(*kMockRedisModule, LoadString(fake_redis_module_io_))
+  ValkeyModuleString* expected_value =
+      TestValkeyModule_CreateStringPrintf(nullptr, "test");
+  EXPECT_CALL(*kMockValkeyModule, LoadString(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   auto actual_value_or = rdb_stream.LoadString();
   VMSDK_EXPECT_OK(actual_value_or.status());
   EXPECT_EQ(actual_value_or.value().get(), expected_value);
 }
 
 TEST_F(SafeRDBTest, LoadStringFailure) {
-  RedisModuleString* expected_value =
-      TestRedisModule_CreateStringPrintf(nullptr, "test");
-  EXPECT_CALL(*kMockRedisModule, LoadString(fake_redis_module_io_))
+  ValkeyModuleString* expected_value =
+      TestValkeyModule_CreateStringPrintf(nullptr, "test");
+  EXPECT_CALL(*kMockValkeyModule, LoadString(fake_valkey_module_io_))
       .WillOnce(testing::Return(expected_value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.LoadString().status().code(),
             absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, SaveSizeTSuccess) {
   size_t value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveUnsigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveUnsigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   VMSDK_EXPECT_OK(rdb_stream.SaveSizeT(value));
 }
 
 TEST_F(SafeRDBTest, SaveSizeTFailure) {
   size_t value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveUnsigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveUnsigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.SaveSizeT(value).code(), absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, SaveUnsignedSuccess) {
   unsigned int value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveUnsigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveUnsigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   VMSDK_EXPECT_OK(rdb_stream.SaveUnsigned(value));
 }
 
 TEST_F(SafeRDBTest, SaveUnsignedFailure) {
   unsigned int value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveUnsigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveUnsigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.SaveUnsigned(value).code(), absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, SaveSignedSuccess) {
   int64_t value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveSigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveSigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   VMSDK_EXPECT_OK(rdb_stream.SaveSigned(value));
 }
 
 TEST_F(SafeRDBTest, SaveSignedFailure) {
   int64_t value = 34;
-  EXPECT_CALL(*kMockRedisModule, SaveSigned(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveSigned(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.SaveSigned(value).code(), absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, SaveDoubleSuccess) {
   double value = 34.5;
-  EXPECT_CALL(*kMockRedisModule, SaveDouble(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveDouble(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   VMSDK_EXPECT_OK(rdb_stream.SaveDouble(value));
 }
 
 TEST_F(SafeRDBTest, SaveDoubleFailure) {
   double value = 34.5;
-  EXPECT_CALL(*kMockRedisModule, SaveDouble(fake_redis_module_io_, value));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveDouble(fake_valkey_module_io_, value));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.SaveDouble(value).code(), absl::StatusCode::kInternal);
 }
 
 TEST_F(SafeRDBTest, SaveStringBufferSuccess) {
   absl::string_view value = "test";
-  EXPECT_CALL(*kMockRedisModule, SaveStringBuffer(fake_redis_module_io_,
-                                                  value.data(), value.size()));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveStringBuffer(fake_valkey_module_io_,
+                                                   value.data(), value.size()));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(0));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   VMSDK_EXPECT_OK(rdb_stream.SaveStringBuffer(value));
 }
 
 TEST_F(SafeRDBTest, SaveStringBufferFailureIOError) {
   absl::string_view value = "test";
-  EXPECT_CALL(*kMockRedisModule, SaveStringBuffer(fake_redis_module_io_,
-                                                  value.data(), value.size()));
-  EXPECT_CALL(*kMockRedisModule, IsIOError(fake_redis_module_io_))
+  EXPECT_CALL(*kMockValkeyModule, SaveStringBuffer(fake_valkey_module_io_,
+                                                   value.data(), value.size()));
+  EXPECT_CALL(*kMockValkeyModule, IsIOError(fake_valkey_module_io_))
       .WillOnce(testing::Return(1));
-  SafeRDB rdb_stream(fake_redis_module_io_);
+  SafeRDB rdb_stream(fake_valkey_module_io_);
   EXPECT_EQ(rdb_stream.SaveStringBuffer(value).code(),
             absl::StatusCode::kInternal);
 }
@@ -265,13 +265,13 @@ TEST_F(SafeRDBTest, SaveStringBufferFailureIOError) {
 class MockRDBSectionCallback {
  public:
   MOCK_METHOD(absl::Status, load,
-              (RedisModuleCtx * ctx,
+              (ValkeyModuleCtx * ctx,
                std::unique_ptr<data_model::RDBSection> section,
                SupplementalContentIter&& iter));
   MOCK_METHOD(absl::Status, save,
-              (RedisModuleCtx * ctx, SafeRDB* rdb, int when));
-  MOCK_METHOD(int, section_count, (RedisModuleCtx * ctx, int when));
-  MOCK_METHOD(int, minimum_semantic_version, (RedisModuleCtx * ctx, int when));
+              (ValkeyModuleCtx * ctx, SafeRDB* rdb, int when));
+  MOCK_METHOD(int, section_count, (ValkeyModuleCtx * ctx, int when));
+  MOCK_METHOD(int, minimum_semantic_version, (ValkeyModuleCtx * ctx, int when));
 };
 
 class RDBSerializationTest : public ValkeySearchTest {
@@ -280,9 +280,9 @@ class RDBSerializationTest : public ValkeySearchTest {
     std::shared_ptr<MockRDBSectionCallback> mock_callbacks;
     RDBSectionCallbacks callbacks_struct;
   };
-  void SetUp() override { TestRedisModule_Init(); }
+  void SetUp() override { TestValkeyModule_Init(); }
   void TearDown() override {
-    TestRedisModule_Teardown();
+    TestValkeyModule_Teardown();
     ClearRDBCallbacks();
   }
   TestRDBSectionCallbacks GenerateRDBSectionCallbacks() {
@@ -290,21 +290,21 @@ class RDBSerializationTest : public ValkeySearchTest {
         std::make_shared<testing::NiceMock<MockRDBSectionCallback>>();
     RDBSectionCallbacks callbacks_struct{
         .load =
-            [mock_callbacks](RedisModuleCtx* ctx,
+            [mock_callbacks](ValkeyModuleCtx* ctx,
                              std::unique_ptr<data_model::RDBSection> section,
                              SupplementalContentIter&& iter) {
               return mock_callbacks->load(ctx, std::move(section),
                                           std::move(iter));
             },
         .save = [mock_callbacks](
-                    RedisModuleCtx* ctx, SafeRDB* rdb,
+                    ValkeyModuleCtx* ctx, SafeRDB* rdb,
                     int when) { return mock_callbacks->save(ctx, rdb, when); },
         .section_count =
-            [mock_callbacks](RedisModuleCtx* ctx, int when) {
+            [mock_callbacks](ValkeyModuleCtx* ctx, int when) {
               return mock_callbacks->section_count(ctx, when);
             },
         .minimum_semantic_version =
-            [mock_callbacks](RedisModuleCtx* ctx, int when) {
+            [mock_callbacks](ValkeyModuleCtx* ctx, int when) {
               return mock_callbacks->minimum_semantic_version(ctx, when);
             },
     };
@@ -317,30 +317,30 @@ class RDBSerializationTest : public ValkeySearchTest {
 
 TEST_F(RDBSerializationTest, RegisterModuleTypeHappyPath) {
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       CreateDataType(&fake_ctx_, testing::StrEq(kValkeySearchModuleTypeName),
                      kCurrentEncVer, testing::_))
       .WillOnce(testing::Invoke(
-          [](RedisModuleCtx* ctx, const char* name, int encver,
-             RedisModuleTypeMethods* type_methods) -> RedisModuleType* {
+          [](ValkeyModuleCtx* ctx, const char* name, int encver,
+             ValkeyModuleTypeMethods* type_methods) -> ValkeyModuleType* {
             EXPECT_EQ(type_methods->aux_load, AuxLoadCallback);
             EXPECT_EQ(type_methods->aux_save2, AuxSaveCallback);
             EXPECT_EQ(type_methods->aux_save, nullptr);
             EXPECT_EQ(type_methods->aux_save_triggers,
-                      REDISMODULE_AUX_AFTER_RDB);
-            return (RedisModuleType*)0xBAADF00D;
+                      VALKEYMODULE_AUX_AFTER_RDB);
+            return (ValkeyModuleType*)0xBAADF00D;
           }));
   VMSDK_EXPECT_OK(RegisterModuleType(&fake_ctx_));
 }
 
 TEST_F(RDBSerializationTest, RegisterModuleTypeReturnNullptr) {
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       CreateDataType(&fake_ctx_, testing::StrEq(kValkeySearchModuleTypeName),
                      kCurrentEncVer, testing::_))
       .WillOnce(testing::Invoke(
-          [](RedisModuleCtx* ctx, const char* name, int encver,
-             RedisModuleTypeMethods* type_methods) -> RedisModuleType* {
+          [](ValkeyModuleCtx* ctx, const char* name, int encver,
+             ValkeyModuleTypeMethods* type_methods) -> ValkeyModuleType* {
             return nullptr;
           }));
   EXPECT_EQ(RegisterModuleType(&fake_ctx_).code(), absl::StatusCode::kInternal);
@@ -349,7 +349,7 @@ TEST_F(RDBSerializationTest, RegisterModuleTypeReturnNullptr) {
 TEST_F(RDBSerializationTest, PerformRDBSaveNoRegisteredTypes) {
   FakeSafeRDB fake_rdb;
   VMSDK_EXPECT_OK(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
   EXPECT_EQ(fake_rdb.buffer_.rdbuf()->in_avail(), 0);
 }
 
@@ -361,7 +361,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveNoRDBSectionDoesNothing) {
   EXPECT_CALL(*test_cb.mock_callbacks, save(testing::_, testing::_, testing::_))
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks,
-              section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+              section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
       .WillOnce(testing::Return(0));
   EXPECT_CALL(*test_cb.mock_callbacks,
               minimum_semantic_version(testing::_, testing::_))
@@ -369,7 +369,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveNoRDBSectionDoesNothing) {
   RegisterRDBCallback(data_model::RDB_SECTION_INDEX_SCHEMA,
                       std::move(test_cb.callbacks_struct));
   VMSDK_EXPECT_OK(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
   EXPECT_EQ(fake_rdb.buffer_.rdbuf()->in_avail(), 0);
 }
 
@@ -380,13 +380,13 @@ TEST_F(RDBSerializationTest, PerformRDBSaveOneRDBSection) {
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks, save(testing::_, testing::_, testing::_))
       .WillOnce(testing::Invoke(
-          [](RedisModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
-            EXPECT_EQ(when, REDISMODULE_AUX_BEFORE_RDB);
+          [](ValkeyModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
+            EXPECT_EQ(when, VALKEYMODULE_AUX_BEFORE_RDB);
             VMSDK_EXPECT_OK(rdb->SaveStringBuffer("test-string"));
             return absl::OkStatus();
           }));
   EXPECT_CALL(*test_cb.mock_callbacks,
-              section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+              section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
       .WillOnce(testing::Return(1));
   EXPECT_CALL(*test_cb.mock_callbacks,
               minimum_semantic_version(testing::_, testing::_))
@@ -394,7 +394,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveOneRDBSection) {
   RegisterRDBCallback(data_model::RDB_SECTION_INDEX_SCHEMA,
                       std::move(test_cb.callbacks_struct));
   VMSDK_EXPECT_OK(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
   auto sem_ver = fake_rdb.LoadUnsigned();
   VMSDK_EXPECT_OK_STATUSOR(sem_ver);
   EXPECT_EQ(sem_ver.value(), 0x0100ff);
@@ -417,14 +417,14 @@ TEST_F(RDBSerializationTest, PerformRDBSaveTwoRDBSection) {
     EXPECT_CALL(*test_cb.mock_callbacks,
                 save(testing::_, testing::_, testing::_))
         .WillOnce(testing::Invoke(
-            [i](RedisModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
-              EXPECT_EQ(when, REDISMODULE_AUX_BEFORE_RDB);
+            [i](ValkeyModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
+              EXPECT_EQ(when, VALKEYMODULE_AUX_BEFORE_RDB);
               std::string save_value = absl::StrCat("test-string-", i);
               VMSDK_EXPECT_OK(rdb->SaveStringBuffer(save_value));
               return absl::OkStatus();
             }));
     EXPECT_CALL(*test_cb.mock_callbacks,
-                section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+                section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
         .WillOnce(testing::Return(1));
     EXPECT_CALL(*test_cb.mock_callbacks,
                 minimum_semantic_version(testing::_, testing::_))
@@ -435,7 +435,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveTwoRDBSection) {
   }
 
   VMSDK_EXPECT_OK(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
   auto sem_ver = fake_rdb.LoadUnsigned();
   VMSDK_EXPECT_OK(sem_ver);
   EXPECT_EQ(sem_ver.value(), 0x0200ff);  // Larger of the two
@@ -465,11 +465,11 @@ TEST_F(RDBSerializationTest, PerformRDBSaveSectionSaveFail) {
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks, save(testing::_, testing::_, testing::_))
       .WillOnce(testing::Invoke(
-          [](RedisModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
+          [](ValkeyModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
             return absl::InternalError("test error");
           }));
   EXPECT_CALL(*test_cb.mock_callbacks,
-              section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+              section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
       .WillOnce(testing::Return(1));
   EXPECT_CALL(*test_cb.mock_callbacks,
               minimum_semantic_version(testing::_, testing::_))
@@ -478,7 +478,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveSectionSaveFail) {
                       std::move(test_cb.callbacks_struct));
 
   EXPECT_EQ(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB).code(),
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB).code(),
       absl::StatusCode::kInternal);
 }
 
@@ -493,13 +493,13 @@ TEST_F(RDBSerializationTest, PerformRDBSaveTwoRDBSectionOneEmpty) {
     if (i == 0) {
       EXPECT_CALL(*test_cb.mock_callbacks,
                   save(testing::_, testing::_, testing::_))
-          .WillOnce(testing::Invoke(
-              [i](RedisModuleCtx* ctx, SafeRDB* rdb, int when) -> absl::Status {
-                EXPECT_EQ(when, REDISMODULE_AUX_BEFORE_RDB);
-                std::string save_value = absl::StrCat("test-string-", i);
-                VMSDK_EXPECT_OK(rdb->SaveStringBuffer(save_value));
-                return absl::OkStatus();
-              }));
+          .WillOnce(testing::Invoke([i](ValkeyModuleCtx* ctx, SafeRDB* rdb,
+                                        int when) -> absl::Status {
+            EXPECT_EQ(when, VALKEYMODULE_AUX_BEFORE_RDB);
+            std::string save_value = absl::StrCat("test-string-", i);
+            VMSDK_EXPECT_OK(rdb->SaveStringBuffer(save_value));
+            return absl::OkStatus();
+          }));
       EXPECT_CALL(*test_cb.mock_callbacks,
                   minimum_semantic_version(testing::_, testing::_))
           .WillOnce(testing::Return(0x0100ff));
@@ -512,7 +512,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveTwoRDBSectionOneEmpty) {
           .Times(0);
     }
     EXPECT_CALL(*test_cb.mock_callbacks,
-                section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+                section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
         .WillOnce(testing::Return(i == 0 ? 1 : 0));
     RegisterRDBCallback(i == 0 ? data_model::RDB_SECTION_INDEX_SCHEMA
                                : data_model::RDB_SECTION_GLOBAL_METADATA,
@@ -520,7 +520,7 @@ TEST_F(RDBSerializationTest, PerformRDBSaveTwoRDBSectionOneEmpty) {
   }
 
   VMSDK_EXPECT_OK(
-      PerformRDBSave(&fake_ctx_, &fake_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      PerformRDBSave(&fake_ctx_, &fake_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
   auto sem_ver = fake_rdb.LoadUnsigned();
   VMSDK_EXPECT_OK(sem_ver);
   EXPECT_EQ(sem_ver.value(), 0x0100ff);
@@ -594,7 +594,7 @@ TEST_F(RDBSerializationTest, PerformRDBLoadRDBSectionRegistered) {
   auto test_cb = GenerateRDBSectionCallbacks();
   EXPECT_CALL(*test_cb.mock_callbacks, load(testing::_, testing::_, testing::_))
       .WillOnce(
-          testing::Invoke([](RedisModuleCtx* ctx,
+          testing::Invoke([](ValkeyModuleCtx* ctx,
                              std::unique_ptr<data_model::RDBSection> section,
                              SupplementalContentIter&& iter) {
             EXPECT_EQ(section->type(), data_model::RDB_SECTION_INDEX_SCHEMA);
@@ -607,7 +607,7 @@ TEST_F(RDBSerializationTest, PerformRDBLoadRDBSectionRegistered) {
   EXPECT_CALL(*test_cb.mock_callbacks, save(testing::_, testing::_, testing::_))
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks,
-              section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+              section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks,
               minimum_semantic_version(testing::_, testing::_))
@@ -631,7 +631,7 @@ TEST_F(RDBSerializationTest, PerformRDBLoadRDBSectionCallbackFailure) {
   auto test_cb = GenerateRDBSectionCallbacks();
   EXPECT_CALL(*test_cb.mock_callbacks, load(testing::_, testing::_, testing::_))
       .WillOnce(
-          testing::Invoke([](RedisModuleCtx* ctx,
+          testing::Invoke([](ValkeyModuleCtx* ctx,
                              std::unique_ptr<data_model::RDBSection> section,
                              SupplementalContentIter&& iter) {
             return absl::InternalError("test");
@@ -639,7 +639,7 @@ TEST_F(RDBSerializationTest, PerformRDBLoadRDBSectionCallbackFailure) {
   EXPECT_CALL(*test_cb.mock_callbacks, save(testing::_, testing::_, testing::_))
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks,
-              section_count(&fake_ctx_, REDISMODULE_AUX_BEFORE_RDB))
+              section_count(&fake_ctx_, VALKEYMODULE_AUX_BEFORE_RDB))
       .Times(0);
   EXPECT_CALL(*test_cb.mock_callbacks,
               minimum_semantic_version(testing::_, testing::_))

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -78,14 +78,14 @@ class SchemaManagerTest : public ValkeySearchTest {
     ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(
         test_index_schema_proto_str, &test_index_schema_proto_));
     mock_client_pool_ = std::make_unique<coordinator::MockClientPool>();
-    ON_CALL(*kMockRedisModule, GetSelectedDb(&fake_ctx_))
+    ON_CALL(*kMockValkeyModule, GetSelectedDb(&fake_ctx_))
         .WillByDefault(testing::Return(db_num_));
-    ON_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
         .WillByDefault(testing::Return(&fake_ctx_));
-    ON_CALL(*kMockRedisModule, FreeThreadSafeContext(testing::_))
+    ON_CALL(*kMockValkeyModule, FreeThreadSafeContext(testing::_))
         .WillByDefault(testing::Return());
-    ON_CALL(*kMockRedisModule, SelectDb(testing::_, db_num_))
-        .WillByDefault(testing::Return(REDISMODULE_OK));
+    ON_CALL(*kMockValkeyModule, SelectDb(testing::_, db_num_))
+        .WillByDefault(testing::Return(VALKEYMODULE_OK));
     test_metadata_manager_ = std::make_unique<coordinator::MetadataManager>(
         &fake_ctx_, *mock_client_pool_);
   }
@@ -245,40 +245,40 @@ TEST_F(SchemaManagerTest, TestOnFlushDB) {
 }
 
 TEST_F(SchemaManagerTest, TestSaveIndexesBeforeRDB) {
-  ON_CALL(*kMockRedisModule, GetContextFromIO(testing::_))
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));
   auto schema =
       CreateIndexSchema(index_name_, &fake_ctx_, nullptr, {}, db_num_).value();
-  RedisModuleIO *fake_rdb = reinterpret_cast<RedisModuleIO *>(0xDEADBEEF);
-  EXPECT_CALL(*kMockRedisModule, SaveUnsigned(fake_rdb, testing::_)).Times(0);
+  ValkeyModuleIO *fake_rdb = reinterpret_cast<ValkeyModuleIO *>(0xDEADBEEF);
+  EXPECT_CALL(*kMockValkeyModule, SaveUnsigned(fake_rdb, testing::_)).Times(0);
   EXPECT_CALL(*schema, RDBSave(testing::_)).Times(0);
   SafeRDB fake_safe_rdb(fake_rdb);
   VMSDK_EXPECT_OK(SchemaManager::Instance().SaveIndexes(
-      &fake_ctx_, &fake_safe_rdb, REDISMODULE_AUX_BEFORE_RDB));
+      &fake_ctx_, &fake_safe_rdb, VALKEYMODULE_AUX_BEFORE_RDB));
 }
 
 TEST_F(SchemaManagerTest, TestSaveIndexesAfterRDB) {
-  ON_CALL(*kMockRedisModule, GetContextFromIO(testing::_))
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));
   auto schema =
       CreateIndexSchema(index_name_, &fake_ctx_, nullptr, {}, db_num_).value();
-  RedisModuleIO *fake_rdb = reinterpret_cast<RedisModuleIO *>(0xDEADBEEF);
+  ValkeyModuleIO *fake_rdb = reinterpret_cast<ValkeyModuleIO *>(0xDEADBEEF);
   EXPECT_CALL(*schema, RDBSave(testing::_))
       .WillOnce(testing::Return(absl::OkStatus()));
   SafeRDB fake_safe_rdb(fake_rdb);
   VMSDK_EXPECT_OK(SchemaManager::Instance().SaveIndexes(
-      &fake_ctx_, &fake_safe_rdb, REDISMODULE_AUX_AFTER_RDB));
+      &fake_ctx_, &fake_safe_rdb, VALKEYMODULE_AUX_AFTER_RDB));
 }
 
 TEST_F(SchemaManagerTest, TestLoadIndexDuringReplication) {
-  RedisModuleEvent eid;
+  ValkeyModuleEvent eid;
   std::string existing_index_name = "test_key_2";
   auto test_index_schema_or = CreateVectorHNSWSchema(
       existing_index_name, &fake_ctx_, nullptr, {}, db_num_);
-  ON_CALL(*kMockRedisModule, GetContextFromIO(testing::_))
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));
   SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_LOADING_REPL_START, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_REPL_START, nullptr);
 
   FakeSafeRDB fake_rdb;
   auto section = std::make_unique<data_model::RDBSection>();
@@ -300,7 +300,7 @@ TEST_F(SchemaManagerTest, TestLoadIndexDuringReplication) {
 
   // Loading callback should apply the new schemas.
   SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_LOADING_ENDED, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   EXPECT_EQ(SchemaManager::Instance()
                 .GetIndexSchema(db_num_, existing_index_name)
                 .status()
@@ -311,8 +311,8 @@ TEST_F(SchemaManagerTest, TestLoadIndexDuringReplication) {
 }
 
 TEST_F(SchemaManagerTest, TestLoadIndexNoReplication) {
-  RedisModuleEvent eid;
-  ON_CALL(*kMockRedisModule, GetContextFromIO(testing::_))
+  ValkeyModuleEvent eid;
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));
 
   FakeSafeRDB fake_rdb;
@@ -330,14 +330,14 @@ TEST_F(SchemaManagerTest, TestLoadIndexNoReplication) {
 
   // Loading callback should not remove the new schemas.
   SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_LOADING_ENDED, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   VMSDK_EXPECT_OK(
       SchemaManager::Instance().GetIndexSchema(db_num_, index_name_));
 }
 
 TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {
-  RedisModuleEvent eid;
-  ON_CALL(*kMockRedisModule, GetContextFromIO(testing::_))
+  ValkeyModuleEvent eid;
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));
 
   // Load two indices as existing
@@ -354,7 +354,7 @@ TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {
         &fake_ctx_, std::move(section), SupplementalContentIter(&fake_rdb, 0)));
   }
   SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_LOADING_ENDED, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   VMSDK_EXPECT_OK(
       SchemaManager::Instance().GetIndexSchema(db_num_, "existing_0"));
   VMSDK_EXPECT_OK(
@@ -375,7 +375,7 @@ TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {
   }
 
   SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_LOADING_ENDED, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   VMSDK_EXPECT_OK(
       SchemaManager::Instance().GetIndexSchema(db_num_, "existing_0"));
   VMSDK_EXPECT_OK(
@@ -400,7 +400,7 @@ TEST_F(SchemaManagerTest, OnServerCronCallback) {
   InitThreadPools(10, 5);
   auto test_index_schema_or = CreateVectorHNSWSchema(
       "index_schema_key", &fake_ctx_, nullptr, {}, db_num_);
-  RedisModuleEvent eid;
+  ValkeyModuleEvent eid;
   EXPECT_TRUE(SchemaManager::Instance().IsIndexingInProgress());
   SchemaManager::Instance().OnServerCronCallback(&fake_ctx_, eid, 0, nullptr);
   EXPECT_FALSE(SchemaManager::Instance().IsIndexingInProgress());
@@ -485,10 +485,10 @@ TEST_P(OnSwapDBCallbackTest, OnSwapDBCallback) {
   VMSDK_EXPECT_OK(test_index_schema_or);
   auto test_index_schema = test_index_schema_or.value();
   EXPECT_TRUE(SchemaManager::Instance().IsIndexingInProgress());
-  RedisModuleSwapDbInfo swap_db_info;
+  ValkeyModuleSwapDbInfo swap_db_info;
   swap_db_info.dbnum_first = test_case.swap_dbnum_first;
   swap_db_info.dbnum_second = test_case.swap_dbnum_second;
-  RedisModuleEvent eid;
+  ValkeyModuleEvent eid;
   int32_t expected_dbnum = -1;
   if (test_case.index_schema_db_num == test_case.swap_dbnum_first) {
     expected_dbnum = test_case.swap_dbnum_second;
@@ -498,13 +498,13 @@ TEST_P(OnSwapDBCallbackTest, OnSwapDBCallback) {
   if (test_case.is_backfill_in_progress) {
     if (expected_dbnum == -1) {
       EXPECT_CALL(
-          *kMockRedisModule,
+          *kMockValkeyModule,
           SelectDb(test_index_schema->backfill_job_.Get()->scan_ctx.get(),
                    test_case.index_schema_db_num))
           .Times(0);
     } else {
       EXPECT_CALL(
-          *kMockRedisModule,
+          *kMockValkeyModule,
           SelectDb(test_index_schema->backfill_job_.Get()->scan_ctx.get(),
                    expected_dbnum))
           .WillOnce(testing::Return(1));

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -415,7 +415,7 @@ TEST_P(PerformVectorSearchTest, PerformVectorSearchTest) {
   query::VectorSearchParameters params;
   params.index_schema_name = kIndexSchemaName;
   params.attribute_alias = kVectorAttributeAlias;
-  params.score_as = vmsdk::MakeUniqueRedisString(kScoreAs);
+  params.score_as = vmsdk::MakeUniqueValkeyString(kScoreAs);
   params.dialect = kDialect;
   params.k = test_case.k;
   params.ef = kEfRuntime;
@@ -577,7 +577,7 @@ TEST_P(SearchTest, ParseParams) {
   params.index_schema = CreateIndexSchemaWithMultipleAttributes(indexer_type);
   params.index_schema_name = kIndexSchemaName;
   params.attribute_alias = kVectorAttributeAlias;
-  params.score_as = vmsdk::MakeUniqueRedisString(kScoreAs);
+  params.score_as = vmsdk::MakeUniqueValkeyString(kScoreAs);
   params.dialect = kDialect;
   params.k = test_case.k;
   params.ef = kEfRuntime;
@@ -728,8 +728,8 @@ struct IndexedContentTestCase {
         for (auto &attribute : *attribute_contents) {
           result.attribute_contents->emplace(
               attribute.first,
-              RecordsMapValue(vmsdk::MakeUniqueRedisString(attribute.first),
-                              vmsdk::MakeUniqueRedisString(attribute.second)));
+              RecordsMapValue(vmsdk::MakeUniqueValkeyString(attribute.first),
+                              vmsdk::MakeUniqueValkeyString(attribute.second)));
         }
       }
       return result;
@@ -850,8 +850,8 @@ TEST_P(IndexedContentTest, MaybeAddIndexedContentTest) {
   auto parameters = query::VectorSearchParameters();
   parameters.index_schema = index_schema;
   for (auto &attribute : test_case.return_attributes) {
-    auto identifier = vmsdk::MakeUniqueRedisString(attribute.identifier);
-    auto alias = vmsdk::MakeUniqueRedisString(attribute.alias);
+    auto identifier = vmsdk::MakeUniqueValkeyString(attribute.identifier);
+    auto alias = vmsdk::MakeUniqueValkeyString(attribute.alias);
     parameters.return_attributes.push_back(query::ReturnAttribute{
         .identifier = std::move(identifier), .alias = std::move(alias)});
   }

--- a/testing/server_events_test.cc
+++ b/testing/server_events_test.cc
@@ -55,15 +55,15 @@ class ServerEventsTest : public ValkeySearchTest {};
 
 TEST_F(ServerEventsTest, SubscribesToServerEvents) {
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SubscribeToServerEvent(
-          testing::_, vmsdk::IsRedisModuleEvent(RedisModuleEvent_CronLoop),
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_CronLoop),
           testing::_))
       .WillOnce(testing::Return(1));
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SubscribeToServerEvent(
-          testing::_, vmsdk::IsRedisModuleEvent(RedisModuleEvent_ForkChild),
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_ForkChild),
           testing::_))
       .WillOnce(testing::Return(1));
 #ifndef TESTING_TMP_DISABLED
@@ -72,21 +72,21 @@ TEST_F(ServerEventsTest, SubscribesToServerEvents) {
       .WillOnce(testing::Return(1));
 #endif  // TESTING_TMP_DISABLED
   EXPECT_CALL(
-      *kMockRedisModule,
-      SubscribeToServerEvent(testing::_,
-                             vmsdk::IsRedisModuleEvent(RedisModuleEvent_SwapDB),
-                             testing::_))
-      .WillOnce(testing::Return(1));
-  EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SubscribeToServerEvent(
-          testing::_, vmsdk::IsRedisModuleEvent(RedisModuleEvent_Loading),
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_SwapDB),
           testing::_))
       .WillOnce(testing::Return(1));
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       SubscribeToServerEvent(
-          testing::_, vmsdk::IsRedisModuleEvent(RedisModuleEvent_FlushDB),
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_Loading),
+          testing::_))
+      .WillOnce(testing::Return(1));
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      SubscribeToServerEvent(
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_FlushDB),
           testing::_))
       .WillOnce(testing::Return(1));
   SubscribeToServerEvents();

--- a/testing/tag_index_test.cc
+++ b/testing/tag_index_test.cc
@@ -44,10 +44,10 @@ namespace valkey_search::indexes {
 
 namespace {
 
-class TagIndexTest : public vmsdk::RedisTest {
+class TagIndexTest : public vmsdk::ValkeyTest {
  public:
   void SetUp() override {
-    vmsdk::RedisTest::SetUp();
+    vmsdk::ValkeyTest::SetUp();
     data_model::TagIndex tag_index_proto;
     tag_index_proto.set_separator(",");
     tag_index_proto.set_case_sensitive(false);

--- a/testing/utils/allocator_test.cc
+++ b/testing/utils/allocator_test.cc
@@ -43,7 +43,7 @@ namespace valkey_search {
 
 namespace {
 
-class AllocatorTest : public vmsdk::RedisTestWithParam<bool> {};
+class AllocatorTest : public vmsdk::ValkeyTestWithParam<bool> {};
 
 TEST_P(AllocatorTest, BasicFixedSizeAllocator) {
   const size_t size = 11;

--- a/testing/utils/string_interning_test.cc
+++ b/testing/utils/string_interning_test.cc
@@ -44,7 +44,7 @@ using testing::TestParamInfo;
 
 namespace {
 
-class StringInterningTest : public vmsdk::RedisTestWithParam<bool> {};
+class StringInterningTest : public vmsdk::ValkeyTestWithParam<bool> {};
 
 TEST_F(StringInterningTest, BasicTest) {
   EXPECT_EQ(StringInternStore::Instance().Size(), 0);

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -61,9 +61,9 @@ namespace valkey_search {
 struct LoadTestCase {
   std::string test_name;
   std::string args;
-  std::optional<int> tls_redis_port;
-  std::optional<int> redis_port;
-  bool use_redis_port{false};
+  std::optional<int> tls_valkey_port;
+  std::optional<int> valkey_port;
+  bool use_valkey_port{false};
   bool cluster_mode;
   bool use_coordinator{false};
   size_t expected_reader_thread_pool_size{0};
@@ -117,30 +117,32 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "use_coordinator_non_tls",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .tls_redis_port = 0,
-            .redis_port = 1000,
-            .use_redis_port = true,
+            .tls_valkey_port = 0,
+            .valkey_port = 1000,
+            .use_valkey_port = true,
             .cluster_mode = true,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
             .expected_writer_thread_pool_size = 10,
             .expected_coordinator_started = true,
-            .expected_coordinator_port = 21294,  // 20294 larger than redis_port
+            .expected_coordinator_port =
+                21294,  // 20294 larger than valkey_port
             .expect_thread_pool_started = true,
         },
         {
             .test_name = "use_coordinator_tls",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .tls_redis_port = 1000,
-            .redis_port = 0,
-            .use_redis_port = true,
+            .tls_valkey_port = 1000,
+            .valkey_port = 0,
+            .use_valkey_port = true,
             .cluster_mode = true,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
             .expected_writer_thread_pool_size = 10,
             .expected_coordinator_started = true,
-            .expected_coordinator_port = 21294,  // 20294 larger than redis_port
+            .expected_coordinator_port =
+                21294,  // 20294 larger than valkey_port
             .expect_thread_pool_started = true,
         },
         {
@@ -155,37 +157,39 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "use_coordinator_not_cluster_not_tls",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .tls_redis_port = 0,
-            .redis_port = 1000,
-            .use_redis_port = true,
+            .tls_valkey_port = 0,
+            .valkey_port = 1000,
+            .use_valkey_port = true,
             .cluster_mode = false,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
             .expected_writer_thread_pool_size = 10,
             .expected_coordinator_started = true,
-            .expected_coordinator_port = 21294,  // 20294 larger than redis_port
+            .expected_coordinator_port =
+                21294,  // 20294 larger than valkey_port
             .expect_thread_pool_started = true,
         },
         {
             .test_name = "use_coordinator_not_cluster_tls",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .tls_redis_port = 1000,
-            .redis_port = 0,
-            .use_redis_port = true,
+            .tls_valkey_port = 1000,
+            .valkey_port = 0,
+            .use_valkey_port = true,
             .cluster_mode = false,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
             .expected_writer_thread_pool_size = 10,
             .expected_coordinator_started = true,
-            .expected_coordinator_port = 21294,  // 20294 larger than redis_port
+            .expected_coordinator_port =
+                21294,  // 20294 larger than valkey_port
             .expect_thread_pool_started = true,
         },
         {
             .test_name = "use_coordinator_not_cluster_fail_to_get_port",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .use_redis_port = true,
+            .use_valkey_port = true,
             .cluster_mode = false,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
@@ -197,7 +201,7 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "use_coordinator_fail_to_get_port",
             .args = "--use-coordinator --writer-threads 10 "
                     "--reader-threads 20",
-            .use_redis_port = true,
+            .use_valkey_port = true,
             .cluster_mode = true,
             .use_coordinator = true,
             .expected_reader_thread_pool_size = 20,
@@ -236,54 +240,54 @@ TEST_P(LoadTest, load) {
   const LoadTestCase& test_case = GetParam();
   std::string port_str, tls_port_str;
   int call_reply_count = 0;
-  auto args = vmsdk::ToRedisStringVector(test_case.args);
-  ON_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&fake_ctx_))
+  auto args = vmsdk::ToValkeyStringVector(test_case.args);
+  ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&fake_ctx_))
       .WillByDefault(testing::Return(&fake_ctx_));
   EXPECT_CALL(
-      *kMockRedisModule,
+      *kMockValkeyModule,
       CreateDataType(&fake_ctx_, testing::StrEq(kValkeySearchModuleTypeName),
                      testing::_, testing::_))
-      .WillOnce(testing::Return((RedisModuleType*)0xBADF00D));
+      .WillOnce(testing::Return((ValkeyModuleType*)0xBADF00D));
   if (test_case.expected_load_ret == 0) {
-    EXPECT_CALL(*kMockRedisModule,
+    EXPECT_CALL(*kMockValkeyModule,
                 Call(testing::_, testing::StrEq("MODULE"), testing::StrEq("c"),
                      testing::StrEq("LIST")))
         .WillOnce(testing::Return(nullptr));
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         SetModuleOptions(&fake_ctx_,
-                         REDISMODULE_OPTIONS_HANDLE_IO_ERRORS |
-                             REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
-                             REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED))
+                         VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS |
+                             VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
+                             VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED))
         .Times(1);
   }
   if (test_case.use_coordinator) {
-    if (test_case.use_redis_port) {
-      RedisModuleCallReply tls_array_reply;
-      RedisModuleCallReply tls_string_reply;
-      RedisModuleCallReply non_tls_array_reply;
-      RedisModuleCallReply non_tls_string_reply;
-      if (test_case.tls_redis_port.has_value()) {
-        tls_port_str = std::to_string(test_case.tls_redis_port.value());
-        if (test_case.redis_port.has_value()) {
-          port_str = std::to_string(test_case.redis_port.value());
+    if (test_case.use_valkey_port) {
+      ValkeyModuleCallReply tls_array_reply;
+      ValkeyModuleCallReply tls_string_reply;
+      ValkeyModuleCallReply non_tls_array_reply;
+      ValkeyModuleCallReply non_tls_string_reply;
+      if (test_case.tls_valkey_port.has_value()) {
+        tls_port_str = std::to_string(test_case.tls_valkey_port.value());
+        if (test_case.valkey_port.has_value()) {
+          port_str = std::to_string(test_case.valkey_port.value());
         }
         EXPECT_CALL(
-            *kMockRedisModule,
+            *kMockValkeyModule,
             Call(testing::_, testing::StrEq("CONFIG"), testing::StrEq("cc"),
                  testing::StrEq("GET"), testing::_))
             .Times(testing::Between(1, 2))
             .WillOnce(testing::Return(&tls_array_reply))
             .WillOnce(testing::Return(&non_tls_array_reply));
-        EXPECT_CALL(*kMockRedisModule, CallReplyArrayElement(testing::_, 1))
+        EXPECT_CALL(*kMockValkeyModule, CallReplyArrayElement(testing::_, 1))
             .Times(testing::Between(1, 2))
             .WillOnce(testing::Return(&tls_string_reply))
             .WillOnce(testing::Return(&non_tls_string_reply));
 
-        EXPECT_CALL(*kMockRedisModule,
+        EXPECT_CALL(*kMockValkeyModule,
                     CallReplyStringPtr(testing::_, testing::_))
             .WillRepeatedly(
-                [&](RedisModuleCallReply* reply, size_t* len) -> const char* {
+                [&](ValkeyModuleCallReply* reply, size_t* len) -> const char* {
                   if (call_reply_count == 1) {
                     *len = port_str.size();
                     return port_str.c_str();
@@ -292,12 +296,12 @@ TEST_P(LoadTest, load) {
                   call_reply_count++;
                   return tls_port_str.c_str();
                 });
-        ON_CALL(*kMockRedisModule, GetMyClusterID())
+        ON_CALL(*kMockValkeyModule, GetMyClusterID())
             .WillByDefault(
                 testing::Return("a415b9df6ce0c3c757ad4270242ae432147cacbb"));
       } else {
         EXPECT_CALL(
-            *kMockRedisModule,
+            *kMockValkeyModule,
             Call(testing::_, testing::StrEq("CONFIG"), testing::StrEq("cc"),
                  testing::StrEq("GET"), testing::StrEq("tls-port")))
             .WillOnce(testing::Return(nullptr));
@@ -305,16 +309,16 @@ TEST_P(LoadTest, load) {
     }
   }
   if (test_case.cluster_mode) {
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx_))
-        .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_CLUSTER));
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
+        .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_CLUSTER));
     EXPECT_CALL(
-        *kMockRedisModule,
+        *kMockValkeyModule,
         RegisterClusterMessageReceiver(
             &fake_ctx_, coordinator::kMetadataBroadcastClusterMessageReceiverId,
             testing::_))
         .Times(1);
   } else {
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx_))
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
         .WillRepeatedly(testing::Return(0));
   }
   vmsdk::module::Options options;
@@ -344,7 +348,7 @@ TEST_P(LoadTest, load) {
                 testing::IsNull());
   }
   for (const auto& arg : args) {
-    TestRedisModule_FreeString(nullptr, arg);
+    TestValkeyModule_FreeString(nullptr, arg);
   }
 }
 
@@ -364,8 +368,8 @@ TEST_F(ValkeySearchTest, FullSyncFork) {
   EXPECT_TRUE(writer_thread_pool->IsSuspended());
   EXPECT_FALSE(reader_thread_pool->IsSuspended());
   absl::SleepFor(absl::Seconds(5));
-  RedisModuleEvent eid;
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleEvent eid;
+  ValkeyModuleCtx fake_ctx;
   ValkeySearch::Instance().OnServerCronCallback(&fake_ctx, eid, 0, nullptr);
   EXPECT_EQ(Metrics::GetStats().writer_worker_thread_pool_resumed_cnt, 1);
   EXPECT_EQ(
@@ -447,7 +451,7 @@ TEST_F(ValkeySearchTest, Info) {
   stats.coordinator_server_search_index_partition_success_cnt = 28;
   auto interned_key_1 = StringInternStore::Intern("key1");
   EXPECT_EQ(std::string(*interned_key_1), "key1");
-  RedisModuleInfoCtx fake_info_ctx;
+  ValkeyModuleInfoCtx fake_info_ctx;
   ValkeySearch::Instance().Info(&fake_info_ctx, false);
 #ifndef TESTING_TMP_DISABLED
   EXPECT_EQ(
@@ -499,13 +503,13 @@ TEST_F(ValkeySearchTest, OnForkChildCallback) {
   InitThreadPools(std::nullopt, 5);
   auto writer_thread_pool = ValkeySearch::Instance().GetWriterThreadPool();
   VMSDK_EXPECT_OK(writer_thread_pool->SuspendWorkers());
-  RedisModuleEvent eid;
+  ValkeyModuleEvent eid;
   Metrics::GetStats().writer_worker_thread_pool_suspension_expired_cnt = 0;
   Metrics::GetStats().writer_worker_thread_pool_resumed_cnt = 0;
   ValkeySearch::Instance().OnForkChildCallback(&fake_ctx_, eid, 0, nullptr);
   EXPECT_TRUE(writer_thread_pool->IsSuspended());
   ValkeySearch::Instance().OnForkChildCallback(
-      &fake_ctx_, eid, REDISMODULE_SUBEVENT_FORK_CHILD_DIED, nullptr);
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_FORK_CHILD_DIED, nullptr);
   EXPECT_FALSE(writer_thread_pool->IsSuspended());
   EXPECT_EQ(
       Metrics::GetStats().writer_worker_thread_pool_suspension_expired_cnt, 0);

--- a/testing/vector_externalizer_test.cc
+++ b/testing/vector_externalizer_test.cc
@@ -65,7 +65,7 @@ class VectorExternalizerTest : public ValkeySearchTestWithParam<bool> {
   }
   void TearDown() override { ValkeySearchTestWithParam<bool>::TearDown(); }
   std::vector<std::vector<float>> vectors;
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   UniqueFixedSizeAllocatorPtr allocator;
 };
 
@@ -113,29 +113,29 @@ void VerifyStats(const VectorExternalizer::Stats &stats) {
 
 TEST_P(VectorExternalizerTest, SimpleExternalize) {
   bool normalize = GetParam();
-  absl::flat_hash_map<RedisModuleKey *, std::string> keys;
-  EXPECT_CALL(*kMockRedisModule,
+  absl::flat_hash_map<ValkeyModuleKey *, std::string> keys;
+  EXPECT_CALL(*kMockValkeyModule,
               OpenKey(VectorExternalizer::Instance().GetCtx(),
-                      testing::An<RedisModuleString *>(), REDISMODULE_WRITE))
+                      testing::An<ValkeyModuleString *>(), VALKEYMODULE_WRITE))
       .Times(vectors.size())
       .WillRepeatedly(
-          [&](RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
-            auto res = TestRedisModule_OpenKeyDefaultImpl(ctx, key, flags);
+          [&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
+            auto res = TestValkeyModule_OpenKeyDefaultImpl(ctx, key, flags);
             keys[res] = vmsdk::ToStringView(key);
             return res;
           });
-  absl::flat_hash_map<std::string, std::pair<RedisModuleHashExternCB, void *>>
+  absl::flat_hash_map<std::string, std::pair<ValkeyModuleHashExternCB, void *>>
       registration;
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               HashExternalize(testing::_, testing::_, testing::_, testing::_))
       .Times(vectors.size())
-      .WillRepeatedly([&](RedisModuleKey *key, RedisModuleString *field,
-                          RedisModuleHashExternCB fn, void *privdata) {
+      .WillRepeatedly([&](ValkeyModuleKey *key, ValkeyModuleString *field,
+                          ValkeyModuleHashExternCB fn, void *privdata) {
         registration.insert({keys[key], std::make_pair(fn, privdata)});
         auto field_str = vmsdk::ToStringView(field);
         EXPECT_EQ(field_str, "attribute_identifier_1");
         EXPECT_EQ(fn, ExternalizeCB);
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
   for (size_t j = 0; j < 2; ++j) {
     ExternalizeVectors(vectors, 0, allocator.get(), normalize);
@@ -175,29 +175,29 @@ TEST_P(VectorExternalizerTest, SimpleExternalize) {
 }
 
 TEST_P(VectorExternalizerTest, PreferNotNormalized) {
-  absl::flat_hash_map<RedisModuleKey *, std::string> keys;
-  EXPECT_CALL(*kMockRedisModule,
+  absl::flat_hash_map<ValkeyModuleKey *, std::string> keys;
+  EXPECT_CALL(*kMockValkeyModule,
               OpenKey(VectorExternalizer::Instance().GetCtx(),
-                      testing::An<RedisModuleString *>(), REDISMODULE_WRITE))
+                      testing::An<ValkeyModuleString *>(), VALKEYMODULE_WRITE))
       .Times(vectors.size())
       .WillRepeatedly(
-          [&](RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
-            auto res = TestRedisModule_OpenKeyDefaultImpl(ctx, key, flags);
+          [&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
+            auto res = TestValkeyModule_OpenKeyDefaultImpl(ctx, key, flags);
             keys[res] = vmsdk::ToStringView(key);
             return res;
           });
-  absl::flat_hash_map<std::string, std::pair<RedisModuleHashExternCB, void *>>
+  absl::flat_hash_map<std::string, std::pair<ValkeyModuleHashExternCB, void *>>
       registration;
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               HashExternalize(testing::_, testing::_, testing::_, testing::_))
       .Times(vectors.size())
-      .WillRepeatedly([&](RedisModuleKey *key, RedisModuleString *field,
-                          RedisModuleHashExternCB fn, void *privdata) {
+      .WillRepeatedly([&](ValkeyModuleKey *key, ValkeyModuleString *field,
+                          ValkeyModuleHashExternCB fn, void *privdata) {
         registration.insert({keys[key], std::make_pair(fn, privdata)});
         auto field_str = vmsdk::ToStringView(field);
         EXPECT_EQ(field_str, "attribute_identifier_1");
         EXPECT_EQ(fn, ExternalizeCB);
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
   ExternalizeVectors(vectors, 0, allocator.get(), true);
   ExternalizeVectors(vectors, 0, allocator.get(), false);
@@ -220,11 +220,11 @@ TEST_P(VectorExternalizerTest, PreferNotNormalized) {
   VerifyStats(stats);
 }
 
-void VerifyCB(
-    const std::vector<std::vector<float>> &vectors, size_t offset,
-    absl::flat_hash_map<std::string, std::pair<RedisModuleHashExternCB, void *>>
-        &registration,
-    bool normalized, size_t expected_lru_promote_cnt) {
+void VerifyCB(const std::vector<std::vector<float>> &vectors, size_t offset,
+              absl::flat_hash_map<std::string,
+                                  std::pair<ValkeyModuleHashExternCB, void *>>
+                  &registration,
+              bool normalized, size_t expected_lru_promote_cnt) {
   VectorExternalizer::Instance().ProcessEngineUpdateQueue();
 
   auto stats = VectorExternalizer::Instance().GetStats();
@@ -258,29 +258,29 @@ void VerifyCB(
 
 TEST_P(VectorExternalizerTest, LRUTest) {
   bool normalized = GetParam();
-  absl::flat_hash_map<RedisModuleKey *, std::string> keys;
-  EXPECT_CALL(*kMockRedisModule,
+  absl::flat_hash_map<ValkeyModuleKey *, std::string> keys;
+  EXPECT_CALL(*kMockValkeyModule,
               OpenKey(VectorExternalizer::Instance().GetCtx(),
-                      testing::An<RedisModuleString *>(), REDISMODULE_WRITE))
+                      testing::An<ValkeyModuleString *>(), VALKEYMODULE_WRITE))
       .Times(vectors.size())
       .WillRepeatedly(
-          [&](RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
-            auto res = TestRedisModule_OpenKeyDefaultImpl(ctx, key, flags);
+          [&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
+            auto res = TestValkeyModule_OpenKeyDefaultImpl(ctx, key, flags);
             keys[res] = vmsdk::ToStringView(key);
             return res;
           });
-  absl::flat_hash_map<std::string, std::pair<RedisModuleHashExternCB, void *>>
+  absl::flat_hash_map<std::string, std::pair<ValkeyModuleHashExternCB, void *>>
       registration;
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               HashExternalize(testing::_, testing::_, testing::_, testing::_))
       .Times(vectors.size())
-      .WillRepeatedly([&](RedisModuleKey *key, RedisModuleString *field,
-                          RedisModuleHashExternCB fn, void *privdata) {
+      .WillRepeatedly([&](ValkeyModuleKey *key, ValkeyModuleString *field,
+                          ValkeyModuleHashExternCB fn, void *privdata) {
         auto field_str = vmsdk::ToStringView(field);
         EXPECT_EQ(field_str, "attribute_identifier_1");
         EXPECT_EQ(fn, ExternalizeCB);
         registration.insert({keys[key], std::make_pair(fn, privdata)});
-        return REDISMODULE_OK;
+        return VALKEYMODULE_OK;
       });
   std::vector<std::vector<float>> generated_vectors;
   generated_vectors.reserve(vectors.size());
@@ -305,24 +305,26 @@ TEST_P(VectorExternalizerTest, OpenKeyFailure) {
   bool during_registration = GetParam();
   auto &vector_externalizer = VectorExternalizer::Instance();
   if (during_registration) {
-    EXPECT_CALL(*kMockRedisModule,
-                OpenKey(VectorExternalizer::Instance().GetCtx(),
-                        testing::An<RedisModuleString *>(), REDISMODULE_WRITE))
+    EXPECT_CALL(
+        *kMockValkeyModule,
+        OpenKey(VectorExternalizer::Instance().GetCtx(),
+                testing::An<ValkeyModuleString *>(), VALKEYMODULE_WRITE))
         .Times(vectors.size())
         .WillRepeatedly(testing::Return(nullptr));
   } else {
-    EXPECT_CALL(*kMockRedisModule,
-                OpenKey(VectorExternalizer::Instance().GetCtx(),
-                        testing::An<RedisModuleString *>(), REDISMODULE_WRITE))
+    EXPECT_CALL(
+        *kMockValkeyModule,
+        OpenKey(VectorExternalizer::Instance().GetCtx(),
+                testing::An<ValkeyModuleString *>(), VALKEYMODULE_WRITE))
         .WillRepeatedly(
-            [&](RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
+            [&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
               static size_t i = 0;
               return (i++ < vectors.size())
-                         ? TestRedisModule_OpenKeyDefaultImpl(ctx, key, flags)
+                         ? TestValkeyModule_OpenKeyDefaultImpl(ctx, key, flags)
                          : nullptr;
             });
   }
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               HashExternalize(testing::_, testing::_, testing::_, testing::_))
       .Times(during_registration ? 0 : vectors.size());
 
@@ -338,10 +340,10 @@ TEST_P(VectorExternalizerTest, OpenKeyFailure) {
 
 TEST_F(VectorExternalizerTest, ModuleApiNotAvailable) {
   auto &vector_externalizer = VectorExternalizer::Instance();
-  EXPECT_CALL(*kMockRedisModule, GetApi(testing::_, testing::_))
-      .WillOnce(testing::Return(REDISMODULE_ERR));
-  EXPECT_CALL(*kMockRedisModule, GetDetachedThreadSafeContext(&fake_ctx))
-      .WillOnce([&](RedisModuleCtx *ctx) { return ctx; });
+  EXPECT_CALL(*kMockValkeyModule, GetApi(testing::_, testing::_))
+      .WillOnce(testing::Return(VALKEYMODULE_ERR));
+  EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&fake_ctx))
+      .WillOnce([&](ValkeyModuleCtx *ctx) { return ctx; });
   VectorExternalizer::Instance().Init(&fake_ctx);
   auto stats = vector_externalizer.GetStats();
   ExternalizeVectors(vectors, 0, allocator.get(), true, false);

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -250,7 +250,7 @@ TEST_P(NormalizeStringRecordTest, NormalizeStringRecord) {
                                  kInitialCap, kM, kEFConstruction, kEFRuntime),
       "attribute_identifier_1",
       data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH);
-  auto record = vmsdk::MakeUniqueRedisString(params.record);
+  auto record = vmsdk::MakeUniqueValkeyString(params.record);
   auto norm_record = index.value()->NormalizeStringRecord(std::move(record));
   if (!params.success) {
     EXPECT_FALSE(norm_record.get());

--- a/vmsdk/src/blocked_client.h
+++ b/vmsdk/src/blocked_client.h
@@ -39,11 +39,11 @@ namespace vmsdk {
 
 class BlockedClient {
  public:
-  BlockedClient(RedisModuleCtx *ctx, bool handle_duplication);
-  BlockedClient(RedisModuleCtx *ctx,
-                RedisModuleCmdFunc reply_callback = nullptr,
-                RedisModuleCmdFunc timeout_callback = nullptr,
-                void (*free_privdata)(RedisModuleCtx *, void *) = nullptr,
+  BlockedClient(ValkeyModuleCtx *ctx, bool handle_duplication);
+  BlockedClient(ValkeyModuleCtx *ctx,
+                ValkeyModuleCmdFunc reply_callback = nullptr,
+                ValkeyModuleCmdFunc timeout_callback = nullptr,
+                void (*free_privdata)(ValkeyModuleCtx *, void *) = nullptr,
                 long long timeout_ms = 0);
   BlockedClient(BlockedClient &&other) noexcept
       : blocked_client_(std::exchange(other.blocked_client_, nullptr)),
@@ -57,7 +57,7 @@ class BlockedClient {
   BlockedClient(const BlockedClient &other) = delete;
   BlockedClient &operator=(const BlockedClient &other) = delete;
 
-  operator RedisModuleBlockedClient *() const { return blocked_client_; }
+  operator ValkeyModuleBlockedClient *() const { return blocked_client_; }
   void SetReplyPrivateData(void *private_data);
   void UnblockClient();
   void MeasureTimeStart();
@@ -65,7 +65,7 @@ class BlockedClient {
   ~BlockedClient() { UnblockClient(); }
 
  private:
-  RedisModuleBlockedClient *blocked_client_{nullptr};
+  ValkeyModuleBlockedClient *blocked_client_{nullptr};
   void *private_data_{nullptr};
   bool time_measurement_ongoing_{false};
   unsigned long long tracked_client_id_{0};
@@ -73,7 +73,7 @@ class BlockedClient {
 
 struct BlockedClientEntry {
   size_t cnt{0};
-  RedisModuleBlockedClient *blocked_client{nullptr};
+  ValkeyModuleBlockedClient *blocked_client{nullptr};
 };
 absl::flat_hash_map<unsigned long long, BlockedClientEntry> &
 TrackedBlockedClients();

--- a/vmsdk/src/command_parser.h
+++ b/vmsdk/src/command_parser.h
@@ -53,7 +53,8 @@ namespace vmsdk {
 
 class ArgsIterator {
  public:
-  ArgsIterator(RedisModuleString **argv, int argc) : argv_(argv), argc_(argc) {}
+  ArgsIterator(ValkeyModuleString **argv, int argc)
+      : argv_(argv), argc_(argc) {}
   absl::StatusOr<ArgsIterator> SubIterator(int distance) {
     if (distance <= 0) {
       return absl::InvalidArgumentError("distance must be positive");
@@ -63,7 +64,7 @@ class ArgsIterator {
     }
     return ArgsIterator(argv_ + itr_, distance);
   }
-  absl::StatusOr<RedisModuleString *> Get() {
+  absl::StatusOr<ValkeyModuleString *> Get() {
     if (itr_ >= argc_) {
       return absl::OutOfRangeError("Missing argument");
     }
@@ -81,7 +82,7 @@ class ArgsIterator {
 
  private:
   int itr_{0};
-  RedisModuleString **argv_;
+  ValkeyModuleString **argv_;
   int argc_;
 };
 
@@ -103,9 +104,9 @@ inline absl::Status ParseParamValue(ArgsIterator &itr,
 }
 
 inline absl::Status ParseParamValue(ArgsIterator &itr,
-                                    UniqueRedisString &value) {
+                                    UniqueValkeyString &value) {
   VMSDK_ASSIGN_OR_RETURN(auto value_rs, itr.Get());
-  value = RetainUniqueRedisString(value_rs);
+  value = RetainUniqueValkeyString(value_rs);
   itr.Next();
   return absl::OkStatus();
 }

--- a/vmsdk/src/log.cc
+++ b/vmsdk/src/log.cc
@@ -51,13 +51,13 @@ namespace vmsdk {
 const char* ToStrLogLevel(int log_level) {
   switch (log_level) {
     case 0:
-      return REDISMODULE_LOGLEVEL_WARNING;
+      return VALKEYMODULE_LOGLEVEL_WARNING;
     case 1:
-      return REDISMODULE_LOGLEVEL_NOTICE;
+      return VALKEYMODULE_LOGLEVEL_NOTICE;
     case 2:
-      return REDISMODULE_LOGLEVEL_VERBOSE;
+      return VALKEYMODULE_LOGLEVEL_VERBOSE;
     case 3:
-      return REDISMODULE_LOGLEVEL_DEBUG;
+      return VALKEYMODULE_LOGLEVEL_DEBUG;
   }
   CHECK(false);
 }
@@ -87,15 +87,15 @@ void SetSinkFormatter(LogFormatterFunc formatter) {
 }
 
 const absl::flat_hash_map<std::string, LogLevel> kLogLevelMap = {
-    {absl::AsciiStrToLower(REDISMODULE_LOGLEVEL_WARNING), LogLevel::kWarning},
-    {absl::AsciiStrToLower(REDISMODULE_LOGLEVEL_NOTICE), LogLevel::kNotice},
-    {absl::AsciiStrToLower(REDISMODULE_LOGLEVEL_VERBOSE), LogLevel::kVerbose},
-    {absl::AsciiStrToLower(REDISMODULE_LOGLEVEL_DEBUG), LogLevel::kDebug},
+    {absl::AsciiStrToLower(VALKEYMODULE_LOGLEVEL_WARNING), LogLevel::kWarning},
+    {absl::AsciiStrToLower(VALKEYMODULE_LOGLEVEL_NOTICE), LogLevel::kNotice},
+    {absl::AsciiStrToLower(VALKEYMODULE_LOGLEVEL_VERBOSE), LogLevel::kVerbose},
+    {absl::AsciiStrToLower(VALKEYMODULE_LOGLEVEL_DEBUG), LogLevel::kDebug},
 };
 
-absl::StatusOr<std::string> FetchEngineLogLevel(RedisModuleCtx* ctx) {
-  auto reply = vmsdk::UniquePtrRedisCallReply(
-      RedisModule_Call(ctx, "CONFIG", "cc", "GET", "loglevel"));
+absl::StatusOr<std::string> FetchEngineLogLevel(ValkeyModuleCtx* ctx) {
+  auto reply = vmsdk::UniquePtrValkeyCallReply(
+      ValkeyModule_Call(ctx, "CONFIG", "cc", "GET", "loglevel"));
   if (reply == nullptr) {
     if (errno == EINVAL) {
       return absl::InvalidArgumentError(
@@ -109,22 +109,22 @@ absl::StatusOr<std::string> FetchEngineLogLevel(RedisModuleCtx* ctx) {
     }
   }
 
-  RedisModuleCallReply* loglevel_reply =
-      RedisModule_CallReplyArrayElement(reply.get(), 1);
+  ValkeyModuleCallReply* loglevel_reply =
+      ValkeyModule_CallReplyArrayElement(reply.get(), 1);
 
   if (loglevel_reply == nullptr ||
-      RedisModule_CallReplyType(loglevel_reply) != REDISMODULE_REPLY_STRING) {
+      ValkeyModule_CallReplyType(loglevel_reply) != VALKEYMODULE_REPLY_STRING) {
     return absl::NotFoundError(
         absl::StrCat("Log level value is missing or not a string."));
   }
 
   size_t len;
   const char* loglevel_str =
-      RedisModule_CallReplyStringPtr(loglevel_reply, &len);
+      ValkeyModule_CallReplyStringPtr(loglevel_reply, &len);
   return std::string(loglevel_str, len);
 }
 
-absl::Status InitLogging(RedisModuleCtx* ctx,
+absl::Status InitLogging(ValkeyModuleCtx* ctx,
                          std::optional<std::string> log_level_str) {
   if (!log_level_str.has_value()) {
     auto engine_log_level = FetchEngineLogLevel(ctx);
@@ -155,19 +155,19 @@ absl::Status InitLogging(RedisModuleCtx* ctx,
 
 const char* ReportedLogLevel(int log_level) {
   if (sink_options.log_level_specified) {
-    return REDISMODULE_LOGLEVEL_WARNING;
+    return VALKEYMODULE_LOGLEVEL_WARNING;
   }
   return ToStrLogLevel(log_level);
 }
 
 void ValkeyLogSink::Send(const absl::LogEntry& entry) {
-  RedisModule_Log(ctx_, ReportedLogLevel(entry.verbosity()), "%s",
-                  GetSinkFormatter()(entry).c_str());
+  ValkeyModule_Log(ctx_, ReportedLogLevel(entry.verbosity()), "%s",
+                   GetSinkFormatter()(entry).c_str());
 }
 
 void ValkeyIOLogSink::Send(const absl::LogEntry& entry) {
-  RedisModule_LogIOError(io_, ReportedLogLevel(entry.verbosity()), "%s",
-                         GetSinkFormatter()(entry).c_str());
+  ValkeyModule_LogIOError(io_, ReportedLogLevel(entry.verbosity()), "%s",
+                          GetSinkFormatter()(entry).c_str());
 }
 
 }  // namespace vmsdk

--- a/vmsdk/src/log.h
+++ b/vmsdk/src/log.h
@@ -66,23 +66,23 @@ void SetSinkFormatter(LogFormatterFunc formatter);
 class ValkeyLogSink : public absl::LogSink {
  public:
   void Send(const absl::LogEntry& entry) override;
-  void SetContext(RedisModuleCtx* ctx) { ctx_ = ctx; }
+  void SetContext(ValkeyModuleCtx* ctx) { ctx_ = ctx; }
 
  private:
-  RedisModuleCtx* ctx_{nullptr};
+  ValkeyModuleCtx* ctx_{nullptr};
 };
 
 class ValkeyIOLogSink : public absl::LogSink {
  public:
   void Send(const absl::LogEntry& entry) override;
-  void SetModuleIO(RedisModuleIO* io) { io_ = io; }
+  void SetModuleIO(ValkeyModuleIO* io) { io_ = io; }
 
  private:
-  RedisModuleIO* io_{nullptr};
+  ValkeyModuleIO* io_{nullptr};
 };
 
 absl::Status InitLogging(
-    RedisModuleCtx* ctx,
+    ValkeyModuleCtx* ctx,
     std::optional<std::string> log_level_str = std::nullopt);
 
 static thread_local ValkeyLogSink log_sink;

--- a/vmsdk/src/managed_pointers.h
+++ b/vmsdk/src/managed_pointers.h
@@ -39,130 +39,134 @@
 
 namespace vmsdk {
 
-struct RedisStringDeleter {
-  void operator()(RedisModuleString *str) {
-    RedisModule_FreeString(nullptr, str);
+struct ValkeyStringDeleter {
+  void operator()(ValkeyModuleString *str) {
+    ValkeyModule_FreeString(nullptr, str);
   }
 };
 
-using UniqueRedisString =
-    std::unique_ptr<RedisModuleString, RedisStringDeleter>;
+using UniqueValkeyString =
+    std::unique_ptr<ValkeyModuleString, ValkeyStringDeleter>;
 
-inline UniqueRedisString UniquePtrRedisString(RedisModuleString *redis_str) {
-  return std::unique_ptr<RedisModuleString, RedisStringDeleter>(redis_str);
+inline UniqueValkeyString UniquePtrValkeyString(ValkeyModuleString *valkey_str) {
+  return std::unique_ptr<ValkeyModuleString, ValkeyStringDeleter>(valkey_str);
 }
 
-inline UniqueRedisString MakeUniqueRedisString(absl::string_view str) {
-  auto redis_str = RedisModule_CreateString(nullptr, str.data(), str.size());
-  return UniquePtrRedisString(redis_str);
+inline UniqueValkeyString MakeUniqueValkeyString(absl::string_view str) {
+  auto valkey_str = ValkeyModule_CreateString(nullptr, str.data(), str.size());
+  return UniquePtrValkeyString(valkey_str);
 }
 
-inline UniqueRedisString MakeUniqueRedisString(const char *str) {
+inline UniqueValkeyString MakeUniqueValkeyString(const char *str) {
   if (str) {
-    return MakeUniqueRedisString(absl::string_view(str));
+    return MakeUniqueValkeyString(absl::string_view(str));
   }
-  return UniquePtrRedisString(nullptr);
+  return UniquePtrValkeyString(nullptr);
 }
 
-inline UniqueRedisString RetainUniqueRedisString(RedisModuleString *redis_str) {
-  RedisModule_RetainString(nullptr, redis_str);
-  return UniquePtrRedisString(redis_str);
+inline UniqueValkeyString RetainUniqueValkeyString(
+    ValkeyModuleString *valkey_str) {
+  ValkeyModule_RetainString(nullptr, valkey_str);
+  return UniquePtrValkeyString(valkey_str);
 }
 
-struct RedisOpenKeyDeleter {
-  void operator()(RedisModuleKey *module_key) {
+struct ValkeyOpenKeyDeleter {
+  void operator()(ValkeyModuleKey *module_key) {
     if (module_key) {
-      RedisModule_CloseKey(module_key);
+      ValkeyModule_CloseKey(module_key);
     }
   }
 };
 
-using UniqueRedisOpenKey = std::unique_ptr<RedisModuleKey, RedisOpenKeyDeleter>;
+using UniqueValkeyOpenKey =
+    std::unique_ptr<ValkeyModuleKey, ValkeyOpenKeyDeleter>;
 
-inline UniqueRedisOpenKey UniquePtrRedisOpenKey(RedisModuleKey *redis_key) {
-  return std::unique_ptr<RedisModuleKey, RedisOpenKeyDeleter>(redis_key);
+inline UniqueValkeyOpenKey UniquePtrValkeyOpenKey(ValkeyModuleKey *valkey_key) {
+  return std::unique_ptr<ValkeyModuleKey, ValkeyOpenKeyDeleter>(valkey_key);
 }
 
-inline UniqueRedisOpenKey MakeUniqueRedisOpenKey(RedisModuleCtx *ctx,
-                                                 RedisModuleString *str,
+inline UniqueValkeyOpenKey MakeUniqueValkeyOpenKey(ValkeyModuleCtx *ctx,
+                                                 ValkeyModuleString *str,
                                                  int flags) {
   VerifyMainThread();
-  auto module_key = RedisModule_OpenKey(ctx, str, flags);
-  return std::unique_ptr<RedisModuleKey, RedisOpenKeyDeleter>(module_key);
+  auto module_key = ValkeyModule_OpenKey(ctx, str, flags);
+  return std::unique_ptr<ValkeyModuleKey, ValkeyOpenKeyDeleter>(module_key);
 }
 
-struct RedisReplyDeleter {
-  void operator()(RedisModuleCallReply *reply) {
-    RedisModule_FreeCallReply(reply);
+struct ValkeyReplyDeleter {
+  void operator()(ValkeyModuleCallReply *reply) {
+    ValkeyModule_FreeCallReply(reply);
   }
 };
 
-using UniqueRedisCallReply =
-    std::unique_ptr<RedisModuleCallReply, RedisReplyDeleter>;
+using UniqueValkeyCallReply =
+    std::unique_ptr<ValkeyModuleCallReply, ValkeyReplyDeleter>;
 
-inline UniqueRedisCallReply UniquePtrRedisCallReply(
-    RedisModuleCallReply *reply) {
-  return std::unique_ptr<RedisModuleCallReply, RedisReplyDeleter>(reply);
+inline UniqueValkeyCallReply UniquePtrValkeyCallReply(
+    ValkeyModuleCallReply *reply) {
+  return std::unique_ptr<ValkeyModuleCallReply, ValkeyReplyDeleter>(reply);
 }
 
-struct RedisScanCursorDeleter {
-  void operator()(RedisModuleScanCursor *cursor) {
-    RedisModule_ScanCursorDestroy(cursor);
+struct ValkeyScanCursorDeleter {
+  void operator()(ValkeyModuleScanCursor *cursor) {
+    ValkeyModule_ScanCursorDestroy(cursor);
   }
 };
 
-using UniqueRedisScanCursor =
-    std::unique_ptr<RedisModuleScanCursor, RedisScanCursorDeleter>;
+using UniqueValkeyScanCursor =
+    std::unique_ptr<ValkeyModuleScanCursor, ValkeyScanCursorDeleter>;
 
-inline UniqueRedisScanCursor UniquePtrRedisScanCursor(
-    RedisModuleScanCursor *cursor) {
-  return std::unique_ptr<RedisModuleScanCursor, RedisScanCursorDeleter>(cursor);
+inline UniqueValkeyScanCursor UniquePtrValkeyScanCursor(
+    ValkeyModuleScanCursor *cursor) {
+  return std::unique_ptr<ValkeyModuleScanCursor, ValkeyScanCursorDeleter>(
+      cursor);
 }
 
-inline UniqueRedisScanCursor MakeUniqueRedisScanCursor() {
-  auto cursor = RedisModule_ScanCursorCreate();
-  return std::unique_ptr<RedisModuleScanCursor, RedisScanCursorDeleter>(cursor);
+inline UniqueValkeyScanCursor MakeUniqueValkeyScanCursor() {
+  auto cursor = ValkeyModule_ScanCursorCreate();
+  return std::unique_ptr<ValkeyModuleScanCursor, ValkeyScanCursorDeleter>(
+      cursor);
 }
 
-struct RedisThreadSafeContextDeleter {
-  void operator()(RedisModuleCtx *ctx) {
+struct ValkeyThreadSafeContextDeleter {
+  void operator()(ValkeyModuleCtx *ctx) {
     // Contexts cannot be safely freed from a background thread since they
     // assert if IO threads are active.
-    RunByMain([ctx]() { RedisModule_FreeThreadSafeContext(ctx); });
+    RunByMain([ctx]() { ValkeyModule_FreeThreadSafeContext(ctx); });
   }
 };
 
-using UniqueRedisDetachedThreadSafeContext =
-    std::unique_ptr<RedisModuleCtx, RedisThreadSafeContextDeleter>;
+using UniqueValkeyDetachedThreadSafeContext =
+    std::unique_ptr<ValkeyModuleCtx, ValkeyThreadSafeContextDeleter>;
 
-inline UniqueRedisDetachedThreadSafeContext
-MakeUniqueRedisDetachedThreadSafeContext(RedisModuleCtx *base_ctx) {
-  auto ctx = RedisModule_GetDetachedThreadSafeContext(base_ctx);
-  return std::unique_ptr<RedisModuleCtx, RedisThreadSafeContextDeleter>(ctx);
+inline UniqueValkeyDetachedThreadSafeContext
+MakeUniqueValkeyDetachedThreadSafeContext(ValkeyModuleCtx *base_ctx) {
+  auto ctx = ValkeyModule_GetDetachedThreadSafeContext(base_ctx);
+  return std::unique_ptr<ValkeyModuleCtx, ValkeyThreadSafeContextDeleter>(ctx);
 }
 
-using UniqueRedisThreadSafeContext =
-    std::unique_ptr<RedisModuleCtx, RedisThreadSafeContextDeleter>;
+using UniqueValkeyThreadSafeContext =
+    std::unique_ptr<ValkeyModuleCtx, ValkeyThreadSafeContextDeleter>;
 
-inline UniqueRedisThreadSafeContext MakeUniqueRedisThreadSafeContext(
-    RedisModuleBlockedClient *bc) {
-  auto ctx = RedisModule_GetThreadSafeContext(bc);
-  return std::unique_ptr<RedisModuleCtx, RedisThreadSafeContextDeleter>(ctx);
+inline UniqueValkeyThreadSafeContext MakeUniqueValkeyThreadSafeContext(
+    ValkeyModuleBlockedClient *bc) {
+  auto ctx = ValkeyModule_GetThreadSafeContext(bc);
+  return std::unique_ptr<ValkeyModuleCtx, ValkeyThreadSafeContextDeleter>(ctx);
 }
 
-struct RedisClusterNodesListDeleter {
+struct ValkeyClusterNodesListDeleter {
   void operator()(char **nodes_list) {
-    RedisModule_FreeClusterNodesList(nodes_list);
+    ValkeyModule_FreeClusterNodesList(nodes_list);
   }
 };
 
-using UniqueRedisClusterNodesList =
-    std::unique_ptr<char *, RedisClusterNodesListDeleter>;
+using UniqueValkeyClusterNodesList =
+    std::unique_ptr<char *, ValkeyClusterNodesListDeleter>;
 
-inline UniqueRedisClusterNodesList MakeUniqueRedisClusterNodesList(
-    RedisModuleCtx *ctx, size_t *num_nodes) {
-  auto nodes_list = RedisModule_GetClusterNodesList(ctx, num_nodes);
-  return std::unique_ptr<char *, RedisClusterNodesListDeleter>(nodes_list);
+inline UniqueValkeyClusterNodesList MakeUniqueValkeyClusterNodesList(
+    ValkeyModuleCtx *ctx, size_t *num_nodes) {
+  auto nodes_list = ValkeyModule_GetClusterNodesList(ctx, num_nodes);
+  return std::unique_ptr<char *, ValkeyClusterNodesListDeleter>(nodes_list);
 }
 
 }  // namespace vmsdk

--- a/vmsdk/src/memory_allocation_overrides.cc
+++ b/vmsdk/src/memory_allocation_overrides.cc
@@ -180,8 +180,8 @@ void* __wrap_malloc(size_t size) noexcept {
   }
   // Forcing 16-byte alignment in Valkey, which may otherwise return 8-byte
   // aligned memory.
-  return vmsdk::PerformAndTrackMalloc(AlignSize(size), RedisModule_Alloc,
-                                      RedisModule_MallocUsableSize);
+  return vmsdk::PerformAndTrackMalloc(AlignSize(size), ValkeyModule_Alloc,
+                                      ValkeyModule_MallocUsableSize);
 }
 void __wrap_free(void* ptr) noexcept {
   if (ptr == nullptr) {
@@ -196,8 +196,8 @@ void __wrap_free(void* ptr) noexcept {
   if (was_tracked || !vmsdk::IsUsingValkeyAlloc()) {
     vmsdk::PerformAndTrackFree(ptr, __real_free, empty_usable_size);
   } else {
-    vmsdk::PerformAndTrackFree(ptr, RedisModule_Free,
-                               RedisModule_MallocUsableSize);
+    vmsdk::PerformAndTrackFree(ptr, ValkeyModule_Free,
+                               ValkeyModule_MallocUsableSize);
   }
 }
 // NOLINTNEXTLINE
@@ -208,8 +208,8 @@ void* __wrap_calloc(size_t __nmemb, size_t size) noexcept {
     vmsdk::SystemAllocTracker::GetInstance().TrackPointer(ptr);
     return ptr;
   }
-  return vmsdk::PerformAndTrackCalloc(__nmemb, AlignSize(size), RedisModule_Calloc,
-                                      RedisModule_MallocUsableSize);
+  return vmsdk::PerformAndTrackCalloc(__nmemb, AlignSize(size), ValkeyModule_Calloc,
+                                      ValkeyModule_MallocUsableSize);
 }
 
 void* __wrap_realloc(void* ptr, size_t size) noexcept {
@@ -221,8 +221,8 @@ void* __wrap_realloc(void* ptr, size_t size) noexcept {
     // Forcing 16-byte alignment in Valkey, which may otherwise return 8-byte
     // aligned memory.
     return vmsdk::PerformAndTrackRealloc(ptr, AlignSize(size),
-                                         RedisModule_Realloc,
-                                         RedisModule_MallocUsableSize);
+                                         ValkeyModule_Realloc,
+                                         ValkeyModule_MallocUsableSize);
   } else {
     auto new_ptr = vmsdk::PerformAndTrackRealloc(ptr, size, __real_realloc,
                                                  empty_usable_size);
@@ -240,15 +240,15 @@ void* __wrap_aligned_alloc(size_t __alignment, size_t __size) noexcept {
   }
 
   return vmsdk::PerformAndTrackMalloc(AlignSize(__size, __alignment),
-                                      RedisModule_Alloc,
-                                      RedisModule_MallocUsableSize);
+                                      ValkeyModule_Alloc,
+                                      ValkeyModule_MallocUsableSize);
 }
 
 int __wrap_malloc_usable_size(void* ptr) noexcept {
   if (vmsdk::SystemAllocTracker::GetInstance().IsTracked(ptr)) {
     return empty_usable_size(ptr);
   }
-  return RedisModule_MallocUsableSize(ptr);
+  return ValkeyModule_MallocUsableSize(ptr);
 }
 
 // NOLINTNEXTLINE

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -45,20 +45,20 @@
 namespace vmsdk {
 namespace module {
 
-absl::Status RegisterInfo(RedisModuleCtx *ctx, RedisModuleInfoFunc info) {
+absl::Status RegisterInfo(ValkeyModuleCtx *ctx, ValkeyModuleInfoFunc info) {
   if (info == nullptr) {
     return absl::OkStatus();
   }
-  if (RedisModule_RegisterInfoFunc(ctx, info) == REDISMODULE_ERR) {
+  if (ValkeyModule_RegisterInfoFunc(ctx, info) == VALKEYMODULE_ERR) {
     return absl::InternalError("Failed to register info");
   }
   return absl::OkStatus();
 }
 
 absl::Status AddACLCategories(
-    RedisModuleCtx *ctx, const std::list<absl::string_view> &acl_categories) {
+    ValkeyModuleCtx *ctx, const std::list<absl::string_view> &acl_categories) {
   for (auto &category : acl_categories) {
-    if (RedisModule_AddACLCategory(ctx, category.data()) == REDISMODULE_ERR) {
+    if (ValkeyModule_AddACLCategory(ctx, category.data()) == VALKEYMODULE_ERR) {
       return absl::InternalError(absl::StrCat(
           "Failed to create a command ACL category: ", category.data()));
     }
@@ -66,22 +66,22 @@ absl::Status AddACLCategories(
   return absl::OkStatus();
 }
 
-absl::Status RegisterCommands(RedisModuleCtx *ctx,
+absl::Status RegisterCommands(ValkeyModuleCtx *ctx,
                               const std::list<CommandOptions> &commands) {
   for (auto &command : commands) {
     auto flags = absl::StrJoin(command.flags, " ");
-    if (RedisModule_CreateCommand(ctx, command.cmd_name.data(),
-                                  command.cmd_func, flags.c_str(),
-                                  command.first_key, command.last_key,
-                                  command.key_step) == REDISMODULE_ERR) {
+    if (ValkeyModule_CreateCommand(ctx, command.cmd_name.data(),
+                                   command.cmd_func, flags.c_str(),
+                                   command.first_key, command.last_key,
+                                   command.key_step) == VALKEYMODULE_ERR) {
       return absl::InternalError(
           absl::StrCat("Failed to create command: ", command.cmd_name.data()));
     }
-    RedisModuleCommand *cmd =
-        RedisModule_GetCommand(ctx, command.cmd_name.data());
+    ValkeyModuleCommand *cmd =
+        ValkeyModule_GetCommand(ctx, command.cmd_name.data());
     auto permissions = absl::StrJoin(command.permissions, " ");
-    if (RedisModule_SetCommandACLCategories(cmd, permissions.c_str()) ==
-        REDISMODULE_ERR) {
+    if (ValkeyModule_SetCommandACLCategories(cmd, permissions.c_str()) ==
+        VALKEYMODULE_ERR) {
       return absl::InternalError(
           absl::StrCat("Failed to set ACL categories `", permissions,
                        "` for the command: ", command.cmd_name.data()));
@@ -90,85 +90,86 @@ absl::Status RegisterCommands(RedisModuleCtx *ctx,
   return absl::OkStatus();
 }
 
-int OnLoad(RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
+int OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
            const Options &options) {
-  if (RedisModule_Init(ctx, options.name.c_str(), options.version,
-                       REDISMODULE_APIVER_1) == REDISMODULE_ERR) {
-    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING, "Failed to init module");
-    return REDISMODULE_ERR;
+  if (ValkeyModule_Init(ctx, options.name.c_str(), options.version,
+                        VALKEYMODULE_APIVER_1) == VALKEYMODULE_ERR) {
+    ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_WARNING,
+                     "Failed to init module");
+    return VALKEYMODULE_ERR;
   }
   auto status = vmsdk::InitLogging(ctx);
   if (!status.ok()) {
-    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING,
-                    "Failed to init logging, %s", status.message().data());
-    return REDISMODULE_ERR;
+    ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_WARNING,
+                     "Failed to init logging, %s", status.message().data());
+    return VALKEYMODULE_ERR;
   }
   if (auto status = AddACLCategories(ctx, options.acl_categories);
       !status.ok()) {
-    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING, "%s",
-                    status.message().data());
-    return REDISMODULE_ERR;
+    ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_WARNING, "%s",
+                     status.message().data());
+    return VALKEYMODULE_ERR;
   }
   if (auto status = RegisterCommands(ctx, options.commands); !status.ok()) {
-    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING, "%s",
-                    status.message().data());
-    return REDISMODULE_ERR;
+    ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_WARNING, "%s",
+                     status.message().data());
+    return VALKEYMODULE_ERR;
   }
   // Initialize counters for request count metric
   if (auto status = RegisterInfo(ctx, options.info); !status.ok()) {
-    RedisModule_Log(ctx, REDISMODULE_LOGLEVEL_WARNING, "%s",
-                    status.message().data());
-    return REDISMODULE_ERR;
+    ValkeyModule_Log(ctx, VALKEYMODULE_LOGLEVEL_WARNING, "%s",
+                     status.message().data());
+    return VALKEYMODULE_ERR;
   }
-  return REDISMODULE_OK;
+  return VALKEYMODULE_OK;
 }
 
-int OnLoadDone(absl::Status status, RedisModuleCtx *ctx,
+int OnLoadDone(absl::Status status, ValkeyModuleCtx *ctx,
                const Options &options) {
   if (status.ok()) {
     VMSDK_LOG(NOTICE, ctx) << options.name
                            << " module was successfully loaded!";
     vmsdk::UseValkeyAlloc();
-    return REDISMODULE_OK;
+    return VALKEYMODULE_OK;
   }
   VMSDK_LOG(WARNING, ctx) << status.message().data();
-  return REDISMODULE_ERR;
+  return VALKEYMODULE_ERR;
 }
 }  // namespace module
 
-bool IsModuleLoaded(RedisModuleCtx *ctx, const std::string &name) {
+bool IsModuleLoaded(ValkeyModuleCtx *ctx, const std::string &name) {
   static absl::flat_hash_set<std::string> loaded_modules;
   if (loaded_modules.contains(name)) {
     return true;
   }
 
   auto reply =
-      UniquePtrRedisCallReply(RedisModule_Call(ctx, "MODULE", "c", "LIST"));
+      UniquePtrValkeyCallReply(ValkeyModule_Call(ctx, "MODULE", "c", "LIST"));
   if (!reply ||
-      RedisModule_CallReplyType(reply.get()) != REDISMODULE_REPLY_ARRAY) {
+      ValkeyModule_CallReplyType(reply.get()) != VALKEYMODULE_REPLY_ARRAY) {
     return false;
   }
 
-  size_t num_modules = RedisModule_CallReplyLength(reply.get());
+  size_t num_modules = ValkeyModule_CallReplyLength(reply.get());
   for (size_t i = 0; i < num_modules; ++i) {
-    RedisModuleCallReply *mod_info =
-        RedisModule_CallReplyArrayElement(reply.get(), i);
+    ValkeyModuleCallReply *mod_info =
+        ValkeyModule_CallReplyArrayElement(reply.get(), i);
     if (!mod_info ||
-        RedisModule_CallReplyType(mod_info) != REDISMODULE_REPLY_ARRAY) {
+        ValkeyModule_CallReplyType(mod_info) != VALKEYMODULE_REPLY_ARRAY) {
       continue;
     }
 
-    size_t len = RedisModule_CallReplyLength(mod_info);
+    size_t len = ValkeyModule_CallReplyLength(mod_info);
 
     for (size_t j = 0; j + 1 < len; j += 2) {
-      RedisModuleCallReply *key =
-          RedisModule_CallReplyArrayElement(mod_info, j);
-      RedisModuleCallReply *val =
-          RedisModule_CallReplyArrayElement(mod_info, j + 1);
+      ValkeyModuleCallReply *key =
+          ValkeyModule_CallReplyArrayElement(mod_info, j);
+      ValkeyModuleCallReply *val =
+          ValkeyModule_CallReplyArrayElement(mod_info, j + 1);
 
       size_t key_len, val_len;
-      const char *key_str = RedisModule_CallReplyStringPtr(key, &key_len);
-      const char *val_str = RedisModule_CallReplyStringPtr(val, &val_len);
+      const char *key_str = ValkeyModule_CallReplyStringPtr(key, &key_len);
+      const char *val_str = ValkeyModule_CallReplyStringPtr(val, &val_len);
       absl::string_view module_key{key_str, key_len};
       absl::string_view module_value{val_str, val_len};
 

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -53,20 +53,20 @@ static T OnGetConfig(const char *config_name, void *priv_data) {
 
 template <typename T>
 static int OnSetConfig(const char *config_name, T value, void *priv_data,
-                       RedisModuleString **err) {
+                       ValkeyModuleString **err) {
   auto entry = static_cast<ConfigBase<T> *>(priv_data);
   CHECK(entry) << "null private data for configuration Number entry.";
   auto res = entry->SetValue(value);  // Calls "Validate" internally
   if (!res.ok()) {
     if (err) {
       *err =
-          RedisModule_CreateStringPrintf(nullptr, "%s", res.message().data());
+          ValkeyModule_CreateStringPrintf(nullptr, "%s", res.message().data());
     }
-    return REDISMODULE_ERR;
+    return VALKEYMODULE_ERR;
   }
 
   entry->NotifyChanged();
-  return REDISMODULE_OK;
+  return VALKEYMODULE_OK;
 }
 
 /// Convert `vector<string>` -> `vector<const char*>`
@@ -94,7 +94,7 @@ void ModuleConfigManager::UnregisterConfig(Registerable *config_item) {
   entries_.erase(config_item->GetName());
 }
 
-absl::Status ModuleConfigManager::Init(RedisModuleCtx *ctx) {
+absl::Status ModuleConfigManager::Init(ValkeyModuleCtx *ctx) {
   for (const auto &[_, entry] : entries_) {
     if (entry->IsHidden()) {
       continue;
@@ -104,8 +104,8 @@ absl::Status ModuleConfigManager::Init(RedisModuleCtx *ctx) {
   return absl::OkStatus();
 }
 
-absl::Status ModuleConfigManager::ParseAndLoadArgv(RedisModuleCtx *ctx,
-                                                   RedisModuleString **argv,
+absl::Status ModuleConfigManager::ParseAndLoadArgv(ValkeyModuleCtx *ctx,
+                                                   ValkeyModuleString **argv,
                                                    int argc) {
   vmsdk::ArgsIterator iter{argv, argc};
   while (iter.HasNext()) {
@@ -136,7 +136,7 @@ absl::Status ModuleConfigManager::ParseAndLoadArgv(RedisModuleCtx *ctx,
 }
 
 absl::Status ModuleConfigManager::UpdateConfigFromKeyVal(
-    RedisModuleCtx *ctx, std::string_view key, std::string_view value) {
+    ValkeyModuleCtx *ctx, std::string_view key, std::string_view value) {
   if (!key.starts_with("--")) {
     return absl::InvalidArgumentError(absl::StrFormat(
         "Command line argument: '%s' must start with '--'", key));
@@ -166,18 +166,19 @@ Number::Number(std::string_view name, int64_t default_value, int64_t min_value,
       max_value_(max_value),
       current_value_(default_value) {}
 
-absl::Status Number::Register(RedisModuleCtx *ctx) {
-  if (RedisModule_RegisterNumericConfig(ctx,
-                                        name_.data(),    // Name
-                                        default_value_,  // Default value
-                                        flags_,          // Flags
-                                        min_value_,      // Minimum value
-                                        max_value_,      // Maximum value
-                                        OnGetConfig<long long>,  // Get callback
-                                        OnSetConfig<long long>,  // Set callback
-                                        nullptr,  // Apply callback (optional)
-                                        this      // privdata
-                                        ) != REDISMODULE_OK) {
+absl::Status Number::Register(ValkeyModuleCtx *ctx) {
+  if (ValkeyModule_RegisterNumericConfig(
+          ctx,
+          name_.data(),            // Name
+          default_value_,          // Default value
+          flags_,                  // Flags
+          min_value_,              // Minimum value
+          max_value_,              // Maximum value
+          OnGetConfig<long long>,  // Get callback
+          OnSetConfig<long long>,  // Set callback
+          nullptr,                 // Apply callback (optional)
+          this                     // privdata
+          ) != VALKEYMODULE_OK) {
     return absl::InternalError(absl::StrCat(
         "Failed to register numeric configuration entry: ", name_));
   }
@@ -214,20 +215,20 @@ Enum::Enum(std::string_view name, int default_value,
         }) != values_.end());
 }
 
-absl::Status Enum::Register(RedisModuleCtx *ctx) {
+absl::Status Enum::Register(ValkeyModuleCtx *ctx) {
   auto names_array = ToCharPtrPtrVec(names_);
-  if (RedisModule_RegisterEnumConfig(ctx,
-                                     name_.data(),        // Name
-                                     default_value_,      // Default value
-                                     flags_,              // Flags
-                                     names_array.data(),  // enumerator names
-                                     values_.data(),      // enumerator values
-                                     names_.size(),     // number of enumerators
-                                     OnGetConfig<int>,  // Get callback
-                                     OnSetConfig<int>,  // Set callback
-                                     nullptr,  // Apply callback (optional)
-                                     this      // privdata
-                                     ) != REDISMODULE_OK) {
+  if (ValkeyModule_RegisterEnumConfig(ctx,
+                                      name_.data(),        // Name
+                                      default_value_,      // Default value
+                                      flags_,              // Flags
+                                      names_array.data(),  // enumerator names
+                                      values_.data(),      // enumerator values
+                                      names_.size(),  // number of enumerators
+                                      OnGetConfig<int>,  // Get callback
+                                      OnSetConfig<int>,  // Set callback
+                                      nullptr,  // Apply callback (optional)
+                                      this      // privdata
+                                      ) != VALKEYMODULE_OK) {
     return absl::InternalError(absl::StrCat(
         "Failed to register enumerator configuration entry: ", name_));
   }
@@ -257,16 +258,16 @@ Boolean::Boolean(std::string_view name, bool default_value)
       default_value_(default_value),
       current_value_(default_value) {}
 
-absl::Status Boolean::Register(RedisModuleCtx *ctx) {
-  if (RedisModule_RegisterBoolConfig(ctx,
-                                     name_.data(),      // Name
-                                     default_value_,    // Default value
-                                     flags_,            // Flags
-                                     OnGetConfig<int>,  // Get callback
-                                     OnSetConfig<int>,  // Set callback
-                                     nullptr,  // Apply callback (optional)
-                                     this      // privdata
-                                     ) != REDISMODULE_OK) {
+absl::Status Boolean::Register(ValkeyModuleCtx *ctx) {
+  if (ValkeyModule_RegisterBoolConfig(ctx,
+                                      name_.data(),      // Name
+                                      default_value_,    // Default value
+                                      flags_,            // Flags
+                                      OnGetConfig<int>,  // Get callback
+                                      OnSetConfig<int>,  // Set callback
+                                      nullptr,  // Apply callback (optional)
+                                      this      // privdata
+                                      ) != VALKEYMODULE_OK) {
     return absl::InternalError(absl::StrCat(
         "Failed to register boolean configuration entry: ", name_));
   }

--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -45,14 +45,14 @@ namespace config {
 /// Flags to further specify the behavior of the config
 /// These can be specified using the Builder().WithFlags(...) method (see below)
 enum Flags {
-  kDefault = REDISMODULE_CONFIG_DEFAULT,
-  kImmutable = REDISMODULE_CONFIG_IMMUTABLE,
-  kSensitive = REDISMODULE_CONFIG_SENSITIVE,
-  kHidden = REDISMODULE_CONFIG_HIDDEN,
-  kProtected = REDISMODULE_CONFIG_PROTECTED,
-  kDenyLoading = REDISMODULE_CONFIG_DENY_LOADING,
-  kMemory = REDISMODULE_CONFIG_MEMORY,
-  kBitFlags = REDISMODULE_CONFIG_BITFLAGS,
+  kDefault = VALKEYMODULE_CONFIG_DEFAULT,
+  kImmutable = VALKEYMODULE_CONFIG_IMMUTABLE,
+  kSensitive = VALKEYMODULE_CONFIG_SENSITIVE,
+  kHidden = VALKEYMODULE_CONFIG_HIDDEN,
+  kProtected = VALKEYMODULE_CONFIG_PROTECTED,
+  kDenyLoading = VALKEYMODULE_CONFIG_DENY_LOADING,
+  kMemory = VALKEYMODULE_CONFIG_MEMORY,
+  kBitFlags = VALKEYMODULE_CONFIG_BITFLAGS,
 };
 
 /// Support Valkey configuration entries in a one-liner.
@@ -82,7 +82,7 @@ enum Flags {
 ///            [](const long long new_value) -> absl::Status {
 ///              return absl::OkStatus();
 ///            })
-///        .WithFlags(REDISMODULE_CONFIG_DEFAULT)
+///        .WithFlags(VALKEYMODULE_CONFIG_DEFAULT)
 ///        .Build();
 /// ```
 ///
@@ -102,10 +102,10 @@ class ModuleConfigManager {
 
   /// Do the actual registration with Valkey for all configuration items that
   /// previously registered themselves with this manager
-  absl::Status Init(RedisModuleCtx *ctx);
+  absl::Status Init(ValkeyModuleCtx *ctx);
 
   /// Parse and load command line arguments
-  absl::Status ParseAndLoadArgv(RedisModuleCtx *ctx, RedisModuleString **argv,
+  absl::Status ParseAndLoadArgv(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                                 int argc);
   /// Call this method to register a configuration item with this manager. This
   /// method is mainly used by the constructor of `ConfigBase` so users should
@@ -118,7 +118,8 @@ class ModuleConfigManager {
   void UnregisterConfig(Registerable *config_item);
 
  private:
-  absl::Status UpdateConfigFromKeyVal(RedisModuleCtx *ctx, std::string_view key,
+  absl::Status UpdateConfigFromKeyVal(ValkeyModuleCtx *ctx,
+                                      std::string_view key,
                                       std::string_view value);
   absl::flat_hash_map<std::string, Registerable *> entries_;
   friend class Configbase;
@@ -130,7 +131,7 @@ class Registerable {
   Registerable(std::string_view name) : name_(name) {}
   virtual ~Registerable() = default;
 
-  virtual absl::Status Register(RedisModuleCtx *ctx) = 0;
+  virtual absl::Status Register(ValkeyModuleCtx *ctx) = 0;
   /// Attempt to initialize the value from a string. For example, a subclass of
   /// `Boolean` should check that `value` is one of: [`yes`, `no`, `true`,
   /// `false`] otherwise return an error status code
@@ -139,7 +140,7 @@ class Registerable {
 
   // bitwise OR'ed flags of `Flags`
   inline void SetFlags(size_t flags) { flags_ = flags; }
-  inline bool IsHidden() const { return flags_ & REDISMODULE_CONFIG_HIDDEN; }
+  inline bool IsHidden() const { return flags_ & VALKEYMODULE_CONFIG_HIDDEN; }
 
  protected:
   std::string name_;
@@ -229,7 +230,7 @@ class Number : public ConfigBase<long long> {
 
  protected:
   // Implementation specific
-  absl::Status Register(RedisModuleCtx *ctx) override;
+  absl::Status Register(ValkeyModuleCtx *ctx) override;
   long long GetValueImpl() const override {
     return current_value_.load(std::memory_order_relaxed);
   }
@@ -256,7 +257,7 @@ class Enum : public ConfigBase<int> {
 
  protected:
   // Implementation specific
-  absl::Status Register(RedisModuleCtx *ctx) override;
+  absl::Status Register(ValkeyModuleCtx *ctx) override;
   int GetValueImpl() const override {
     return current_value_.load(std::memory_order_relaxed);
   }
@@ -280,7 +281,7 @@ class Boolean : public ConfigBase<bool> {
 
  protected:
   // Implementation specific
-  absl::Status Register(RedisModuleCtx *ctx) override;
+  absl::Status Register(ValkeyModuleCtx *ctx) override;
   bool GetValueImpl() const override {
     return current_value_.load(std::memory_order_relaxed);
   }

--- a/vmsdk/src/module_type.h
+++ b/vmsdk/src/module_type.h
@@ -41,19 +41,19 @@ namespace vmsdk {
 
 class ModuleType {
  public:
-  ModuleType(RedisModuleCtx *ctx, absl::string_view key,
-             RedisModuleType *module_type);
+  ModuleType(ValkeyModuleCtx *ctx, absl::string_view key,
+             ValkeyModuleType *module_type);
   virtual ~ModuleType() = default;
-  absl::Status Register(RedisModuleCtx *ctx);
-  absl::Status Deregister(RedisModuleCtx *ctx);
+  absl::Status Register(ValkeyModuleCtx *ctx);
+  absl::Status Deregister(ValkeyModuleCtx *ctx);
 
-  static absl::Status Register(RedisModuleCtx *ctx, absl::string_view key,
-                               void *ptr, RedisModuleType *module_type);
-  static absl::Status Deregister(RedisModuleCtx *ctx, absl::string_view key);
+  static absl::Status Register(ValkeyModuleCtx *ctx, absl::string_view key,
+                               void *ptr, ValkeyModuleType *module_type);
+  static absl::Status Deregister(ValkeyModuleCtx *ctx, absl::string_view key);
 
  protected:
-  RedisModuleType *module_type_{nullptr};
-  vmsdk::UniqueRedisDetachedThreadSafeContext detached_ctx_;
+  ValkeyModuleType *module_type_{nullptr};
+  vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   std::string key_;
 };
 

--- a/vmsdk/src/status/status_builder.cc
+++ b/vmsdk/src/status/status_builder.cc
@@ -134,8 +134,8 @@ void StatusBuilder::ConditionallyLog(const absl::Status& status) const {
       }
     }
   }
-  RedisModule_Log(nullptr, REDISMODULE_LOGLEVEL_NOTICE, "%s:%d, %s",
-                  loc_.file_name(), loc_.line(), status.message().data());
+  ValkeyModule_Log(nullptr, VALKEYMODULE_LOGLEVEL_NOTICE, "%s:%d, %s",
+                   loc_.file_name(), loc_.line(), status.message().data());
 }
 
 absl::Status StatusBuilder::CreateStatusAndConditionallyLog() && {

--- a/vmsdk/src/status/status_builder.h
+++ b/vmsdk/src/status/status_builder.h
@@ -350,7 +350,7 @@ class ABSL_MUST_USE_RESULT StatusBuilder {
   template <typename Adaptor>
   ABSL_MUST_USE_RESULT auto
   With(Adaptor&& adaptor) && -> decltype(std::forward<Adaptor>(adaptor)(
-                                 std::move(*this))) {
+      std::move(*this))) {
     return std::forward<Adaptor>(adaptor)(std::move(*this));
   }
 

--- a/vmsdk/src/testing_infra/module.h
+++ b/vmsdk/src/testing_infra/module.h
@@ -53,283 +53,290 @@
 #include "vmsdk/src/utils.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
-class MockRedisModule {
+class MockValkeyModule {
  public:
-  MockRedisModule() {
+  MockValkeyModule() {
     ON_CALL(*this, EventLoopAddOneShot)
         .WillByDefault(
-            [](RedisModuleEventLoopOneShotFunc callback, void *data) -> int {
+            [](ValkeyModuleEventLoopOneShotFunc callback, void *data) -> int {
               if (callback) {
                 callback(data);
               }
               return 0;
             });
   };
-  MOCK_METHOD(RedisModuleBlockedClient *, BlockClientOnAuth,
-              (RedisModuleCtx * ctx, RedisModuleAuthCallback reply_callback,
-               void (*free_privdata)(RedisModuleCtx *, void *)));
-  MOCK_METHOD(RedisModuleBlockedClient *, BlockClient,
-              (RedisModuleCtx * ctx, RedisModuleCmdFunc reply_callback,
-               RedisModuleCmdFunc timeout_callback,
-               void (*free_privdata)(RedisModuleCtx *, void *),
+  MOCK_METHOD(ValkeyModuleBlockedClient *, BlockClientOnAuth,
+              (ValkeyModuleCtx * ctx, ValkeyModuleAuthCallback reply_callback,
+               void (*free_privdata)(ValkeyModuleCtx *, void *)));
+  MOCK_METHOD(ValkeyModuleBlockedClient *, BlockClient,
+              (ValkeyModuleCtx * ctx, ValkeyModuleCmdFunc reply_callback,
+               ValkeyModuleCmdFunc timeout_callback,
+               void (*free_privdata)(ValkeyModuleCtx *, void *),
                long long timeout_ms));  // NOLINT
   MOCK_METHOD(void, Log,
-              (RedisModuleCtx * ctx, const char *levelstr, const char *msg));
+              (ValkeyModuleCtx * ctx, const char *levelstr, const char *msg));
   MOCK_METHOD(void, LogIOError,
-              (RedisModuleIO * io, const char *levelstr, const char *msg));
+              (ValkeyModuleIO * io, const char *levelstr, const char *msg));
   MOCK_METHOD(int, UnblockClient,
-              (RedisModuleBlockedClient * bc, void *privdata));
-  MOCK_METHOD(void *, GetBlockedClientPrivateData, (RedisModuleCtx * ctx));
+              (ValkeyModuleBlockedClient * bc, void *privdata));
+  MOCK_METHOD(void *, GetBlockedClientPrivateData, (ValkeyModuleCtx * ctx));
   MOCK_METHOD(int, AuthenticateClientWithACLUser,
-              (RedisModuleCtx * ctx, const char *name, size_t len,
-               RedisModuleUserChangedFunc callback, void *privdata,
+              (ValkeyModuleCtx * ctx, const char *name, size_t len,
+               ValkeyModuleUserChangedFunc callback, void *privdata,
                uint64_t *client_id));
   MOCK_METHOD(void, ACLAddLogEntryByUserName,
-              (RedisModuleCtx * ctx, RedisModuleString *user,
-               RedisModuleString *object, RedisModuleACLLogEntryReason reason));
+              (ValkeyModuleCtx * ctx, ValkeyModuleString *user,
+               ValkeyModuleString *object,
+               ValkeyModuleACLLogEntryReason reason));
   MOCK_METHOD(int, EventLoopAdd,
-              (int fd, int mask, RedisModuleEventLoopFunc func,
+              (int fd, int mask, ValkeyModuleEventLoopFunc func,
                void *user_data));
   MOCK_METHOD(int, EventLoopAddOneShot,
-              (RedisModuleEventLoopOneShotFunc func, void *user_data));
+              (ValkeyModuleEventLoopOneShotFunc func, void *user_data));
   MOCK_METHOD(int, EventLoopDel, (int fd, int mask));
-  MOCK_METHOD(RedisModuleTimerID, CreateTimer,
-              (RedisModuleCtx * ctx, mstime_t period,
-               RedisModuleTimerProc callback, void *data));
+  MOCK_METHOD(ValkeyModuleTimerID, CreateTimer,
+              (ValkeyModuleCtx * ctx, mstime_t period,
+               ValkeyModuleTimerProc callback, void *data));
   MOCK_METHOD(int, StopTimer,
-              (RedisModuleCtx * ctx, RedisModuleTimerID id, void **data));
-  MOCK_METHOD(void, SetModuleOptions, (RedisModuleCtx * ctx, int options));
+              (ValkeyModuleCtx * ctx, ValkeyModuleTimerID id, void **data));
+  MOCK_METHOD(void, SetModuleOptions, (ValkeyModuleCtx * ctx, int options));
   MOCK_METHOD(unsigned long long, GetClientId,  // NOLINT
-              (RedisModuleCtx *ctx));
+              (ValkeyModuleCtx *ctx));
   MOCK_METHOD(int, GetClientInfoById, (void *ci, uint64_t id));
   MOCK_METHOD(int, SubscribeToKeyspaceEvents,
-              (RedisModuleCtx * ctx, int types,
-               RedisModuleNotificationFunc cb));
-  MOCK_METHOD(int, KeyExists, (RedisModuleCtx * ctx, RedisModuleString *key));
-  MOCK_METHOD(RedisModuleKey *, OpenKey,
-              (RedisModuleCtx * ctx, RedisModuleString *key, int flags));
+              (ValkeyModuleCtx * ctx, int types,
+               ValkeyModuleNotificationFunc cb));
+  MOCK_METHOD(int, KeyExists, (ValkeyModuleCtx * ctx, ValkeyModuleString *key));
+  MOCK_METHOD(ValkeyModuleKey *, OpenKey,
+              (ValkeyModuleCtx * ctx, ValkeyModuleString *key, int flags));
   MOCK_METHOD(int, HashExternalize,
-              (RedisModuleKey * key, RedisModuleString *field,
-               RedisModuleHashExternCB fn, void *privdata));
+              (ValkeyModuleKey * key, ValkeyModuleString *field,
+               ValkeyModuleHashExternCB fn, void *privdata));
   MOCK_METHOD(int, GetApi, (const char *name, void *func));
   MOCK_METHOD(int, HashGet,
-              (RedisModuleKey * key, int flags, const char *field,
+              (ValkeyModuleKey * key, int flags, const char *field,
                int *exists_out, void *terminating_null));
   MOCK_METHOD(int, HashGet,
-              (RedisModuleKey * key, int flags, const char *field,
-               RedisModuleString **value_out, void *terminating_null));
+              (ValkeyModuleKey * key, int flags, const char *field,
+               ValkeyModuleString **value_out, void *terminating_null));
   MOCK_METHOD(int, HashSet,
-              (RedisModuleKey * key, int flags, RedisModuleString *field,
-               RedisModuleString *value_out, void *terminating_null));
-  MOCK_METHOD(void, CloseKey, (RedisModuleKey * key));
+              (ValkeyModuleKey * key, int flags, ValkeyModuleString *field,
+               ValkeyModuleString *value_out, void *terminating_null));
+  MOCK_METHOD(void, CloseKey, (ValkeyModuleKey * key));
   MOCK_METHOD(int, CreateCommand,
-              (RedisModuleCtx * ctx, const char *name,
-               RedisModuleCmdFunc cmdfunc, const char *strflags, int firstkey,
+              (ValkeyModuleCtx * ctx, const char *name,
+               ValkeyModuleCmdFunc cmdfunc, const char *strflags, int firstkey,
                int lastkey, int keystep));
-  MOCK_METHOD(int, KeyType, (RedisModuleKey * key));
+  MOCK_METHOD(int, KeyType, (ValkeyModuleKey * key));
   MOCK_METHOD(int, ModuleTypeSetValue,
-              (RedisModuleKey * key, RedisModuleType *mt, void *value));
-  MOCK_METHOD(int, DeleteKey, (RedisModuleKey * key));
+              (ValkeyModuleKey * key, ValkeyModuleType *mt, void *value));
+  MOCK_METHOD(int, DeleteKey, (ValkeyModuleKey * key));
   MOCK_METHOD(int, RegisterInfoFunc,
-              (RedisModuleCtx * ctx, RedisModuleInfoFunc cb));
+              (ValkeyModuleCtx * ctx, ValkeyModuleInfoFunc cb));
   MOCK_METHOD(int, Init,
-              (RedisModuleCtx * ctx, const char *name, int ver, int apiver));
-  MOCK_METHOD(int, ReplyWithArray, (RedisModuleCtx * ctx, long len));  // NOLINT
+              (ValkeyModuleCtx * ctx, const char *name, int ver, int apiver));
+  MOCK_METHOD(int, ReplyWithArray,
+              (ValkeyModuleCtx * ctx, long len));  // NOLINT
   MOCK_METHOD(void, ReplySetArrayLength,
-              (RedisModuleCtx * ctx, long len));  // NOLINT
+              (ValkeyModuleCtx * ctx, long len));  // NOLINT
   MOCK_METHOD(int, ReplyWithLongLong,
-              (RedisModuleCtx * ctx, long long ll));  // NOLINT
+              (ValkeyModuleCtx * ctx, long long ll));  // NOLINT
   MOCK_METHOD(int, ReplyWithSimpleString,
-              (RedisModuleCtx * ctx, const char *str));
+              (ValkeyModuleCtx * ctx, const char *str));
   MOCK_METHOD(int, ReplyWithString,
-              (RedisModuleCtx * ctx, RedisModuleString *str));
-  MOCK_METHOD(int, ReplyWithDouble, (RedisModuleCtx * ctx, double val));
-  MOCK_METHOD(int, ReplyWithCString, (RedisModuleCtx * ctx, const char *str));
+              (ValkeyModuleCtx * ctx, ValkeyModuleString *str));
+  MOCK_METHOD(int, ReplyWithDouble, (ValkeyModuleCtx * ctx, double val));
+  MOCK_METHOD(int, ReplyWithCString, (ValkeyModuleCtx * ctx, const char *str));
   MOCK_METHOD(int, ReplyWithStringBuffer,
-              (RedisModuleCtx * ctx, const char *buf, size_t len));
-  MOCK_METHOD(int, FreeString, (RedisModuleCtx * ctx, RedisModuleString *str));
-  MOCK_METHOD(RedisModuleType *, CreateDataType,
-              (RedisModuleCtx * ctx, const char *name, int encver,
-               RedisModuleTypeMethods *typemethods));
-  MOCK_METHOD(int, ReplyWithError, (RedisModuleCtx * ctx, const char *err));
+              (ValkeyModuleCtx * ctx, const char *buf, size_t len));
+  MOCK_METHOD(int, FreeString,
+              (ValkeyModuleCtx * ctx, ValkeyModuleString *str));
+  MOCK_METHOD(ValkeyModuleType *, CreateDataType,
+              (ValkeyModuleCtx * ctx, const char *name, int encver,
+               ValkeyModuleTypeMethods *typemethods));
+  MOCK_METHOD(int, ReplyWithError, (ValkeyModuleCtx * ctx, const char *err));
   MOCK_METHOD(int, ScanKey,
-              (RedisModuleKey * key, RedisModuleScanCursor *cursor,
-               RedisModuleScanKeyCB fn, void *privdata));
-  MOCK_METHOD(RedisModuleScanCursor *, ScanCursorCreate, ());
-  MOCK_METHOD(void, ScanCursorDestroy, (RedisModuleScanCursor * cursor));
+              (ValkeyModuleKey * key, ValkeyModuleScanCursor *cursor,
+               ValkeyModuleScanKeyCB fn, void *privdata));
+  MOCK_METHOD(ValkeyModuleScanCursor *, ScanCursorCreate, ());
+  MOCK_METHOD(void, ScanCursorDestroy, (ValkeyModuleScanCursor * cursor));
   MOCK_METHOD(int, SubscribeToServerEvent,
-              (RedisModuleCtx * ctx, RedisModuleEvent event,
-               RedisModuleEventCallback cb));
+              (ValkeyModuleCtx * ctx, ValkeyModuleEvent event,
+               ValkeyModuleEventCallback cb));
   MOCK_METHOD(int, Scan,
-              (RedisModuleCtx * ctx, RedisModuleScanCursor *cursor,
-               RedisModuleScanCB fn, void *privdata));
-  MOCK_METHOD(int, ReplicateVerbatim, (RedisModuleCtx * ctx));
-  MOCK_METHOD(RedisModuleType *, ModuleTypeGetType, (RedisModuleKey * key));
-  MOCK_METHOD(RedisModuleCtx *, GetDetachedThreadSafeContext,
-              (RedisModuleCtx * ctx));
-  MOCK_METHOD(void, FreeThreadSafeContext, (RedisModuleCtx * ctx));
-  MOCK_METHOD(int, SelectDb, (RedisModuleCtx * ctx, int newid));
-  MOCK_METHOD(int, GetSelectedDb, (RedisModuleCtx * ctx));
-  MOCK_METHOD(void *, ModuleTypeGetValue, (RedisModuleKey * key));
-  MOCK_METHOD(unsigned long long, DbSize, (RedisModuleCtx * ctx));  // NOLINT
-  MOCK_METHOD(int, InfoAddSection, (RedisModuleInfoCtx * ctx, const char *str));
+              (ValkeyModuleCtx * ctx, ValkeyModuleScanCursor *cursor,
+               ValkeyModuleScanCB fn, void *privdata));
+  MOCK_METHOD(int, ReplicateVerbatim, (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(ValkeyModuleType *, ModuleTypeGetType, (ValkeyModuleKey * key));
+  MOCK_METHOD(ValkeyModuleCtx *, GetDetachedThreadSafeContext,
+              (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(void, FreeThreadSafeContext, (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(int, SelectDb, (ValkeyModuleCtx * ctx, int newid));
+  MOCK_METHOD(int, GetSelectedDb, (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(void *, ModuleTypeGetValue, (ValkeyModuleKey * key));
+  MOCK_METHOD(unsigned long long, DbSize, (ValkeyModuleCtx * ctx));  // NOLINT
+  MOCK_METHOD(int, InfoAddSection,
+              (ValkeyModuleInfoCtx * ctx, const char *str));
   MOCK_METHOD(int, InfoBeginDictField,
-              (RedisModuleInfoCtx * ctx, const char *str));
-  MOCK_METHOD(int, InfoEndDictField, (RedisModuleInfoCtx * ctx));
+              (ValkeyModuleInfoCtx * ctx, const char *str));
+  MOCK_METHOD(int, InfoEndDictField, (ValkeyModuleInfoCtx * ctx));
   MOCK_METHOD(int, InfoAddFieldLongLong,
-              (RedisModuleInfoCtx * ctx, const char *str,
+              (ValkeyModuleInfoCtx * ctx, const char *str,
                long long field));  // NOLINT
   MOCK_METHOD(int, InfoAddFieldCString,
-              (RedisModuleInfoCtx * ctx, const char *str, const char *field));
+              (ValkeyModuleInfoCtx * ctx, const char *str, const char *field));
   MOCK_METHOD(int, RegisterStringConfig,
-              (RedisModuleCtx * ctx, const char *name, const char *default_val,
-               unsigned int flags, RedisModuleConfigGetStringFunc getfn,
-               RedisModuleConfigSetStringFunc setfn,
-               RedisModuleConfigApplyFunc applyfn, void *privdata));
+              (ValkeyModuleCtx * ctx, const char *name, const char *default_val,
+               unsigned int flags, ValkeyModuleConfigGetStringFunc getfn,
+               ValkeyModuleConfigSetStringFunc setfn,
+               ValkeyModuleConfigApplyFunc applyfn, void *privdata));
   MOCK_METHOD(int, RegisterEnumConfig,
-              (RedisModuleCtx * ctx, const char *name, int default_val,
+              (ValkeyModuleCtx * ctx, const char *name, int default_val,
                unsigned int flags, const char **enum_values,
                const int *int_values, int num_enum_vals,
-               RedisModuleConfigGetEnumFunc getfn,
-               RedisModuleConfigSetEnumFunc setfn,
-               RedisModuleConfigApplyFunc applyfn, void *privdata));
+               ValkeyModuleConfigGetEnumFunc getfn,
+               ValkeyModuleConfigSetEnumFunc setfn,
+               ValkeyModuleConfigApplyFunc applyfn, void *privdata));
   MOCK_METHOD(int, RegisterNumericConfig,
-              (RedisModuleCtx * ctx, const char *name, long long default_val,
+              (ValkeyModuleCtx * ctx, const char *name, long long default_val,
                unsigned int flags, long long min, long long max,
-               RedisModuleConfigGetNumericFunc getfn,
-               RedisModuleConfigSetNumericFunc setfn,
-               RedisModuleConfigApplyFunc applyfn, void *privdata));
+               ValkeyModuleConfigGetNumericFunc getfn,
+               ValkeyModuleConfigSetNumericFunc setfn,
+               ValkeyModuleConfigApplyFunc applyfn, void *privdata));
   MOCK_METHOD(int, RegisterBoolConfig,
-              (RedisModuleCtx * ctx, const char *name, int default_val,
-               unsigned int flags, RedisModuleConfigGetBoolFunc getfn,
-               RedisModuleConfigSetBoolFunc setfn,
-               RedisModuleConfigApplyFunc applyfn, void *privdata));
-  MOCK_METHOD(int, LoadConfigs, (RedisModuleCtx * ctx));
+              (ValkeyModuleCtx * ctx, const char *name, int default_val,
+               unsigned int flags, ValkeyModuleConfigGetBoolFunc getfn,
+               ValkeyModuleConfigSetBoolFunc setfn,
+               ValkeyModuleConfigApplyFunc applyfn, void *privdata));
+  MOCK_METHOD(int, LoadConfigs, (ValkeyModuleCtx * ctx));
   MOCK_METHOD(int, SetConnectionProperties,
-              (const RedisModuleConnectionProperty *properties, int length));
+              (const ValkeyModuleConnectionProperty *properties, int length));
   MOCK_METHOD(int, SetShardId, (const char *shard_id, int len));
   MOCK_METHOD(int, GetClusterInfo, (void *cli));
   MOCK_METHOD(const char *, GetMyShardID, ());
-  MOCK_METHOD(int, GetContextFlags, (RedisModuleCtx * ctx));
-  MOCK_METHOD(uint64_t, LoadUnsigned, (RedisModuleIO * io));
-  MOCK_METHOD(int64_t, LoadSigned, (RedisModuleIO * io));
-  MOCK_METHOD(double, LoadDouble, (RedisModuleIO * io));
-  MOCK_METHOD(char *, LoadStringBuffer, (RedisModuleIO * io, size_t *lenptr));
-  MOCK_METHOD(RedisModuleString *, LoadString, (RedisModuleIO * io));
-  MOCK_METHOD(void, SaveUnsigned, (RedisModuleIO * io, uint64_t val));
-  MOCK_METHOD(void, SaveSigned, (RedisModuleIO * io, int64_t val));
-  MOCK_METHOD(void, SaveDouble, (RedisModuleIO * io, double val));
+  MOCK_METHOD(int, GetContextFlags, (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(uint64_t, LoadUnsigned, (ValkeyModuleIO * io));
+  MOCK_METHOD(int64_t, LoadSigned, (ValkeyModuleIO * io));
+  MOCK_METHOD(double, LoadDouble, (ValkeyModuleIO * io));
+  MOCK_METHOD(char *, LoadStringBuffer, (ValkeyModuleIO * io, size_t *lenptr));
+  MOCK_METHOD(ValkeyModuleString *, LoadString, (ValkeyModuleIO * io));
+  MOCK_METHOD(void, SaveUnsigned, (ValkeyModuleIO * io, uint64_t val));
+  MOCK_METHOD(void, SaveSigned, (ValkeyModuleIO * io, int64_t val));
+  MOCK_METHOD(void, SaveDouble, (ValkeyModuleIO * io, double val));
   MOCK_METHOD(void, SaveStringBuffer,
-              (RedisModuleIO * io, const char *str, size_t len));
-  MOCK_METHOD(int, IsIOError, (RedisModuleIO * io));
+              (ValkeyModuleIO * io, const char *str, size_t len));
+  MOCK_METHOD(int, IsIOError, (ValkeyModuleIO * io));
   MOCK_METHOD(int, ReplicationSetMasterCrossCluster,
-              (RedisModuleCtx * ctx, const char *ip, const int port));
-  MOCK_METHOD(int, ReplicationUnsetMasterCrossCluster, (RedisModuleCtx * ctx));
+              (ValkeyModuleCtx * ctx, const char *ip, const int port));
+  MOCK_METHOD(int, ReplicationUnsetMasterCrossCluster, (ValkeyModuleCtx * ctx));
   MOCK_METHOD(const char *, GetMyClusterID, ());
   MOCK_METHOD(int, GetClusterNodeInfo,
-              (RedisModuleCtx * ctx, const char *id, char *ip, char *master_id,
+              (ValkeyModuleCtx * ctx, const char *id, char *ip, char *master_id,
                int *port, int *flags));
   MOCK_METHOD(int, ReplicationSetSecondaryCluster,
-              (RedisModuleCtx * ctx, bool is_secondary_cluster));
-  MOCK_METHOD(RedisModuleCrossClusterReplicasList *,
+              (ValkeyModuleCtx * ctx, bool is_secondary_cluster));
+  MOCK_METHOD(ValkeyModuleCrossClusterReplicasList *,
               GetCrossClusterReplicasList, ());
   MOCK_METHOD(void, FreeCrossClusterReplicasList,
-              (RedisModuleCrossClusterReplicasList * list));
+              (ValkeyModuleCrossClusterReplicasList * list));
   MOCK_METHOD(void *, Alloc, (size_t size));
   MOCK_METHOD(void, Free, (void *ptr));
   MOCK_METHOD(void *, Realloc, (void *ptr, size_t size));
   MOCK_METHOD(void *, Calloc, (size_t nmemb, size_t size));
   MOCK_METHOD(size_t, MallocUsableSize, (void *ptr));
   MOCK_METHOD(size_t, GetClusterSize, ());
-  MOCK_METHOD(RedisModuleCallReply *, Call,
-              (RedisModuleCtx * ctx, const char *cmd, const char *fmt,
+  MOCK_METHOD(ValkeyModuleCallReply *, Call,
+              (ValkeyModuleCtx * ctx, const char *cmd, const char *fmt,
                const char *arg1, const char *arg2));
-  MOCK_METHOD(RedisModuleCallReply *, Call,
-              (RedisModuleCtx * ctx, const char *cmd, const char *fmt,
+  MOCK_METHOD(ValkeyModuleCallReply *, Call,
+              (ValkeyModuleCtx * ctx, const char *cmd, const char *fmt,
                const char *arg1));
-  MOCK_METHOD(RedisModuleCallReply *, CallReplyArrayElement,
-              (RedisModuleCallReply * reply, size_t index));
+  MOCK_METHOD(ValkeyModuleCallReply *, CallReplyArrayElement,
+              (ValkeyModuleCallReply * reply, size_t index));
   MOCK_METHOD(int, CallReplyMapElement,
-              (RedisModuleCallReply * reply, size_t index,
-               RedisModuleCallReply **key, RedisModuleCallReply **val));
+              (ValkeyModuleCallReply * reply, size_t index,
+               ValkeyModuleCallReply **key, ValkeyModuleCallReply **val));
   MOCK_METHOD(const char *, CallReplyStringPtr,
-              (RedisModuleCallReply * reply, size_t *len));
-  MOCK_METHOD(void, FreeCallReply, (RedisModuleCallReply * reply));
+              (ValkeyModuleCallReply * reply, size_t *len));
+  MOCK_METHOD(void, FreeCallReply, (ValkeyModuleCallReply * reply));
   MOCK_METHOD(void, RegisterClusterMessageReceiver,
-              (RedisModuleCtx * ctx, uint8_t type,
-               RedisModuleClusterMessageReceiver callback));
+              (ValkeyModuleCtx * ctx, uint8_t type,
+               ValkeyModuleClusterMessageReceiver callback));
   MOCK_METHOD(int, SendClusterMessage,
-              (RedisModuleCtx * ctx, const char *target_id, uint8_t type,
+              (ValkeyModuleCtx * ctx, const char *target_id, uint8_t type,
                const char *msg, uint32_t len));
   MOCK_METHOD(char **, GetClusterNodesList,
-              (RedisModuleCtx * ctx, size_t *numnodes));
-  MOCK_METHOD(RedisModuleCtx *, GetContextFromIO, (RedisModuleIO * rdb));
-  MOCK_METHOD(int, GetDbIdFromIO, (RedisModuleIO * rdb));
+              (ValkeyModuleCtx * ctx, size_t *numnodes));
+  MOCK_METHOD(ValkeyModuleCtx *, GetContextFromIO, (ValkeyModuleIO * rdb));
+  MOCK_METHOD(int, GetDbIdFromIO, (ValkeyModuleIO * rdb));
   MOCK_METHOD(void, FreeClusterNodesList, (char **ids));
-  MOCK_METHOD(int, CallReplyType, (RedisModuleCallReply * reply));
-  MOCK_METHOD(size_t, CallReplyLength, (RedisModuleCallReply * reply));
-  MOCK_METHOD(RedisModuleString *, CreateStringFromCallReply,
-              (RedisModuleCallReply * reply));
-  MOCK_METHOD(int, WrongArity, (RedisModuleCtx * ctx));
-  MOCK_METHOD(int, Fork, (RedisModuleForkDoneHandler cb, void *user_data));
+  MOCK_METHOD(int, CallReplyType, (ValkeyModuleCallReply * reply));
+  MOCK_METHOD(size_t, CallReplyLength, (ValkeyModuleCallReply * reply));
+  MOCK_METHOD(ValkeyModuleString *, CreateStringFromCallReply,
+              (ValkeyModuleCallReply * reply));
+  MOCK_METHOD(int, WrongArity, (ValkeyModuleCtx * ctx));
+  MOCK_METHOD(int, Fork, (ValkeyModuleForkDoneHandler cb, void *user_data));
   MOCK_METHOD(int, ExitFromChild, (int retcode));
-  MOCK_METHOD(RedisModuleRdbStream *, RdbStreamCreateFromRioHandler,
-              (const RedisModuleRIOHandler *handler));
+  MOCK_METHOD(ValkeyModuleRdbStream *, RdbStreamCreateFromRioHandler,
+              (const ValkeyModuleRIOHandler *handler));
   MOCK_METHOD(int, RdbLoad,
-              (RedisModuleCtx * ctx, RedisModuleRdbStream *stream, int flags));
+              (ValkeyModuleCtx * ctx, ValkeyModuleRdbStream *stream,
+               int flags));
   MOCK_METHOD(int, RdbSave,
-              (RedisModuleCtx * ctx, RedisModuleRdbStream *stream, int flags));
-  MOCK_METHOD(void, RdbStreamFree, (RedisModuleRdbStream * stream));
-  MOCK_METHOD(RedisModuleString *, GetCurrentUserName, (RedisModuleCtx * ctx));
+              (ValkeyModuleCtx * ctx, ValkeyModuleRdbStream *stream,
+               int flags));
+  MOCK_METHOD(void, RdbStreamFree, (ValkeyModuleRdbStream * stream));
+  MOCK_METHOD(ValkeyModuleString *, GetCurrentUserName,
+              (ValkeyModuleCtx * ctx));
 };
 // NOLINTBEGIN(readability-identifier-naming)
-// Global kMockRedisModule is a fake Redis module used for static wrappers
-// around MockRedisModule methods.
-MockRedisModule *kMockRedisModule REDISMODULE_ATTR;
+// Global kMockValkeyModule is a fake Valkey module used for static wrappers
+// around MockValkeyModule methods.
+MockValkeyModule *kMockValkeyModule VALKEYMODULE_ATTR;
 
-inline void TestRedisModule_Log(RedisModuleCtx *ctx [[maybe_unused]],
-                                const char *levelstr [[maybe_unused]],
-                                const char *fmt [[maybe_unused]], ...) {
+inline void TestValkeyModule_Log(ValkeyModuleCtx *ctx [[maybe_unused]],
+                                 const char *levelstr [[maybe_unused]],
+                                 const char *fmt [[maybe_unused]], ...) {
   char out[2048];
   va_list args;
   va_start(args, fmt);
   vsnprintf(out, sizeof(out), fmt, args);
   va_end(args);
-  printf("TestRedis[%s]: %s\n", levelstr, out);
-  kMockRedisModule->Log(ctx, levelstr, out);
+  printf("TestValkey[%s]: %s\n", levelstr, out);
+  kMockValkeyModule->Log(ctx, levelstr, out);
 }
 
-inline void TestRedisModule_LogIOError(RedisModuleIO *io [[maybe_unused]],
-                                       const char *levelstr [[maybe_unused]],
-                                       const char *fmt [[maybe_unused]], ...) {
+inline void TestValkeyModule_LogIOError(ValkeyModuleIO *io [[maybe_unused]],
+                                        const char *levelstr [[maybe_unused]],
+                                        const char *fmt [[maybe_unused]], ...) {
   char out[2048];
   va_list args;
   va_start(args, fmt);
   vsnprintf(out, sizeof(out), fmt, args);
   va_end(args);
-  printf("TestRedis[%s]: %s\n", levelstr, out);
-  kMockRedisModule->LogIOError(io, levelstr, out);
+  printf("TestValkey[%s]: %s\n", levelstr, out);
+  kMockValkeyModule->LogIOError(io, levelstr, out);
 }
 
-inline int TestRedisModule_BlockedClientMeasureTimeStart(
-    RedisModuleBlockedClient *bc [[maybe_unused]]) {
+inline int TestValkeyModule_BlockedClientMeasureTimeStart(
+    ValkeyModuleBlockedClient *bc [[maybe_unused]]) {
   return 0;
 }
 
-inline int TestRedisModule_BlockedClientMeasureTimeEnd(
-    RedisModuleBlockedClient *bc [[maybe_unused]]) {
+inline int TestValkeyModule_BlockedClientMeasureTimeEnd(
+    ValkeyModuleBlockedClient *bc [[maybe_unused]]) {
   return 0;
 }
 
-inline int TestRedisModule_UnblockClient(RedisModuleBlockedClient *bc,
-                                         void *privdata) {
-  return kMockRedisModule->UnblockClient(bc, privdata);
+inline int TestValkeyModule_UnblockClient(ValkeyModuleBlockedClient *bc,
+                                          void *privdata) {
+  return kMockValkeyModule->UnblockClient(bc, privdata);
 }
 
-struct RedisModuleBlockedClient {};
+struct ValkeyModuleBlockedClient {};
 
-// Simple test implementation of RedisModuleString
-struct RedisModuleString {
+// Simple test implementation of ValkeyModuleString
+struct ValkeyModuleString {
   std::string data;
   std::atomic<int> cnt{1};
 };
@@ -351,7 +358,7 @@ class ReplyCapture {
   void ReplyWithArray(long len) {  // NOLINT
     auto result = AllocateElement();
     result->array_value = ReplyArray{.target_length = len};
-    if (len == REDISMODULE_POSTPONED_ARRAY_LEN) {
+    if (len == VALKEYMODULE_POSTPONED_ARRAY_LEN) {
       curr_postponed_length_arrays.push_back(result);
     }
   }
@@ -368,7 +375,7 @@ class ReplyCapture {
     auto result = AllocateElement();
     result->simple_string_value = msg;
   }
-  void ReplyWithString(RedisModuleString *str) {
+  void ReplyWithString(ValkeyModuleString *str) {
     auto result = AllocateElement();
     result->string_value = vmsdk::ToStringView(str);
   }
@@ -430,7 +437,7 @@ class ReplyCapture {
         return result;
       }
     }
-    if (array.target_length == REDISMODULE_POSTPONED_ARRAY_LEN ||
+    if (array.target_length == VALKEYMODULE_POSTPONED_ARRAY_LEN ||
         array.elements.size() < (size_t)array.target_length) {
       array.elements.push_back(ReplyElement{});
       return &array.elements.back();
@@ -456,19 +463,19 @@ class ReplyCapture {
 struct RegisteredKey {
   std::string key;
   void *data;
-  RedisModuleType *module_type;
+  ValkeyModuleType *module_type;
   bool operator==(const RegisteredKey &other) const {
     return key == other.key && data == other.data &&
            module_type == other.module_type;
   }
 };
 
-struct RedisModuleCtx {
+struct ValkeyModuleCtx {
   ReplyCapture reply_capture;
   absl::flat_hash_map<std::string, RegisteredKey> registered_keys;
 };
 
-struct RedisModuleIO {};
+struct ValkeyModuleIO {};
 
 class InfoCapture {
  public:
@@ -507,394 +514,395 @@ class InfoCapture {
   std::stringstream info_;
 };
 
-struct RedisModuleInfoCtx {
+struct ValkeyModuleInfoCtx {
   InfoCapture info_capture;
   int in_dict_field = 0;
 };
 
-struct RedisModuleKey {
-  RedisModuleCtx *ctx;
+struct ValkeyModuleKey {
+  ValkeyModuleCtx *ctx;
   std::string key;
 };
 
-inline const char *TestRedisModule_StringPtrLen(const RedisModuleString *str,
-                                                size_t *len) {
+inline const char *TestValkeyModule_StringPtrLen(const ValkeyModuleString *str,
+                                                 size_t *len) {
   if (len != nullptr) {
     *len = str->data.size();
   }
   return str->data.c_str();
 }
 
-inline RedisModuleString *TestRedisModule_CreateStringPrintf(RedisModuleCtx *ctx
-                                                             [[maybe_unused]],
-                                                             const char *fmt,
-                                                             ...) {
+inline ValkeyModuleString *TestValkeyModule_CreateStringPrintf(
+    ValkeyModuleCtx *ctx [[maybe_unused]], const char *fmt, ...) {
   char out[1024];
   va_list args;
   va_start(args, fmt);
   vsnprintf(out, sizeof(out), fmt, args);
   va_end(args);
-  return new RedisModuleString{std::string(out)};
+  return new ValkeyModuleString{std::string(out)};
 }
 
-inline void *TestRedisModule_GetBlockedClientPrivateData(RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetBlockedClientPrivateData(ctx);
+inline void *TestValkeyModule_GetBlockedClientPrivateData(
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetBlockedClientPrivateData(ctx);
 }
 
-inline RedisModuleBlockedClient *TestRedisModule_BlockClientOnAuth(
-    RedisModuleCtx *ctx, RedisModuleAuthCallback reply_callback,
-    void (*free_privdata)(RedisModuleCtx *, void *)) {
-  return kMockRedisModule->BlockClientOnAuth(ctx, reply_callback,
-                                             free_privdata);
+inline ValkeyModuleBlockedClient *TestValkeyModule_BlockClientOnAuth(
+    ValkeyModuleCtx *ctx, ValkeyModuleAuthCallback reply_callback,
+    void (*free_privdata)(ValkeyModuleCtx *, void *)) {
+  return kMockValkeyModule->BlockClientOnAuth(ctx, reply_callback,
+                                              free_privdata);
 }
 
-inline RedisModuleBlockedClient *TestRedisModule_BlockClient(
-    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback,
-    RedisModuleCmdFunc timeout_callback,
-    void (*free_privdata)(RedisModuleCtx *, void *),
+inline ValkeyModuleBlockedClient *TestValkeyModule_BlockClient(
+    ValkeyModuleCtx *ctx, ValkeyModuleCmdFunc reply_callback,
+    ValkeyModuleCmdFunc timeout_callback,
+    void (*free_privdata)(ValkeyModuleCtx *, void *),
     long long timeout_ms) {  // NOLINT
-  return kMockRedisModule->BlockClient(ctx, reply_callback, timeout_callback,
-                                       free_privdata, timeout_ms);
+  return kMockValkeyModule->BlockClient(ctx, reply_callback, timeout_callback,
+                                        free_privdata, timeout_ms);
 }
 
-inline int TestRedisModule_AuthenticateClientWithACLUser(
-    RedisModuleCtx *ctx, const char *name, size_t len,
-    RedisModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) {
-  return kMockRedisModule->AuthenticateClientWithACLUser(
+inline int TestValkeyModule_AuthenticateClientWithACLUser(
+    ValkeyModuleCtx *ctx, const char *name, size_t len,
+    ValkeyModuleUserChangedFunc callback, void *privdata, uint64_t *client_id) {
+  return kMockValkeyModule->AuthenticateClientWithACLUser(
       ctx, name, len, callback, privdata, client_id);
 }
 
-inline void TestRedisModule_ACLAddLogEntryByUserName(
-    RedisModuleCtx *ctx, RedisModuleString *user, RedisModuleString *object,
-    RedisModuleACLLogEntryReason reason) {
-  return kMockRedisModule->ACLAddLogEntryByUserName(ctx, user, object, reason);
+inline void TestValkeyModule_ACLAddLogEntryByUserName(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *user, ValkeyModuleString *object,
+    ValkeyModuleACLLogEntryReason reason) {
+  return kMockValkeyModule->ACLAddLogEntryByUserName(ctx, user, object, reason);
 }
 
-inline RedisModuleString *TestRedisModule_CreateString(RedisModuleCtx *ctx
-                                                       [[maybe_unused]],
-                                                       const char *ptr,
-                                                       size_t len) {
-  return new RedisModuleString{std::string(ptr, len)};
+inline ValkeyModuleString *TestValkeyModule_CreateString(ValkeyModuleCtx *ctx
+                                                         [[maybe_unused]],
+                                                         const char *ptr,
+                                                         size_t len) {
+  return new ValkeyModuleString{std::string(ptr, len)};
 }
 
-inline void TestRedisModule_FreeString(RedisModuleCtx *ctx [[maybe_unused]],
-                                       RedisModuleString *str) {
+inline void TestValkeyModule_FreeString(ValkeyModuleCtx *ctx [[maybe_unused]],
+                                        ValkeyModuleString *str) {
   str->cnt--;
   if (str->cnt == 0) {
     delete str;
   }
 }
 
-inline void TestRedisModule_RetainString(RedisModuleCtx *ctx [[maybe_unused]],
-                                         RedisModuleString *str) {
+inline void TestValkeyModule_RetainString(ValkeyModuleCtx *ctx [[maybe_unused]],
+                                          ValkeyModuleString *str) {
   str->cnt++;
 }
 
-inline int TestRedisModule_EventLoopAdd(int fd, int mask,
-                                        RedisModuleEventLoopFunc func,
-                                        void *user_data) {
-  return kMockRedisModule->EventLoopAdd(fd, mask, func, user_data);
+inline int TestValkeyModule_EventLoopAdd(int fd, int mask,
+                                         ValkeyModuleEventLoopFunc func,
+                                         void *user_data) {
+  return kMockValkeyModule->EventLoopAdd(fd, mask, func, user_data);
 }
 
-inline int TestRedisModule_EventLoopAddOneShot(
-    RedisModuleEventLoopOneShotFunc func, void *user_data) {
-  return kMockRedisModule->EventLoopAddOneShot(func, user_data);
+inline int TestValkeyModule_EventLoopAddOneShot(
+    ValkeyModuleEventLoopOneShotFunc func, void *user_data) {
+  return kMockValkeyModule->EventLoopAddOneShot(func, user_data);
 }
 
-inline int TestRedisModule_EventLoopDel(int fd, int mask) {
-  return kMockRedisModule->EventLoopDel(fd, mask);
+inline int TestValkeyModule_EventLoopDel(int fd, int mask) {
+  return kMockValkeyModule->EventLoopDel(fd, mask);
 }
 
-inline RedisModuleTimerID TestRedisModule_CreateTimer(
-    RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback,
+inline ValkeyModuleTimerID TestValkeyModule_CreateTimer(
+    ValkeyModuleCtx *ctx, mstime_t period, ValkeyModuleTimerProc callback,
     void *data) {
-  return kMockRedisModule->CreateTimer(ctx, period, callback, data);
+  return kMockValkeyModule->CreateTimer(ctx, period, callback, data);
 }
 
-inline int TestRedisModule_StopTimer(RedisModuleCtx *ctx, RedisModuleTimerID id,
-                                     void **data) {
-  return kMockRedisModule->StopTimer(ctx, id, data);
+inline int TestValkeyModule_StopTimer(ValkeyModuleCtx *ctx,
+                                      ValkeyModuleTimerID id, void **data) {
+  return kMockValkeyModule->StopTimer(ctx, id, data);
 }
 
-inline void TestRedisModule_SetModuleOptions(RedisModuleCtx *ctx, int options) {
-  return kMockRedisModule->SetModuleOptions(ctx, options);
+inline void TestValkeyModule_SetModuleOptions(ValkeyModuleCtx *ctx,
+                                              int options) {
+  return kMockValkeyModule->SetModuleOptions(ctx, options);
 }
 
-inline unsigned long long TestRedisModule_GetClientId(  // NOLINT
-    RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetClientId(ctx);
+inline unsigned long long TestValkeyModule_GetClientId(  // NOLINT
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetClientId(ctx);
 }
 
-inline int TestRedisModule_GetClientInfoById(void *ci, uint64_t id) {
-  return kMockRedisModule->GetClientInfoById(ci, id);
+inline int TestValkeyModule_GetClientInfoById(void *ci, uint64_t id) {
+  return kMockValkeyModule->GetClientInfoById(ci, id);
 }
 
-inline int TestRedisModule_SubscribeToKeyspaceEvents(
-    RedisModuleCtx *ctx, int types, RedisModuleNotificationFunc cb) {
-  return kMockRedisModule->SubscribeToKeyspaceEvents(ctx, types, cb);
+inline int TestValkeyModule_SubscribeToKeyspaceEvents(
+    ValkeyModuleCtx *ctx, int types, ValkeyModuleNotificationFunc cb) {
+  return kMockValkeyModule->SubscribeToKeyspaceEvents(ctx, types, cb);
 }
 
-inline int TestRedisModule_KeyExistsDefaultImpl(RedisModuleCtx *ctx,
-                                                RedisModuleString *key) {
+inline int TestValkeyModule_KeyExistsDefaultImpl(ValkeyModuleCtx *ctx,
+                                                 ValkeyModuleString *key) {
   if (ctx != nullptr) {
     return ctx->registered_keys.contains(key->data) ? 1 : 0;
   }
   return 0;
 }
 
-inline int TestRedisModule_HashExternalizeDefaultImpl(
-    RedisModuleKey *key, RedisModuleString *field, RedisModuleHashExternCB fn,
-    void *privdata) {
-  return REDISMODULE_OK;
+inline int TestValkeyModule_HashExternalizeDefaultImpl(
+    ValkeyModuleKey *key, ValkeyModuleString *field,
+    ValkeyModuleHashExternCB fn, void *privdata) {
+  return VALKEYMODULE_OK;
 }
 
-inline int TestRedisModule_GetApiDefaultImpl(const char *name, void *func) {
-  return REDISMODULE_OK;
+inline int TestValkeyModule_GetApiDefaultImpl(const char *name, void *func) {
+  return VALKEYMODULE_OK;
 }
 
-inline int TestRedisModule_KeyExists(RedisModuleCtx *ctx,
-                                     RedisModuleString *key) {
-  return kMockRedisModule->KeyExists(ctx, key);
+inline int TestValkeyModule_KeyExists(ValkeyModuleCtx *ctx,
+                                      ValkeyModuleString *key) {
+  return kMockValkeyModule->KeyExists(ctx, key);
 }
 
-inline RedisModuleKey *TestRedisModule_OpenKeyDefaultImpl(
-    RedisModuleCtx *ctx, RedisModuleString *key, int flags) {
-  return new RedisModuleKey{ctx, key->data};
+inline ValkeyModuleKey *TestValkeyModule_OpenKeyDefaultImpl(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
+  return new ValkeyModuleKey{ctx, key->data};
 }
 
-inline RedisModuleKey *TestRedisModule_OpenKey(RedisModuleCtx *ctx,
-                                               RedisModuleString *key,
-                                               int flags) {
-  return kMockRedisModule->OpenKey(ctx, key, flags);
+inline ValkeyModuleKey *TestValkeyModule_OpenKey(ValkeyModuleCtx *ctx,
+                                                 ValkeyModuleString *key,
+                                                 int flags) {
+  return kMockValkeyModule->OpenKey(ctx, key, flags);
 }
 
-inline int TestRedisModule_HashExternalize(RedisModuleKey *key,
-                                           RedisModuleString *field,
-                                           RedisModuleHashExternCB fn,
-                                           void *privdata) {
-  return kMockRedisModule->HashExternalize(key, field, fn, privdata);
+inline int TestValkeyModule_HashExternalize(ValkeyModuleKey *key,
+                                            ValkeyModuleString *field,
+                                            ValkeyModuleHashExternCB fn,
+                                            void *privdata) {
+  return kMockValkeyModule->HashExternalize(key, field, fn, privdata);
 }
 
-inline int TestRedisModule_GetApi(const char *name, void *func) {
-  return kMockRedisModule->GetApi(name, func);
+inline int TestValkeyModule_GetApi(const char *name, void *func) {
+  return kMockValkeyModule->GetApi(name, func);
 }
 
-inline int TestRedisModule_HashGet(RedisModuleKey *key, int flags, ...) {
+inline int TestValkeyModule_HashGet(ValkeyModuleKey *key, int flags, ...) {
   va_list args;
   va_start(args, flags);
 
   const char *field = va_arg(args, const char *);
   int result;
-  if (flags & REDISMODULE_HASH_EXISTS) {
+  if (flags & VALKEYMODULE_HASH_EXISTS) {
     int *exists_out = va_arg(args, int *);
     void *terminating_null = va_arg(args, void *);
-    result = kMockRedisModule->HashGet(key, flags, field, exists_out,
-                                       terminating_null);
+    result = kMockValkeyModule->HashGet(key, flags, field, exists_out,
+                                        terminating_null);
   } else {
-    RedisModuleString **value_out = va_arg(args, RedisModuleString **);
+    ValkeyModuleString **value_out = va_arg(args, ValkeyModuleString **);
     void *terminating_null = va_arg(args, void *);
-    result = kMockRedisModule->HashGet(key, flags, field, value_out,
-                                       terminating_null);
+    result = kMockValkeyModule->HashGet(key, flags, field, value_out,
+                                        terminating_null);
   }
 
   va_end(args);
   return result;
 }
 
-inline int TestRedisModule_HashSet(RedisModuleKey *key, int flags, ...) {
+inline int TestValkeyModule_HashSet(ValkeyModuleKey *key, int flags, ...) {
   va_list args;
   va_start(args, flags);
 
-  RedisModuleString *field = va_arg(args, RedisModuleString *);
-  RedisModuleString *value = va_arg(args, RedisModuleString *);
+  ValkeyModuleString *field = va_arg(args, ValkeyModuleString *);
+  ValkeyModuleString *value = va_arg(args, ValkeyModuleString *);
   void *terminating_null = va_arg(args, void *);
   int result =
-      kMockRedisModule->HashSet(key, flags, field, value, terminating_null);
+      kMockValkeyModule->HashSet(key, flags, field, value, terminating_null);
   va_end(args);
   return result;
 }
 
-struct RedisModuleScanCursor {
+struct ValkeyModuleScanCursor {
   int cursor{0};
 };
 
-inline int TestRedisModule_ScanKey(RedisModuleKey *key,
-                                   RedisModuleScanCursor *cursor,
-                                   RedisModuleScanKeyCB fn, void *privdata) {
-  return kMockRedisModule->ScanKey(key, cursor, fn, privdata);
+inline int TestValkeyModule_ScanKey(ValkeyModuleKey *key,
+                                    ValkeyModuleScanCursor *cursor,
+                                    ValkeyModuleScanKeyCB fn, void *privdata) {
+  return kMockValkeyModule->ScanKey(key, cursor, fn, privdata);
 }
 
-inline RedisModuleScanCursor *TestRedisModule_ScanCursorCreate() {
-  return new RedisModuleScanCursor();
+inline ValkeyModuleScanCursor *TestValkeyModule_ScanCursorCreate() {
+  return new ValkeyModuleScanCursor();
 }
 
-inline void TestRedisModule_ScanCursorDestroy(RedisModuleScanCursor *cursor) {
+inline void TestValkeyModule_ScanCursorDestroy(ValkeyModuleScanCursor *cursor) {
   delete cursor;
 }
 
-inline void TestRedisModule_CloseKeyDefaultImpl(RedisModuleKey *key) {
+inline void TestValkeyModule_CloseKeyDefaultImpl(ValkeyModuleKey *key) {
   delete key;
 }
 
-inline void TestRedisModule_CloseKey(RedisModuleKey *key) {
-  return kMockRedisModule->CloseKey(key);
+inline void TestValkeyModule_CloseKey(ValkeyModuleKey *key) {
+  return kMockValkeyModule->CloseKey(key);
 }
 
-inline int TestRedisModule_CreateCommand(RedisModuleCtx *ctx, const char *name,
-                                         RedisModuleCmdFunc cmdfunc,
-                                         const char *strflags, int firstkey,
-                                         int lastkey, int keystep) {
-  return kMockRedisModule->CreateCommand(ctx, name, cmdfunc, strflags, firstkey,
-                                         lastkey, keystep);
+inline int TestValkeyModule_CreateCommand(ValkeyModuleCtx *ctx,
+                                          const char *name,
+                                          ValkeyModuleCmdFunc cmdfunc,
+                                          const char *strflags, int firstkey,
+                                          int lastkey, int keystep) {
+  return kMockValkeyModule->CreateCommand(ctx, name, cmdfunc, strflags,
+                                          firstkey, lastkey, keystep);
 }
 
-inline int TestRedisModule_KeyTypeDefaultImpl(RedisModuleKey *key) {
+inline int TestValkeyModule_KeyTypeDefaultImpl(ValkeyModuleKey *key) {
   if (key->ctx && key->ctx->registered_keys.contains(key->key)) {
-    return REDISMODULE_KEYTYPE_MODULE;
+    return VALKEYMODULE_KEYTYPE_MODULE;
   }
-  return REDISMODULE_KEYTYPE_EMPTY;
+  return VALKEYMODULE_KEYTYPE_EMPTY;
 }
 
-inline int TestRedisModule_KeyType(RedisModuleKey *key) {
-  return kMockRedisModule->KeyType(key);
+inline int TestValkeyModule_KeyType(ValkeyModuleKey *key) {
+  return kMockValkeyModule->KeyType(key);
 }
 
-inline int TestRedisModule_ModuleTypeSetValueDefaultImpl(RedisModuleKey *key,
-                                                         RedisModuleType *mt,
-                                                         void *value) {
+inline int TestValkeyModule_ModuleTypeSetValueDefaultImpl(ValkeyModuleKey *key,
+                                                          ValkeyModuleType *mt,
+                                                          void *value) {
   key->ctx->registered_keys[key->key] = RegisteredKey{
       .key = key->key,
       .data = value,
       .module_type = mt,
   };
-  return REDISMODULE_OK;
+  return VALKEYMODULE_OK;
 }
 
-inline int TestRedisModule_ModuleTypeSetValue(RedisModuleKey *key,
-                                              RedisModuleType *mt,
-                                              void *value) {
-  return kMockRedisModule->ModuleTypeSetValue(key, mt, value);
+inline int TestValkeyModule_ModuleTypeSetValue(ValkeyModuleKey *key,
+                                               ValkeyModuleType *mt,
+                                               void *value) {
+  return kMockValkeyModule->ModuleTypeSetValue(key, mt, value);
 }
 
-inline int TestRedisModule_DeleteKeyDefaultImpl(RedisModuleKey *key) {
+inline int TestValkeyModule_DeleteKeyDefaultImpl(ValkeyModuleKey *key) {
   if (key->ctx != nullptr) {
     if (key->ctx->registered_keys.contains(key->key)) {
       key->ctx->registered_keys.erase(key->key);
-      return REDISMODULE_OK;
+      return VALKEYMODULE_OK;
     }
   }
-  return REDISMODULE_ERR;
+  return VALKEYMODULE_ERR;
 }
 
-inline int TestRedisModule_DeleteKey(RedisModuleKey *key) {
-  return kMockRedisModule->DeleteKey(key);
+inline int TestValkeyModule_DeleteKey(ValkeyModuleKey *key) {
+  return kMockValkeyModule->DeleteKey(key);
 }
 
-inline int TestRedisModule_ReplyWithArray(RedisModuleCtx *ctx,
-                                          long len) {  // NOLINT
+inline int TestValkeyModule_ReplyWithArray(ValkeyModuleCtx *ctx,
+                                           long len) {  // NOLINT
   if (ctx) {
     ctx->reply_capture.ReplyWithArray(len);
   }
-  return kMockRedisModule->ReplyWithArray(ctx, len);
+  return kMockValkeyModule->ReplyWithArray(ctx, len);
 }
 
-inline void TestRedisModule_ReplySetArrayLength(RedisModuleCtx *ctx,
-                                                long len) {  // NOLINT
+inline void TestValkeyModule_ReplySetArrayLength(ValkeyModuleCtx *ctx,
+                                                 long len) {  // NOLINT
   if (ctx) {
     ctx->reply_capture.ReplySetArrayLength(len);
   }
-  kMockRedisModule->ReplySetArrayLength(ctx, len);
+  kMockValkeyModule->ReplySetArrayLength(ctx, len);
 }
 
-inline int TestRedisModule_ReplyWithLongLong(RedisModuleCtx *ctx,
-                                             long long ll) {  // NOLINT
+inline int TestValkeyModule_ReplyWithLongLong(ValkeyModuleCtx *ctx,
+                                              long long ll) {  // NOLINT
   if (ctx) {
     ctx->reply_capture.ReplyWithLongLong(ll);
   }
-  return kMockRedisModule->ReplyWithLongLong(ctx, ll);
+  return kMockValkeyModule->ReplyWithLongLong(ctx, ll);
 }
 
-inline int TestRedisModule_ReplyWithSimpleString(RedisModuleCtx *ctx,
-                                                 const char *msg) {
+inline int TestValkeyModule_ReplyWithSimpleString(ValkeyModuleCtx *ctx,
+                                                  const char *msg) {
   if (ctx) {
     ctx->reply_capture.ReplyWithSimpleString(msg);
   }
-  return kMockRedisModule->ReplyWithSimpleString(ctx, msg);
+  return kMockValkeyModule->ReplyWithSimpleString(ctx, msg);
 }
 
-inline int TestRedisModule_ReplyWithString(RedisModuleCtx *ctx,
-                                           RedisModuleString *msg) {
+inline int TestValkeyModule_ReplyWithString(ValkeyModuleCtx *ctx,
+                                            ValkeyModuleString *msg) {
   if (ctx) {
     ctx->reply_capture.ReplyWithString(msg);
   }
-  return kMockRedisModule->ReplyWithString(ctx, msg);
+  return kMockValkeyModule->ReplyWithString(ctx, msg);
 }
 
-inline int TestRedisModule_ReplyWithDouble(RedisModuleCtx *ctx, double val) {
+inline int TestValkeyModule_ReplyWithDouble(ValkeyModuleCtx *ctx, double val) {
   if (ctx) {
     ctx->reply_capture.ReplyWithDouble(val);
   }
-  return kMockRedisModule->ReplyWithDouble(ctx, val);
+  return kMockValkeyModule->ReplyWithDouble(ctx, val);
 }
 
-inline int TestRedisModule_ReplyWithCString(RedisModuleCtx *ctx,
-                                            const char *str) {
+inline int TestValkeyModule_ReplyWithCString(ValkeyModuleCtx *ctx,
+                                             const char *str) {
   if (ctx) {
     ctx->reply_capture.ReplyWithCString(str);
   }
-  return kMockRedisModule->ReplyWithCString(ctx, str);
+  return kMockValkeyModule->ReplyWithCString(ctx, str);
 }
 
-inline int TestRedisModule_ReplyWithStringBuffer(RedisModuleCtx *ctx,
-                                                 const char *buf, size_t len) {
+inline int TestValkeyModule_ReplyWithStringBuffer(ValkeyModuleCtx *ctx,
+                                                  const char *buf, size_t len) {
   if (ctx) {
     ctx->reply_capture.ReplyWithStringBuffer(buf, len);
   }
-  return kMockRedisModule->ReplyWithStringBuffer(ctx, buf, len);
+  return kMockValkeyModule->ReplyWithStringBuffer(ctx, buf, len);
 }
 
-inline int TestRedisModule_RegisterInfoFunc(RedisModuleCtx *ctx,
-                                            RedisModuleInfoFunc cb) {
-  return kMockRedisModule->RegisterInfoFunc(ctx, cb);
+inline int TestValkeyModule_RegisterInfoFunc(ValkeyModuleCtx *ctx,
+                                             ValkeyModuleInfoFunc cb) {
+  return kMockValkeyModule->RegisterInfoFunc(ctx, cb);
 }
 
-inline int TestRedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
-                                int apiver) {
-  return kMockRedisModule->Init(ctx, name, ver, apiver);
+inline int TestValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name,
+                                 int ver, int apiver) {
+  return kMockValkeyModule->Init(ctx, name, ver, apiver);
 }
 
-inline RedisModuleType *TestRedisModule_CreateDataType(
-    RedisModuleCtx *ctx, const char *name, int encver,
-    RedisModuleTypeMethods *typemethods) {
-  return kMockRedisModule->CreateDataType(ctx, name, encver, typemethods);
+inline ValkeyModuleType *TestValkeyModule_CreateDataType(
+    ValkeyModuleCtx *ctx, const char *name, int encver,
+    ValkeyModuleTypeMethods *typemethods) {
+  return kMockValkeyModule->CreateDataType(ctx, name, encver, typemethods);
 }
 
-inline int TestRedisModule_ReplyWithError(RedisModuleCtx *ctx,
-                                          const char *err) {
+inline int TestValkeyModule_ReplyWithError(ValkeyModuleCtx *ctx,
+                                           const char *err) {
   if (ctx) {
     ctx->reply_capture.ReplyWithError(err);
   }
-  return kMockRedisModule->ReplyWithError(ctx, err);
+  return kMockValkeyModule->ReplyWithError(ctx, err);
 }
 
-inline int TestRedisModule_SubscribeToServerEvent(RedisModuleCtx *ctx,
-                                                  RedisModuleEvent event,
-                                                  RedisModuleEventCallback cb) {
-  return kMockRedisModule->SubscribeToServerEvent(ctx, event, cb);
+inline int TestValkeyModule_SubscribeToServerEvent(
+    ValkeyModuleCtx *ctx, ValkeyModuleEvent event,
+    ValkeyModuleEventCallback cb) {
+  return kMockValkeyModule->SubscribeToServerEvent(ctx, event, cb);
 }
 
-inline int TestRedisModule_Scan(RedisModuleCtx *ctx,
-                                RedisModuleScanCursor *cursor,
-                                RedisModuleScanCB fn, void *privdata) {
-  return kMockRedisModule->Scan(ctx, cursor, fn, privdata);
+inline int TestValkeyModule_Scan(ValkeyModuleCtx *ctx,
+                                 ValkeyModuleScanCursor *cursor,
+                                 ValkeyModuleScanCB fn, void *privdata) {
+  return kMockValkeyModule->Scan(ctx, cursor, fn, privdata);
 }
 
-inline int TestRedisModule_ReplicateVerbatim(RedisModuleCtx *ctx) {
-  return kMockRedisModule->ReplicateVerbatim(ctx);
+inline int TestValkeyModule_ReplicateVerbatim(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->ReplicateVerbatim(ctx);
 }
 
-inline RedisModuleType *TestRedisModule_ModuleTypeGetTypeDefaultImpl(
-    RedisModuleKey *key) {
+inline ValkeyModuleType *TestValkeyModule_ModuleTypeGetTypeDefaultImpl(
+    ValkeyModuleKey *key) {
   if (key->ctx->registered_keys.contains(key->key)) {
     return key->ctx->registered_keys[key->key].module_type;
   } else {
@@ -903,29 +911,30 @@ inline RedisModuleType *TestRedisModule_ModuleTypeGetTypeDefaultImpl(
   return key->ctx->registered_keys[key->key].module_type;
 }
 
-inline RedisModuleType *TestRedisModule_ModuleTypeGetType(RedisModuleKey *key) {
-  return kMockRedisModule->ModuleTypeGetType(key);
+inline ValkeyModuleType *TestValkeyModule_ModuleTypeGetType(
+    ValkeyModuleKey *key) {
+  return kMockValkeyModule->ModuleTypeGetType(key);
 }
 
-inline RedisModuleCtx *TestRedisModule_GetDetachedThreadSafeContext(
-    RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetDetachedThreadSafeContext(ctx);
+inline ValkeyModuleCtx *TestValkeyModule_GetDetachedThreadSafeContext(
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetDetachedThreadSafeContext(ctx);
 }
 
-inline void TestRedisModule_FreeThreadSafeContext(RedisModuleCtx *ctx) {
-  return kMockRedisModule->FreeThreadSafeContext(ctx);
+inline void TestValkeyModule_FreeThreadSafeContext(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->FreeThreadSafeContext(ctx);
 }
 
-inline int TestRedisModule_SelectDb(RedisModuleCtx *ctx, int newid) {
-  return kMockRedisModule->SelectDb(ctx, newid);
+inline int TestValkeyModule_SelectDb(ValkeyModuleCtx *ctx, int newid) {
+  return kMockValkeyModule->SelectDb(ctx, newid);
 }
 
-inline int TestRedisModule_GetSelectedDb(RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetSelectedDb(ctx);
+inline int TestValkeyModule_GetSelectedDb(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetSelectedDb(ctx);
 }
 
-inline void *TestRedisModule_ModuleTypeGetValueDefaultImpl(
-    RedisModuleKey *key) {
+inline void *TestValkeyModule_ModuleTypeGetValueDefaultImpl(
+    ValkeyModuleKey *key) {
   if (key->ctx->registered_keys.contains(key->key)) {
     return key->ctx->registered_keys[key->key].data;
   } else {
@@ -933,101 +942,101 @@ inline void *TestRedisModule_ModuleTypeGetValueDefaultImpl(
   }
 }
 
-inline void *TestRedisModule_ModuleTypeGetValue(RedisModuleKey *key) {
-  return kMockRedisModule->ModuleTypeGetValue(key);
+inline void *TestValkeyModule_ModuleTypeGetValue(ValkeyModuleKey *key) {
+  return kMockValkeyModule->ModuleTypeGetValue(key);
 }
 
-inline unsigned long long TestRedisModule_DbSize(  // NOLINT
-    RedisModuleCtx *ctx) {
-  return kMockRedisModule->DbSize(ctx);
+inline unsigned long long TestValkeyModule_DbSize(  // NOLINT
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->DbSize(ctx);
 }
 
-inline int TestRedisModule_InfoAddSection(RedisModuleInfoCtx *ctx,
-                                          const char *str) {
+inline int TestValkeyModule_InfoAddSection(ValkeyModuleInfoCtx *ctx,
+                                           const char *str) {
   if (ctx) {
     ctx->info_capture.InfoAddSection(str);
   }
-  return kMockRedisModule->InfoAddSection(ctx, str);
+  return kMockValkeyModule->InfoAddSection(ctx, str);
 }
 
-inline int TestRedisModule_InfoAddFieldLongLong(RedisModuleInfoCtx *ctx,
-                                                const char *str,
-                                                long long field) {  // NOLINT
+inline int TestValkeyModule_InfoAddFieldLongLong(ValkeyModuleInfoCtx *ctx,
+                                                 const char *str,
+                                                 long long field) {  // NOLINT
   if (ctx) {
     ctx->info_capture.InfoAddFieldLongLong(str, field, ctx->in_dict_field);
   }
-  return kMockRedisModule->InfoAddFieldLongLong(ctx, str, field);
+  return kMockValkeyModule->InfoAddFieldLongLong(ctx, str, field);
 }
 
-inline int TestRedisModule_InfoAddFieldCString(RedisModuleInfoCtx *ctx,
-                                               const char *str,
-                                               const char *field) {
+inline int TestValkeyModule_InfoAddFieldCString(ValkeyModuleInfoCtx *ctx,
+                                                const char *str,
+                                                const char *field) {
   if (ctx) {
     ctx->info_capture.InfoAddFieldCString(str, field, ctx->in_dict_field);
   }
-  return kMockRedisModule->InfoAddFieldCString(ctx, str, field);
+  return kMockValkeyModule->InfoAddFieldCString(ctx, str, field);
 }
 
-inline int TestRedisModule_InfoBeginDictField(RedisModuleInfoCtx *ctx,
-                                              const char *str) {
+inline int TestValkeyModule_InfoBeginDictField(ValkeyModuleInfoCtx *ctx,
+                                               const char *str) {
   if (ctx) {
     ctx->info_capture.InfoBeginDictField(str, ctx->in_dict_field);
     ctx->in_dict_field = 1;
   }
-  return kMockRedisModule->InfoBeginDictField(ctx, str);
+  return kMockValkeyModule->InfoBeginDictField(ctx, str);
 }
 
-inline int TestRedisModule_InfoEndDictField(RedisModuleInfoCtx *ctx) {
+inline int TestValkeyModule_InfoEndDictField(ValkeyModuleInfoCtx *ctx) {
   if (ctx) {
     ctx->info_capture.InfoEndDictField();
   }
   ctx->in_dict_field = 0;
-  return kMockRedisModule->InfoEndDictField(ctx);
+  return kMockValkeyModule->InfoEndDictField(ctx);
 }
 
-inline int TestRedisModule_RegisterStringConfig(
-    RedisModuleCtx *ctx, const char *name, const char *default_val,
-    unsigned int flags, RedisModuleConfigGetStringFunc getfn,
-    RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn,
+inline int TestValkeyModule_RegisterStringConfig(
+    ValkeyModuleCtx *ctx, const char *name, const char *default_val,
+    unsigned int flags, ValkeyModuleConfigGetStringFunc getfn,
+    ValkeyModuleConfigSetStringFunc setfn, ValkeyModuleConfigApplyFunc applyfn,
     void *privdata) {
-  return kMockRedisModule->RegisterStringConfig(
+  return kMockValkeyModule->RegisterStringConfig(
       ctx, name, default_val, flags, getfn, setfn, applyfn, privdata);
 }
 
-inline int TestRedisModule_RegisterEnumConfig(
-    RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
+inline int TestValkeyModule_RegisterEnumConfig(
+    ValkeyModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
     const char **enum_values, const int *int_values, int num_enum_vals,
-    RedisModuleConfigGetEnumFunc getfn, RedisModuleConfigSetEnumFunc setfn,
-    RedisModuleConfigApplyFunc applyfn, void *privdata) {
-  return kMockRedisModule->RegisterEnumConfig(
+    ValkeyModuleConfigGetEnumFunc getfn, ValkeyModuleConfigSetEnumFunc setfn,
+    ValkeyModuleConfigApplyFunc applyfn, void *privdata) {
+  return kMockValkeyModule->RegisterEnumConfig(
       ctx, name, default_val, flags, enum_values, int_values, num_enum_vals,
       getfn, setfn, applyfn, privdata);
 }
 
-inline int TestRedisModule_RegisterNumericConfig(
-    RedisModuleCtx *ctx, const char *name, long long default_val,
+inline int TestValkeyModule_RegisterNumericConfig(
+    ValkeyModuleCtx *ctx, const char *name, long long default_val,
     unsigned int flags, long long min, long long max,
-    RedisModuleConfigGetNumericFunc getfn,
-    RedisModuleConfigSetNumericFunc setfn, RedisModuleConfigApplyFunc applyfn,
+    ValkeyModuleConfigGetNumericFunc getfn,
+    ValkeyModuleConfigSetNumericFunc setfn, ValkeyModuleConfigApplyFunc applyfn,
     void *privdata) {
-  return kMockRedisModule->RegisterNumericConfig(
+  return kMockValkeyModule->RegisterNumericConfig(
       ctx, name, default_val, flags, min, max, getfn, setfn, applyfn, privdata);
 }
 
-inline int TestRedisModule_RegisterBoolConfig(
-    RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
-    RedisModuleConfigGetBoolFunc getfn, RedisModuleConfigSetBoolFunc setfn,
-    RedisModuleConfigApplyFunc applyfn, void *privdata) {
-  return kMockRedisModule->RegisterBoolConfig(ctx, name, default_val, flags,
-                                              getfn, setfn, applyfn, privdata);
+inline int TestValkeyModule_RegisterBoolConfig(
+    ValkeyModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
+    ValkeyModuleConfigGetBoolFunc getfn, ValkeyModuleConfigSetBoolFunc setfn,
+    ValkeyModuleConfigApplyFunc applyfn, void *privdata) {
+  return kMockValkeyModule->RegisterBoolConfig(ctx, name, default_val, flags,
+                                               getfn, setfn, applyfn, privdata);
 }
 
-inline int TestRedisModule_LoadConfigs(RedisModuleCtx *ctx) {
-  return kMockRedisModule->LoadConfigs(ctx);
+inline int TestValkeyModule_LoadConfigs(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->LoadConfigs(ctx);
 }
 
-inline int TestRedisModule_StringCompare(RedisModuleString *a,
-                                         RedisModuleString *b) {
+inline int TestValkeyModule_StringCompare(ValkeyModuleString *a,
+                                          ValkeyModuleString *b) {
   if (a == nullptr && b == nullptr) {
     return 0;
   }
@@ -1040,205 +1049,204 @@ inline int TestRedisModule_StringCompare(RedisModuleString *a,
   return strcmp(a->data.c_str(), b->data.c_str());
 }
 
-inline int TestRedisModule_SetConnectionProperties(
-    const RedisModuleConnectionProperty *properties, int length) {
-  return kMockRedisModule->SetConnectionProperties(properties, length);
+inline int TestValkeyModule_SetConnectionProperties(
+    const ValkeyModuleConnectionProperty *properties, int length) {
+  return kMockValkeyModule->SetConnectionProperties(properties, length);
 }
 
-inline int TestRedisModule_SetShardId(const char *shardId, int len) {
-  return kMockRedisModule->SetShardId(shardId, len);
+inline int TestValkeyModule_SetShardId(const char *shardId, int len) {
+  return kMockValkeyModule->SetShardId(shardId, len);
 }
 
-inline int TestRedisModule_GetClusterInfo(void *cli) {
-  return kMockRedisModule->GetClusterInfo(cli);
+inline int TestValkeyModule_GetClusterInfo(void *cli) {
+  return kMockValkeyModule->GetClusterInfo(cli);
 }
 
-inline const char *TestRedisModule_GetMyShardID() {
-  return kMockRedisModule->GetMyShardID();
+inline const char *TestValkeyModule_GetMyShardID() {
+  return kMockValkeyModule->GetMyShardID();
 }
 
-inline int TestRedisModule_GetContextFlags(RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetContextFlags(ctx);
+inline int TestValkeyModule_GetContextFlags(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetContextFlags(ctx);
 }
 
-inline uint64_t TestRedisModule_LoadUnsigned(RedisModuleIO *io) {
-  return kMockRedisModule->LoadUnsigned(io);
+inline uint64_t TestValkeyModule_LoadUnsigned(ValkeyModuleIO *io) {
+  return kMockValkeyModule->LoadUnsigned(io);
 }
 
-inline int64_t TestRedisModule_LoadSigned(RedisModuleIO *io) {
-  return kMockRedisModule->LoadSigned(io);
+inline int64_t TestValkeyModule_LoadSigned(ValkeyModuleIO *io) {
+  return kMockValkeyModule->LoadSigned(io);
 }
 
-inline double TestRedisModule_LoadDouble(RedisModuleIO *io) {
-  return kMockRedisModule->LoadDouble(io);
+inline double TestValkeyModule_LoadDouble(ValkeyModuleIO *io) {
+  return kMockValkeyModule->LoadDouble(io);
 }
 
-inline char *TestRedisModule_LoadStringBuffer(RedisModuleIO *io,
-                                              size_t *lenptr) {
-  return kMockRedisModule->LoadStringBuffer(io, lenptr);
+inline char *TestValkeyModule_LoadStringBuffer(ValkeyModuleIO *io,
+                                               size_t *lenptr) {
+  return kMockValkeyModule->LoadStringBuffer(io, lenptr);
 }
 
-inline RedisModuleString *TestRedisModule_LoadString(RedisModuleIO *io) {
-  return kMockRedisModule->LoadString(io);
+inline ValkeyModuleString *TestValkeyModule_LoadString(ValkeyModuleIO *io) {
+  return kMockValkeyModule->LoadString(io);
 }
 
-inline void TestRedisModule_SaveUnsigned(RedisModuleIO *io, uint64_t val) {
-  return kMockRedisModule->SaveUnsigned(io, val);
+inline void TestValkeyModule_SaveUnsigned(ValkeyModuleIO *io, uint64_t val) {
+  return kMockValkeyModule->SaveUnsigned(io, val);
 }
 
-inline void TestRedisModule_SaveSigned(RedisModuleIO *io, int64_t val) {
-  return kMockRedisModule->SaveSigned(io, val);
+inline void TestValkeyModule_SaveSigned(ValkeyModuleIO *io, int64_t val) {
+  return kMockValkeyModule->SaveSigned(io, val);
 }
 
-inline void TestRedisModule_SaveDouble(RedisModuleIO *io, double val) {
-  return kMockRedisModule->SaveDouble(io, val);
+inline void TestValkeyModule_SaveDouble(ValkeyModuleIO *io, double val) {
+  return kMockValkeyModule->SaveDouble(io, val);
 }
 
-inline void TestRedisModule_SaveStringBuffer(RedisModuleIO *io, const char *str,
-                                             size_t len) {
-  return kMockRedisModule->SaveStringBuffer(io, str, len);
+inline void TestValkeyModule_SaveStringBuffer(ValkeyModuleIO *io,
+                                              const char *str, size_t len) {
+  return kMockValkeyModule->SaveStringBuffer(io, str, len);
 }
 
-inline int TestRedisModule_IsIOError(RedisModuleIO *io) {
-  return kMockRedisModule->IsIOError(io);
+inline int TestValkeyModule_IsIOError(ValkeyModuleIO *io) {
+  return kMockValkeyModule->IsIOError(io);
 }
 
-inline int TestRedisModule_ReplicationSetMasterCrossCluster(RedisModuleCtx *ctx,
-                                                            const char *ip,
-                                                            int port) {
-  return kMockRedisModule->ReplicationSetMasterCrossCluster(ctx, ip, port);
+inline int TestValkeyModule_ReplicationSetMasterCrossCluster(
+    ValkeyModuleCtx *ctx, const char *ip, int port) {
+  return kMockValkeyModule->ReplicationSetMasterCrossCluster(ctx, ip, port);
 }
 
-inline int TestRedisModule_ReplicationUnsetMasterCrossCluster(
-    RedisModuleCtx *ctx) {
-  return kMockRedisModule->ReplicationUnsetMasterCrossCluster(ctx);
+inline int TestValkeyModule_ReplicationUnsetMasterCrossCluster(
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->ReplicationUnsetMasterCrossCluster(ctx);
 }
 
-inline const char *TestRedisModule_GetMyClusterID() {
-  return kMockRedisModule->GetMyClusterID();
+inline const char *TestValkeyModule_GetMyClusterID() {
+  return kMockValkeyModule->GetMyClusterID();
 }
 
-inline int TestRedisModule_GetClusterNodeInfo(RedisModuleCtx *ctx,
-                                              const char *id, char *ip,
-                                              char *master_id, int *port,
-                                              int *flags) {
-  return kMockRedisModule->GetClusterNodeInfo(ctx, id, ip, master_id, port,
-                                              flags);
+inline int TestValkeyModule_GetClusterNodeInfo(ValkeyModuleCtx *ctx,
+                                               const char *id, char *ip,
+                                               char *master_id, int *port,
+                                               int *flags) {
+  return kMockValkeyModule->GetClusterNodeInfo(ctx, id, ip, master_id, port,
+                                               flags);
 }
 
-inline int TestRedisModule_ReplicationSetSecondaryCluster(
-    RedisModuleCtx *ctx, bool is_secondary_cluster) {
-  return kMockRedisModule->ReplicationSetSecondaryCluster(ctx,
-                                                          is_secondary_cluster);
+inline int TestValkeyModule_ReplicationSetSecondaryCluster(
+    ValkeyModuleCtx *ctx, bool is_secondary_cluster) {
+  return kMockValkeyModule->ReplicationSetSecondaryCluster(
+      ctx, is_secondary_cluster);
 }
 
-inline RedisModuleCrossClusterReplicasList *
-TestRedisModule_GetCrossClusterReplicasList() {
-  return kMockRedisModule->GetCrossClusterReplicasList();
+inline ValkeyModuleCrossClusterReplicasList *
+TestValkeyModule_GetCrossClusterReplicasList() {
+  return kMockValkeyModule->GetCrossClusterReplicasList();
 }
 
-inline void TestRedisModule_FreeCrossClusterReplicasList(
-    RedisModuleCrossClusterReplicasList *list) {
-  return kMockRedisModule->FreeCrossClusterReplicasList(list);
+inline void TestValkeyModule_FreeCrossClusterReplicasList(
+    ValkeyModuleCrossClusterReplicasList *list) {
+  return kMockValkeyModule->FreeCrossClusterReplicasList(list);
 }
 
-inline void *TestRedisModule_Alloc(size_t size) {
-  return kMockRedisModule->Alloc(size);
+inline void *TestValkeyModule_Alloc(size_t size) {
+  return kMockValkeyModule->Alloc(size);
 }
 
-inline void TestRedisModule_Free(void *ptr) {
-  return kMockRedisModule->Free(ptr);
+inline void TestValkeyModule_Free(void *ptr) {
+  return kMockValkeyModule->Free(ptr);
 }
 
-inline void *TestRedisModule_Realloc(void *ptr, size_t size) {
-  return kMockRedisModule->Realloc(ptr, size);
+inline void *TestValkeyModule_Realloc(void *ptr, size_t size) {
+  return kMockValkeyModule->Realloc(ptr, size);
 }
 
-inline void *TestRedisModule_Calloc(size_t nmemb, size_t size) {
-  return kMockRedisModule->Calloc(nmemb, size);
+inline void *TestValkeyModule_Calloc(size_t nmemb, size_t size) {
+  return kMockValkeyModule->Calloc(nmemb, size);
 }
 
-inline size_t TestRedisModule_MallocUsableSize(void *ptr) {
-  return kMockRedisModule->MallocUsableSize(ptr);
+inline size_t TestValkeyModule_MallocUsableSize(void *ptr) {
+  return kMockValkeyModule->MallocUsableSize(ptr);
 }
 
-inline size_t TestRedisModule_GetClusterSize() {
-  return kMockRedisModule->GetClusterSize();
+inline size_t TestValkeyModule_GetClusterSize() {
+  return kMockValkeyModule->GetClusterSize();
 }
 
-inline int TestRedisModule_WrongArity(RedisModuleCtx *ctx) {
-  return kMockRedisModule->WrongArity(ctx);
+inline int TestValkeyModule_WrongArity(ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->WrongArity(ctx);
 }
 
-inline int TestRedisModule_Fork(RedisModuleForkDoneHandler cb,
-                                void *user_data) {
-  return kMockRedisModule->Fork(cb, user_data);
+inline int TestValkeyModule_Fork(ValkeyModuleForkDoneHandler cb,
+                                 void *user_data) {
+  return kMockValkeyModule->Fork(cb, user_data);
 }
 
-inline int TestRedisModule_ExitFromChild(int retcode) {
-  return kMockRedisModule->ExitFromChild(retcode);
+inline int TestValkeyModule_ExitFromChild(int retcode) {
+  return kMockValkeyModule->ExitFromChild(retcode);
 }
 
-inline RedisModuleRdbStream *TestRedisModule_RdbStreamCreateFromRioHandler(
-    const RedisModuleRIOHandler *handler) {
-  return kMockRedisModule->RdbStreamCreateFromRioHandler(handler);
+inline ValkeyModuleRdbStream *TestValkeyModule_RdbStreamCreateFromRioHandler(
+    const ValkeyModuleRIOHandler *handler) {
+  return kMockValkeyModule->RdbStreamCreateFromRioHandler(handler);
 }
 
-inline void TestRedisModule_RdbStreamFree(RedisModuleRdbStream *stream) {
-  return kMockRedisModule->RdbStreamFree(stream);
+inline void TestValkeyModule_RdbStreamFree(ValkeyModuleRdbStream *stream) {
+  return kMockValkeyModule->RdbStreamFree(stream);
 }
 
-inline int TestRedisModule_RdbSave(RedisModuleCtx *ctx,
-                                   RedisModuleRdbStream *stream, int flags) {
-  return kMockRedisModule->RdbSave(ctx, stream, flags);
+inline int TestValkeyModule_RdbSave(ValkeyModuleCtx *ctx,
+                                    ValkeyModuleRdbStream *stream, int flags) {
+  return kMockValkeyModule->RdbSave(ctx, stream, flags);
 }
 
-inline int TestRedisModule_RdbLoad(RedisModuleCtx *ctx,
-                                   RedisModuleRdbStream *stream, int flags) {
-  return kMockRedisModule->RdbLoad(ctx, stream, flags);
+inline int TestValkeyModule_RdbLoad(ValkeyModuleCtx *ctx,
+                                    ValkeyModuleRdbStream *stream, int flags) {
+  return kMockValkeyModule->RdbLoad(ctx, stream, flags);
 }
 
 /* The same order as the reply types in valkey_module.h */
 using CallReplyString = std::string;
 using CallReplyInteger = long long;
-using CallReplyArray = std::vector<std::unique_ptr<RedisModuleCallReply>>;
+using CallReplyArray = std::vector<std::unique_ptr<ValkeyModuleCallReply>>;
 using CallReplyNull = void *;
 using CallReplyMap =
-    std::vector<std::pair<std::unique_ptr<RedisModuleCallReply>,
-                          std::unique_ptr<RedisModuleCallReply>>>;
+    std::vector<std::pair<std::unique_ptr<ValkeyModuleCallReply>,
+                          std::unique_ptr<ValkeyModuleCallReply>>>;
 using CallReplyDouble = double;
 
 using CallReplyVariant =
     std::variant<CallReplyString, CallReplyInteger, CallReplyArray,
                  CallReplyNull, CallReplyMap, CallReplyDouble>;
 
-struct RedisModuleCallReply {
-  int type = REDISMODULE_REPLY_UNKNOWN;
+struct ValkeyModuleCallReply {
+  int type = VALKEYMODULE_REPLY_UNKNOWN;
   CallReplyVariant val;
   std::string msg;
 };
-std::unique_ptr<RedisModuleCallReply> default_reply REDISMODULE_ATTR;
+std::unique_ptr<ValkeyModuleCallReply> default_reply VALKEYMODULE_ATTR;
 
-inline std::unique_ptr<RedisModuleCallReply> CreateRedisModuleCallReply(
+inline std::unique_ptr<ValkeyModuleCallReply> CreateValkeyModuleCallReply(
     CallReplyVariant value) {
-  std::unique_ptr<RedisModuleCallReply> reply{new RedisModuleCallReply{
+  std::unique_ptr<ValkeyModuleCallReply> reply{new ValkeyModuleCallReply{
       .type = std::visit(
           [&](auto &value) {
             using T = std::decay_t<decltype(value)>;
             if constexpr (std::is_same_v<T, CallReplyString>) {
-              return REDISMODULE_REPLY_STRING;
+              return VALKEYMODULE_REPLY_STRING;
             } else if constexpr (std::is_same_v<T, CallReplyInteger>) {
-              return REDISMODULE_REPLY_INTEGER;
+              return VALKEYMODULE_REPLY_INTEGER;
             } else if constexpr (std::is_same_v<T, CallReplyArray>) {
-              return REDISMODULE_REPLY_ARRAY;
+              return VALKEYMODULE_REPLY_ARRAY;
             } else if constexpr (std::is_same_v<T, CallReplyNull>) {
-              return REDISMODULE_REPLY_NULL;
+              return VALKEYMODULE_REPLY_NULL;
             } else if constexpr (std::is_same_v<T, CallReplyMap>) {
-              return REDISMODULE_REPLY_MAP;
+              return VALKEYMODULE_REPLY_MAP;
             } else if constexpr (std::is_same_v<T, CallReplyDouble>) {
-              return REDISMODULE_REPLY_DOUBLE;
+              return VALKEYMODULE_REPLY_DOUBLE;
             }
-            return REDISMODULE_REPLY_UNKNOWN;
+            return VALKEYMODULE_REPLY_UNKNOWN;
           },
           value),
       .val = std::move(value)}};
@@ -1247,59 +1255,59 @@ inline std::unique_ptr<RedisModuleCallReply> CreateRedisModuleCallReply(
 
 inline void AddElementToCallReplyMap(CallReplyMap &map, CallReplyVariant key,
                                      CallReplyVariant val) {
-  std::unique_ptr<RedisModuleCallReply> k =
-      CreateRedisModuleCallReply(std::move(key));
-  std::unique_ptr<RedisModuleCallReply> v =
-      CreateRedisModuleCallReply(std::move(val));
-  map.emplace_back(std::pair<std::unique_ptr<RedisModuleCallReply>,
-                             std::unique_ptr<RedisModuleCallReply>>(
+  std::unique_ptr<ValkeyModuleCallReply> k =
+      CreateValkeyModuleCallReply(std::move(key));
+  std::unique_ptr<ValkeyModuleCallReply> v =
+      CreateValkeyModuleCallReply(std::move(val));
+  map.emplace_back(std::pair<std::unique_ptr<ValkeyModuleCallReply>,
+                             std::unique_ptr<ValkeyModuleCallReply>>(
       std::move(k), std::move(v)));
 }
 
-inline RedisModuleCallReply *TestRedisModule_Call(RedisModuleCtx *ctx,
-                                                  const char *cmdname,
-                                                  const char *fmt, ...) {
+inline ValkeyModuleCallReply *TestValkeyModule_Call(ValkeyModuleCtx *ctx,
+                                                    const char *cmdname,
+                                                    const char *fmt, ...) {
   va_list args;
   va_start(args, fmt);
   std::string format(fmt);
   if (format == "c") {
     const char *arg1 = va_arg(args, const char *);
-    auto ret = kMockRedisModule->Call(ctx, cmdname, fmt, arg1);
+    auto ret = kMockValkeyModule->Call(ctx, cmdname, fmt, arg1);
     return ret;
   }
   if (format == "cc") {
     const char *arg1 = va_arg(args, const char *);
     const char *arg2 = va_arg(args, const char *);
-    auto ret = kMockRedisModule->Call(ctx, cmdname, fmt, arg1, arg2);
+    auto ret = kMockValkeyModule->Call(ctx, cmdname, fmt, arg1, arg2);
     return ret;
   }
   if (format == "cs3") {
     const char *arg1 = va_arg(args, const char *);
     std::string sub_command(arg1);
-    const RedisModuleString *arg2 = va_arg(args, RedisModuleString *);
+    const ValkeyModuleString *arg2 = va_arg(args, ValkeyModuleString *);
     std::string maybe_username(arg2->data);
     if (sub_command == "GETUSER" && maybe_username == "default") {
       CallReplyMap reply_map;
       AddElementToCallReplyMap(reply_map, "commands", "+@all");
       AddElementToCallReplyMap(reply_map, "keys", "~*");
-      default_reply = CreateRedisModuleCallReply(std::move(reply_map));
+      default_reply = CreateValkeyModuleCallReply(std::move(reply_map));
       return default_reply.get();
     }
     auto ret =
-        kMockRedisModule->Call(ctx, cmdname, fmt, arg1, arg2->data.c_str());
+        kMockValkeyModule->Call(ctx, cmdname, fmt, arg1, arg2->data.c_str());
     return ret;
   }
   CHECK(false && "Unsupported format specifier");
   return nullptr;
 }
 
-inline RedisModuleCallReply *TestRedisModule_CallReplyArrayElement(
-    RedisModuleCallReply *reply, size_t idx) {
-  return kMockRedisModule->CallReplyArrayElement(reply, idx);
+inline ValkeyModuleCallReply *TestValkeyModule_CallReplyArrayElement(
+    ValkeyModuleCallReply *reply, size_t idx) {
+  return kMockValkeyModule->CallReplyArrayElement(reply, idx);
 }
-inline RedisModuleCallReply *TestRedisModule_CallReplyArrayElementImpl(
-    RedisModuleCallReply *reply, size_t idx) {
-  if (reply == nullptr || reply->type != REDISMODULE_REPLY_ARRAY) {
+inline ValkeyModuleCallReply *TestValkeyModule_CallReplyArrayElementImpl(
+    ValkeyModuleCallReply *reply, size_t idx) {
+  if (reply == nullptr || reply->type != VALKEYMODULE_REPLY_ARRAY) {
     return nullptr;
   }
   CHECK(std::holds_alternative<CallReplyArray>(reply->val));
@@ -1310,23 +1318,22 @@ inline RedisModuleCallReply *TestRedisModule_CallReplyArrayElementImpl(
   return list[idx].get();
 }
 
-inline int TestRedisModule_CallReplyMapElement(RedisModuleCallReply *reply,
-                                               size_t idx,
-                                               RedisModuleCallReply **key,
-                                               RedisModuleCallReply **val) {
-  return kMockRedisModule->CallReplyMapElement(reply, idx, key, val);
+inline int TestValkeyModule_CallReplyMapElement(ValkeyModuleCallReply *reply,
+                                                size_t idx,
+                                                ValkeyModuleCallReply **key,
+                                                ValkeyModuleCallReply **val) {
+  return kMockValkeyModule->CallReplyMapElement(reply, idx, key, val);
 }
-inline int TestRedisModule_CallReplyMapElementImpl(RedisModuleCallReply *reply,
-                                                   size_t idx,
-                                                   RedisModuleCallReply **key,
-                                                   RedisModuleCallReply **val) {
-  if (reply == nullptr || reply->type != REDISMODULE_REPLY_MAP) {
-    return REDISMODULE_ERR;
+inline int TestValkeyModule_CallReplyMapElementImpl(
+    ValkeyModuleCallReply *reply, size_t idx, ValkeyModuleCallReply **key,
+    ValkeyModuleCallReply **val) {
+  if (reply == nullptr || reply->type != VALKEYMODULE_REPLY_MAP) {
+    return VALKEYMODULE_ERR;
   }
   CHECK(std::holds_alternative<CallReplyMap>(reply->val));
   auto &map = std::get<CallReplyMap>(reply->val);
   if (map.size() <= idx) {
-    return REDISMODULE_ERR;
+    return VALKEYMODULE_ERR;
   }
 
   if (key != nullptr) {
@@ -1335,16 +1342,16 @@ inline int TestRedisModule_CallReplyMapElementImpl(RedisModuleCallReply *reply,
   if (val != nullptr) {
     *val = map[idx].second.get();
   }
-  return REDISMODULE_OK;
+  return VALKEYMODULE_OK;
 }
 
-inline const char *TestRedisModule_CallReplyStringPtr(
-    RedisModuleCallReply *reply, size_t *len) {
-  return kMockRedisModule->CallReplyStringPtr(reply, len);
+inline const char *TestValkeyModule_CallReplyStringPtr(
+    ValkeyModuleCallReply *reply, size_t *len) {
+  return kMockValkeyModule->CallReplyStringPtr(reply, len);
 }
-inline const char *TestRedisModule_CallReplyStringPtrImpl(
-    RedisModuleCallReply *reply, size_t *len) {
-  if (reply == nullptr || reply->type != REDISMODULE_REPLY_STRING) {
+inline const char *TestValkeyModule_CallReplyStringPtrImpl(
+    ValkeyModuleCallReply *reply, size_t *len) {
+  if (reply == nullptr || reply->type != VALKEYMODULE_REPLY_STRING) {
     return nullptr;
   }
   CHECK(std::holds_alternative<std::string>(reply->val));
@@ -1353,253 +1360,254 @@ inline const char *TestRedisModule_CallReplyStringPtrImpl(
   return s.c_str();
 }
 
-inline void TestRedisModule_FreeCallReply(RedisModuleCallReply *reply) {
-  return kMockRedisModule->FreeCallReply(reply);
+inline void TestValkeyModule_FreeCallReply(ValkeyModuleCallReply *reply) {
+  return kMockValkeyModule->FreeCallReply(reply);
 }
 
-inline void TestRedisModule_RegisterClusterMessageReceiver(
-    RedisModuleCtx *ctx, uint8_t type,
-    RedisModuleClusterMessageReceiver callback) {
-  return kMockRedisModule->RegisterClusterMessageReceiver(ctx, type, callback);
+inline void TestValkeyModule_RegisterClusterMessageReceiver(
+    ValkeyModuleCtx *ctx, uint8_t type,
+    ValkeyModuleClusterMessageReceiver callback) {
+  return kMockValkeyModule->RegisterClusterMessageReceiver(ctx, type, callback);
 }
 
-inline int TestRedisModule_SendClusterMessage(RedisModuleCtx *ctx,
-                                              const char *target_id,
-                                              uint8_t type, const char *msg,
-                                              uint32_t len) {
-  return kMockRedisModule->SendClusterMessage(ctx, target_id, type, msg, len);
+inline int TestValkeyModule_SendClusterMessage(ValkeyModuleCtx *ctx,
+                                               const char *target_id,
+                                               uint8_t type, const char *msg,
+                                               uint32_t len) {
+  return kMockValkeyModule->SendClusterMessage(ctx, target_id, type, msg, len);
 }
 
-inline char **TestRedisModule_GetClusterNodesList(RedisModuleCtx *ctx,
-                                                  size_t *numnodes) {
-  return kMockRedisModule->GetClusterNodesList(ctx, numnodes);
+inline char **TestValkeyModule_GetClusterNodesList(ValkeyModuleCtx *ctx,
+                                                   size_t *numnodes) {
+  return kMockValkeyModule->GetClusterNodesList(ctx, numnodes);
 }
 
-inline RedisModuleCtx *TestRedisModule_GetContextFromIO(RedisModuleIO *rdb) {
-  return kMockRedisModule->GetContextFromIO(rdb);
+inline ValkeyModuleCtx *TestValkeyModule_GetContextFromIO(ValkeyModuleIO *rdb) {
+  return kMockValkeyModule->GetContextFromIO(rdb);
 }
 
-inline int TestRedisModule_GetDbIdFromIO(RedisModuleIO *rdb) {
-  return kMockRedisModule->GetDbIdFromIO(rdb);
+inline int TestValkeyModule_GetDbIdFromIO(ValkeyModuleIO *rdb) {
+  return kMockValkeyModule->GetDbIdFromIO(rdb);
 }
 
-inline void TestRedisModule_FreeClusterNodesList(char **ids) {
-  return kMockRedisModule->FreeClusterNodesList(ids);
+inline void TestValkeyModule_FreeClusterNodesList(char **ids) {
+  return kMockValkeyModule->FreeClusterNodesList(ids);
 }
 
-inline int TestRedisModule_CallReplyType(RedisModuleCallReply *reply) {
-  return kMockRedisModule->CallReplyType(reply);
+inline int TestValkeyModule_CallReplyType(ValkeyModuleCallReply *reply) {
+  return kMockValkeyModule->CallReplyType(reply);
 }
 
-inline size_t TestRedisModule_CallReplyLength(RedisModuleCallReply *reply) {
-  return kMockRedisModule->CallReplyLength(reply);
+inline size_t TestValkeyModule_CallReplyLength(ValkeyModuleCallReply *reply) {
+  return kMockValkeyModule->CallReplyLength(reply);
 }
 
-inline int TestRedisModule_CallReplyTypeImpl(RedisModuleCallReply *reply) {
+inline int TestValkeyModule_CallReplyTypeImpl(ValkeyModuleCallReply *reply) {
   return reply->type;
 }
 
-inline RedisModuleString *TestRedisModule_CreateStringFromCallReply(
-    RedisModuleCallReply *reply) {
-  return kMockRedisModule->CreateStringFromCallReply(reply);
+inline ValkeyModuleString *TestValkeyModule_CreateStringFromCallReply(
+    ValkeyModuleCallReply *reply) {
+  return kMockValkeyModule->CreateStringFromCallReply(reply);
 }
 
-inline RedisModuleString *TestRedisModule_GetCurrentUserName(
-    RedisModuleCtx *ctx) {
-  return kMockRedisModule->GetCurrentUserName(ctx);
+inline ValkeyModuleString *TestValkeyModule_GetCurrentUserName(
+    ValkeyModuleCtx *ctx) {
+  return kMockValkeyModule->GetCurrentUserName(ctx);
 }
 
-inline RedisModuleString *TestRedisModule_GetCurrentUserNameImpl(
-    RedisModuleCtx *ctx) {
-  return new RedisModuleString{std::string("default")};
+inline ValkeyModuleString *TestValkeyModule_GetCurrentUserNameImpl(
+    ValkeyModuleCtx *ctx) {
+  return new ValkeyModuleString{std::string("default")};
 }
 
-// TestRedisModule_Init initializes the module API function table with mock
+// TestValkeyModule_Init initializes the module API function table with mock
 // implementations of functions to prevent segmentation faults when
-// executing tests and to allow validation of Redis module API calls.
-inline void TestRedisModule_Init() {
-  RedisModule_Log = &TestRedisModule_Log;
-  RedisModule_LogIOError = &TestRedisModule_LogIOError;
-  RedisModule_BlockClientOnAuth = &TestRedisModule_BlockClientOnAuth;
-  RedisModule_BlockedClientMeasureTimeEnd =
-      &TestRedisModule_BlockedClientMeasureTimeEnd;
-  RedisModule_BlockedClientMeasureTimeStart =
-      &TestRedisModule_BlockedClientMeasureTimeStart;
-  RedisModule_BlockClient = &TestRedisModule_BlockClient;
-  RedisModule_UnblockClient = &TestRedisModule_UnblockClient;
-  RedisModule_StringPtrLen = &TestRedisModule_StringPtrLen;
-  RedisModule_CreateStringPrintf = &TestRedisModule_CreateStringPrintf;
-  RedisModule_GetBlockedClientPrivateData =
-      &TestRedisModule_GetBlockedClientPrivateData;
-  RedisModule_AuthenticateClientWithACLUser =
-      &TestRedisModule_AuthenticateClientWithACLUser;
-  RedisModule_ACLAddLogEntryByUserName =
-      &TestRedisModule_ACLAddLogEntryByUserName;
-  RedisModule_CreateString = &TestRedisModule_CreateString;
-  RedisModule_FreeString = &TestRedisModule_FreeString;
-  RedisModule_RetainString = &TestRedisModule_RetainString;
-  RedisModule_EventLoopAdd = &TestRedisModule_EventLoopAdd;
-  RedisModule_EventLoopAddOneShot = &TestRedisModule_EventLoopAddOneShot;
-  RedisModule_EventLoopDel = &TestRedisModule_EventLoopDel;
-  RedisModule_CreateTimer = &TestRedisModule_CreateTimer;
-  RedisModule_StopTimer = &TestRedisModule_StopTimer;
-  RedisModule_SetModuleOptions = &TestRedisModule_SetModuleOptions;
-  RedisModule_GetClientId = &TestRedisModule_GetClientId;
-  RedisModule_GetClientInfoById = &TestRedisModule_GetClientInfoById;
-  RedisModule_SubscribeToKeyspaceEvents =
-      &TestRedisModule_SubscribeToKeyspaceEvents;
-  RedisModule_KeyExists = &TestRedisModule_KeyExists;
-  RedisModule_OpenKey = &TestRedisModule_OpenKey;
-  RedisModule_HashExternalize = &TestRedisModule_HashExternalize;
-  RedisModule_GetApi = &TestRedisModule_GetApi;
-  RedisModule_HashGet = &TestRedisModule_HashGet;
-  RedisModule_HashSet = &TestRedisModule_HashSet;
-  RedisModule_ScanKey = &TestRedisModule_ScanKey;
-  RedisModule_ScanCursorCreate = &TestRedisModule_ScanCursorCreate;
-  RedisModule_ScanCursorDestroy = &TestRedisModule_ScanCursorDestroy;
-  RedisModule_CloseKey = &TestRedisModule_CloseKey;
-  RedisModule_CreateCommand = &TestRedisModule_CreateCommand;
-  RedisModule_KeyType = &TestRedisModule_KeyType;
-  RedisModule_ModuleTypeSetValue = &TestRedisModule_ModuleTypeSetValue;
-  RedisModule_DeleteKey = &TestRedisModule_DeleteKey;
-  RedisModule_RegisterInfoFunc = &TestRedisModule_RegisterInfoFunc;
-  RedisModule_ReplyWithArray = &TestRedisModule_ReplyWithArray;
-  RedisModule_ReplySetArrayLength = &TestRedisModule_ReplySetArrayLength;
-  RedisModule_ReplyWithLongLong = &TestRedisModule_ReplyWithLongLong;
-  RedisModule_ReplyWithSimpleString = &TestRedisModule_ReplyWithSimpleString;
-  RedisModule_ReplyWithString = &TestRedisModule_ReplyWithString;
-  RedisModule_ReplyWithDouble = &TestRedisModule_ReplyWithDouble;
-  RedisModule_ReplyWithCString = &TestRedisModule_ReplyWithCString;
-  RedisModule_ReplyWithStringBuffer = &TestRedisModule_ReplyWithStringBuffer;
-  RedisModule_CreateDataType = &TestRedisModule_CreateDataType;
-  RedisModule_ReplyWithError = &TestRedisModule_ReplyWithError;
-  RedisModule_SubscribeToServerEvent = &TestRedisModule_SubscribeToServerEvent;
-  RedisModule_Scan = &TestRedisModule_Scan;
-  RedisModule_ReplicateVerbatim = &TestRedisModule_ReplicateVerbatim;
-  RedisModule_ModuleTypeGetType = &TestRedisModule_ModuleTypeGetType;
-  RedisModule_GetDetachedThreadSafeContext =
-      &TestRedisModule_GetDetachedThreadSafeContext;
-  RedisModule_FreeThreadSafeContext = &TestRedisModule_FreeThreadSafeContext;
-  RedisModule_SelectDb = &TestRedisModule_SelectDb;
-  RedisModule_GetSelectedDb = &TestRedisModule_GetSelectedDb;
-  RedisModule_ModuleTypeGetValue = &TestRedisModule_ModuleTypeGetValue;
-  RedisModule_DbSize = &TestRedisModule_DbSize;
-  RedisModule_InfoAddSection = &TestRedisModule_InfoAddSection;
-  RedisModule_InfoAddFieldLongLong = &TestRedisModule_InfoAddFieldLongLong;
-  RedisModule_InfoAddFieldCString = &TestRedisModule_InfoAddFieldCString;
-  RedisModule_InfoBeginDictField = &TestRedisModule_InfoBeginDictField;
-  RedisModule_InfoEndDictField = &TestRedisModule_InfoEndDictField;
-  RedisModule_RegisterStringConfig = &TestRedisModule_RegisterStringConfig;
-  RedisModule_RegisterEnumConfig = &TestRedisModule_RegisterEnumConfig;
-  RedisModule_LoadConfigs = &TestRedisModule_LoadConfigs;
-  RedisModule_SetConnectionProperties =
-      &TestRedisModule_SetConnectionProperties;
-  RedisModule_SetShardId = &TestRedisModule_SetShardId;
-  RedisModule_GetClusterInfo = &TestRedisModule_GetClusterInfo;
-  RedisModule_GetMyShardID = &TestRedisModule_GetMyShardID;
-  RedisModule_GetContextFlags = &TestRedisModule_GetContextFlags;
-  RedisModule_LoadUnsigned = &TestRedisModule_LoadUnsigned;
-  RedisModule_LoadSigned = &TestRedisModule_LoadSigned;
-  RedisModule_LoadDouble = &TestRedisModule_LoadDouble;
-  RedisModule_LoadStringBuffer = &TestRedisModule_LoadStringBuffer;
-  RedisModule_LoadString = &TestRedisModule_LoadString;
-  RedisModule_SaveUnsigned = &TestRedisModule_SaveUnsigned;
-  RedisModule_SaveSigned = &TestRedisModule_SaveSigned;
-  RedisModule_SaveDouble = &TestRedisModule_SaveDouble;
-  RedisModule_SaveStringBuffer = &TestRedisModule_SaveStringBuffer;
-  RedisModule_IsIOError = &TestRedisModule_IsIOError;
-  RedisModule_ReplicationSetMasterCrossCluster =
-      &TestRedisModule_ReplicationSetMasterCrossCluster;
-  RedisModule_ReplicationUnsetMasterCrossCluster =
-      &TestRedisModule_ReplicationUnsetMasterCrossCluster;
-  RedisModule_GetMyClusterID = &TestRedisModule_GetMyClusterID;
-  RedisModule_GetClusterNodeInfo = &TestRedisModule_GetClusterNodeInfo;
-  RedisModule_ReplicationSetSecondaryCluster =
-      &TestRedisModule_ReplicationSetSecondaryCluster;
-  RedisModule_GetCrossClusterReplicasList =
-      &TestRedisModule_GetCrossClusterReplicasList;
-  RedisModule_FreeCrossClusterReplicasList =
-      &TestRedisModule_FreeCrossClusterReplicasList;
-  RedisModule_Alloc = &TestRedisModule_Alloc;
-  RedisModule_Free = &TestRedisModule_Free;
-  RedisModule_Realloc = &TestRedisModule_Realloc;
-  RedisModule_Calloc = &TestRedisModule_Calloc;
-  RedisModule_MallocUsableSize = &TestRedisModule_MallocUsableSize;
-  RedisModule_GetClusterSize = &TestRedisModule_GetClusterSize;
-  RedisModule_Call = &TestRedisModule_Call;
-  RedisModule_CallReplyArrayElement = &TestRedisModule_CallReplyArrayElement;
-  RedisModule_CallReplyMapElement = &TestRedisModule_CallReplyMapElement;
-  RedisModule_CallReplyStringPtr = &TestRedisModule_CallReplyStringPtr;
-  RedisModule_FreeCallReply = &TestRedisModule_FreeCallReply;
-  RedisModule_RegisterClusterMessageReceiver =
-      &TestRedisModule_RegisterClusterMessageReceiver;
-  RedisModule_SendClusterMessage = &TestRedisModule_SendClusterMessage;
-  RedisModule_GetClusterNodesList = &TestRedisModule_GetClusterNodesList;
-  RedisModule_GetContextFromIO = &TestRedisModule_GetContextFromIO;
-  RedisModule_GetDbIdFromIO = &TestRedisModule_GetDbIdFromIO;
-  RedisModule_FreeClusterNodesList = &TestRedisModule_FreeClusterNodesList;
-  RedisModule_CallReplyType = &TestRedisModule_CallReplyType;
-  RedisModule_CallReplyLength = &TestRedisModule_CallReplyLength;
-  RedisModule_CreateStringFromCallReply =
-      &TestRedisModule_CreateStringFromCallReply;
-  RedisModule_WrongArity = &TestRedisModule_WrongArity;
-  RedisModule_Fork = &TestRedisModule_Fork;
-  RedisModule_ExitFromChild = &TestRedisModule_ExitFromChild;
-  RedisModule_RdbStreamCreateFromRioHandler =
-      &TestRedisModule_RdbStreamCreateFromRioHandler;
-  RedisModule_RdbStreamFree = &TestRedisModule_RdbStreamFree;
-  RedisModule_RdbSave = &TestRedisModule_RdbSave;
-  RedisModule_RdbLoad = &TestRedisModule_RdbLoad;
-  RedisModule_GetCurrentUserName = &TestRedisModule_GetCurrentUserName;
-  RedisModule_RegisterNumericConfig = &TestRedisModule_RegisterNumericConfig;
-  RedisModule_RegisterBoolConfig = &TestRedisModule_RegisterBoolConfig;
+// executing tests and to allow validation of Valkey module API calls.
+inline void TestValkeyModule_Init() {
+  ValkeyModule_Log = &TestValkeyModule_Log;
+  ValkeyModule_LogIOError = &TestValkeyModule_LogIOError;
+  ValkeyModule_BlockClientOnAuth = &TestValkeyModule_BlockClientOnAuth;
+  ValkeyModule_BlockedClientMeasureTimeEnd =
+      &TestValkeyModule_BlockedClientMeasureTimeEnd;
+  ValkeyModule_BlockedClientMeasureTimeStart =
+      &TestValkeyModule_BlockedClientMeasureTimeStart;
+  ValkeyModule_BlockClient = &TestValkeyModule_BlockClient;
+  ValkeyModule_UnblockClient = &TestValkeyModule_UnblockClient;
+  ValkeyModule_StringPtrLen = &TestValkeyModule_StringPtrLen;
+  ValkeyModule_CreateStringPrintf = &TestValkeyModule_CreateStringPrintf;
+  ValkeyModule_GetBlockedClientPrivateData =
+      &TestValkeyModule_GetBlockedClientPrivateData;
+  ValkeyModule_AuthenticateClientWithACLUser =
+      &TestValkeyModule_AuthenticateClientWithACLUser;
+  ValkeyModule_ACLAddLogEntryByUserName =
+      &TestValkeyModule_ACLAddLogEntryByUserName;
+  ValkeyModule_CreateString = &TestValkeyModule_CreateString;
+  ValkeyModule_FreeString = &TestValkeyModule_FreeString;
+  ValkeyModule_RetainString = &TestValkeyModule_RetainString;
+  ValkeyModule_EventLoopAdd = &TestValkeyModule_EventLoopAdd;
+  ValkeyModule_EventLoopAddOneShot = &TestValkeyModule_EventLoopAddOneShot;
+  ValkeyModule_EventLoopDel = &TestValkeyModule_EventLoopDel;
+  ValkeyModule_CreateTimer = &TestValkeyModule_CreateTimer;
+  ValkeyModule_StopTimer = &TestValkeyModule_StopTimer;
+  ValkeyModule_SetModuleOptions = &TestValkeyModule_SetModuleOptions;
+  ValkeyModule_GetClientId = &TestValkeyModule_GetClientId;
+  ValkeyModule_GetClientInfoById = &TestValkeyModule_GetClientInfoById;
+  ValkeyModule_SubscribeToKeyspaceEvents =
+      &TestValkeyModule_SubscribeToKeyspaceEvents;
+  ValkeyModule_KeyExists = &TestValkeyModule_KeyExists;
+  ValkeyModule_OpenKey = &TestValkeyModule_OpenKey;
+  ValkeyModule_HashExternalize = &TestValkeyModule_HashExternalize;
+  ValkeyModule_GetApi = &TestValkeyModule_GetApi;
+  ValkeyModule_HashGet = &TestValkeyModule_HashGet;
+  ValkeyModule_HashSet = &TestValkeyModule_HashSet;
+  ValkeyModule_ScanKey = &TestValkeyModule_ScanKey;
+  ValkeyModule_ScanCursorCreate = &TestValkeyModule_ScanCursorCreate;
+  ValkeyModule_ScanCursorDestroy = &TestValkeyModule_ScanCursorDestroy;
+  ValkeyModule_CloseKey = &TestValkeyModule_CloseKey;
+  ValkeyModule_CreateCommand = &TestValkeyModule_CreateCommand;
+  ValkeyModule_KeyType = &TestValkeyModule_KeyType;
+  ValkeyModule_ModuleTypeSetValue = &TestValkeyModule_ModuleTypeSetValue;
+  ValkeyModule_DeleteKey = &TestValkeyModule_DeleteKey;
+  ValkeyModule_RegisterInfoFunc = &TestValkeyModule_RegisterInfoFunc;
+  ValkeyModule_ReplyWithArray = &TestValkeyModule_ReplyWithArray;
+  ValkeyModule_ReplySetArrayLength = &TestValkeyModule_ReplySetArrayLength;
+  ValkeyModule_ReplyWithLongLong = &TestValkeyModule_ReplyWithLongLong;
+  ValkeyModule_ReplyWithSimpleString = &TestValkeyModule_ReplyWithSimpleString;
+  ValkeyModule_ReplyWithString = &TestValkeyModule_ReplyWithString;
+  ValkeyModule_ReplyWithDouble = &TestValkeyModule_ReplyWithDouble;
+  ValkeyModule_ReplyWithCString = &TestValkeyModule_ReplyWithCString;
+  ValkeyModule_ReplyWithStringBuffer = &TestValkeyModule_ReplyWithStringBuffer;
+  ValkeyModule_CreateDataType = &TestValkeyModule_CreateDataType;
+  ValkeyModule_ReplyWithError = &TestValkeyModule_ReplyWithError;
+  ValkeyModule_SubscribeToServerEvent =
+      &TestValkeyModule_SubscribeToServerEvent;
+  ValkeyModule_Scan = &TestValkeyModule_Scan;
+  ValkeyModule_ReplicateVerbatim = &TestValkeyModule_ReplicateVerbatim;
+  ValkeyModule_ModuleTypeGetType = &TestValkeyModule_ModuleTypeGetType;
+  ValkeyModule_GetDetachedThreadSafeContext =
+      &TestValkeyModule_GetDetachedThreadSafeContext;
+  ValkeyModule_FreeThreadSafeContext = &TestValkeyModule_FreeThreadSafeContext;
+  ValkeyModule_SelectDb = &TestValkeyModule_SelectDb;
+  ValkeyModule_GetSelectedDb = &TestValkeyModule_GetSelectedDb;
+  ValkeyModule_ModuleTypeGetValue = &TestValkeyModule_ModuleTypeGetValue;
+  ValkeyModule_DbSize = &TestValkeyModule_DbSize;
+  ValkeyModule_InfoAddSection = &TestValkeyModule_InfoAddSection;
+  ValkeyModule_InfoAddFieldLongLong = &TestValkeyModule_InfoAddFieldLongLong;
+  ValkeyModule_InfoAddFieldCString = &TestValkeyModule_InfoAddFieldCString;
+  ValkeyModule_InfoBeginDictField = &TestValkeyModule_InfoBeginDictField;
+  ValkeyModule_InfoEndDictField = &TestValkeyModule_InfoEndDictField;
+  ValkeyModule_RegisterStringConfig = &TestValkeyModule_RegisterStringConfig;
+  ValkeyModule_RegisterEnumConfig = &TestValkeyModule_RegisterEnumConfig;
+  ValkeyModule_LoadConfigs = &TestValkeyModule_LoadConfigs;
+  ValkeyModule_SetConnectionProperties =
+      &TestValkeyModule_SetConnectionProperties;
+  ValkeyModule_SetShardId = &TestValkeyModule_SetShardId;
+  ValkeyModule_GetClusterInfo = &TestValkeyModule_GetClusterInfo;
+  ValkeyModule_GetMyShardID = &TestValkeyModule_GetMyShardID;
+  ValkeyModule_GetContextFlags = &TestValkeyModule_GetContextFlags;
+  ValkeyModule_LoadUnsigned = &TestValkeyModule_LoadUnsigned;
+  ValkeyModule_LoadSigned = &TestValkeyModule_LoadSigned;
+  ValkeyModule_LoadDouble = &TestValkeyModule_LoadDouble;
+  ValkeyModule_LoadStringBuffer = &TestValkeyModule_LoadStringBuffer;
+  ValkeyModule_LoadString = &TestValkeyModule_LoadString;
+  ValkeyModule_SaveUnsigned = &TestValkeyModule_SaveUnsigned;
+  ValkeyModule_SaveSigned = &TestValkeyModule_SaveSigned;
+  ValkeyModule_SaveDouble = &TestValkeyModule_SaveDouble;
+  ValkeyModule_SaveStringBuffer = &TestValkeyModule_SaveStringBuffer;
+  ValkeyModule_IsIOError = &TestValkeyModule_IsIOError;
+  ValkeyModule_ReplicationSetMasterCrossCluster =
+      &TestValkeyModule_ReplicationSetMasterCrossCluster;
+  ValkeyModule_ReplicationUnsetMasterCrossCluster =
+      &TestValkeyModule_ReplicationUnsetMasterCrossCluster;
+  ValkeyModule_GetMyClusterID = &TestValkeyModule_GetMyClusterID;
+  ValkeyModule_GetClusterNodeInfo = &TestValkeyModule_GetClusterNodeInfo;
+  ValkeyModule_ReplicationSetSecondaryCluster =
+      &TestValkeyModule_ReplicationSetSecondaryCluster;
+  ValkeyModule_GetCrossClusterReplicasList =
+      &TestValkeyModule_GetCrossClusterReplicasList;
+  ValkeyModule_FreeCrossClusterReplicasList =
+      &TestValkeyModule_FreeCrossClusterReplicasList;
+  ValkeyModule_Alloc = &TestValkeyModule_Alloc;
+  ValkeyModule_Free = &TestValkeyModule_Free;
+  ValkeyModule_Realloc = &TestValkeyModule_Realloc;
+  ValkeyModule_Calloc = &TestValkeyModule_Calloc;
+  ValkeyModule_MallocUsableSize = &TestValkeyModule_MallocUsableSize;
+  ValkeyModule_GetClusterSize = &TestValkeyModule_GetClusterSize;
+  ValkeyModule_Call = &TestValkeyModule_Call;
+  ValkeyModule_CallReplyArrayElement = &TestValkeyModule_CallReplyArrayElement;
+  ValkeyModule_CallReplyMapElement = &TestValkeyModule_CallReplyMapElement;
+  ValkeyModule_CallReplyStringPtr = &TestValkeyModule_CallReplyStringPtr;
+  ValkeyModule_FreeCallReply = &TestValkeyModule_FreeCallReply;
+  ValkeyModule_RegisterClusterMessageReceiver =
+      &TestValkeyModule_RegisterClusterMessageReceiver;
+  ValkeyModule_SendClusterMessage = &TestValkeyModule_SendClusterMessage;
+  ValkeyModule_GetClusterNodesList = &TestValkeyModule_GetClusterNodesList;
+  ValkeyModule_GetContextFromIO = &TestValkeyModule_GetContextFromIO;
+  ValkeyModule_GetDbIdFromIO = &TestValkeyModule_GetDbIdFromIO;
+  ValkeyModule_FreeClusterNodesList = &TestValkeyModule_FreeClusterNodesList;
+  ValkeyModule_CallReplyType = &TestValkeyModule_CallReplyType;
+  ValkeyModule_CallReplyLength = &TestValkeyModule_CallReplyLength;
+  ValkeyModule_CreateStringFromCallReply =
+      &TestValkeyModule_CreateStringFromCallReply;
+  ValkeyModule_WrongArity = &TestValkeyModule_WrongArity;
+  ValkeyModule_Fork = &TestValkeyModule_Fork;
+  ValkeyModule_ExitFromChild = &TestValkeyModule_ExitFromChild;
+  ValkeyModule_RdbStreamCreateFromRioHandler =
+      &TestValkeyModule_RdbStreamCreateFromRioHandler;
+  ValkeyModule_RdbStreamFree = &TestValkeyModule_RdbStreamFree;
+  ValkeyModule_RdbSave = &TestValkeyModule_RdbSave;
+  ValkeyModule_RdbLoad = &TestValkeyModule_RdbLoad;
+  ValkeyModule_GetCurrentUserName = &TestValkeyModule_GetCurrentUserName;
+  ValkeyModule_RegisterNumericConfig = &TestValkeyModule_RegisterNumericConfig;
+  ValkeyModule_RegisterBoolConfig = &TestValkeyModule_RegisterBoolConfig;
 
-  kMockRedisModule = new testing::NiceMock<MockRedisModule>();
+  kMockValkeyModule = new testing::NiceMock<MockValkeyModule>();
 
   // Implement basic key registration functions with simple implementations by
   // default.
-  ON_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
-      .WillByDefault(TestRedisModule_OpenKeyDefaultImpl);
-  ON_CALL(*kMockRedisModule, CloseKey(testing::_))
-      .WillByDefault(TestRedisModule_CloseKeyDefaultImpl);
-  ON_CALL(*kMockRedisModule,
+  ON_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
+      .WillByDefault(TestValkeyModule_OpenKeyDefaultImpl);
+  ON_CALL(*kMockValkeyModule, CloseKey(testing::_))
+      .WillByDefault(TestValkeyModule_CloseKeyDefaultImpl);
+  ON_CALL(*kMockValkeyModule,
           ModuleTypeSetValue(testing::_, testing::_, testing::_))
-      .WillByDefault(TestRedisModule_ModuleTypeSetValueDefaultImpl);
-  ON_CALL(*kMockRedisModule, ModuleTypeGetValue(testing::_))
-      .WillByDefault(TestRedisModule_ModuleTypeGetValueDefaultImpl);
-  ON_CALL(*kMockRedisModule, ModuleTypeGetType(testing::_))
-      .WillByDefault(TestRedisModule_ModuleTypeGetTypeDefaultImpl);
-  ON_CALL(*kMockRedisModule, KeyType(testing::_))
-      .WillByDefault(TestRedisModule_KeyTypeDefaultImpl);
-  ON_CALL(*kMockRedisModule, DeleteKey(testing::_))
-      .WillByDefault(TestRedisModule_DeleteKeyDefaultImpl);
-  ON_CALL(*kMockRedisModule, KeyExists(testing::_, testing::_))
-      .WillByDefault(TestRedisModule_KeyExistsDefaultImpl);
-  ON_CALL(*kMockRedisModule,
+      .WillByDefault(TestValkeyModule_ModuleTypeSetValueDefaultImpl);
+  ON_CALL(*kMockValkeyModule, ModuleTypeGetValue(testing::_))
+      .WillByDefault(TestValkeyModule_ModuleTypeGetValueDefaultImpl);
+  ON_CALL(*kMockValkeyModule, ModuleTypeGetType(testing::_))
+      .WillByDefault(TestValkeyModule_ModuleTypeGetTypeDefaultImpl);
+  ON_CALL(*kMockValkeyModule, KeyType(testing::_))
+      .WillByDefault(TestValkeyModule_KeyTypeDefaultImpl);
+  ON_CALL(*kMockValkeyModule, DeleteKey(testing::_))
+      .WillByDefault(TestValkeyModule_DeleteKeyDefaultImpl);
+  ON_CALL(*kMockValkeyModule, KeyExists(testing::_, testing::_))
+      .WillByDefault(TestValkeyModule_KeyExistsDefaultImpl);
+  ON_CALL(*kMockValkeyModule,
           HashExternalize(testing::_, testing::_, testing::_, testing::_))
-      .WillByDefault(TestRedisModule_HashExternalizeDefaultImpl);
-  ON_CALL(*kMockRedisModule, GetApi(testing::_, testing::_))
-      .WillByDefault(TestRedisModule_GetApiDefaultImpl);
+      .WillByDefault(TestValkeyModule_HashExternalizeDefaultImpl);
+  ON_CALL(*kMockValkeyModule, GetApi(testing::_, testing::_))
+      .WillByDefault(TestValkeyModule_GetApiDefaultImpl);
 
-  ON_CALL(*kMockRedisModule, GetCurrentUserName(testing::_))
-      .WillByDefault(TestRedisModule_GetCurrentUserNameImpl);
+  ON_CALL(*kMockValkeyModule, GetCurrentUserName(testing::_))
+      .WillByDefault(TestValkeyModule_GetCurrentUserNameImpl);
 
-  ON_CALL(*kMockRedisModule, CallReplyType(testing::_))
-      .WillByDefault(TestRedisModule_CallReplyTypeImpl);
-  ON_CALL(*kMockRedisModule, CallReplyStringPtr(testing::_, testing::_))
-      .WillByDefault(TestRedisModule_CallReplyStringPtrImpl);
-  ON_CALL(*kMockRedisModule, CallReplyArrayElement(testing::_, testing::_))
-      .WillByDefault(TestRedisModule_CallReplyArrayElementImpl);
-  ON_CALL(*kMockRedisModule,
+  ON_CALL(*kMockValkeyModule, CallReplyType(testing::_))
+      .WillByDefault(TestValkeyModule_CallReplyTypeImpl);
+  ON_CALL(*kMockValkeyModule, CallReplyStringPtr(testing::_, testing::_))
+      .WillByDefault(TestValkeyModule_CallReplyStringPtrImpl);
+  ON_CALL(*kMockValkeyModule, CallReplyArrayElement(testing::_, testing::_))
+      .WillByDefault(TestValkeyModule_CallReplyArrayElementImpl);
+  ON_CALL(*kMockValkeyModule,
           CallReplyMapElement(testing::_, testing::_, testing::_, testing::_))
-      .WillByDefault(TestRedisModule_CallReplyMapElementImpl);
+      .WillByDefault(TestValkeyModule_CallReplyMapElementImpl);
   static absl::once_flag flag;
   absl::call_once(flag, []() { vmsdk::TrackCurrentAsMainThread(); });
   CHECK(vmsdk::InitLogging(nullptr, "debug").ok());
 }
 
-inline void TestRedisModule_Teardown() {
-  delete kMockRedisModule;
+inline void TestValkeyModule_Teardown() {
+  delete kMockValkeyModule;
   // Explicitly delete any remaining reference pointer from `default_reply`
   default_reply.reset();
 }

--- a/vmsdk/src/testing_infra/utils.cc
+++ b/vmsdk/src/testing_infra/utils.cc
@@ -36,22 +36,22 @@
 
 namespace vmsdk {
 
-std::vector<RedisModuleString*> ToRedisStringVector(
+std::vector<ValkeyModuleString*> ToValkeyStringVector(
     absl::string_view params_str, absl::string_view exclude) {
   std::vector<absl::string_view> params =
       absl::StrSplit(params_str, ' ', absl::SkipEmpty());
-  std::vector<RedisModuleString*> ret;
+  std::vector<ValkeyModuleString*> ret;
   for (size_t i = 0; i < params.size(); i += 2) {
     if (exclude == params[i]) {
       continue;
     }
     ret.push_back(
-        RedisModule_CreateString(nullptr, params[i].data(), params[i].size()));
+        ValkeyModule_CreateString(nullptr, params[i].data(), params[i].size()));
     if (i + 1 == params.size()) {
       break;
     }
-    ret.push_back(RedisModule_CreateString(nullptr, params[i + 1].data(),
-                                           params[i + 1].size()));
+    ret.push_back(ValkeyModule_CreateString(nullptr, params[i + 1].data(),
+                                            params[i + 1].size()));
   }
   return ret;
 }

--- a/vmsdk/src/testing_infra/utils.h
+++ b/vmsdk/src/testing_infra/utils.h
@@ -58,39 +58,39 @@ using ::testing::TestWithParam;
 
 namespace vmsdk {
 
-class RedisTest : public testing::Test {
+class ValkeyTest : public testing::Test {
  protected:
-  void SetUp() override { TestRedisModule_Init(); }
+  void SetUp() override { TestValkeyModule_Init(); }
 
-  void TearDown() override { TestRedisModule_Teardown(); }
+  void TearDown() override { TestValkeyModule_Teardown(); }
 };
 
 template <typename T>
-class RedisTestWithParam : public TestWithParam<T> {
+class ValkeyTestWithParam : public TestWithParam<T> {
  protected:
-  void SetUp() override { TestRedisModule_Init(); }
+  void SetUp() override { TestValkeyModule_Init(); }
 
-  void TearDown() override { TestRedisModule_Teardown(); }
+  void TearDown() override { TestValkeyModule_Teardown(); }
 };
 
-std::vector<RedisModuleString*> ToRedisStringVector(
+std::vector<ValkeyModuleString*> ToValkeyStringVector(
     absl::string_view params_str, absl::string_view exclude = "");
 
-MATCHER_P(RedisModuleStringEq, value, "") {
+MATCHER_P(ValkeyModuleStringEq, value, "") {
   return *((std::string*)arg) == *((std::string*)value);
 }
 
-MATCHER_P(RedisModuleStringValueEq, value, "") {
+MATCHER_P(ValkeyModuleStringValueEq, value, "") {
   *result_listener << "where the string is " << *((std::string*)arg);
   return *((std::string*)arg) == value;
 }
 
-MATCHER_P(RedisModuleKeyIsForString, value, "") {
-  *result_listener << "where the key is " << ((RedisModuleKey*)arg)->key;
-  return ((RedisModuleKey*)arg)->key == value;
+MATCHER_P(ValkeyModuleKeyIsForString, value, "") {
+  *result_listener << "where the key is " << ((ValkeyModuleKey*)arg)->key;
+  return ((ValkeyModuleKey*)arg)->key == value;
 }
 
-MATCHER_P(IsRedisModuleEvent, expected, "") {
+MATCHER_P(IsValkeyModuleEvent, expected, "") {
   return arg.id == expected.id && arg.dataver == expected.dataver;
 }
 

--- a/vmsdk/src/type_conversions.h
+++ b/vmsdk/src/type_conversions.h
@@ -113,17 +113,17 @@ inline absl::StatusOr<int> To(absl::string_view str) {
   return ToNumeric<int>(str);
 }
 
-inline absl::string_view ToStringView(const RedisModuleString *str) {
+inline absl::string_view ToStringView(const ValkeyModuleString *str) {
   if (!str) {
     return {};
   }
   size_t length = 0;
-  const char *str_ptr = RedisModule_StringPtrLen(str, &length);
+  const char *str_ptr = ValkeyModule_StringPtrLen(str, &length);
   return {str_ptr, length};
 }
 
 template <typename T>
-inline absl::StatusOr<T> To(const RedisModuleString *str) {
+inline absl::StatusOr<T> To(const ValkeyModuleString *str) {
   return To<T>(ToStringView(str));
 }
 
@@ -184,7 +184,7 @@ inline absl::StatusOr<T> ToEnum(
 
 template <typename T>
 inline absl::StatusOr<T> ToEnum(
-    const RedisModuleString *param,
+    const ValkeyModuleString *param,
     const absl::flat_hash_map<absl::string_view, T> &map) {
   if (!param) {
     return absl::InvalidArgumentError("unexpected nullptr");

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -59,15 +59,15 @@ class StopWatch {
 //
 // This function creates a timer from a background thread by creating a task
 // that is added to the event loop, which then creates the timer.
-int StartTimerFromBackgroundThread(RedisModuleCtx *ctx, mstime_t period,
-                                   RedisModuleTimerProc callback, void *data);
+int StartTimerFromBackgroundThread(ValkeyModuleCtx *ctx, mstime_t period,
+                                   ValkeyModuleTimerProc callback, void *data);
 struct TimerDeletionTask {
-  RedisModuleCtx *ctx;
-  RedisModuleTimerID timer_id;
+  ValkeyModuleCtx *ctx;
+  ValkeyModuleTimerID timer_id;
   absl::AnyInvocable<void(void *)> user_data_deleter;
 };
 int StopTimerFromBackgroundThread(
-    RedisModuleCtx *ctx, RedisModuleTimerID timer_id,
+    ValkeyModuleCtx *ctx, ValkeyModuleTimerID timer_id,
     absl::AnyInvocable<void(void *)> user_data_deleter);
 
 void TrackCurrentAsMainThread();
@@ -114,7 +114,7 @@ std::string WrongArity(absl::string_view cmd);
 //
 std::optional<absl::string_view> ParseHashTag(absl::string_view);
 
-bool IsRealUserClient(RedisModuleCtx *ctx);
-bool MultiOrLua(RedisModuleCtx *ctx);
+bool IsRealUserClient(ValkeyModuleCtx *ctx);
+bool MultiOrLua(ValkeyModuleCtx *ctx);
 }  // namespace vmsdk
 #endif  // VMSDK_SRC_UTILS_H_

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -39,394 +39,394 @@
 /* ---------------- Defines common between core and modules --------------- */
 
 /* Error status return values. */
-#define REDISMODULE_OK 0
-#define REDISMODULE_ERR 1
+#define VALKEYMODULE_OK 0
+#define VALKEYMODULE_ERR 1
 
 /* Module Based Authentication status return values. */
-#define REDISMODULE_AUTH_HANDLED 0
-#define REDISMODULE_AUTH_NOT_HANDLED 1
+#define VALKEYMODULE_AUTH_HANDLED 0
+#define VALKEYMODULE_AUTH_NOT_HANDLED 1
 
 /* API versions. */
-#define REDISMODULE_APIVER_1 1
+#define VALKEYMODULE_APIVER_1 1
 
-/* Version of the RedisModuleTypeMethods structure. Once the
- * RedisModuleTypeMethods structure is changed, this version number needs to be
+/* Version of the ValkeyModuleTypeMethods structure. Once the
+ * ValkeyModuleTypeMethods structure is changed, this version number needs to be
  * changed synchronistically. */
-#define REDISMODULE_TYPE_METHOD_VERSION 5
+#define VALKEYMODULE_TYPE_METHOD_VERSION 5
 
 /* API flags and constants */
-#define REDISMODULE_READ (1 << 0)
-#define REDISMODULE_WRITE (1 << 1)
+#define VALKEYMODULE_READ (1 << 0)
+#define VALKEYMODULE_WRITE (1 << 1)
 
-/* RedisModule_OpenKey extra flags for the 'mode' argument.
+/* ValkeyModule_OpenKey extra flags for the 'mode' argument.
  * Avoid touching the LRU/LFU of the key when opened. */
-#define REDISMODULE_OPEN_KEY_NOTOUCH (1 << 16)
+#define VALKEYMODULE_OPEN_KEY_NOTOUCH (1 << 16)
 /* Don't trigger keyspace event on key misses. */
-#define REDISMODULE_OPEN_KEY_NONOTIFY (1 << 17)
+#define VALKEYMODULE_OPEN_KEY_NONOTIFY (1 << 17)
 /* Don't update keyspace hits/misses counters. */
-#define REDISMODULE_OPEN_KEY_NOSTATS (1 << 18)
+#define VALKEYMODULE_OPEN_KEY_NOSTATS (1 << 18)
 /* Avoid deleting lazy expired keys. */
-#define REDISMODULE_OPEN_KEY_NOEXPIRE (1 << 19)
+#define VALKEYMODULE_OPEN_KEY_NOEXPIRE (1 << 19)
 /* Avoid any effects from fetching the key */
-#define REDISMODULE_OPEN_KEY_NOEFFECTS (1 << 20)
-/* Mask of all REDISMODULE_OPEN_KEY_* values. Any new mode should be added to
+#define VALKEYMODULE_OPEN_KEY_NOEFFECTS (1 << 20)
+/* Mask of all VALKEYMODULE_OPEN_KEY_* values. Any new mode should be added to
  * this list. Should not be used directly by the module, use
  * RM_GetOpenKeyModesAll instead. Located here so when we will add new modes we
  * will not forget to update it. */
-#define _REDISMODULE_OPEN_KEY_ALL                                       \
-  REDISMODULE_READ | REDISMODULE_WRITE | REDISMODULE_OPEN_KEY_NOTOUCH | \
-      REDISMODULE_OPEN_KEY_NONOTIFY | REDISMODULE_OPEN_KEY_NOSTATS |    \
-      REDISMODULE_OPEN_KEY_NOEXPIRE | REDISMODULE_OPEN_KEY_NOEFFECTS
+#define _VALKEYMODULE_OPEN_KEY_ALL                                         \
+  VALKEYMODULE_READ | VALKEYMODULE_WRITE | VALKEYMODULE_OPEN_KEY_NOTOUCH | \
+      VALKEYMODULE_OPEN_KEY_NONOTIFY | VALKEYMODULE_OPEN_KEY_NOSTATS |     \
+      VALKEYMODULE_OPEN_KEY_NOEXPIRE | VALKEYMODULE_OPEN_KEY_NOEFFECTS
 
 /* List push and pop */
-#define REDISMODULE_LIST_HEAD 0
-#define REDISMODULE_LIST_TAIL 1
+#define VALKEYMODULE_LIST_HEAD 0
+#define VALKEYMODULE_LIST_TAIL 1
 
 /* Key types. */
-#define REDISMODULE_KEYTYPE_EMPTY 0
-#define REDISMODULE_KEYTYPE_STRING 1
-#define REDISMODULE_KEYTYPE_LIST 2
-#define REDISMODULE_KEYTYPE_HASH 3
-#define REDISMODULE_KEYTYPE_SET 4
-#define REDISMODULE_KEYTYPE_ZSET 5
-#define REDISMODULE_KEYTYPE_MODULE 6
-#define REDISMODULE_KEYTYPE_STREAM 7
+#define VALKEYMODULE_KEYTYPE_EMPTY 0
+#define VALKEYMODULE_KEYTYPE_STRING 1
+#define VALKEYMODULE_KEYTYPE_LIST 2
+#define VALKEYMODULE_KEYTYPE_HASH 3
+#define VALKEYMODULE_KEYTYPE_SET 4
+#define VALKEYMODULE_KEYTYPE_ZSET 5
+#define VALKEYMODULE_KEYTYPE_MODULE 6
+#define VALKEYMODULE_KEYTYPE_STREAM 7
 
 /* Reply types. */
-#define REDISMODULE_REPLY_UNKNOWN -1
-#define REDISMODULE_REPLY_STRING 0
-#define REDISMODULE_REPLY_ERROR 1
-#define REDISMODULE_REPLY_INTEGER 2
-#define REDISMODULE_REPLY_ARRAY 3
-#define REDISMODULE_REPLY_NULL 4
-#define REDISMODULE_REPLY_MAP 5
-#define REDISMODULE_REPLY_SET 6
-#define REDISMODULE_REPLY_BOOL 7
-#define REDISMODULE_REPLY_DOUBLE 8
-#define REDISMODULE_REPLY_BIG_NUMBER 9
-#define REDISMODULE_REPLY_VERBATIM_STRING 10
-#define REDISMODULE_REPLY_ATTRIBUTE 11
+#define VALKEYMODULE_REPLY_UNKNOWN -1
+#define VALKEYMODULE_REPLY_STRING 0
+#define VALKEYMODULE_REPLY_ERROR 1
+#define VALKEYMODULE_REPLY_INTEGER 2
+#define VALKEYMODULE_REPLY_ARRAY 3
+#define VALKEYMODULE_REPLY_NULL 4
+#define VALKEYMODULE_REPLY_MAP 5
+#define VALKEYMODULE_REPLY_SET 6
+#define VALKEYMODULE_REPLY_BOOL 7
+#define VALKEYMODULE_REPLY_DOUBLE 8
+#define VALKEYMODULE_REPLY_BIG_NUMBER 9
+#define VALKEYMODULE_REPLY_VERBATIM_STRING 10
+#define VALKEYMODULE_REPLY_ATTRIBUTE 11
 
 /* Postponed array length. */
-#define REDISMODULE_POSTPONED_ARRAY_LEN \
-  -1 /* Deprecated, please use REDISMODULE_POSTPONED_LEN */
-#define REDISMODULE_POSTPONED_LEN -1
+#define VALKEYMODULE_POSTPONED_ARRAY_LEN \
+  -1 /* Deprecated, please use VALKEYMODULE_POSTPONED_LEN */
+#define VALKEYMODULE_POSTPONED_LEN -1
 
 /* Expire */
-#define REDISMODULE_NO_EXPIRE -1
+#define VALKEYMODULE_NO_EXPIRE -1
 
 /* Sorted set API flags. */
-#define REDISMODULE_ZADD_XX (1 << 0)
-#define REDISMODULE_ZADD_NX (1 << 1)
-#define REDISMODULE_ZADD_ADDED (1 << 2)
-#define REDISMODULE_ZADD_UPDATED (1 << 3)
-#define REDISMODULE_ZADD_NOP (1 << 4)
-#define REDISMODULE_ZADD_GT (1 << 5)
-#define REDISMODULE_ZADD_LT (1 << 6)
+#define VALKEYMODULE_ZADD_XX (1 << 0)
+#define VALKEYMODULE_ZADD_NX (1 << 1)
+#define VALKEYMODULE_ZADD_ADDED (1 << 2)
+#define VALKEYMODULE_ZADD_UPDATED (1 << 3)
+#define VALKEYMODULE_ZADD_NOP (1 << 4)
+#define VALKEYMODULE_ZADD_GT (1 << 5)
+#define VALKEYMODULE_ZADD_LT (1 << 6)
 
 /* Hash API flags. */
-#define REDISMODULE_HASH_NONE 0
-#define REDISMODULE_HASH_NX (1 << 0)
-#define REDISMODULE_HASH_XX (1 << 1)
-#define REDISMODULE_HASH_CFIELDS (1 << 2)
-#define REDISMODULE_HASH_EXISTS (1 << 3)
-#define REDISMODULE_HASH_COUNT_ALL (1 << 4)
+#define VALKEYMODULE_HASH_NONE 0
+#define VALKEYMODULE_HASH_NX (1 << 0)
+#define VALKEYMODULE_HASH_XX (1 << 1)
+#define VALKEYMODULE_HASH_CFIELDS (1 << 2)
+#define VALKEYMODULE_HASH_EXISTS (1 << 3)
+#define VALKEYMODULE_HASH_COUNT_ALL (1 << 4)
 
-#define REDISMODULE_CONFIG_DEFAULT \
+#define VALKEYMODULE_CONFIG_DEFAULT \
   0 /* This is the default for a module config. */
-#define REDISMODULE_CONFIG_IMMUTABLE \
+#define VALKEYMODULE_CONFIG_IMMUTABLE \
   (1ULL << 0) /* Can this value only be set at startup? */
-#define REDISMODULE_CONFIG_SENSITIVE \
+#define VALKEYMODULE_CONFIG_SENSITIVE \
   (1ULL << 1) /* Does this value contain sensitive information */
-#define REDISMODULE_CONFIG_HIDDEN                                          \
+#define VALKEYMODULE_CONFIG_HIDDEN                                         \
   (1ULL << 4) /* This config is hidden in `config get <pattern>` (used for \
                  tests/debugging) */
-#define REDISMODULE_CONFIG_PROTECTED \
+#define VALKEYMODULE_CONFIG_PROTECTED \
   (1ULL << 5) /* Becomes immutable if enable-protected-configs is enabled. */
-#define REDISMODULE_CONFIG_DENY_LOADING \
+#define VALKEYMODULE_CONFIG_DENY_LOADING \
   (1ULL << 6) /* This config is forbidden during loading. */
 
-#define REDISMODULE_CONFIG_MEMORY \
+#define VALKEYMODULE_CONFIG_MEMORY \
   (1ULL << 7) /* Indicates if this value can be set as a memory value */
-#define REDISMODULE_CONFIG_BITFLAGS                                           \
+#define VALKEYMODULE_CONFIG_BITFLAGS                                          \
   (1ULL << 8) /* Indicates if this value can be set as a multiple enum values \
                */
 
 /* StreamID type. */
-typedef struct RedisModuleStreamID {
+typedef struct ValkeyModuleStreamID {
   uint64_t ms;
   uint64_t seq;
-} RedisModuleStreamID;
+} ValkeyModuleStreamID;
 
 /* StreamAdd() flags. */
-#define REDISMODULE_STREAM_ADD_AUTOID (1 << 0)
+#define VALKEYMODULE_STREAM_ADD_AUTOID (1 << 0)
 /* StreamIteratorStart() flags. */
-#define REDISMODULE_STREAM_ITERATOR_EXCLUSIVE (1 << 0)
-#define REDISMODULE_STREAM_ITERATOR_REVERSE (1 << 1)
+#define VALKEYMODULE_STREAM_ITERATOR_EXCLUSIVE (1 << 0)
+#define VALKEYMODULE_STREAM_ITERATOR_REVERSE (1 << 1)
 /* StreamIteratorTrim*() flags. */
-#define REDISMODULE_STREAM_TRIM_APPROX (1 << 0)
+#define VALKEYMODULE_STREAM_TRIM_APPROX (1 << 0)
 
 /* Context Flags: Info about the current context returned by
  * RM_GetContextFlags(). */
 
 /* The command is running in the context of a Lua script */
-#define REDISMODULE_CTX_FLAGS_LUA (1 << 0)
-/* The command is running inside a Redis transaction */
-#define REDISMODULE_CTX_FLAGS_MULTI (1 << 1)
+#define VALKEYMODULE_CTX_FLAGS_LUA (1 << 0)
+/* The command is running inside a Valkey transaction */
+#define VALKEYMODULE_CTX_FLAGS_MULTI (1 << 1)
 /* The instance is a master */
-#define REDISMODULE_CTX_FLAGS_MASTER (1 << 2)
+#define VALKEYMODULE_CTX_FLAGS_MASTER (1 << 2)
 /* The instance is a slave */
-#define REDISMODULE_CTX_FLAGS_SLAVE (1 << 3)
+#define VALKEYMODULE_CTX_FLAGS_SLAVE (1 << 3)
 /* The instance is read-only (usually meaning it's a slave as well) */
-#define REDISMODULE_CTX_FLAGS_READONLY (1 << 4)
+#define VALKEYMODULE_CTX_FLAGS_READONLY (1 << 4)
 /* The instance is running in cluster mode */
-#define REDISMODULE_CTX_FLAGS_CLUSTER (1 << 5)
+#define VALKEYMODULE_CTX_FLAGS_CLUSTER (1 << 5)
 /* The instance has AOF enabled */
-#define REDISMODULE_CTX_FLAGS_AOF (1 << 6)
+#define VALKEYMODULE_CTX_FLAGS_AOF (1 << 6)
 /* The instance has RDB enabled */
-#define REDISMODULE_CTX_FLAGS_RDB (1 << 7)
+#define VALKEYMODULE_CTX_FLAGS_RDB (1 << 7)
 /* The instance has Maxmemory set */
-#define REDISMODULE_CTX_FLAGS_MAXMEMORY (1 << 8)
+#define VALKEYMODULE_CTX_FLAGS_MAXMEMORY (1 << 8)
 /* Maxmemory is set and has an eviction policy that may delete keys */
-#define REDISMODULE_CTX_FLAGS_EVICT (1 << 9)
-/* Redis is out of memory according to the maxmemory flag. */
-#define REDISMODULE_CTX_FLAGS_OOM (1 << 10)
+#define VALKEYMODULE_CTX_FLAGS_EVICT (1 << 9)
+/* Valkey is out of memory according to the maxmemory flag. */
+#define VALKEYMODULE_CTX_FLAGS_OOM (1 << 10)
 /* Less than 25% of memory available according to maxmemory. */
-#define REDISMODULE_CTX_FLAGS_OOM_WARNING (1 << 11)
+#define VALKEYMODULE_CTX_FLAGS_OOM_WARNING (1 << 11)
 /* The command was sent over the replication link. */
-#define REDISMODULE_CTX_FLAGS_REPLICATED (1 << 12)
-/* Redis is currently loading either from AOF or RDB. */
-#define REDISMODULE_CTX_FLAGS_LOADING (1 << 13)
+#define VALKEYMODULE_CTX_FLAGS_REPLICATED (1 << 12)
+/* Valkey is currently loading either from AOF or RDB. */
+#define VALKEYMODULE_CTX_FLAGS_LOADING (1 << 13)
 /* The replica has no link with its master, note that
  * there is the inverse flag as well:
  *
- *  REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE
+ *  VALKEYMODULE_CTX_FLAGS_REPLICA_IS_ONLINE
  *
  * The two flags are exclusive, one or the other can be set. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_STALE (1 << 14)
+#define VALKEYMODULE_CTX_FLAGS_REPLICA_IS_STALE (1 << 14)
 /* The replica is trying to connect with the master.
  * (REPL_STATE_CONNECT and REPL_STATE_CONNECTING states) */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_CONNECTING (1 << 15)
+#define VALKEYMODULE_CTX_FLAGS_REPLICA_IS_CONNECTING (1 << 15)
 /* THe replica is receiving an RDB file from its master. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_TRANSFERRING (1 << 16)
+#define VALKEYMODULE_CTX_FLAGS_REPLICA_IS_TRANSFERRING (1 << 16)
 /* The replica is online, receiving updates from its master. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_ONLINE (1 << 17)
+#define VALKEYMODULE_CTX_FLAGS_REPLICA_IS_ONLINE (1 << 17)
 /* There is currently some background process active. */
-#define REDISMODULE_CTX_FLAGS_ACTIVE_CHILD (1 << 18)
+#define VALKEYMODULE_CTX_FLAGS_ACTIVE_CHILD (1 << 18)
 /* The next EXEC will fail due to dirty CAS (touched keys). */
-#define REDISMODULE_CTX_FLAGS_MULTI_DIRTY (1 << 19)
-/* Redis is currently running inside background child process. */
-#define REDISMODULE_CTX_FLAGS_IS_CHILD (1 << 20)
+#define VALKEYMODULE_CTX_FLAGS_MULTI_DIRTY (1 << 19)
+/* Valkey is currently running inside background child process. */
+#define VALKEYMODULE_CTX_FLAGS_IS_CHILD (1 << 20)
 /* The current client does not allow blocking, either called from
  * within multi, lua, or from another module using RM_Call */
-#define REDISMODULE_CTX_FLAGS_DENY_BLOCKING (1 << 21)
+#define VALKEYMODULE_CTX_FLAGS_DENY_BLOCKING (1 << 21)
 /* The current client uses RESP3 protocol */
-#define REDISMODULE_CTX_FLAGS_RESP3 (1 << 22)
-/* Redis is currently async loading database for diskless replication. */
-#define REDISMODULE_CTX_FLAGS_ASYNC_LOADING (1 << 23)
+#define VALKEYMODULE_CTX_FLAGS_RESP3 (1 << 22)
+/* Valkey is currently async loading database for diskless replication. */
+#define VALKEYMODULE_CTX_FLAGS_ASYNC_LOADING (1 << 23)
 /* The replica isn't trying to connect to a master and is offline. */
-#define REDISMODULE_CTX_FLAGS_REPLICA_IS_OFFLINE (1 << 24)
+#define VALKEYMODULE_CTX_FLAGS_REPLICA_IS_OFFLINE (1 << 24)
 
 /* Next context flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
- * Use RedisModule_GetContextFlagsAll instead. */
-#define _REDISMODULE_CTX_FLAGS_NEXT (1 << 25)
+ * Use ValkeyModule_GetContextFlagsAll instead. */
+#define _VALKEYMODULE_CTX_FLAGS_NEXT (1 << 25)
 
 /* Keyspace changes notification classes. Every class is associated with a
  * character for configuration purposes.
  * NOTE: These have to be in sync with NOTIFY_* in server.h */
-#define REDISMODULE_NOTIFY_KEYSPACE (1 << 0) /* K */
-#define REDISMODULE_NOTIFY_KEYEVENT (1 << 1) /* E */
-#define REDISMODULE_NOTIFY_GENERIC (1 << 2)  /* g */
-#define REDISMODULE_NOTIFY_STRING (1 << 3)   /* $ */
-#define REDISMODULE_NOTIFY_LIST (1 << 4)     /* l */
-#define REDISMODULE_NOTIFY_SET (1 << 5)      /* s */
-#define REDISMODULE_NOTIFY_HASH (1 << 6)     /* h */
-#define REDISMODULE_NOTIFY_ZSET (1 << 7)     /* z */
-#define REDISMODULE_NOTIFY_EXPIRED (1 << 8)  /* x */
-#define REDISMODULE_NOTIFY_EVICTED (1 << 9)  /* e */
-#define REDISMODULE_NOTIFY_STREAM (1 << 10)  /* t */
-#define REDISMODULE_NOTIFY_KEY_MISS                                         \
-  (1 << 11) /* m (Note: This one is excluded from REDISMODULE_NOTIFY_ALL on \
+#define VALKEYMODULE_NOTIFY_KEYSPACE (1 << 0) /* K */
+#define VALKEYMODULE_NOTIFY_KEYEVENT (1 << 1) /* E */
+#define VALKEYMODULE_NOTIFY_GENERIC (1 << 2)  /* g */
+#define VALKEYMODULE_NOTIFY_STRING (1 << 3)   /* $ */
+#define VALKEYMODULE_NOTIFY_LIST (1 << 4)     /* l */
+#define VALKEYMODULE_NOTIFY_SET (1 << 5)      /* s */
+#define VALKEYMODULE_NOTIFY_HASH (1 << 6)     /* h */
+#define VALKEYMODULE_NOTIFY_ZSET (1 << 7)     /* z */
+#define VALKEYMODULE_NOTIFY_EXPIRED (1 << 8)  /* x */
+#define VALKEYMODULE_NOTIFY_EVICTED (1 << 9)  /* e */
+#define VALKEYMODULE_NOTIFY_STREAM (1 << 10)  /* t */
+#define VALKEYMODULE_NOTIFY_KEY_MISS                                         \
+  (1 << 11) /* m (Note: This one is excluded from VALKEYMODULE_NOTIFY_ALL on \
                purpose) */
-#define REDISMODULE_NOTIFY_LOADED                                             \
+#define VALKEYMODULE_NOTIFY_LOADED                                            \
   (1 << 12) /* module only key space notification, indicate a key loaded from \
                rdb */
-#define REDISMODULE_NOTIFY_MODULE \
-  (1 << 13)                              /* d, module key space notification */
-#define REDISMODULE_NOTIFY_NEW (1 << 14) /* n, new key notification */
+#define VALKEYMODULE_NOTIFY_MODULE \
+  (1 << 13)                               /* d, module key space notification */
+#define VALKEYMODULE_NOTIFY_NEW (1 << 14) /* n, new key notification */
 
 /* Next notification flag, must be updated when adding new flags above!
 This flag should not be used directly by the module.
- * Use RedisModule_GetKeyspaceNotificationFlagsAll instead. */
-#define _REDISMODULE_NOTIFY_NEXT (1 << 15)
+ * Use ValkeyModule_GetKeyspaceNotificationFlagsAll instead. */
+#define _VALKEYMODULE_NOTIFY_NEXT (1 << 15)
 
-#define REDISMODULE_NOTIFY_ALL                               \
-  (REDISMODULE_NOTIFY_GENERIC | REDISMODULE_NOTIFY_STRING |  \
-   REDISMODULE_NOTIFY_LIST | REDISMODULE_NOTIFY_SET |        \
-   REDISMODULE_NOTIFY_HASH | REDISMODULE_NOTIFY_ZSET |       \
-   REDISMODULE_NOTIFY_EXPIRED | REDISMODULE_NOTIFY_EVICTED | \
-   REDISMODULE_NOTIFY_STREAM | REDISMODULE_NOTIFY_MODULE) /* A */
+#define VALKEYMODULE_NOTIFY_ALL                                \
+  (VALKEYMODULE_NOTIFY_GENERIC | VALKEYMODULE_NOTIFY_STRING |  \
+   VALKEYMODULE_NOTIFY_LIST | VALKEYMODULE_NOTIFY_SET |        \
+   VALKEYMODULE_NOTIFY_HASH | VALKEYMODULE_NOTIFY_ZSET |       \
+   VALKEYMODULE_NOTIFY_EXPIRED | VALKEYMODULE_NOTIFY_EVICTED | \
+   VALKEYMODULE_NOTIFY_STREAM | VALKEYMODULE_NOTIFY_MODULE) /* A */
 
 /* A special pointer that we can use between the core and the module to signal
  * field deletion, and that is impossible to be a valid pointer. */
-#define REDISMODULE_HASH_DELETE ((RedisModuleString *)(long)1)
+#define VALKEYMODULE_HASH_DELETE ((ValkeyModuleString *)(long)1)
 
 /* Error messages. */
-#define REDISMODULE_ERRORMSG_WRONGTYPE \
+#define VALKEYMODULE_ERRORMSG_WRONGTYPE \
   "WRONGTYPE Operation against a key holding the wrong kind of value"
 
-#define REDISMODULE_POSITIVE_INFINITE (1.0 / 0.0)
-#define REDISMODULE_NEGATIVE_INFINITE (-1.0 / 0.0)
+#define VALKEYMODULE_POSITIVE_INFINITE (1.0 / 0.0)
+#define VALKEYMODULE_NEGATIVE_INFINITE (-1.0 / 0.0)
 
 /* Cluster API defines. */
-#define REDISMODULE_NODE_ID_LEN 40
-#define REDISMODULE_NODE_MYSELF (1 << 0)
-#define REDISMODULE_NODE_MASTER (1 << 1)
-#define REDISMODULE_NODE_SLAVE (1 << 2)
-#define REDISMODULE_NODE_PFAIL (1 << 3)
-#define REDISMODULE_NODE_FAIL (1 << 4)
-#define REDISMODULE_NODE_NOFAILOVER (1 << 5)
+#define VALKEYMODULE_NODE_ID_LEN 40
+#define VALKEYMODULE_NODE_MYSELF (1 << 0)
+#define VALKEYMODULE_NODE_MASTER (1 << 1)
+#define VALKEYMODULE_NODE_SLAVE (1 << 2)
+#define VALKEYMODULE_NODE_PFAIL (1 << 3)
+#define VALKEYMODULE_NODE_FAIL (1 << 4)
+#define VALKEYMODULE_NODE_NOFAILOVER (1 << 5)
 
-#define REDISMODULE_CLUSTER_FLAG_NONE 0
-#define REDISMODULE_CLUSTER_FLAG_NO_FAILOVER (1 << 1)
-#define REDISMODULE_CLUSTER_FLAG_NO_REDIRECTION (1 << 2)
+#define VALKEYMODULE_CLUSTER_FLAG_NONE 0
+#define VALKEYMODULE_CLUSTER_FLAG_NO_FAILOVER (1 << 1)
+#define VALKEYMODULE_CLUSTER_FLAG_NO_REDIRECTION (1 << 2)
 
-#define REDISMODULE_CLUSTER_STATE_OK 0
-#define REDISMODULE_CLUSTER_STATE_FAIL 1
+#define VALKEYMODULE_CLUSTER_STATE_OK 0
+#define VALKEYMODULE_CLUSTER_STATE_FAIL 1
 
-#define REDISMODULE_CLUSTER_MY_STATE_OK 0
-#define REDISMODULE_CLUSTER_MY_STATE_LEAVING 1
+#define VALKEYMODULE_CLUSTER_MY_STATE_OK 0
+#define VALKEYMODULE_CLUSTER_MY_STATE_LEAVING 1
 
-#define REDISMODULE_NOT_USED(V) ((void)V)
+#define VALKEYMODULE_NOT_USED(V) ((void)V)
 
 /* Logging level strings */
-#define REDISMODULE_LOGLEVEL_DEBUG "debug"
-#define REDISMODULE_LOGLEVEL_VERBOSE "verbose"
-#define REDISMODULE_LOGLEVEL_NOTICE "notice"
-#define REDISMODULE_LOGLEVEL_WARNING "warning"
+#define VALKEYMODULE_LOGLEVEL_DEBUG "debug"
+#define VALKEYMODULE_LOGLEVEL_VERBOSE "verbose"
+#define VALKEYMODULE_LOGLEVEL_NOTICE "notice"
+#define VALKEYMODULE_LOGLEVEL_WARNING "warning"
 
 /* Bit flags for aux_save_triggers and the aux_load and aux_save callbacks */
-#define REDISMODULE_AUX_BEFORE_RDB (1 << 0)
-#define REDISMODULE_AUX_AFTER_RDB (1 << 1)
+#define VALKEYMODULE_AUX_BEFORE_RDB (1 << 0)
+#define VALKEYMODULE_AUX_AFTER_RDB (1 << 1)
 
 /* RM_Yield flags */
-#define REDISMODULE_YIELD_FLAG_NONE (1 << 0)
-#define REDISMODULE_YIELD_FLAG_CLIENTS (1 << 1)
+#define VALKEYMODULE_YIELD_FLAG_NONE (1 << 0)
+#define VALKEYMODULE_YIELD_FLAG_CLIENTS (1 << 1)
 
 /* This type represents a timer handle, and is returned when a timer is
  * registered and used in order to invalidate a timer. It's just a 64 bit
  * number, because this is how each timer is represented inside the radix tree
  * of timers that are going to expire, sorted by expire time. */
-typedef uint64_t RedisModuleTimerID;
+typedef uint64_t ValkeyModuleTimerID;
 
 /* CommandFilter Flags */
 
-/* Do filter RedisModule_Call() commands initiated by module itself. */
-#define REDISMODULE_CMDFILTER_NOSELF (1 << 0)
+/* Do filter ValkeyModule_Call() commands initiated by module itself. */
+#define VALKEYMODULE_CMDFILTER_NOSELF (1 << 0)
 
-/* Declare that the module can handle errors with RedisModule_SetModuleOptions.
+/* Declare that the module can handle errors with ValkeyModule_SetModuleOptions.
  */
-#define REDISMODULE_OPTIONS_HANDLE_IO_ERRORS (1 << 0)
+#define VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS (1 << 0)
 
-/* When set, Redis will not call RedisModule_SignalModifiedKey(), implicitly in
- * RedisModule_CloseKey, and the module needs to do that when manually when keys
- * are modified from the user's perspective, to invalidate WATCH. */
-#define REDISMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1 << 1)
+/* When set, Valkey will not call ValkeyModule_SignalModifiedKey(), implicitly in
+ * ValkeyModule_CloseKey, and the module needs to do that when manually when
+ * keys are modified from the user's perspective, to invalidate WATCH. */
+#define VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1 << 1)
 
 /* Declare that the module can handle diskless async replication with
- * RedisModule_SetModuleOptions. */
-#define REDISMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD (1 << 2)
+ * ValkeyModule_SetModuleOptions. */
+#define VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD (1 << 2)
 
 /* Declare that the module is an internal module*/
-#define REDISMODULE_OPTIONS_G_INTERNAL (1 << 1)
+#define VALKEYMODULE_OPTIONS_G_INTERNAL (1 << 1)
 
-/* Definitions for RedisModule_SetCommandInfo. */
+/* Definitions for ValkeyModule_SetCommandInfo. */
 
 typedef enum {
-  REDISMODULE_ARG_TYPE_STRING,
-  REDISMODULE_ARG_TYPE_INTEGER,
-  REDISMODULE_ARG_TYPE_DOUBLE,
-  REDISMODULE_ARG_TYPE_KEY, /* A string, but represents a keyname */
-  REDISMODULE_ARG_TYPE_PATTERN,
-  REDISMODULE_ARG_TYPE_UNIX_TIME,
-  REDISMODULE_ARG_TYPE_PURE_TOKEN,
-  REDISMODULE_ARG_TYPE_ONEOF, /* Must have sub-arguments */
-  REDISMODULE_ARG_TYPE_BLOCK  /* Must have sub-arguments */
-} RedisModuleCommandArgType;
+  VALKEYMODULE_ARG_TYPE_STRING,
+  VALKEYMODULE_ARG_TYPE_INTEGER,
+  VALKEYMODULE_ARG_TYPE_DOUBLE,
+  VALKEYMODULE_ARG_TYPE_KEY, /* A string, but represents a keyname */
+  VALKEYMODULE_ARG_TYPE_PATTERN,
+  VALKEYMODULE_ARG_TYPE_UNIX_TIME,
+  VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+  VALKEYMODULE_ARG_TYPE_ONEOF, /* Must have sub-arguments */
+  VALKEYMODULE_ARG_TYPE_BLOCK  /* Must have sub-arguments */
+} ValkeyModuleCommandArgType;
 
-#define REDISMODULE_CMD_ARG_NONE (0)
-#define REDISMODULE_CMD_ARG_OPTIONAL \
+#define VALKEYMODULE_CMD_ARG_NONE (0)
+#define VALKEYMODULE_CMD_ARG_OPTIONAL \
   (1 << 0) /* The argument is optional (like GET in SET command) */
-#define REDISMODULE_CMD_ARG_MULTIPLE \
+#define VALKEYMODULE_CMD_ARG_MULTIPLE \
   (1 << 1) /* The argument may repeat itself (like key in DEL) */
-#define REDISMODULE_CMD_ARG_MULTIPLE_TOKEN                                     \
+#define VALKEYMODULE_CMD_ARG_MULTIPLE_TOKEN                                    \
   (1 << 2) /* The argument may repeat itself, and so does its token (like `GET \
               pattern` in SORT) */
-#define _REDISMODULE_CMD_ARG_NEXT (1 << 3)
+#define _VALKEYMODULE_CMD_ARG_NEXT (1 << 3)
 
 typedef enum {
-  REDISMODULE_KSPEC_BS_INVALID = 0, /* Must be zero. An implicitly value of
-                                     * zero is provided when the field is
-                                     * absent in a struct literal. */
-  REDISMODULE_KSPEC_BS_UNKNOWN,
-  REDISMODULE_KSPEC_BS_INDEX,
-  REDISMODULE_KSPEC_BS_KEYWORD
-} RedisModuleKeySpecBeginSearchType;
+  VALKEYMODULE_KSPEC_BS_INVALID = 0, /* Must be zero. An implicitly value of
+                                      * zero is provided when the field is
+                                      * absent in a struct literal. */
+  VALKEYMODULE_KSPEC_BS_UNKNOWN,
+  VALKEYMODULE_KSPEC_BS_INDEX,
+  VALKEYMODULE_KSPEC_BS_KEYWORD
+} ValkeyModuleKeySpecBeginSearchType;
 
 typedef enum {
-  REDISMODULE_KSPEC_FK_OMITTED = 0, /* Used when the field is absent in a
-                                     * struct literal. Don't use this value
-                                     * explicitly. */
-  REDISMODULE_KSPEC_FK_UNKNOWN,
-  REDISMODULE_KSPEC_FK_RANGE,
-  REDISMODULE_KSPEC_FK_KEYNUM
-} RedisModuleKeySpecFindKeysType;
+  VALKEYMODULE_KSPEC_FK_OMITTED = 0, /* Used when the field is absent in a
+                                      * struct literal. Don't use this value
+                                      * explicitly. */
+  VALKEYMODULE_KSPEC_FK_UNKNOWN,
+  VALKEYMODULE_KSPEC_FK_RANGE,
+  VALKEYMODULE_KSPEC_FK_KEYNUM
+} ValkeyModuleKeySpecFindKeysType;
 
 /* Key-spec flags. For details, see the documentation of
- * RedisModule_SetCommandInfo and the key-spec flags in server.h. */
-#define REDISMODULE_CMD_KEY_RO (1ULL << 0)
-#define REDISMODULE_CMD_KEY_RW (1ULL << 1)
-#define REDISMODULE_CMD_KEY_OW (1ULL << 2)
-#define REDISMODULE_CMD_KEY_RM (1ULL << 3)
-#define REDISMODULE_CMD_KEY_ACCESS (1ULL << 4)
-#define REDISMODULE_CMD_KEY_UPDATE (1ULL << 5)
-#define REDISMODULE_CMD_KEY_INSERT (1ULL << 6)
-#define REDISMODULE_CMD_KEY_DELETE (1ULL << 7)
-#define REDISMODULE_CMD_KEY_NOT_KEY (1ULL << 8)
-#define REDISMODULE_CMD_KEY_INCOMPLETE (1ULL << 9)
-#define REDISMODULE_CMD_KEY_VARIABLE_FLAGS (1ULL << 10)
+ * ValkeyModule_SetCommandInfo and the key-spec flags in server.h. */
+#define VALKEYMODULE_CMD_KEY_RO (1ULL << 0)
+#define VALKEYMODULE_CMD_KEY_RW (1ULL << 1)
+#define VALKEYMODULE_CMD_KEY_OW (1ULL << 2)
+#define VALKEYMODULE_CMD_KEY_RM (1ULL << 3)
+#define VALKEYMODULE_CMD_KEY_ACCESS (1ULL << 4)
+#define VALKEYMODULE_CMD_KEY_UPDATE (1ULL << 5)
+#define VALKEYMODULE_CMD_KEY_INSERT (1ULL << 6)
+#define VALKEYMODULE_CMD_KEY_DELETE (1ULL << 7)
+#define VALKEYMODULE_CMD_KEY_NOT_KEY (1ULL << 8)
+#define VALKEYMODULE_CMD_KEY_INCOMPLETE (1ULL << 9)
+#define VALKEYMODULE_CMD_KEY_VARIABLE_FLAGS (1ULL << 10)
 
 /* Channel flags, for details see the documentation of
- * RedisModule_ChannelAtPosWithFlags. */
-#define REDISMODULE_CMD_CHANNEL_PATTERN (1ULL << 0)
-#define REDISMODULE_CMD_CHANNEL_PUBLISH (1ULL << 1)
-#define REDISMODULE_CMD_CHANNEL_SUBSCRIBE (1ULL << 2)
-#define REDISMODULE_CMD_CHANNEL_UNSUBSCRIBE (1ULL << 3)
+ * ValkeyModule_ChannelAtPosWithFlags. */
+#define VALKEYMODULE_CMD_CHANNEL_PATTERN (1ULL << 0)
+#define VALKEYMODULE_CMD_CHANNEL_PUBLISH (1ULL << 1)
+#define VALKEYMODULE_CMD_CHANNEL_SUBSCRIBE (1ULL << 2)
+#define VALKEYMODULE_CMD_CHANNEL_UNSUBSCRIBE (1ULL << 3)
 
-typedef struct RedisModuleCommandArg {
+typedef struct ValkeyModuleCommandArg {
   const char *name;
-  RedisModuleCommandArgType type;
+  ValkeyModuleCommandArgType type;
   int key_spec_index; /* If type is KEY, this is a zero-based index of
                        * the key_spec in the command. For other types,
                        * you may specify -1. */
   const char *token;  /* If type is PURE_TOKEN, this is the token. */
   const char *summary;
   const char *since;
-  int flags; /* The REDISMODULE_CMD_ARG_* macros. */
+  int flags; /* The VALKEYMODULE_CMD_ARG_* macros. */
   const char *deprecated_since;
-  struct RedisModuleCommandArg *subargs;
-} RedisModuleCommandArg;
+  struct ValkeyModuleCommandArg *subargs;
+} ValkeyModuleCommandArg;
 
 typedef struct {
   const char *since;
   const char *changes;
-} RedisModuleCommandHistoryEntry;
+} ValkeyModuleCommandHistoryEntry;
 
 typedef struct {
   const char *notes;
-  uint64_t flags; /* REDISMODULE_CMD_KEY_* macros. */
-  RedisModuleKeySpecBeginSearchType begin_search_type;
+  uint64_t flags; /* VALKEYMODULE_CMD_KEY_* macros. */
+  ValkeyModuleKeySpecBeginSearchType begin_search_type;
   union {
     struct {
       /* The index from which we start the search for keys */
@@ -441,7 +441,7 @@ typedef struct {
       int startfrom;
     } keyword;
   } bs;
-  RedisModuleKeySpecFindKeysType find_keys_type;
+  ValkeyModuleKeySpecFindKeysType find_keys_type;
   union {
     struct {
       /* Index of the last key relative to the result of the begin search
@@ -470,222 +470,222 @@ typedef struct {
       int keystep;
     } keynum;
   } fk;
-} RedisModuleCommandKeySpec;
+} ValkeyModuleCommandKeySpec;
 
 typedef struct {
   int version;
   size_t sizeof_historyentry;
   size_t sizeof_keyspec;
   size_t sizeof_arg;
-} RedisModuleCommandInfoVersion;
+} ValkeyModuleCommandInfoVersion;
 
-static const RedisModuleCommandInfoVersion
-    RedisModule_CurrentCommandInfoVersion = {
+static const ValkeyModuleCommandInfoVersion
+    ValkeyModule_CurrentCommandInfoVersion = {
         .version = 1,
-        .sizeof_historyentry = sizeof(RedisModuleCommandHistoryEntry),
-        .sizeof_keyspec = sizeof(RedisModuleCommandKeySpec),
-        .sizeof_arg = sizeof(RedisModuleCommandArg)};
+        .sizeof_historyentry = sizeof(ValkeyModuleCommandHistoryEntry),
+        .sizeof_keyspec = sizeof(ValkeyModuleCommandKeySpec),
+        .sizeof_arg = sizeof(ValkeyModuleCommandArg)};
 
-#define REDISMODULE_COMMAND_INFO_VERSION \
-  (&RedisModule_CurrentCommandInfoVersion)
+#define VALKEYMODULE_COMMAND_INFO_VERSION \
+  (&ValkeyModule_CurrentCommandInfoVersion)
 
 typedef struct {
-  /* Always set version to REDISMODULE_COMMAND_INFO_VERSION */
-  const RedisModuleCommandInfoVersion *version;
-  /* Version 1 fields (added in Redis 7.0.0) */
+  /* Always set version to VALKEYMODULE_COMMAND_INFO_VERSION */
+  const ValkeyModuleCommandInfoVersion *version;
+  /* Version 1 fields (added in Valkey 7.0.0) */
   const char *summary;    /* Summary of the command */
   const char *complexity; /* Complexity description */
   const char *since;      /* Debut module version of the command */
-  RedisModuleCommandHistoryEntry *history; /* History */
+  ValkeyModuleCommandHistoryEntry *history; /* History */
   /* A string of space-separated tips meant for clients/proxies regarding this
    * command */
   const char *tips;
   /* Number of arguments, it is possible to use -N to say >= N */
   int arity;
-  RedisModuleCommandKeySpec *key_specs;
-  RedisModuleCommandArg *args;
-} RedisModuleCommandInfo;
+  ValkeyModuleCommandKeySpec *key_specs;
+  ValkeyModuleCommandArg *args;
+} ValkeyModuleCommandInfo;
 
 /* Eventloop definitions. */
-#define REDISMODULE_EVENTLOOP_READABLE 1
-#define REDISMODULE_EVENTLOOP_WRITABLE 2
-typedef void (*RedisModuleEventLoopFunc)(int fd, void *user_data, int mask);
-typedef void (*RedisModuleEventLoopOneShotFunc)(void *user_data);
+#define VALKEYMODULE_EVENTLOOP_READABLE 1
+#define VALKEYMODULE_EVENTLOOP_WRITABLE 2
+typedef void (*ValkeyModuleEventLoopFunc)(int fd, void *user_data, int mask);
+typedef void (*ValkeyModuleEventLoopOneShotFunc)(void *user_data);
 
 /* Server events definitions.
  * Those flags should not be used directly by the module, instead
- * the module should use RedisModuleEvent_* variables.
+ * the module should use ValkeyModuleEvent_* variables.
  * Note: This must be synced with moduleEventVersions */
-#define REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED 0
-#define REDISMODULE_EVENT_PERSISTENCE 1
-#define REDISMODULE_EVENT_FLUSHDB 2
-#define REDISMODULE_EVENT_LOADING 3
-#define REDISMODULE_EVENT_CLIENT_CHANGE 4
-#define REDISMODULE_EVENT_SHUTDOWN 5
-#define REDISMODULE_EVENT_REPLICA_CHANGE 6
-#define REDISMODULE_EVENT_MASTER_LINK_CHANGE 7
-#define REDISMODULE_EVENT_CRON_LOOP 8
-#define REDISMODULE_EVENT_MODULE_CHANGE 9
-#define REDISMODULE_EVENT_LOADING_PROGRESS 10
-#define REDISMODULE_EVENT_SWAPDB 11
-#define REDISMODULE_EVENT_REPL_BACKUP \
-  12 /* Deprecated since Redis 7.0, not used anymore. */
-#define REDISMODULE_EVENT_FORK_CHILD 13
-#define REDISMODULE_EVENT_REPL_ASYNC_LOAD 14
-#define REDISMODULE_EVENT_EVENTLOOP 15
-#define REDISMODULE_EVENT_CONFIG 16
-#define REDISMODULE_EVENT_CLUSTER_STATE_CHANGED 17
-#define _REDISMODULE_EVENT_NEXT \
+#define VALKEYMODULE_EVENT_REPLICATION_ROLE_CHANGED 0
+#define VALKEYMODULE_EVENT_PERSISTENCE 1
+#define VALKEYMODULE_EVENT_FLUSHDB 2
+#define VALKEYMODULE_EVENT_LOADING 3
+#define VALKEYMODULE_EVENT_CLIENT_CHANGE 4
+#define VALKEYMODULE_EVENT_SHUTDOWN 5
+#define VALKEYMODULE_EVENT_REPLICA_CHANGE 6
+#define VALKEYMODULE_EVENT_MASTER_LINK_CHANGE 7
+#define VALKEYMODULE_EVENT_CRON_LOOP 8
+#define VALKEYMODULE_EVENT_MODULE_CHANGE 9
+#define VALKEYMODULE_EVENT_LOADING_PROGRESS 10
+#define VALKEYMODULE_EVENT_SWAPDB 11
+#define VALKEYMODULE_EVENT_REPL_BACKUP \
+  12 /* Deprecated since Valkey 7.0, not used anymore. */
+#define VALKEYMODULE_EVENT_FORK_CHILD 13
+#define VALKEYMODULE_EVENT_REPL_ASYNC_LOAD 14
+#define VALKEYMODULE_EVENT_EVENTLOOP 15
+#define VALKEYMODULE_EVENT_CONFIG 16
+#define VALKEYMODULE_EVENT_CLUSTER_STATE_CHANGED 17
+#define _VALKEYMODULE_EVENT_NEXT \
   18 /* Next event flag, should be updated if a new event added. */
 
-typedef struct RedisModuleEvent {
-  uint64_t id;      /* REDISMODULE_EVENT_... defines. */
+typedef struct ValkeyModuleEvent {
+  uint64_t id;      /* VALKEYMODULE_EVENT_... defines. */
   uint64_t dataver; /* Version of the structure we pass as 'data'. */
-} RedisModuleEvent;
+} ValkeyModuleEvent;
 
-struct RedisModuleCtx;
-struct RedisModuleDefragCtx;
-typedef void (*RedisModuleEventCallback)(struct RedisModuleCtx *ctx,
-                                         RedisModuleEvent eid,
-                                         uint64_t subevent, void *data);
+struct ValkeyModuleCtx;
+struct ValkeyModuleDefragCtx;
+typedef void (*ValkeyModuleEventCallback)(struct ValkeyModuleCtx *ctx,
+                                          ValkeyModuleEvent eid,
+                                          uint64_t subevent, void *data);
 
 /* IMPORTANT: When adding a new version of one of below structures that contain
- * event data (RedisModuleFlushInfoV1 for example) we have to avoid renaming the
- * old RedisModuleEvent structure.
- * For example, if we want to add RedisModuleFlushInfoV2, the RedisModuleEvent
- * structures should be:
- *      RedisModuleEvent_FlushDB = {
- *          REDISMODULE_EVENT_FLUSHDB,
+ * event data (ValkeyModuleFlushInfoV1 for example) we have to avoid renaming
+ * the old ValkeyModuleEvent structure. For example, if we want to add
+ * ValkeyModuleFlushInfoV2, the ValkeyModuleEvent structures should be:
+ *      ValkeyModuleEvent_FlushDB = {
+ *          VALKEYMODULE_EVENT_FLUSHDB,
  *          1
  *      },
- *      RedisModuleEvent_FlushDBV2 = {
- *          REDISMODULE_EVENT_FLUSHDB,
+ *      ValkeyModuleEvent_FlushDBV2 = {
+ *          VALKEYMODULE_EVENT_FLUSHDB,
  *          2
  *      }
  * and NOT:
- *      RedisModuleEvent_FlushDBV1 = {
- *          REDISMODULE_EVENT_FLUSHDB,
+ *      ValkeyModuleEvent_FlushDBV1 = {
+ *          VALKEYMODULE_EVENT_FLUSHDB,
  *          1
  *      },
- *      RedisModuleEvent_FlushDB = {
- *          REDISMODULE_EVENT_FLUSHDB,
+ *      ValkeyModuleEvent_FlushDB = {
+ *          VALKEYMODULE_EVENT_FLUSHDB,
  *          2
  *      }
  * The reason for that is forward-compatibility: We want that module that
  * compiled with a new redismodule.h to be able to work with a old server,
  * unless the author explicitly decided to use the newer event type.
  */
-static const RedisModuleEvent
-    RedisModuleEvent_ReplicationRoleChanged =
-        {REDISMODULE_EVENT_REPLICATION_ROLE_CHANGED, 1},
-    RedisModuleEvent_Persistence = {REDISMODULE_EVENT_PERSISTENCE, 1},
-    RedisModuleEvent_FlushDB = {REDISMODULE_EVENT_FLUSHDB, 1},
-    RedisModuleEvent_Loading = {REDISMODULE_EVENT_LOADING, 1},
-    RedisModuleEvent_ClientChange = {REDISMODULE_EVENT_CLIENT_CHANGE, 1},
-    RedisModuleEvent_Shutdown = {REDISMODULE_EVENT_SHUTDOWN, 1},
-    RedisModuleEvent_ReplicaChange = {REDISMODULE_EVENT_REPLICA_CHANGE, 1},
-    RedisModuleEvent_CronLoop = {REDISMODULE_EVENT_CRON_LOOP, 1},
-    RedisModuleEvent_MasterLinkChange = {REDISMODULE_EVENT_MASTER_LINK_CHANGE,
+static const ValkeyModuleEvent
+    ValkeyModuleEvent_ReplicationRoleChanged =
+        {VALKEYMODULE_EVENT_REPLICATION_ROLE_CHANGED, 1},
+    ValkeyModuleEvent_Persistence = {VALKEYMODULE_EVENT_PERSISTENCE, 1},
+    ValkeyModuleEvent_FlushDB = {VALKEYMODULE_EVENT_FLUSHDB, 1},
+    ValkeyModuleEvent_Loading = {VALKEYMODULE_EVENT_LOADING, 1},
+    ValkeyModuleEvent_ClientChange = {VALKEYMODULE_EVENT_CLIENT_CHANGE, 1},
+    ValkeyModuleEvent_Shutdown = {VALKEYMODULE_EVENT_SHUTDOWN, 1},
+    ValkeyModuleEvent_ReplicaChange = {VALKEYMODULE_EVENT_REPLICA_CHANGE, 1},
+    ValkeyModuleEvent_CronLoop = {VALKEYMODULE_EVENT_CRON_LOOP, 1},
+    ValkeyModuleEvent_MasterLinkChange = {VALKEYMODULE_EVENT_MASTER_LINK_CHANGE,
+                                          1},
+    ValkeyModuleEvent_ModuleChange = {VALKEYMODULE_EVENT_MODULE_CHANGE, 1},
+    ValkeyModuleEvent_LoadingProgress = {VALKEYMODULE_EVENT_LOADING_PROGRESS,
                                          1},
-    RedisModuleEvent_ModuleChange = {REDISMODULE_EVENT_MODULE_CHANGE, 1},
-    RedisModuleEvent_LoadingProgress = {REDISMODULE_EVENT_LOADING_PROGRESS, 1},
-    RedisModuleEvent_SwapDB = {REDISMODULE_EVENT_SWAPDB, 1},
-    /* Deprecated since Redis 7.0, not used anymore. */
-    __attribute__((deprecated)) RedisModuleEvent_ReplBackup =
-        {REDISMODULE_EVENT_REPL_BACKUP, 1},
-    RedisModuleEvent_ReplAsyncLoad = {REDISMODULE_EVENT_REPL_ASYNC_LOAD, 1},
-    RedisModuleEvent_ForkChild = {REDISMODULE_EVENT_FORK_CHILD, 1},
-    RedisModuleEvent_EventLoop = {REDISMODULE_EVENT_EVENTLOOP, 1},
-    RedisModuleEvent_Config = {REDISMODULE_EVENT_CONFIG, 1},
-    RedisModuleEvent_ClusterStateChanged = {
-        REDISMODULE_EVENT_CLUSTER_STATE_CHANGED, 1};
+    ValkeyModuleEvent_SwapDB = {VALKEYMODULE_EVENT_SWAPDB, 1},
+    /* Deprecated since Valkey 7.0, not used anymore. */
+    __attribute__((deprecated)) ValkeyModuleEvent_ReplBackup =
+        {VALKEYMODULE_EVENT_REPL_BACKUP, 1},
+    ValkeyModuleEvent_ReplAsyncLoad = {VALKEYMODULE_EVENT_REPL_ASYNC_LOAD, 1},
+    ValkeyModuleEvent_ForkChild = {VALKEYMODULE_EVENT_FORK_CHILD, 1},
+    ValkeyModuleEvent_EventLoop = {VALKEYMODULE_EVENT_EVENTLOOP, 1},
+    ValkeyModuleEvent_Config = {VALKEYMODULE_EVENT_CONFIG, 1},
+    ValkeyModuleEvent_ClusterStateChanged = {
+        VALKEYMODULE_EVENT_CLUSTER_STATE_CHANGED, 1};
 
 /* Those are values that are used for the 'subevent' callback argument. */
-#define REDISMODULE_SUBEVENT_PERSISTENCE_RDB_START 0
-#define REDISMODULE_SUBEVENT_PERSISTENCE_AOF_START 1
-#define REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START 2
-#define REDISMODULE_SUBEVENT_PERSISTENCE_ENDED 3
-#define REDISMODULE_SUBEVENT_PERSISTENCE_FAILED 4
-#define REDISMODULE_SUBEVENT_PERSISTENCE_SYNC_AOF_START 5
-#define _REDISMODULE_SUBEVENT_PERSISTENCE_NEXT 6
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_RDB_START 0
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_AOF_START 1
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_SYNC_RDB_START 2
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_ENDED 3
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_FAILED 4
+#define VALKEYMODULE_SUBEVENT_PERSISTENCE_SYNC_AOF_START 5
+#define _VALKEYMODULE_SUBEVENT_PERSISTENCE_NEXT 6
 
-#define REDISMODULE_SUBEVENT_LOADING_RDB_START 0
-#define REDISMODULE_SUBEVENT_LOADING_AOF_START 1
-#define REDISMODULE_SUBEVENT_LOADING_REPL_START 2
-#define REDISMODULE_SUBEVENT_LOADING_ENDED 3
-#define REDISMODULE_SUBEVENT_LOADING_FAILED 4
-#define _REDISMODULE_SUBEVENT_LOADING_NEXT 5
+#define VALKEYMODULE_SUBEVENT_LOADING_RDB_START 0
+#define VALKEYMODULE_SUBEVENT_LOADING_AOF_START 1
+#define VALKEYMODULE_SUBEVENT_LOADING_REPL_START 2
+#define VALKEYMODULE_SUBEVENT_LOADING_ENDED 3
+#define VALKEYMODULE_SUBEVENT_LOADING_FAILED 4
+#define _VALKEYMODULE_SUBEVENT_LOADING_NEXT 5
 
-#define REDISMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED 0
-#define REDISMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED 1
-#define _REDISMODULE_SUBEVENT_CLIENT_CHANGE_NEXT 2
+#define VALKEYMODULE_SUBEVENT_CLIENT_CHANGE_CONNECTED 0
+#define VALKEYMODULE_SUBEVENT_CLIENT_CHANGE_DISCONNECTED 1
+#define _VALKEYMODULE_SUBEVENT_CLIENT_CHANGE_NEXT 2
 
-#define REDISMODULE_SUBEVENT_MASTER_LINK_UP 0
-#define REDISMODULE_SUBEVENT_MASTER_LINK_DOWN 1
-#define _REDISMODULE_SUBEVENT_MASTER_NEXT 2
+#define VALKEYMODULE_SUBEVENT_MASTER_LINK_UP 0
+#define VALKEYMODULE_SUBEVENT_MASTER_LINK_DOWN 1
+#define _VALKEYMODULE_SUBEVENT_MASTER_NEXT 2
 
-#define REDISMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE 0
-#define REDISMODULE_SUBEVENT_REPLICA_CHANGE_OFFLINE 1
-#define _REDISMODULE_SUBEVENT_REPLICA_CHANGE_NEXT 2
+#define VALKEYMODULE_SUBEVENT_REPLICA_CHANGE_ONLINE 0
+#define VALKEYMODULE_SUBEVENT_REPLICA_CHANGE_OFFLINE 1
+#define _VALKEYMODULE_SUBEVENT_REPLICA_CHANGE_NEXT 2
 
-#define REDISMODULE_EVENT_REPLROLECHANGED_NOW_MASTER 0
-#define REDISMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA 1
-#define _REDISMODULE_EVENT_REPLROLECHANGED_NEXT 2
+#define VALKEYMODULE_EVENT_REPLROLECHANGED_NOW_MASTER 0
+#define VALKEYMODULE_EVENT_REPLROLECHANGED_NOW_REPLICA 1
+#define _VALKEYMODULE_EVENT_REPLROLECHANGED_NEXT 2
 
-#define REDISMODULE_SUBEVENT_FLUSHDB_START 0
-#define REDISMODULE_SUBEVENT_FLUSHDB_END 1
-#define _REDISMODULE_SUBEVENT_FLUSHDB_NEXT 2
+#define VALKEYMODULE_SUBEVENT_FLUSHDB_START 0
+#define VALKEYMODULE_SUBEVENT_FLUSHDB_END 1
+#define _VALKEYMODULE_SUBEVENT_FLUSHDB_NEXT 2
 
-#define REDISMODULE_SUBEVENT_MODULE_LOADED 0
-#define REDISMODULE_SUBEVENT_MODULE_UNLOADED 1
-#define _REDISMODULE_SUBEVENT_MODULE_NEXT 2
+#define VALKEYMODULE_SUBEVENT_MODULE_LOADED 0
+#define VALKEYMODULE_SUBEVENT_MODULE_UNLOADED 1
+#define _VALKEYMODULE_SUBEVENT_MODULE_NEXT 2
 
-#define REDISMODULE_SUBEVENT_CONFIG_CHANGE 0
-#define _REDISMODULE_SUBEVENT_CONFIG_NEXT 1
+#define VALKEYMODULE_SUBEVENT_CONFIG_CHANGE 0
+#define _VALKEYMODULE_SUBEVENT_CONFIG_NEXT 1
 
-#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
-#define REDISMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
-#define _REDISMODULE_SUBEVENT_LOADING_PROGRESS_NEXT 2
+#define VALKEYMODULE_SUBEVENT_LOADING_PROGRESS_RDB 0
+#define VALKEYMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
+#define _VALKEYMODULE_SUBEVENT_LOADING_PROGRESS_NEXT 2
 
-/* Replication Backup events are deprecated since Redis 7.0 and are never fired.
+/* Replication Backup events are deprecated since Valkey 7.0 and are never fired.
  */
-#define REDISMODULE_SUBEVENT_REPL_BACKUP_CREATE 0
-#define REDISMODULE_SUBEVENT_REPL_BACKUP_RESTORE 1
-#define REDISMODULE_SUBEVENT_REPL_BACKUP_DISCARD 2
-#define _REDISMODULE_SUBEVENT_REPL_BACKUP_NEXT 3
+#define VALKEYMODULE_SUBEVENT_REPL_BACKUP_CREATE 0
+#define VALKEYMODULE_SUBEVENT_REPL_BACKUP_RESTORE 1
+#define VALKEYMODULE_SUBEVENT_REPL_BACKUP_DISCARD 2
+#define _VALKEYMODULE_SUBEVENT_REPL_BACKUP_NEXT 3
 
-#define REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_STARTED 0
-#define REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_ABORTED 1
-#define REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_COMPLETED 2
-#define _REDISMODULE_SUBEVENT_REPL_ASYNC_LOAD_NEXT 3
+#define VALKEYMODULE_SUBEVENT_REPL_ASYNC_LOAD_STARTED 0
+#define VALKEYMODULE_SUBEVENT_REPL_ASYNC_LOAD_ABORTED 1
+#define VALKEYMODULE_SUBEVENT_REPL_ASYNC_LOAD_COMPLETED 2
+#define _VALKEYMODULE_SUBEVENT_REPL_ASYNC_LOAD_NEXT 3
 
-#define REDISMODULE_SUBEVENT_FORK_CHILD_BORN 0
-#define REDISMODULE_SUBEVENT_FORK_CHILD_DIED 1
-#define _REDISMODULE_SUBEVENT_FORK_CHILD_NEXT 2
+#define VALKEYMODULE_SUBEVENT_FORK_CHILD_BORN 0
+#define VALKEYMODULE_SUBEVENT_FORK_CHILD_DIED 1
+#define _VALKEYMODULE_SUBEVENT_FORK_CHILD_NEXT 2
 
-#define REDISMODULE_SUBEVENT_EVENTLOOP_BEFORE_SLEEP 0
-#define REDISMODULE_SUBEVENT_EVENTLOOP_AFTER_SLEEP 1
-#define _REDISMODULE_SUBEVENT_EVENTLOOP_NEXT 2
+#define VALKEYMODULE_SUBEVENT_EVENTLOOP_BEFORE_SLEEP 0
+#define VALKEYMODULE_SUBEVENT_EVENTLOOP_AFTER_SLEEP 1
+#define _VALKEYMODULE_SUBEVENT_EVENTLOOP_NEXT 2
 
-#define _REDISMODULE_SUBEVENT_SHUTDOWN_NEXT 0
-#define _REDISMODULE_SUBEVENT_CRON_LOOP_NEXT 0
-#define _REDISMODULE_SUBEVENT_SWAPDB_NEXT 0
+#define _VALKEYMODULE_SUBEVENT_SHUTDOWN_NEXT 0
+#define _VALKEYMODULE_SUBEVENT_CRON_LOOP_NEXT 0
+#define _VALKEYMODULE_SUBEVENT_SWAPDB_NEXT 0
 
-#define REDISMODULE_SUBEVENT_CLUSTERSTATECHANGED_NOW_OK 0
-#define REDISMODULE_SUBEVENT_CLUSTERSTATECHANGED_NOW_FAIL 1
-#define _REDISMODULE_SUBEVENT_CLUSTERSTATECHANGED_NEXT 2
+#define VALKEYMODULE_SUBEVENT_CLUSTERSTATECHANGED_NOW_OK 0
+#define VALKEYMODULE_SUBEVENT_CLUSTERSTATECHANGED_NOW_FAIL 1
+#define _VALKEYMODULE_SUBEVENT_CLUSTERSTATECHANGED_NEXT 2
 
-/* RedisModuleClientInfo flags. */
-#define REDISMODULE_CLIENTINFO_FLAG_SSL (1 << 0)
-#define REDISMODULE_CLIENTINFO_FLAG_PUBSUB (1 << 1)
-#define REDISMODULE_CLIENTINFO_FLAG_BLOCKED (1 << 2)
-#define REDISMODULE_CLIENTINFO_FLAG_TRACKING (1 << 3)
-#define REDISMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1 << 4)
-#define REDISMODULE_CLIENTINFO_FLAG_MULTI (1 << 5)
+/* ValkeyModuleClientInfo flags. */
+#define VALKEYMODULE_CLIENTINFO_FLAG_SSL (1 << 0)
+#define VALKEYMODULE_CLIENTINFO_FLAG_PUBSUB (1 << 1)
+#define VALKEYMODULE_CLIENTINFO_FLAG_BLOCKED (1 << 2)
+#define VALKEYMODULE_CLIENTINFO_FLAG_TRACKING (1 << 3)
+#define VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1 << 4)
+#define VALKEYMODULE_CLIENTINFO_FLAG_MULTI (1 << 5)
 
 /* Here we take all the structures that the module pass to the core
  * and the other way around. Notably the list here contains the structures
- * used by the hooks API RedisModule_RegisterToServerEvent().
+ * used by the hooks API ValkeyModule_RegisterToServerEvent().
  *
  * The structures always start with a 'version' field. This is useful
  * when we want to pass a reference to the structure to the core APIs,
@@ -698,22 +698,22 @@ static const RedisModuleEvent
  * however using a define, we'll make sure to use the last version as the
  * public name for the module to use. */
 
-#define REDISMODULE_CLIENTINFO_VERSION 1
-typedef struct RedisModuleClientInfo {
+#define VALKEYMODULE_CLIENTINFO_VERSION 1
+typedef struct ValkeyModuleClientInfo {
   uint64_t version; /* Version of this structure for ABI compat. */
-  uint64_t flags;   /* REDISMODULE_CLIENTINFO_FLAG_* */
+  uint64_t flags;   /* VALKEYMODULE_CLIENTINFO_FLAG_* */
   uint64_t id;      /* Client ID. */
   char addr[46];    /* IPv4 or IPv6 address. */
   uint16_t port;    /* TCP port. */
   uint16_t db;      /* Selected DB. */
-} RedisModuleClientInfoV1;
+} ValkeyModuleClientInfoV1;
 
-#define RedisModuleClientInfo RedisModuleClientInfoV1
+#define ValkeyModuleClientInfo ValkeyModuleClientInfoV1
 
-#define REDISMODULE_CLIENTINFO_INITIALIZER_V1 {.version = 1}
+#define VALKEYMODULE_CLIENTINFO_INITIALIZER_V1 {.version = 1}
 
-#define REDISMODULE_REPLICATIONINFO_VERSION 1
-typedef struct RedisModuleReplicationInfo {
+#define VALKEYMODULE_REPLICATIONINFO_VERSION 1
+typedef struct ValkeyModuleReplicationInfo {
   uint64_t version;      /* Not used since this structure is never passed
                             from the module to the core right now. Here
                             for future compatibility. */
@@ -724,110 +724,110 @@ typedef struct RedisModuleReplicationInfo {
   char *replid2;         /* Secondary replication ID */
   uint64_t repl1_offset; /* Main replication offset */
   uint64_t repl2_offset; /* Offset of replid2 validity */
-} RedisModuleReplicationInfoV1;
+} ValkeyModuleReplicationInfoV1;
 
-#define RedisModuleReplicationInfo RedisModuleReplicationInfoV1
+#define ValkeyModuleReplicationInfo ValkeyModuleReplicationInfoV1
 
-#define REDISMODULE_FLUSHINFO_VERSION 1
-typedef struct RedisModuleFlushInfo {
+#define VALKEYMODULE_FLUSHINFO_VERSION 1
+typedef struct ValkeyModuleFlushInfo {
   uint64_t version; /* Not used since this structure is never passed
                        from the module to the core right now. Here
                        for future compatibility. */
   int32_t sync;     /* Synchronous or threaded flush?. */
   int32_t dbnum;    /* Flushed database number, -1 for ALL. */
-} RedisModuleFlushInfoV1;
+} ValkeyModuleFlushInfoV1;
 
-#define RedisModuleFlushInfo RedisModuleFlushInfoV1
+#define ValkeyModuleFlushInfo ValkeyModuleFlushInfoV1
 
-#define REDISMODULE_MODULE_CHANGE_VERSION 1
-typedef struct RedisModuleModuleChange {
+#define VALKEYMODULE_MODULE_CHANGE_VERSION 1
+typedef struct ValkeyModuleModuleChange {
   uint64_t version;        /* Not used since this structure is never passed
                               from the module to the core right now. Here
                               for future compatibility. */
   const char *module_name; /* Name of module loaded or unloaded. */
   int32_t module_version;  /* Module version. */
-} RedisModuleModuleChangeV1;
+} ValkeyModuleModuleChangeV1;
 
-#define RedisModuleModuleChange RedisModuleModuleChangeV1
+#define ValkeyModuleModuleChange ValkeyModuleModuleChangeV1
 
-#define REDISMODULE_CONFIGCHANGE_VERSION 1
-typedef struct RedisModuleConfigChange {
+#define VALKEYMODULE_CONFIGCHANGE_VERSION 1
+typedef struct ValkeyModuleConfigChange {
   uint64_t version;          /* Not used since this structure is never passed
                                 from the module to the core right now. Here
                                 for future compatibility. */
-  uint32_t num_changes;      /* how many redis config options were changed */
+  uint32_t num_changes;      /* how many valkey config options were changed */
   const char **config_names; /* the config names that were changed */
-} RedisModuleConfigChangeV1;
+} ValkeyModuleConfigChangeV1;
 
-#define RedisModuleConfigChange RedisModuleConfigChangeV1
+#define ValkeyModuleConfigChange ValkeyModuleConfigChangeV1
 
-#define REDISMODULE_CRON_LOOP_VERSION 1
-typedef struct RedisModuleCronLoopInfo {
+#define VALKEYMODULE_CRON_LOOP_VERSION 1
+typedef struct ValkeyModuleCronLoopInfo {
   uint64_t version; /* Not used since this structure is never passed
                        from the module to the core right now. Here
                        for future compatibility. */
   int32_t hz;       /* Approximate number of events per second. */
-} RedisModuleCronLoopV1;
+} ValkeyModuleCronLoopV1;
 
-#define RedisModuleCronLoop RedisModuleCronLoopV1
+#define ValkeyModuleCronLoop ValkeyModuleCronLoopV1
 
-#define REDISMODULE_LOADING_PROGRESS_VERSION 1
-typedef struct RedisModuleLoadingProgressInfo {
+#define VALKEYMODULE_LOADING_PROGRESS_VERSION 1
+typedef struct ValkeyModuleLoadingProgressInfo {
   uint64_t version; /* Not used since this structure is never passed
                        from the module to the core right now. Here
                        for future compatibility. */
   int32_t hz;       /* Approximate number of events per second. */
   int32_t progress; /* Approximate progress between 0 and 1024, or -1
                      * if unknown. */
-} RedisModuleLoadingProgressV1;
+} ValkeyModuleLoadingProgressV1;
 
-#define RedisModuleLoadingProgress RedisModuleLoadingProgressV1
+#define ValkeyModuleLoadingProgress ValkeyModuleLoadingProgressV1
 
-#define REDISMODULE_SWAPDBINFO_VERSION 1
-typedef struct RedisModuleSwapDbInfo {
+#define VALKEYMODULE_SWAPDBINFO_VERSION 1
+typedef struct ValkeyModuleSwapDbInfo {
   uint64_t version;     /* Not used since this structure is never passed
                            from the module to the core right now. Here
                            for future compatibility. */
   int32_t dbnum_first;  /* Swap Db first dbnum */
   int32_t dbnum_second; /* Swap Db second dbnum */
-} RedisModuleSwapDbInfoV1;
+} ValkeyModuleSwapDbInfoV1;
 
-#define RedisModuleSwapDbInfo RedisModuleSwapDbInfoV1
+#define ValkeyModuleSwapDbInfo ValkeyModuleSwapDbInfoV1
 
-#define REDISMODULE_CLUSTERINFO_VERSION 1
-typedef struct RedisModuleClusterInfo {
+#define VALKEYMODULE_CLUSTERINFO_VERSION 1
+typedef struct ValkeyModuleClusterInfo {
   uint64_t version; /* Not used since this structure is never passed
                        from the module to the core right now. Here
                        for future compatibility. */
   int cluster_state;
   int cluster_my_state;
   int cluster_slots_assigned;
-} RedisModuleClusterInfoV1;
+} ValkeyModuleClusterInfoV1;
 
-#define RedisModuleClusterInfo RedisModuleClusterInfoV1
+#define ValkeyModuleClusterInfo ValkeyModuleClusterInfoV1
 
-#define REDISMODULE_CLUSTERINFO_INITIALIZER_V1 {.version = 1}
+#define VALKEYMODULE_CLUSTERINFO_INITIALIZER_V1 {.version = 1}
 
 /* If PSC connection cannot be extracted from a client,
  * Consider it to be 0. */
-#define REDISMODULE_PSC_CONNECTION_ID_ABSENT 0
+#define VALKEYMODULE_PSC_CONNECTION_ID_ABSENT 0
 
-typedef struct RedisModuleCrossClusterReplicaInfo {
+typedef struct ValkeyModuleCrossClusterReplicaInfo {
   uint64_t psc_connection_id;
-  char node_id[REDISMODULE_NODE_ID_LEN];
-} RedisModuleCrossClusterReplicaInfo;
+  char node_id[VALKEYMODULE_NODE_ID_LEN];
+} ValkeyModuleCrossClusterReplicaInfo;
 
-typedef struct RedisModuleCrossClusterReplicasList {
-  RedisModuleCrossClusterReplicaInfo *info;
-  struct RedisModuleCrossClusterReplicasList *next;
-} RedisModuleCrossClusterReplicasList;
+typedef struct ValkeyModuleCrossClusterReplicasList {
+  ValkeyModuleCrossClusterReplicaInfo *info;
+  struct ValkeyModuleCrossClusterReplicasList *next;
+} ValkeyModuleCrossClusterReplicasList;
 
 typedef enum {
-  REDISMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */
-  REDISMODULE_ACL_LOG_CMD,      /* Command authorization failure */
-  REDISMODULE_ACL_LOG_KEY,      /* Key authorization failure */
-  REDISMODULE_ACL_LOG_CHANNEL   /* Channel authorization failure */
-} RedisModuleACLLogEntryReason;
+  VALKEYMODULE_ACL_LOG_AUTH = 0, /* Authentication failure */
+  VALKEYMODULE_ACL_LOG_CMD,      /* Command authorization failure */
+  VALKEYMODULE_ACL_LOG_KEY,      /* Key authorization failure */
+  VALKEYMODULE_ACL_LOG_CHANNEL   /* Channel authorization failure */
+} ValkeyModuleACLLogEntryReason;
 
 typedef struct {
   uint64_t psc_connection_id; /* PSC connection ID to uniquely identify a PSC
@@ -836,7 +836,7 @@ typedef struct {
   const char *psc_ilb_ip;          /* PSC ILB IP address */
   int is_internal; /* Flag to indicate if the connection is from an internal
                       source */
-} RedisModuleConnectionProperty;
+} ValkeyModuleConnectionProperty;
 
 /* flags on the purpose of module rdb save or load */
 #define RDB_STREAM_FLAG_NONE 0
@@ -845,1387 +845,1408 @@ typedef struct {
 #define RDB_STREAM_FLAG_USE_RDB_COMPRESSION \
   (1 << 21) /* Use RDB compression when saving. */
 
-/* Version of the RedisModuleRIOHandler structure. Once the
- * RedisModuleRIOHandler structure is changed, this version number needs to be
+/* Version of the ValkeyModuleRIOHandler structure. Once the
+ * ValkeyModuleRIOHandler structure is changed, this version number needs to be
  * changed synchronistically. */
-#define REDISMODULE_RIO_HANDLER_VERSION 1
+#define VALKEYMODULE_RIO_HANDLER_VERSION 1
 
-typedef int (*RedisModuleRIOWriteFunc)(const void *buf, size_t len);
-typedef int (*RedisModuleRIOReadFunc)(void *buf, size_t len);
-typedef int (*RedisModuleRIOTellFunc)();
-typedef int (*RedisModuleRIOFlushFunc)();
-typedef int (*RedisModuleRIOCloseFunc)();
+typedef int (*ValkeyModuleRIOWriteFunc)(const void *buf, size_t len);
+typedef int (*ValkeyModuleRIOReadFunc)(void *buf, size_t len);
+typedef int (*ValkeyModuleRIOTellFunc)();
+typedef int (*ValkeyModuleRIOFlushFunc)();
+typedef int (*ValkeyModuleRIOCloseFunc)();
 
-typedef struct RedisModuleRIOHandler {
+typedef struct ValkeyModuleRIOHandler {
   uint64_t version;
-  RedisModuleRIOWriteFunc write_func;
-  RedisModuleRIOReadFunc read_func;
-  RedisModuleRIOTellFunc tell_func;
-  RedisModuleRIOFlushFunc flush_func;
-  RedisModuleRIOCloseFunc close_func;
-} RedisModuleRIOHandler;
+  ValkeyModuleRIOWriteFunc write_func;
+  ValkeyModuleRIOReadFunc read_func;
+  ValkeyModuleRIOTellFunc tell_func;
+  ValkeyModuleRIOFlushFunc flush_func;
+  ValkeyModuleRIOCloseFunc close_func;
+} ValkeyModuleRIOHandler;
 
 /* ------------------------- End of common defines ------------------------ */
 
-#ifndef REDISMODULE_CORE
+#ifndef VALKEYMODULE_CORE
 
 typedef long long mstime_t;
 
 /* Macro definitions specific to individual compilers */
-#ifndef REDISMODULE_ATTR_UNUSED
+#ifndef VALKEYMODULE_ATTR_UNUSED
 #ifdef __GNUC__
-#define REDISMODULE_ATTR_UNUSED __attribute__((unused))
+#define VALKEYMODULE_ATTR_UNUSED __attribute__((unused))
 #else
-#define REDISMODULE_ATTR_UNUSED
+#define VALKEYMODULE_ATTR_UNUSED
 #endif
 #endif
 
-#ifndef REDISMODULE_ATTR_PRINTF
+#ifndef VALKEYMODULE_ATTR_PRINTF
 #ifdef __GNUC__
-#define REDISMODULE_ATTR_PRINTF(idx, cnt) \
+#define VALKEYMODULE_ATTR_PRINTF(idx, cnt) \
   __attribute__((format(printf, idx, cnt)))
 #else
-#define REDISMODULE_ATTR_PRINTF(idx, cnt)
+#define VALKEYMODULE_ATTR_PRINTF(idx, cnt)
 #endif
 #endif
 
-#ifndef REDISMODULE_ATTR_COMMON
+#ifndef VALKEYMODULE_ATTR_COMMON
 #if defined(__GNUC__) && !(defined(__clang__) && defined(__cplusplus))
-#define REDISMODULE_ATTR_COMMON __attribute__((__common__))
+#define VALKEYMODULE_ATTR_COMMON __attribute__((__common__))
 #elif defined(__clang__)
-#define REDISMODULE_ATTR_COMMON __attribute__((weak))
+#define VALKEYMODULE_ATTR_COMMON __attribute__((weak))
 #else
-#define REDISMODULE_ATTR_COMMON
+#define VALKEYMODULE_ATTR_COMMON
 #endif
 #endif
 
 /* Incomplete structures for compiler checks but opaque access. */
-typedef struct RedisModuleCtx RedisModuleCtx;
-typedef struct RedisModuleCommand RedisModuleCommand;
-typedef struct RedisModuleKey RedisModuleKey;
-typedef struct RedisModuleString RedisModuleString;
-typedef struct RedisModuleCallReply RedisModuleCallReply;
-typedef struct RedisModuleIO RedisModuleIO;
-typedef struct RedisModuleType RedisModuleType;
-typedef struct RedisModuleDigest RedisModuleDigest;
-typedef struct RedisModuleBlockedClient RedisModuleBlockedClient;
-typedef struct RedisModuleDict RedisModuleDict;
-typedef struct RedisModuleDictIter RedisModuleDictIter;
-typedef struct RedisModuleCommandFilterCtx RedisModuleCommandFilterCtx;
-typedef struct RedisModuleCommandFilter RedisModuleCommandFilter;
-typedef struct RedisModuleInfoCtx RedisModuleInfoCtx;
-typedef struct RedisModuleServerInfoData RedisModuleServerInfoData;
-typedef struct RedisModuleScanCursor RedisModuleScanCursor;
-typedef struct RedisModuleDefragCtx RedisModuleDefragCtx;
-typedef struct RedisModuleUser RedisModuleUser;
-typedef struct RedisModuleKeyOptCtx RedisModuleKeyOptCtx;
-typedef struct RedisModuleRdbStream RedisModuleRdbStream;
+typedef struct ValkeyModuleCtx ValkeyModuleCtx;
+typedef struct ValkeyModuleCommand ValkeyModuleCommand;
+typedef struct ValkeyModuleKey ValkeyModuleKey;
+typedef struct ValkeyModuleString ValkeyModuleString;
+typedef struct ValkeyModuleCallReply ValkeyModuleCallReply;
+typedef struct ValkeyModuleIO ValkeyModuleIO;
+typedef struct ValkeyModuleType ValkeyModuleType;
+typedef struct ValkeyModuleDigest ValkeyModuleDigest;
+typedef struct ValkeyModuleBlockedClient ValkeyModuleBlockedClient;
+typedef struct ValkeyModuleDict ValkeyModuleDict;
+typedef struct ValkeyModuleDictIter ValkeyModuleDictIter;
+typedef struct ValkeyModuleCommandFilterCtx ValkeyModuleCommandFilterCtx;
+typedef struct ValkeyModuleCommandFilter ValkeyModuleCommandFilter;
+typedef struct ValkeyModuleInfoCtx ValkeyModuleInfoCtx;
+typedef struct ValkeyModuleServerInfoData ValkeyModuleServerInfoData;
+typedef struct ValkeyModuleScanCursor ValkeyModuleScanCursor;
+typedef struct ValkeyModuleDefragCtx ValkeyModuleDefragCtx;
+typedef struct ValkeyModuleUser ValkeyModuleUser;
+typedef struct ValkeyModuleKeyOptCtx ValkeyModuleKeyOptCtx;
+typedef struct ValkeyModuleRdbStream ValkeyModuleRdbStream;
 
-typedef int (*RedisModuleCmdFunc)(RedisModuleCtx *ctx, RedisModuleString **argv,
-                                  int argc);
-typedef void (*RedisModuleDisconnectFunc)(RedisModuleCtx *ctx,
-                                          RedisModuleBlockedClient *bc);
-typedef int (*RedisModuleNotificationFunc)(RedisModuleCtx *ctx, int type,
-                                           const char *event,
-                                           RedisModuleString *key);
-typedef void *(*RedisModuleTypeLoadFunc)(RedisModuleIO *rdb, int encver);
-typedef void (*RedisModuleTypeSaveFunc)(RedisModuleIO *rdb, void *value);
-typedef int (*RedisModuleTypeAuxLoadFunc)(RedisModuleIO *rdb, int encver,
-                                          int when);
-typedef void (*RedisModuleTypeAuxSaveFunc)(RedisModuleIO *rdb, int when);
-typedef void (*RedisModuleTypeRewriteFunc)(RedisModuleIO *aof,
-                                           RedisModuleString *key, void *value);
-typedef size_t (*RedisModuleTypeMemUsageFunc)(const void *value);
-typedef size_t (*RedisModuleTypeMemUsageFunc2)(RedisModuleKeyOptCtx *ctx,
-                                               const void *value,
-                                               size_t sample_size);
-typedef void (*RedisModuleTypeDigestFunc)(RedisModuleDigest *digest,
-                                          void *value);
-typedef void (*RedisModuleTypeFreeFunc)(void *value);
-typedef size_t (*RedisModuleTypeFreeEffortFunc)(RedisModuleString *key,
-                                                const void *value);
-typedef size_t (*RedisModuleTypeFreeEffortFunc2)(RedisModuleKeyOptCtx *ctx,
+typedef int (*ValkeyModuleCmdFunc)(ValkeyModuleCtx *ctx,
+                                   ValkeyModuleString **argv, int argc);
+typedef void (*ValkeyModuleDisconnectFunc)(ValkeyModuleCtx *ctx,
+                                           ValkeyModuleBlockedClient *bc);
+typedef int (*ValkeyModuleNotificationFunc)(ValkeyModuleCtx *ctx, int type,
+                                            const char *event,
+                                            ValkeyModuleString *key);
+typedef void *(*ValkeyModuleTypeLoadFunc)(ValkeyModuleIO *rdb, int encver);
+typedef void (*ValkeyModuleTypeSaveFunc)(ValkeyModuleIO *rdb, void *value);
+typedef int (*ValkeyModuleTypeAuxLoadFunc)(ValkeyModuleIO *rdb, int encver,
+                                           int when);
+typedef void (*ValkeyModuleTypeAuxSaveFunc)(ValkeyModuleIO *rdb, int when);
+typedef void (*ValkeyModuleTypeRewriteFunc)(ValkeyModuleIO *aof,
+                                            ValkeyModuleString *key,
+                                            void *value);
+typedef size_t (*ValkeyModuleTypeMemUsageFunc)(const void *value);
+typedef size_t (*ValkeyModuleTypeMemUsageFunc2)(ValkeyModuleKeyOptCtx *ctx,
+                                                const void *value,
+                                                size_t sample_size);
+typedef void (*ValkeyModuleTypeDigestFunc)(ValkeyModuleDigest *digest,
+                                           void *value);
+typedef void (*ValkeyModuleTypeFreeFunc)(void *value);
+typedef size_t (*ValkeyModuleTypeFreeEffortFunc)(ValkeyModuleString *key,
                                                  const void *value);
-typedef void (*RedisModuleTypeUnlinkFunc)(RedisModuleString *key,
-                                          const void *value);
-typedef void (*RedisModuleTypeUnlinkFunc2)(RedisModuleKeyOptCtx *ctx,
+typedef size_t (*ValkeyModuleTypeFreeEffortFunc2)(ValkeyModuleKeyOptCtx *ctx,
+                                                  const void *value);
+typedef void (*ValkeyModuleTypeUnlinkFunc)(ValkeyModuleString *key,
                                            const void *value);
-typedef void *(*RedisModuleTypeCopyFunc)(RedisModuleString *fromkey,
-                                         RedisModuleString *tokey,
-                                         const void *value);
-typedef void *(*RedisModuleTypeCopyFunc2)(RedisModuleKeyOptCtx *ctx,
+typedef void (*ValkeyModuleTypeUnlinkFunc2)(ValkeyModuleKeyOptCtx *ctx,
+                                            const void *value);
+typedef void *(*ValkeyModuleTypeCopyFunc)(ValkeyModuleString *fromkey,
+                                          ValkeyModuleString *tokey,
                                           const void *value);
-typedef int (*RedisModuleTypeDefragFunc)(RedisModuleDefragCtx *ctx,
-                                         RedisModuleString *key, void **value);
-typedef void (*RedisModuleClusterMessageReceiver)(RedisModuleCtx *ctx,
-                                                  const char *sender_id,
-                                                  uint8_t type,
-                                                  const unsigned char *payload,
-                                                  uint32_t len);
-typedef void (*RedisModuleTimerProc)(RedisModuleCtx *ctx, void *data);
-typedef void (*RedisModuleCommandFilterFunc)(
-    RedisModuleCommandFilterCtx *filter);
-typedef void (*RedisModuleForkDoneHandler)(int exitcode, int bysignal,
-                                           void *user_data);
-typedef void (*RedisModuleInfoFunc)(RedisModuleInfoCtx *ctx,
-                                    int for_crash_report);
-typedef void (*RedisModuleScanCB)(RedisModuleCtx *ctx,
-                                  RedisModuleString *keyname,
-                                  RedisModuleKey *key, void *privdata);
-typedef void (*RedisModuleScanKeyCB)(RedisModuleKey *key,
-                                     RedisModuleString *field,
-                                     RedisModuleString *value, void *privdata);
-typedef void (*RedisModuleUserChangedFunc)(uint64_t client_id, void *privdata);
-typedef int (*RedisModuleDefragFunc)(RedisModuleDefragCtx *ctx);
-typedef RedisModuleString *(*RedisModuleConfigGetStringFunc)(const char *name,
-                                                             void *privdata);
-typedef long long (*RedisModuleConfigGetNumericFunc)(const char *name,
-                                                     void *privdata);
-typedef int (*RedisModuleConfigGetBoolFunc)(const char *name, void *privdata);
-typedef int (*RedisModuleConfigGetEnumFunc)(const char *name, void *privdata);
-typedef int (*RedisModuleConfigSetStringFunc)(const char *name,
-                                              RedisModuleString *val,
-                                              void *privdata,
-                                              RedisModuleString **err);
-typedef int (*RedisModuleConfigSetNumericFunc)(const char *name, long long val,
+typedef void *(*ValkeyModuleTypeCopyFunc2)(ValkeyModuleKeyOptCtx *ctx,
+                                           const void *value);
+typedef int (*ValkeyModuleTypeDefragFunc)(ValkeyModuleDefragCtx *ctx,
+                                          ValkeyModuleString *key,
+                                          void **value);
+typedef void (*ValkeyModuleClusterMessageReceiver)(ValkeyModuleCtx *ctx,
+                                                   const char *sender_id,
+                                                   uint8_t type,
+                                                   const unsigned char *payload,
+                                                   uint32_t len);
+typedef void (*ValkeyModuleTimerProc)(ValkeyModuleCtx *ctx, void *data);
+typedef void (*ValkeyModuleCommandFilterFunc)(
+    ValkeyModuleCommandFilterCtx *filter);
+typedef void (*ValkeyModuleForkDoneHandler)(int exitcode, int bysignal,
+                                            void *user_data);
+typedef void (*ValkeyModuleInfoFunc)(ValkeyModuleInfoCtx *ctx,
+                                     int for_crash_report);
+typedef void (*ValkeyModuleScanCB)(ValkeyModuleCtx *ctx,
+                                   ValkeyModuleString *keyname,
+                                   ValkeyModuleKey *key, void *privdata);
+typedef void (*ValkeyModuleScanKeyCB)(ValkeyModuleKey *key,
+                                      ValkeyModuleString *field,
+                                      ValkeyModuleString *value,
+                                      void *privdata);
+typedef void (*ValkeyModuleUserChangedFunc)(uint64_t client_id, void *privdata);
+typedef int (*ValkeyModuleDefragFunc)(ValkeyModuleDefragCtx *ctx);
+typedef ValkeyModuleString *(*ValkeyModuleConfigGetStringFunc)(const char *name,
+                                                               void *privdata);
+typedef long long (*ValkeyModuleConfigGetNumericFunc)(const char *name,
+                                                      void *privdata);
+typedef int (*ValkeyModuleConfigGetBoolFunc)(const char *name, void *privdata);
+typedef int (*ValkeyModuleConfigGetEnumFunc)(const char *name, void *privdata);
+typedef int (*ValkeyModuleConfigSetStringFunc)(const char *name,
+                                               ValkeyModuleString *val,
                                                void *privdata,
-                                               RedisModuleString **err);
-typedef int (*RedisModuleConfigSetBoolFunc)(const char *name, int val,
-                                            void *privdata,
-                                            RedisModuleString **err);
-typedef int (*RedisModuleConfigSetEnumFunc)(const char *name, int val,
-                                            void *privdata,
-                                            RedisModuleString **err);
-typedef int (*RedisModuleConfigApplyFunc)(RedisModuleCtx *ctx, void *privdata,
-                                          RedisModuleString **err);
-typedef int (*RedisModuleAuthCallback)(RedisModuleCtx *ctx,
-                                       RedisModuleString *username,
-                                       RedisModuleString *password,
-                                       RedisModuleString **err);
-typedef char *(*RedisModuleHashExternCB)(void *privdata, size_t *len);
+                                               ValkeyModuleString **err);
+typedef int (*ValkeyModuleConfigSetNumericFunc)(const char *name, long long val,
+                                                void *privdata,
+                                                ValkeyModuleString **err);
+typedef int (*ValkeyModuleConfigSetBoolFunc)(const char *name, int val,
+                                             void *privdata,
+                                             ValkeyModuleString **err);
+typedef int (*ValkeyModuleConfigSetEnumFunc)(const char *name, int val,
+                                             void *privdata,
+                                             ValkeyModuleString **err);
+typedef int (*ValkeyModuleConfigApplyFunc)(ValkeyModuleCtx *ctx, void *privdata,
+                                           ValkeyModuleString **err);
+typedef int (*ValkeyModuleAuthCallback)(ValkeyModuleCtx *ctx,
+                                        ValkeyModuleString *username,
+                                        ValkeyModuleString *password,
+                                        ValkeyModuleString **err);
+typedef char *(*ValkeyModuleHashExternCB)(void *privdata, size_t *len);
 
-typedef struct RedisModuleTypeMethods {
+typedef struct ValkeyModuleTypeMethods {
   uint64_t version;
-  RedisModuleTypeLoadFunc rdb_load;
-  RedisModuleTypeSaveFunc rdb_save;
-  RedisModuleTypeRewriteFunc aof_rewrite;
-  RedisModuleTypeMemUsageFunc mem_usage;
-  RedisModuleTypeDigestFunc digest;
-  RedisModuleTypeFreeFunc free;
-  RedisModuleTypeAuxLoadFunc aux_load;
-  RedisModuleTypeAuxSaveFunc aux_save;
+  ValkeyModuleTypeLoadFunc rdb_load;
+  ValkeyModuleTypeSaveFunc rdb_save;
+  ValkeyModuleTypeRewriteFunc aof_rewrite;
+  ValkeyModuleTypeMemUsageFunc mem_usage;
+  ValkeyModuleTypeDigestFunc digest;
+  ValkeyModuleTypeFreeFunc free;
+  ValkeyModuleTypeAuxLoadFunc aux_load;
+  ValkeyModuleTypeAuxSaveFunc aux_save;
   int aux_save_triggers;
-  RedisModuleTypeFreeEffortFunc free_effort;
-  RedisModuleTypeUnlinkFunc unlink;
-  RedisModuleTypeCopyFunc copy;
-  RedisModuleTypeDefragFunc defrag;
-  RedisModuleTypeMemUsageFunc2 mem_usage2;
-  RedisModuleTypeFreeEffortFunc2 free_effort2;
-  RedisModuleTypeUnlinkFunc2 unlink2;
-  RedisModuleTypeCopyFunc2 copy2;
-  RedisModuleTypeAuxSaveFunc aux_save2;
-} RedisModuleTypeMethods;
+  ValkeyModuleTypeFreeEffortFunc free_effort;
+  ValkeyModuleTypeUnlinkFunc unlink;
+  ValkeyModuleTypeCopyFunc copy;
+  ValkeyModuleTypeDefragFunc defrag;
+  ValkeyModuleTypeMemUsageFunc2 mem_usage2;
+  ValkeyModuleTypeFreeEffortFunc2 free_effort2;
+  ValkeyModuleTypeUnlinkFunc2 unlink2;
+  ValkeyModuleTypeCopyFunc2 copy2;
+  ValkeyModuleTypeAuxSaveFunc aux_save2;
+} ValkeyModuleTypeMethods;
 
-#define REDISMODULE_GET_API(name) \
-  RedisModule_GetApi("RedisModule_" #name, ((void **)&RedisModule_##name))
+#define VALKEYMODULE_GET_API(name) \
+  ValkeyModule_GetApi("ValkeyModule_" #name, ((void **)&ValkeyModule_##name))
 
 /* Default API declaration prefix (not 'extern' for backwards compatibility) */
-#ifndef REDISMODULE_API
-#define REDISMODULE_API
+#ifndef VALKEYMODULE_API
+#define VALKEYMODULE_API
 #endif
 
 /* Default API declaration suffix (compiler attributes) */
-#ifndef REDISMODULE_ATTR
-#define REDISMODULE_ATTR REDISMODULE_ATTR_COMMON
+#ifndef VALKEYMODULE_ATTR
+#define VALKEYMODULE_ATTR VALKEYMODULE_ATTR_COMMON
 #endif
 
-REDISMODULE_API void *(*RedisModule_Alloc)(size_t bytes)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_TryAlloc)(size_t bytes)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_Realloc)(void *ptr,
-                                             size_t bytes)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_Free)(void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_Calloc)(size_t nmemb,
-                                            size_t size)REDISMODULE_ATTR;
-REDISMODULE_API char *(*RedisModule_Strdup)(const char *str)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetApi)(const char *,
-                                          void *) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CreateCommand)(RedisModuleCtx *ctx,
-                                                 const char *name,
-                                                 RedisModuleCmdFunc cmdfunc,
-                                                 const char *strflags,
-                                                 int firstkey, int lastkey,
-                                                 int keystep) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AddACLCategory)(
-    RedisModuleCtx *ctx, const char *name) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandACLCategories)(
-    RedisModuleCommand *command, const char *aclflags) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCommand *(*RedisModule_GetCommand)(
-    RedisModuleCtx *ctx, const char *name)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CreateSubcommand)(
-    RedisModuleCommand *parent, const char *name, RedisModuleCmdFunc cmdfunc,
+VALKEYMODULE_API void *(*ValkeyModule_Alloc)(size_t bytes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_TryAlloc)(size_t bytes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_Realloc)(void *ptr,
+                                               size_t bytes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_Free)(void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_Calloc)(size_t nmemb,
+                                              size_t size)VALKEYMODULE_ATTR;
+VALKEYMODULE_API char *(*ValkeyModule_Strdup)(const char *str)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetApi)(const char *,
+                                            void *) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CreateCommand)(
+    ValkeyModuleCtx *ctx, const char *name, ValkeyModuleCmdFunc cmdfunc,
     const char *strflags, int firstkey, int lastkey,
-    int keystep) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetCommandInfo)(
-    RedisModuleCommand *command,
-    const RedisModuleCommandInfo *info) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetModuleAttribs)(
-    RedisModuleCtx *ctx, const char *name, int ver,
-    int apiver) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsModuleNameBusy)(const char *name)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_WrongArity)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithLongLong)(
-    RedisModuleCtx *ctx, long long ll) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetSelectedDb)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SelectDb)(RedisModuleCtx *ctx,
-                                            int newid) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_KeyExists)(
-    RedisModuleCtx *ctx, RedisModuleString *keyname) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleKey *(*RedisModule_OpenKey)(
-    RedisModuleCtx *ctx, RedisModuleString *keyname, int mode)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetOpenKeyModesAll)() REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_CloseKey)(RedisModuleKey *kp)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_KeyType)(RedisModuleKey *kp) REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_ValueLength)(RedisModuleKey *kp)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ListPush)(
-    RedisModuleKey *kp, int where, RedisModuleString *ele) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_ListPop)(
-    RedisModuleKey *key, int where)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_ListGet)(
-    RedisModuleKey *key, long index)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ListSet)(
-    RedisModuleKey *key, long index, RedisModuleString *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ListInsert)(
-    RedisModuleKey *key, long index, RedisModuleString *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ListDelete)(RedisModuleKey *key,
-                                              long index) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply *(*RedisModule_Call)(RedisModuleCtx *ctx,
-                                                          const char *cmdname,
-                                                          const char *fmt,
-                                                          ...)REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_CallReplyProto)(
-    RedisModuleCallReply *reply, size_t *len)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeCallReply)(RedisModuleCallReply *reply)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CallReplyType)(RedisModuleCallReply *reply)
-    REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_CallReplyInteger)(
-    RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API double (*RedisModule_CallReplyDouble)(
-    RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CallReplyBool)(RedisModuleCallReply *reply)
-    REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_CallReplyBigNumber)(
-    RedisModuleCallReply *reply, size_t *len)REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_CallReplyVerbatim)(
-    RedisModuleCallReply *reply, size_t *len,
-    const char **format)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply *(*RedisModule_CallReplySetElement)(
-    RedisModuleCallReply *reply, size_t idx)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CallReplyMapElement)(
-    RedisModuleCallReply *reply, size_t idx, RedisModuleCallReply **key,
-    RedisModuleCallReply **val) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CallReplyAttributeElement)(
-    RedisModuleCallReply *reply, size_t idx, RedisModuleCallReply **key,
-    RedisModuleCallReply **val) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply *(*RedisModule_CallReplyAttribute)(
-    RedisModuleCallReply *reply)REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_CallReplyLength)(
-    RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCallReply *(*RedisModule_CallReplyArrayElement)(
-    RedisModuleCallReply *reply, size_t idx)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateString)(
-    RedisModuleCtx *ctx, const char *ptr, size_t len)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromLongLong)(
-    RedisModuleCtx *ctx, long long ll)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromULongLong)(
-    RedisModuleCtx *ctx, unsigned long long ull)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromDouble)(
-    RedisModuleCtx *ctx, double d)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromLongDouble)(
-    RedisModuleCtx *ctx, long double ld, int humanfriendly)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromString)(
-    RedisModuleCtx *ctx, const RedisModuleString *str)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromStreamID)(
-    RedisModuleCtx *ctx, const RedisModuleStreamID *id)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringPrintf)(
-    RedisModuleCtx *ctx, const char *fmt,
-    ...)REDISMODULE_ATTR_PRINTF(2, 3) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeString)(
-    RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_StringPtrLen)(
-    const RedisModuleString *str, size_t *len)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetConnectionProperties)(
-    const RedisModuleConnectionProperty *properties, int len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithError)(
-    RedisModuleCtx *ctx, const char *err) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithSimpleString)(
-    RedisModuleCtx *ctx, const char *msg) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithArray)(RedisModuleCtx *ctx,
-                                                  long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithMap)(RedisModuleCtx *ctx,
-                                                long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithSet)(RedisModuleCtx *ctx,
-                                                long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithAttribute)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithNullArray)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithEmptyArray)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetArrayLength)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetMapLength)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetSetLength)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetAttributeLength)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ReplySetPushLength)(
-    RedisModuleCtx *ctx, long len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithStringBuffer)(
-    RedisModuleCtx *ctx, const char *buf, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithCString)(
-    RedisModuleCtx *ctx, const char *buf) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithString)(
-    RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithEmptyString)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithVerbatimString)(
-    RedisModuleCtx *ctx, const char *buf, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithVerbatimStringType)(
-    RedisModuleCtx *ctx, const char *buf, size_t len,
-    const char *ext) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithNull)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithBool)(RedisModuleCtx *ctx,
-                                                 int b) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithLongDouble)(
-    RedisModuleCtx *ctx, long double d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithDouble)(RedisModuleCtx *ctx,
-                                                   double d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithBigNumber)(
-    RedisModuleCtx *ctx, const char *bignum, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplyWithCallReply)(
-    RedisModuleCtx *ctx, RedisModuleCallReply *reply) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToLongLong)(
-    const RedisModuleString *str, long long *ll) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToULongLong)(
-    const RedisModuleString *str, unsigned long long *ull) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToDouble)(const RedisModuleString *str,
-                                                  double *d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToLongDouble)(
-    const RedisModuleString *str, long double *d) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringToStreamID)(
-    const RedisModuleString *str, RedisModuleStreamID *id) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_AutoMemory)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Replicate)(RedisModuleCtx *ctx,
-                                             const char *cmdname,
-                                             const char *fmt,
-                                             ...) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplicateVerbatim)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_CallReplyStringPtr)(
-    RedisModuleCallReply *reply, size_t *len)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CreateStringFromCallReply)(
-    RedisModuleCallReply *reply)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DeleteKey)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_UnlinkKey)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringSet)(
-    RedisModuleKey *key, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API char *(*RedisModule_StringDMA)(RedisModuleKey *key, size_t *len,
-                                               int mode)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringTruncate)(
-    RedisModuleKey *key, size_t newlen) REDISMODULE_ATTR;
-REDISMODULE_API mstime_t (*RedisModule_GetExpire)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetExpire)(RedisModuleKey *key,
-                                             mstime_t expire) REDISMODULE_ATTR;
-REDISMODULE_API mstime_t (*RedisModule_GetAbsExpire)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetAbsExpire)(
-    RedisModuleKey *key, mstime_t expire) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ResetDataset)(int restart_aof,
-                                                 int async) REDISMODULE_ATTR;
-REDISMODULE_API unsigned long long (*RedisModule_DbSize)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_RandomKey)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetAdd)(RedisModuleKey *key, double score,
-                                           RedisModuleString *ele,
-                                           int *flagsptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetIncrby)(
-    RedisModuleKey *key, double score, RedisModuleString *ele, int *flagsptr,
-    double *newscore) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetScore)(RedisModuleKey *key,
-                                             RedisModuleString *ele,
-                                             double *score) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetRem)(RedisModuleKey *key,
-                                           RedisModuleString *ele,
-                                           int *deleted) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ZsetRangeStop)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetFirstInScoreRange)(
-    RedisModuleKey *key, double min, double max, int minex,
-    int maxex) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetLastInScoreRange)(
-    RedisModuleKey *key, double min, double max, int minex,
-    int maxex) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetFirstInLexRange)(
-    RedisModuleKey *key, RedisModuleString *min,
-    RedisModuleString *max) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetLastInLexRange)(
-    RedisModuleKey *key, RedisModuleString *min,
-    RedisModuleString *max) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_ZsetRangeCurrentElement)(
-    RedisModuleKey *key, double *score)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetRangeNext)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetRangePrev)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ZsetRangeEndReached)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_HashSet)(RedisModuleKey *key, int flags,
-                                           ...) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_HashGet)(RedisModuleKey *key, int flags,
-                                           ...) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamAdd)(
-    RedisModuleKey *key, int flags, RedisModuleStreamID *id,
-    RedisModuleString **argv, int64_t numfields) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamDelete)(
-    RedisModuleKey *key, RedisModuleStreamID *id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorStart)(
-    RedisModuleKey *key, int flags, RedisModuleStreamID *startid,
-    RedisModuleStreamID *endid) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorStop)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorNextID)(
-    RedisModuleKey *key, RedisModuleStreamID *id,
-    long *numfields) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorNextField)(
-    RedisModuleKey *key, RedisModuleString **field_ptr,
-    RedisModuleString **value_ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StreamIteratorDelete)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_StreamTrimByLength)(
-    RedisModuleKey *key, int flags, long long length) REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_StreamTrimByID)(
-    RedisModuleKey *key, int flags, RedisModuleStreamID *id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsKeysPositionRequest)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_KeyAtPos)(RedisModuleCtx *ctx,
-                                             int pos) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_KeyAtPosWithFlags)(
-    RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsChannelsPositionRequest)(
-    RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ChannelAtPosWithFlags)(
-    RedisModuleCtx *ctx, int pos, int flags) REDISMODULE_ATTR;
-REDISMODULE_API unsigned long long (*RedisModule_GetClientId)(
-    RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetClientUserNameById)(
-    RedisModuleCtx *ctx, uint64_t id)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetClientInfoById)(void *ci, uint64_t id)
-    REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetClientNameById)(
-    RedisModuleCtx *ctx, uint64_t id)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetClientNameById)(
-    uint64_t id, RedisModuleString *name) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_PublishMessage)(
-    RedisModuleCtx *ctx, RedisModuleString *channel,
-    RedisModuleString *message) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_PublishMessageShard)(
-    RedisModuleCtx *ctx, RedisModuleString *channel,
-    RedisModuleString *message) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetContextFlags)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AvoidReplicaTraffic)() REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_PoolAlloc)(RedisModuleCtx *ctx,
-                                               size_t bytes)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleType *(*RedisModule_CreateDataType)(
-    RedisModuleCtx *ctx, const char *name, int encver,
-    RedisModuleTypeMethods *typemethods)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ModuleTypeSetValue)(
-    RedisModuleKey *key, RedisModuleType *mt, void *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ModuleTypeReplaceValue)(
-    RedisModuleKey *key, RedisModuleType *mt, void *new_value,
-    void **old_value) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleType *(*RedisModule_ModuleTypeGetType)(
-    RedisModuleKey *key)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_ModuleTypeGetValue)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsIOError)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetModuleOptions)(
-    RedisModuleCtx *ctx, int options) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetModuleExtendedOptions)(
-    RedisModuleCtx *ctx, int options) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SignalModifiedKey)(
-    RedisModuleCtx *ctx, RedisModuleString *keyname) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveUnsigned)(
-    RedisModuleIO *io, uint64_t value) REDISMODULE_ATTR;
-REDISMODULE_API uint64_t (*RedisModule_LoadUnsigned)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveSigned)(RedisModuleIO *io,
-                                               int64_t value) REDISMODULE_ATTR;
-REDISMODULE_API int64_t (*RedisModule_LoadSigned)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_EmitAOF)(RedisModuleIO *io,
-                                            const char *cmdname,
-                                            const char *fmt,
-                                            ...) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveString)(
-    RedisModuleIO *io, RedisModuleString *s) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveStringBuffer)(
-    RedisModuleIO *io, const char *str, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_LoadString)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API char *(*RedisModule_LoadStringBuffer)(
-    RedisModuleIO *io, size_t *lenptr)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveDouble)(RedisModuleIO *io,
-                                               double value) REDISMODULE_ATTR;
-REDISMODULE_API double (*RedisModule_LoadDouble)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveFloat)(RedisModuleIO *io,
-                                              float value) REDISMODULE_ATTR;
-REDISMODULE_API float (*RedisModule_LoadFloat)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SaveLongDouble)(
-    RedisModuleIO *io, long double value) REDISMODULE_ATTR;
-REDISMODULE_API long double (*RedisModule_LoadLongDouble)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_LoadDataTypeFromString)(
-    const RedisModuleString *str, const RedisModuleType *mt)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_LoadDataTypeFromStringEncver)(
-    const RedisModuleString *str, const RedisModuleType *mt,
-    int encver)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_SaveDataTypeToString)(
-    RedisModuleCtx *ctx, void *data, const RedisModuleType *mt)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_Log)(RedisModuleCtx *ctx, const char *level,
-                                        const char *fmt, ...) REDISMODULE_ATTR
-    REDISMODULE_ATTR_PRINTF(3, 4);
-REDISMODULE_API void (*RedisModule_LogIOError)(RedisModuleIO *io,
-                                               const char *levelstr,
+    int keystep) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AddACLCategory)(
+    ValkeyModuleCtx *ctx, const char *name) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetCommandACLCategories)(
+    ValkeyModuleCommand *command, const char *aclflags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCommand *(*ValkeyModule_GetCommand)(
+    ValkeyModuleCtx *ctx, const char *name)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CreateSubcommand)(
+    ValkeyModuleCommand *parent, const char *name, ValkeyModuleCmdFunc cmdfunc,
+    const char *strflags, int firstkey, int lastkey,
+    int keystep) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetCommandInfo)(
+    ValkeyModuleCommand *command,
+    const ValkeyModuleCommandInfo *info) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetModuleAttribs)(
+    ValkeyModuleCtx *ctx, const char *name, int ver,
+    int apiver) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsModuleNameBusy)(const char *name)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_WrongArity)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithLongLong)(
+    ValkeyModuleCtx *ctx, long long ll) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetSelectedDb)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SelectDb)(ValkeyModuleCtx *ctx,
+                                              int newid) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_KeyExists)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *keyname) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleKey *(*ValkeyModule_OpenKey)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *keyname,
+    int mode)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetOpenKeyModesAll)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_CloseKey)(ValkeyModuleKey *kp)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_KeyType)(ValkeyModuleKey *kp)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_ValueLength)(ValkeyModuleKey *kp)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ListPush)(
+    ValkeyModuleKey *kp, int where, ValkeyModuleString *ele) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_ListPop)(
+    ValkeyModuleKey *key, int where)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_ListGet)(
+    ValkeyModuleKey *key, long index)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ListSet)(ValkeyModuleKey *key, long index,
+                                             ValkeyModuleString *value)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ListInsert)(
+    ValkeyModuleKey *key, long index,
+    ValkeyModuleString *value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ListDelete)(ValkeyModuleKey *key,
+                                                long index) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCallReply *(*ValkeyModule_Call)(
+    ValkeyModuleCtx *ctx, const char *cmdname, const char *fmt,
+    ...)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_CallReplyProto)(
+    ValkeyModuleCallReply *reply, size_t *len)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeCallReply)(
+    ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallReplyType)(ValkeyModuleCallReply *reply)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API long long (*ValkeyModule_CallReplyInteger)(
+    ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API double (*ValkeyModule_CallReplyDouble)(
+    ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallReplyBool)(ValkeyModuleCallReply *reply)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_CallReplyBigNumber)(
+    ValkeyModuleCallReply *reply, size_t *len)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_CallReplyVerbatim)(
+    ValkeyModuleCallReply *reply, size_t *len,
+    const char **format)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCallReply *(*ValkeyModule_CallReplySetElement)(
+    ValkeyModuleCallReply *reply, size_t idx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallReplyMapElement)(
+    ValkeyModuleCallReply *reply, size_t idx, ValkeyModuleCallReply **key,
+    ValkeyModuleCallReply **val) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CallReplyAttributeElement)(
+    ValkeyModuleCallReply *reply, size_t idx, ValkeyModuleCallReply **key,
+    ValkeyModuleCallReply **val) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCallReply *(*ValkeyModule_CallReplyAttribute)(
+    ValkeyModuleCallReply *reply)VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_CallReplyLength)(
+    ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCallReply *(*ValkeyModule_CallReplyArrayElement)(
+    ValkeyModuleCallReply *reply, size_t idx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateString)(
+    ValkeyModuleCtx *ctx, const char *ptr, size_t len)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromLongLong)(
+    ValkeyModuleCtx *ctx, long long ll)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromULongLong)(
+    ValkeyModuleCtx *ctx, unsigned long long ull)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromDouble)(
+    ValkeyModuleCtx *ctx, double d)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromLongDouble)(
+    ValkeyModuleCtx *ctx, long double ld, int humanfriendly)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromString)(
+    ValkeyModuleCtx *ctx, const ValkeyModuleString *str)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromStreamID)(
+    ValkeyModuleCtx *ctx, const ValkeyModuleStreamID *id)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringPrintf)(
+    ValkeyModuleCtx *ctx, const char *fmt,
+    ...)VALKEYMODULE_ATTR_PRINTF(2, 3) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeString)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_StringPtrLen)(
+    const ValkeyModuleString *str, size_t *len)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetConnectionProperties)(
+    const ValkeyModuleConnectionProperty *properties,
+    int len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithError)(
+    ValkeyModuleCtx *ctx, const char *err) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithSimpleString)(
+    ValkeyModuleCtx *ctx, const char *msg) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithArray)(ValkeyModuleCtx *ctx,
+                                                    long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithMap)(ValkeyModuleCtx *ctx,
+                                                  long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithSet)(ValkeyModuleCtx *ctx,
+                                                  long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithAttribute)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithNullArray)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithEmptyArray)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ReplySetArrayLength)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ReplySetMapLength)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ReplySetSetLength)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ReplySetAttributeLength)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ReplySetPushLength)(
+    ValkeyModuleCtx *ctx, long len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithStringBuffer)(
+    ValkeyModuleCtx *ctx, const char *buf, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithCString)(
+    ValkeyModuleCtx *ctx, const char *buf) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithString)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithEmptyString)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithVerbatimString)(
+    ValkeyModuleCtx *ctx, const char *buf, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithVerbatimStringType)(
+    ValkeyModuleCtx *ctx, const char *buf, size_t len,
+    const char *ext) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithNull)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithBool)(ValkeyModuleCtx *ctx,
+                                                   int b) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithLongDouble)(
+    ValkeyModuleCtx *ctx, long double d) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithDouble)(
+    ValkeyModuleCtx *ctx, double d) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithBigNumber)(
+    ValkeyModuleCtx *ctx, const char *bignum, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplyWithCallReply)(
+    ValkeyModuleCtx *ctx, ValkeyModuleCallReply *reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringToLongLong)(
+    const ValkeyModuleString *str, long long *ll) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringToULongLong)(
+    const ValkeyModuleString *str, unsigned long long *ull) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringToDouble)(
+    const ValkeyModuleString *str, double *d) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringToLongDouble)(
+    const ValkeyModuleString *str, long double *d) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringToStreamID)(
+    const ValkeyModuleString *str, ValkeyModuleStreamID *id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_AutoMemory)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_Replicate)(ValkeyModuleCtx *ctx,
+                                               const char *cmdname,
                                                const char *fmt,
-                                               ...) REDISMODULE_ATTR
-    REDISMODULE_ATTR_PRINTF(3, 4);
-REDISMODULE_API void (*RedisModule__Assert)(const char *estr, const char *file,
-                                            int line) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_LatencyAddSample)(
-    const char *event, mstime_t latency) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringAppendBuffer)(
-    RedisModuleCtx *ctx, RedisModuleString *str, const char *buf,
-    size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_TrimStringAllocation)(RedisModuleString *str)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RetainString)(
-    RedisModuleCtx *ctx, RedisModuleString *str) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_HoldString)(
-    RedisModuleCtx *ctx, RedisModuleString *str)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StringCompare)(
-    RedisModuleString *a, RedisModuleString *b) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx *(*RedisModule_GetContextFromIO)(
-    RedisModuleIO *io)REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromIO)(
-    RedisModuleIO *io)REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromModuleKey)(
-    RedisModuleKey *key)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetDbIdFromModuleKey)(RedisModuleKey *key)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetDbIdFromIO)(RedisModuleIO *io)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetDbIdFromOptCtx)(RedisModuleKeyOptCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetToDbIdFromOptCtx)(
-    RedisModuleKeyOptCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromOptCtx)(
-    RedisModuleKeyOptCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetToKeyNameFromOptCtx)(
-    RedisModuleKeyOptCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_Milliseconds)(void) REDISMODULE_ATTR;
-REDISMODULE_API uint64_t (*RedisModule_MonotonicMicroseconds)(void)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DigestAddStringBuffer)(
-    RedisModuleDigest *md, const char *ele, size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DigestAddLongLong)(
-    RedisModuleDigest *md, long long ele) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DigestEndSequence)(RedisModuleDigest *md)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetDbIdFromDigest)(RedisModuleDigest *dig)
-    REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromDigest)(
-    RedisModuleDigest *dig)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDict *(*RedisModule_CreateDict)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeDict)(
-    RedisModuleCtx *ctx, RedisModuleDict *d) REDISMODULE_ATTR;
-REDISMODULE_API uint64_t (*RedisModule_DictSize)(RedisModuleDict *d)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictSetC)(RedisModuleDict *d, void *key,
-                                            size_t keylen,
-                                            void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictReplaceC)(RedisModuleDict *d, void *key,
-                                                size_t keylen,
-                                                void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictSet)(RedisModuleDict *d,
-                                           RedisModuleString *key,
-                                           void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictReplace)(RedisModuleDict *d,
-                                               RedisModuleString *key,
-                                               void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_DictGetC)(RedisModuleDict *d, void *key,
+                                               ...) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplicateVerbatim)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_CallReplyStringPtr)(
+    ValkeyModuleCallReply *reply, size_t *len)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CreateStringFromCallReply)(
+    ValkeyModuleCallReply *reply)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DeleteKey)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_UnlinkKey)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringSet)(
+    ValkeyModuleKey *key, ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API char *(*ValkeyModule_StringDMA)(ValkeyModuleKey *key,
+                                                 size_t *len,
+                                                 int mode)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringTruncate)(
+    ValkeyModuleKey *key, size_t newlen) VALKEYMODULE_ATTR;
+VALKEYMODULE_API mstime_t (*ValkeyModule_GetExpire)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetExpire)(
+    ValkeyModuleKey *key, mstime_t expire) VALKEYMODULE_ATTR;
+VALKEYMODULE_API mstime_t (*ValkeyModule_GetAbsExpire)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetAbsExpire)(
+    ValkeyModuleKey *key, mstime_t expire) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ResetDataset)(int restart_aof,
+                                                   int async) VALKEYMODULE_ATTR;
+VALKEYMODULE_API unsigned long long (*ValkeyModule_DbSize)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_RandomKey)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetAdd)(ValkeyModuleKey *key, double score,
+                                             ValkeyModuleString *ele,
+                                             int *flagsptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetIncrby)(
+    ValkeyModuleKey *key, double score, ValkeyModuleString *ele, int *flagsptr,
+    double *newscore) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetScore)(ValkeyModuleKey *key,
+                                               ValkeyModuleString *ele,
+                                               double *score) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetRem)(ValkeyModuleKey *key,
+                                             ValkeyModuleString *ele,
+                                             int *deleted) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ZsetRangeStop)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetFirstInScoreRange)(
+    ValkeyModuleKey *key, double min, double max, int minex,
+    int maxex) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetLastInScoreRange)(
+    ValkeyModuleKey *key, double min, double max, int minex,
+    int maxex) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetFirstInLexRange)(
+    ValkeyModuleKey *key, ValkeyModuleString *min,
+    ValkeyModuleString *max) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetLastInLexRange)(
+    ValkeyModuleKey *key, ValkeyModuleString *min,
+    ValkeyModuleString *max) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_ZsetRangeCurrentElement)(
+    ValkeyModuleKey *key, double *score)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetRangeNext)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetRangePrev)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ZsetRangeEndReached)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_HashSet)(ValkeyModuleKey *key, int flags,
+                                             ...) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_HashGet)(ValkeyModuleKey *key, int flags,
+                                             ...) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamAdd)(
+    ValkeyModuleKey *key, int flags, ValkeyModuleStreamID *id,
+    ValkeyModuleString **argv, int64_t numfields) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamDelete)(
+    ValkeyModuleKey *key, ValkeyModuleStreamID *id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamIteratorStart)(
+    ValkeyModuleKey *key, int flags, ValkeyModuleStreamID *startid,
+    ValkeyModuleStreamID *endid) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamIteratorStop)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamIteratorNextID)(
+    ValkeyModuleKey *key, ValkeyModuleStreamID *id,
+    long *numfields) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamIteratorNextField)(
+    ValkeyModuleKey *key, ValkeyModuleString **field_ptr,
+    ValkeyModuleString **value_ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StreamIteratorDelete)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API long long (*ValkeyModule_StreamTrimByLength)(
+    ValkeyModuleKey *key, int flags, long long length) VALKEYMODULE_ATTR;
+VALKEYMODULE_API long long (*ValkeyModule_StreamTrimByID)(
+    ValkeyModuleKey *key, int flags,
+    ValkeyModuleStreamID *id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsKeysPositionRequest)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_KeyAtPos)(ValkeyModuleCtx *ctx,
+                                               int pos) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_KeyAtPosWithFlags)(
+    ValkeyModuleCtx *ctx, int pos, int flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsChannelsPositionRequest)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ChannelAtPosWithFlags)(
+    ValkeyModuleCtx *ctx, int pos, int flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API unsigned long long (*ValkeyModule_GetClientId)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientUserNameById)(
+    ValkeyModuleCtx *ctx, uint64_t id)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetClientInfoById)(void *ci, uint64_t id)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientNameById)(
+    ValkeyModuleCtx *ctx, uint64_t id)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetClientNameById)(
+    uint64_t id, ValkeyModuleString *name) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_PublishMessage)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *channel,
+    ValkeyModuleString *message) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_PublishMessageShard)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *channel,
+    ValkeyModuleString *message) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetContextFlags)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AvoidReplicaTraffic)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_PoolAlloc)(ValkeyModuleCtx *ctx,
+                                                 size_t bytes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleType *(*ValkeyModule_CreateDataType)(
+    ValkeyModuleCtx *ctx, const char *name, int encver,
+    ValkeyModuleTypeMethods *typemethods)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ModuleTypeSetValue)(
+    ValkeyModuleKey *key, ValkeyModuleType *mt, void *value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ModuleTypeReplaceValue)(
+    ValkeyModuleKey *key, ValkeyModuleType *mt, void *new_value,
+    void **old_value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleType *(*ValkeyModule_ModuleTypeGetType)(
+    ValkeyModuleKey *key)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_ModuleTypeGetValue)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsIOError)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetModuleOptions)(
+    ValkeyModuleCtx *ctx, int options) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetModuleExtendedOptions)(
+    ValkeyModuleCtx *ctx, int options) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SignalModifiedKey)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *keyname) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveUnsigned)(
+    ValkeyModuleIO *io, uint64_t value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API uint64_t (*ValkeyModule_LoadUnsigned)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveSigned)(
+    ValkeyModuleIO *io, int64_t value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int64_t (*ValkeyModule_LoadSigned)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_EmitAOF)(ValkeyModuleIO *io,
+                                              const char *cmdname,
+                                              const char *fmt,
+                                              ...) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveString)(
+    ValkeyModuleIO *io, ValkeyModuleString *s) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveStringBuffer)(
+    ValkeyModuleIO *io, const char *str, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_LoadString)(
+    ValkeyModuleIO *io)VALKEYMODULE_ATTR;
+VALKEYMODULE_API char *(*ValkeyModule_LoadStringBuffer)(
+    ValkeyModuleIO *io, size_t *lenptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveDouble)(
+    ValkeyModuleIO *io, double value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API double (*ValkeyModule_LoadDouble)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveFloat)(ValkeyModuleIO *io,
+                                                float value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API float (*ValkeyModule_LoadFloat)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SaveLongDouble)(
+    ValkeyModuleIO *io, long double value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API long double (*ValkeyModule_LoadLongDouble)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_LoadDataTypeFromString)(
+    const ValkeyModuleString *str, const ValkeyModuleType *mt)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_LoadDataTypeFromStringEncver)(
+    const ValkeyModuleString *str, const ValkeyModuleType *mt,
+    int encver)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_SaveDataTypeToString)(
+    ValkeyModuleCtx *ctx, void *data,
+    const ValkeyModuleType *mt)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_Log)(ValkeyModuleCtx *ctx,
+                                          const char *level, const char *fmt,
+                                          ...) VALKEYMODULE_ATTR
+    VALKEYMODULE_ATTR_PRINTF(3, 4);
+VALKEYMODULE_API void (*ValkeyModule_LogIOError)(ValkeyModuleIO *io,
+                                                 const char *levelstr,
+                                                 const char *fmt,
+                                                 ...) VALKEYMODULE_ATTR
+    VALKEYMODULE_ATTR_PRINTF(3, 4);
+VALKEYMODULE_API void (*ValkeyModule__Assert)(const char *estr,
+                                              const char *file,
+                                              int line) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_LatencyAddSample)(
+    const char *event, mstime_t latency) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringAppendBuffer)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *str, const char *buf,
+    size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_TrimStringAllocation)(
+    ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_RetainString)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_HoldString)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *str)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StringCompare)(
+    ValkeyModuleString *a, ValkeyModuleString *b) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCtx *(*ValkeyModule_GetContextFromIO)(
+    ValkeyModuleIO *io)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(*ValkeyModule_GetKeyNameFromIO)(
+    ValkeyModuleIO *io)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(
+    *ValkeyModule_GetKeyNameFromModuleKey)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetDbIdFromModuleKey)(ValkeyModuleKey *key)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetDbIdFromIO)(ValkeyModuleIO *io)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetDbIdFromOptCtx)(
+    ValkeyModuleKeyOptCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetToDbIdFromOptCtx)(
+    ValkeyModuleKeyOptCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(*ValkeyModule_GetKeyNameFromOptCtx)(
+    ValkeyModuleKeyOptCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(
+    *ValkeyModule_GetToKeyNameFromOptCtx)(ValkeyModuleKeyOptCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API long long (*ValkeyModule_Milliseconds)(void) VALKEYMODULE_ATTR;
+VALKEYMODULE_API uint64_t (*ValkeyModule_MonotonicMicroseconds)(void)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_DigestAddStringBuffer)(
+    ValkeyModuleDigest *md, const char *ele, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_DigestAddLongLong)(
+    ValkeyModuleDigest *md, long long ele) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_DigestEndSequence)(ValkeyModuleDigest *md)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetDbIdFromDigest)(ValkeyModuleDigest *dig)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(*ValkeyModule_GetKeyNameFromDigest)(
+    ValkeyModuleDigest *dig)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleDict *(*ValkeyModule_CreateDict)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeDict)(
+    ValkeyModuleCtx *ctx, ValkeyModuleDict *d) VALKEYMODULE_ATTR;
+VALKEYMODULE_API uint64_t (*ValkeyModule_DictSize)(ValkeyModuleDict *d)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictSetC)(ValkeyModuleDict *d, void *key,
                                               size_t keylen,
-                                              int *nokey)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_DictGet)(RedisModuleDict *d,
-                                             RedisModuleString *key,
-                                             int *nokey)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictDelC)(RedisModuleDict *d, void *key,
-                                            size_t keylen,
-                                            void *oldval) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictDel)(RedisModuleDict *d,
-                                           RedisModuleString *key,
-                                           void *oldval) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDictIter *(*RedisModule_DictIteratorStartC)(
-    RedisModuleDict *d, const char *op, void *key,
-    size_t keylen)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleDictIter *(*RedisModule_DictIteratorStart)(
-    RedisModuleDict *d, const char *op, RedisModuleString *key)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_DictIteratorStop)(RedisModuleDictIter *di)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictIteratorReseekC)(
-    RedisModuleDictIter *di, const char *op, void *key,
-    size_t keylen) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictIteratorReseek)(
-    RedisModuleDictIter *di, const char *op,
-    RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_DictNextC)(RedisModuleDictIter *di,
-                                               size_t *keylen,
-                                               void **dataptr)REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_DictPrevC)(RedisModuleDictIter *di,
-                                               size_t *keylen,
-                                               void **dataptr)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_DictNext)(
-    RedisModuleCtx *ctx, RedisModuleDictIter *di,
-    void **dataptr)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_DictPrev)(
-    RedisModuleCtx *ctx, RedisModuleDictIter *di,
-    void **dataptr)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictCompareC)(RedisModuleDictIter *di,
-                                                const char *op, void *key,
-                                                size_t keylen) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DictCompare)(
-    RedisModuleDictIter *di, const char *op,
-    RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterInfoFunc)(
-    RedisModuleCtx *ctx, RedisModuleInfoFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RegisterAuthCallback)(
-    RedisModuleCtx *ctx, RedisModuleAuthCallback cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddSection)(
-    RedisModuleInfoCtx *ctx, const char *name) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoBeginDictField)(
-    RedisModuleInfoCtx *ctx, const char *name) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoEndDictField)(RedisModuleInfoCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldString)(
-    RedisModuleInfoCtx *ctx, const char *field,
-    RedisModuleString *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldCString)(
-    RedisModuleInfoCtx *ctx, const char *field,
-    const char *value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldDouble)(
-    RedisModuleInfoCtx *ctx, const char *field, double value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldLongLong)(
-    RedisModuleInfoCtx *ctx, const char *field,
-    long long value) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_InfoAddFieldULongLong)(
-    RedisModuleInfoCtx *ctx, const char *field,
-    unsigned long long value) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleServerInfoData *(*RedisModule_GetServerInfo)(
-    RedisModuleCtx *ctx, const char *section)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeServerInfo)(
-    RedisModuleCtx *ctx, RedisModuleServerInfoData *data) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_ServerInfoGetField)(
-    RedisModuleCtx *ctx, RedisModuleServerInfoData *data,
-    const char *field)REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_ServerInfoGetFieldC)(
-    RedisModuleServerInfoData *data, const char *field)REDISMODULE_ATTR;
-REDISMODULE_API long long (*RedisModule_ServerInfoGetFieldSigned)(
-    RedisModuleServerInfoData *data, const char *field,
-    int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API unsigned long long (*RedisModule_ServerInfoGetFieldUnsigned)(
-    RedisModuleServerInfoData *data, const char *field,
-    int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API double (*RedisModule_ServerInfoGetFieldDouble)(
-    RedisModuleServerInfoData *data, const char *field,
-    int *out_err) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetClusterInfo)(void *cli) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SubscribeToServerEvent)(
-    RedisModuleCtx *ctx, RedisModuleEvent event,
-    RedisModuleEventCallback callback) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetLRU)(RedisModuleKey *key,
-                                          mstime_t lru_idle) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetLRU)(RedisModuleKey *key,
-                                          mstime_t *lru_idle) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetLFU)(RedisModuleKey *key,
-                                          long long lfu_freq) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetLFU)(RedisModuleKey *key,
-                                          long long *lfu_freq) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_BlockClientOnKeys)(
-    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback,
-    RedisModuleCmdFunc timeout_callback,
-    void (*free_privdata)(RedisModuleCtx *, void *), long long timeout_ms,
-    RedisModuleString **keys, int numkeys, void *privdata)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SignalKeyAsReady)(
-    RedisModuleCtx *ctx, RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetBlockedClientReadyKey)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleScanCursor *(*RedisModule_ScanCursorCreate)()
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ScanCursorRestart)(
-    RedisModuleScanCursor *cursor) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ScanCursorDestroy)(
-    RedisModuleScanCursor *cursor) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Scan)(RedisModuleCtx *ctx,
-                                        RedisModuleScanCursor *cursor,
-                                        RedisModuleScanCB fn,
-                                        void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ScanKey)(RedisModuleKey *key,
-                                           RedisModuleScanCursor *cursor,
-                                           RedisModuleScanKeyCB fn,
-                                           void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetContextFlagsAll)() REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetKeyspaceNotificationFlagsAll)()
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsSubEventSupported)(
-    RedisModuleEvent event, uint64_t subevent) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetServerVersion)() REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetTypeMethodVersion)() REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_Yield)(
-    RedisModuleCtx *ctx, int flags, const char *busy_reply) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_BlockClient)(
-    RedisModuleCtx *ctx, RedisModuleCmdFunc reply_callback,
-    RedisModuleCmdFunc timeout_callback,
-    void (*free_privdata)(RedisModuleCtx *, void *),
-    long long timeout_ms)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_BlockClientOnAuth)(
-    RedisModuleCtx *ctx, RedisModuleAuthCallback reply_callback,
-    void (*free_privdata)(RedisModuleCtx *, void *))REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_UnblockClient)(
-    RedisModuleBlockedClient *bc, void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsBlockedReplyRequest)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_IsBlockedTimeoutRequest)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_GetBlockedClientPrivateData)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleBlockedClient *(*RedisModule_GetBlockedClientHandle)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AbortBlock)(RedisModuleBlockedClient *bc)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_BlockedClientMeasureTimeStart)(
-    RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_BlockedClientMeasureTimeEnd)(
-    RedisModuleBlockedClient *bc) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx *(*RedisModule_GetThreadSafeContext)(
-    RedisModuleBlockedClient *bc)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCtx *(*RedisModule_GetDetachedThreadSafeContext)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeThreadSafeContext)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ThreadSafeContextLock)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ThreadSafeContextTryLock)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ThreadSafeContextUnlock)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SubscribeToKeyspaceEvents)(
-    RedisModuleCtx *ctx, int types,
-    RedisModuleNotificationFunc cb) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_NotifyKeyspaceEvent)(
-    RedisModuleCtx *ctx, int type, const char *event,
-    RedisModuleString *key) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetNotifyKeyspaceEvents)() REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_BlockedClientDisconnected)(
-    RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RegisterClusterMessageReceiver)(
-    RedisModuleCtx *ctx, uint8_t type,
-    RedisModuleClusterMessageReceiver callback) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SendClusterMessage)(
-    RedisModuleCtx *ctx, const char *target_id, uint8_t type, const char *msg,
-    uint32_t len) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetClusterNodeInfo)(
-    RedisModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port,
-    int *flags) REDISMODULE_ATTR;
-REDISMODULE_API char **(*RedisModule_GetClusterNodesList)(
-    RedisModuleCtx *ctx, size_t *numnodes)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeClusterNodesList)(char **ids)
-    REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleTimerID (*RedisModule_CreateTimer)(
-    RedisModuleCtx *ctx, mstime_t period, RedisModuleTimerProc callback,
-    void *data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_StopTimer)(RedisModuleCtx *ctx,
-                                             RedisModuleTimerID id,
-                                             void **data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetTimerInfo)(RedisModuleCtx *ctx,
-                                                RedisModuleTimerID id,
-                                                uint64_t *remaining,
-                                                void **data) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCrossClusterReplicasList *(
-    *RedisModule_GetCrossClusterReplicasList)(void)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeCrossClusterReplicasList)(
-    RedisModuleCrossClusterReplicasList *head) REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_GetMyClusterID)(void)REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_GetMyShardID)(void)REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_GetClusterSize)(void) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_GetRandomBytes)(unsigned char *dst,
-                                                   size_t len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_GetRandomHexChars)(char *dst, size_t len)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetShardId)(const char *shardId,
-                                              int len) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetDisconnectCallback)(
-    RedisModuleBlockedClient *bc,
-    RedisModuleDisconnectFunc callback) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetClusterFlags)(
-    RedisModuleCtx *ctx, uint64_t flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ExportSharedAPI)(RedisModuleCtx *ctx,
-                                                   const char *apiname,
-                                                   void *func) REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_GetSharedAPI)(
-    RedisModuleCtx *ctx, const char *apiname)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleCommandFilter *(*RedisModule_RegisterCommandFilter)(
-    RedisModuleCtx *ctx, RedisModuleCommandFilterFunc cb,
-    int flags)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_UnregisterCommandFilter)(
-    RedisModuleCtx *ctx, RedisModuleCommandFilter *filter) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgsCount)(
-    RedisModuleCommandFilterCtx *fctx) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_CommandFilterArgGet)(
-    RedisModuleCommandFilterCtx *fctx, int pos)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgInsert)(
-    RedisModuleCommandFilterCtx *fctx, int pos,
-    RedisModuleString *arg) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgReplace)(
-    RedisModuleCommandFilterCtx *fctx, int pos,
-    RedisModuleString *arg) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_CommandFilterArgDelete)(
-    RedisModuleCommandFilterCtx *fctx, int pos) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_Fork)(RedisModuleForkDoneHandler cb,
-                                        void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SendChildHeartbeat)(double progress)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ExitFromChild)(int retcode) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_KillForkChild)(int child_pid)
-    REDISMODULE_ATTR;
-REDISMODULE_API float (*RedisModule_GetUsedMemoryRatio)() REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_MallocSize)(void *ptr) REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_MallocUsableSize)(void *ptr)
-    REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_MallocSizeString)(RedisModuleString *str)
-    REDISMODULE_ATTR;
-REDISMODULE_API size_t (*RedisModule_MallocSizeDict)(RedisModuleDict *dict)
-    REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleUser *(*RedisModule_CreateModuleUser)(
-    const char *name)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_FreeModuleUser)(RedisModuleUser *user)
-    REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_SetContextUser)(
-    RedisModuleCtx *ctx, const RedisModuleUser *user) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetModuleUserACL)(
-    RedisModuleUser *user, const char *acl) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_SetModuleUserACLString)(
-    RedisModuleCtx *ctx, RedisModuleUser *user, const char *acl,
-    RedisModuleString **error) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetModuleUserACLString)(
-    RedisModuleUser *user)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetCurrentUserName)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleUser *(*RedisModule_GetModuleUserFromUserName)(
-    RedisModuleString *name)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ACLCheckCommandPermissions)(
-    RedisModuleUser *user, RedisModuleString **argv, int argc) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ACLCheckKeyPermissions)(
-    RedisModuleUser *user, RedisModuleString *key, int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ACLCheckChannelPermissions)(
-    RedisModuleUser *user, RedisModuleString *ch, int literal) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ACLAddLogEntry)(
-    RedisModuleCtx *ctx, RedisModuleUser *user, RedisModuleString *object,
-    RedisModuleACLLogEntryReason reason) REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_ACLAddLogEntryByUserName)(
-    RedisModuleCtx *ctx, RedisModuleString *user, RedisModuleString *object,
-    RedisModuleACLLogEntryReason reason) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AuthenticateClientWithACLUser)(
-    RedisModuleCtx *ctx, const char *name, size_t len,
-    RedisModuleUserChangedFunc callback, void *privdata,
-    uint64_t *client_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_AuthenticateClientWithUser)(
-    RedisModuleCtx *ctx, RedisModuleUser *user,
-    RedisModuleUserChangedFunc callback, void *privdata,
-    uint64_t *client_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DeauthenticateAndCloseClient)(
-    RedisModuleCtx *ctx, uint64_t client_id) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RedactClientCommandArgument)(
-    RedisModuleCtx *ctx, int pos) REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_GetClientCertificate)(
-    RedisModuleCtx *ctx, uint64_t id)REDISMODULE_ATTR;
-REDISMODULE_API int *(*RedisModule_GetCommandKeys)(
-    RedisModuleCtx *ctx, RedisModuleString **argv, int argc,
-    int *num_keys)REDISMODULE_ATTR;
-REDISMODULE_API int *(*RedisModule_GetCommandKeysWithFlags)(
-    RedisModuleCtx *ctx, RedisModuleString **argv, int argc, int *num_keys,
-    int **out_flags)REDISMODULE_ATTR;
-REDISMODULE_API const char *(*RedisModule_GetCurrentCommandName)(
-    RedisModuleCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterDefragFunc)(
-    RedisModuleCtx *ctx, RedisModuleDefragFunc func) REDISMODULE_ATTR;
-REDISMODULE_API void *(*RedisModule_DefragAlloc)(RedisModuleDefragCtx *ctx,
-                                                 void *ptr)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleString *(*RedisModule_DefragRedisModuleString)(
-    RedisModuleDefragCtx *ctx, RedisModuleString *str)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DefragShouldStop)(RedisModuleDefragCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DefragCursorSet)(
-    RedisModuleDefragCtx *ctx, unsigned long cursor) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_DefragCursorGet)(
-    RedisModuleDefragCtx *ctx, unsigned long *cursor) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_GetDbIdFromDefragCtx)(
-    RedisModuleDefragCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API const RedisModuleString *(*RedisModule_GetKeyNameFromDefragCtx)(
-    RedisModuleDefragCtx *ctx)REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_EventLoopAdd)(
-    int fd, int mask, RedisModuleEventLoopFunc func,
-    void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_EventLoopDel)(int fd,
-                                                int mask) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_EventLoopAddOneShot)(
-    RedisModuleEventLoopOneShotFunc func, void *user_data) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterBoolConfig)(
-    RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
-    RedisModuleConfigGetBoolFunc getfn, RedisModuleConfigSetBoolFunc setfn,
-    RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterNumericConfig)(
-    RedisModuleCtx *ctx, const char *name, long long default_val,
+                                              void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictReplaceC)(ValkeyModuleDict *d,
+                                                  void *key, size_t keylen,
+                                                  void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictSet)(ValkeyModuleDict *d,
+                                             ValkeyModuleString *key,
+                                             void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictReplace)(ValkeyModuleDict *d,
+                                                 ValkeyModuleString *key,
+                                                 void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_DictGetC)(ValkeyModuleDict *d, void *key,
+                                                size_t keylen,
+                                                int *nokey)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_DictGet)(ValkeyModuleDict *d,
+                                               ValkeyModuleString *key,
+                                               int *nokey)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictDelC)(ValkeyModuleDict *d, void *key,
+                                              size_t keylen,
+                                              void *oldval) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictDel)(ValkeyModuleDict *d,
+                                             ValkeyModuleString *key,
+                                             void *oldval) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleDictIter *(*ValkeyModule_DictIteratorStartC)(
+    ValkeyModuleDict *d, const char *op, void *key,
+    size_t keylen)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleDictIter *(*ValkeyModule_DictIteratorStart)(
+    ValkeyModuleDict *d, const char *op,
+    ValkeyModuleString *key)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_DictIteratorStop)(ValkeyModuleDictIter *di)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictIteratorReseekC)(
+    ValkeyModuleDictIter *di, const char *op, void *key,
+    size_t keylen) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictIteratorReseek)(
+    ValkeyModuleDictIter *di, const char *op,
+    ValkeyModuleString *key) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_DictNextC)(
+    ValkeyModuleDictIter *di, size_t *keylen, void **dataptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_DictPrevC)(
+    ValkeyModuleDictIter *di, size_t *keylen, void **dataptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_DictNext)(
+    ValkeyModuleCtx *ctx, ValkeyModuleDictIter *di,
+    void **dataptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_DictPrev)(
+    ValkeyModuleCtx *ctx, ValkeyModuleDictIter *di,
+    void **dataptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictCompareC)(
+    ValkeyModuleDictIter *di, const char *op, void *key,
+    size_t keylen) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DictCompare)(
+    ValkeyModuleDictIter *di, const char *op,
+    ValkeyModuleString *key) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterInfoFunc)(
+    ValkeyModuleCtx *ctx, ValkeyModuleInfoFunc cb) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_RegisterAuthCallback)(
+    ValkeyModuleCtx *ctx, ValkeyModuleAuthCallback cb) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddSection)(
+    ValkeyModuleInfoCtx *ctx, const char *name) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoBeginDictField)(
+    ValkeyModuleInfoCtx *ctx, const char *name) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoEndDictField)(ValkeyModuleInfoCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddFieldString)(
+    ValkeyModuleInfoCtx *ctx, const char *field,
+    ValkeyModuleString *value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddFieldCString)(
+    ValkeyModuleInfoCtx *ctx, const char *field,
+    const char *value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddFieldDouble)(
+    ValkeyModuleInfoCtx *ctx, const char *field,
+    double value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddFieldLongLong)(
+    ValkeyModuleInfoCtx *ctx, const char *field,
+    long long value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_InfoAddFieldULongLong)(
+    ValkeyModuleInfoCtx *ctx, const char *field,
+    unsigned long long value) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleServerInfoData *(*ValkeyModule_GetServerInfo)(
+    ValkeyModuleCtx *ctx, const char *section)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeServerInfo)(
+    ValkeyModuleCtx *ctx, ValkeyModuleServerInfoData *data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_ServerInfoGetField)(
+    ValkeyModuleCtx *ctx, ValkeyModuleServerInfoData *data,
+    const char *field)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_ServerInfoGetFieldC)(
+    ValkeyModuleServerInfoData *data, const char *field)VALKEYMODULE_ATTR;
+VALKEYMODULE_API long long (*ValkeyModule_ServerInfoGetFieldSigned)(
+    ValkeyModuleServerInfoData *data, const char *field,
+    int *out_err) VALKEYMODULE_ATTR;
+VALKEYMODULE_API unsigned long long (*ValkeyModule_ServerInfoGetFieldUnsigned)(
+    ValkeyModuleServerInfoData *data, const char *field,
+    int *out_err) VALKEYMODULE_ATTR;
+VALKEYMODULE_API double (*ValkeyModule_ServerInfoGetFieldDouble)(
+    ValkeyModuleServerInfoData *data, const char *field,
+    int *out_err) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetClusterInfo)(void *cli)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SubscribeToServerEvent)(
+    ValkeyModuleCtx *ctx, ValkeyModuleEvent event,
+    ValkeyModuleEventCallback callback) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetLRU)(
+    ValkeyModuleKey *key, mstime_t lru_idle) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetLRU)(
+    ValkeyModuleKey *key, mstime_t *lru_idle) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetLFU)(
+    ValkeyModuleKey *key, long long lfu_freq) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetLFU)(
+    ValkeyModuleKey *key, long long *lfu_freq) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleBlockedClient *(*ValkeyModule_BlockClientOnKeys)(
+    ValkeyModuleCtx *ctx, ValkeyModuleCmdFunc reply_callback,
+    ValkeyModuleCmdFunc timeout_callback,
+    void (*free_privdata)(ValkeyModuleCtx *, void *), long long timeout_ms,
+    ValkeyModuleString **keys, int numkeys, void *privdata)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SignalKeyAsReady)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *key) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetBlockedClientReadyKey)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleScanCursor *(*ValkeyModule_ScanCursorCreate)()
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ScanCursorRestart)(
+    ValkeyModuleScanCursor *cursor) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ScanCursorDestroy)(
+    ValkeyModuleScanCursor *cursor) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_Scan)(ValkeyModuleCtx *ctx,
+                                          ValkeyModuleScanCursor *cursor,
+                                          ValkeyModuleScanCB fn,
+                                          void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ScanKey)(ValkeyModuleKey *key,
+                                             ValkeyModuleScanCursor *cursor,
+                                             ValkeyModuleScanKeyCB fn,
+                                             void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetContextFlagsAll)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetKeyspaceNotificationFlagsAll)()
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsSubEventSupported)(
+    ValkeyModuleEvent event, uint64_t subevent) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetServerVersion)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetTypeMethodVersion)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_Yield)(
+    ValkeyModuleCtx *ctx, int flags, const char *busy_reply) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleBlockedClient *(*ValkeyModule_BlockClient)(
+    ValkeyModuleCtx *ctx, ValkeyModuleCmdFunc reply_callback,
+    ValkeyModuleCmdFunc timeout_callback,
+    void (*free_privdata)(ValkeyModuleCtx *, void *),
+    long long timeout_ms)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleBlockedClient *(*ValkeyModule_BlockClientOnAuth)(
+    ValkeyModuleCtx *ctx, ValkeyModuleAuthCallback reply_callback,
+    void (*free_privdata)(ValkeyModuleCtx *, void *))VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_UnblockClient)(
+    ValkeyModuleBlockedClient *bc, void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsBlockedReplyRequest)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_IsBlockedTimeoutRequest)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_GetBlockedClientPrivateData)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleBlockedClient *(
+    *ValkeyModule_GetBlockedClientHandle)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AbortBlock)(ValkeyModuleBlockedClient *bc)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_BlockedClientMeasureTimeStart)(
+    ValkeyModuleBlockedClient *bc) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_BlockedClientMeasureTimeEnd)(
+    ValkeyModuleBlockedClient *bc) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCtx *(*ValkeyModule_GetThreadSafeContext)(
+    ValkeyModuleBlockedClient *bc)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCtx *(*ValkeyModule_GetDetachedThreadSafeContext)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeThreadSafeContext)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ThreadSafeContextLock)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ThreadSafeContextTryLock)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ThreadSafeContextUnlock)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SubscribeToKeyspaceEvents)(
+    ValkeyModuleCtx *ctx, int types,
+    ValkeyModuleNotificationFunc cb) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_NotifyKeyspaceEvent)(
+    ValkeyModuleCtx *ctx, int type, const char *event,
+    ValkeyModuleString *key) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetNotifyKeyspaceEvents)()
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_BlockedClientDisconnected)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_RegisterClusterMessageReceiver)(
+    ValkeyModuleCtx *ctx, uint8_t type,
+    ValkeyModuleClusterMessageReceiver callback) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SendClusterMessage)(
+    ValkeyModuleCtx *ctx, const char *target_id, uint8_t type, const char *msg,
+    uint32_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetClusterNodeInfo)(
+    ValkeyModuleCtx *ctx, const char *id, char *ip, char *master_id, int *port,
+    int *flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API char **(*ValkeyModule_GetClusterNodesList)(
+    ValkeyModuleCtx *ctx, size_t *numnodes)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeClusterNodesList)(char **ids)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleTimerID (*ValkeyModule_CreateTimer)(
+    ValkeyModuleCtx *ctx, mstime_t period, ValkeyModuleTimerProc callback,
+    void *data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_StopTimer)(ValkeyModuleCtx *ctx,
+                                               ValkeyModuleTimerID id,
+                                               void **data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetTimerInfo)(
+    ValkeyModuleCtx *ctx, ValkeyModuleTimerID id, uint64_t *remaining,
+    void **data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCrossClusterReplicasList *(
+    *ValkeyModule_GetCrossClusterReplicasList)(void)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeCrossClusterReplicasList)(
+    ValkeyModuleCrossClusterReplicasList *head) VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_GetMyClusterID)(void)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_GetMyShardID)(void)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_GetClusterSize)(void) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_GetRandomBytes)(
+    unsigned char *dst, size_t len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_GetRandomHexChars)(char *dst, size_t len)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetShardId)(const char *shardId,
+                                                int len) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetDisconnectCallback)(
+    ValkeyModuleBlockedClient *bc,
+    ValkeyModuleDisconnectFunc callback) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetClusterFlags)(
+    ValkeyModuleCtx *ctx, uint64_t flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ExportSharedAPI)(
+    ValkeyModuleCtx *ctx, const char *apiname, void *func) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_GetSharedAPI)(
+    ValkeyModuleCtx *ctx, const char *apiname)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleCommandFilter *(
+    *ValkeyModule_RegisterCommandFilter)(ValkeyModuleCtx *ctx,
+                                         ValkeyModuleCommandFilterFunc cb,
+                                         int flags)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_UnregisterCommandFilter)(
+    ValkeyModuleCtx *ctx, ValkeyModuleCommandFilter *filter) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CommandFilterArgsCount)(
+    ValkeyModuleCommandFilterCtx *fctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_CommandFilterArgGet)(
+    ValkeyModuleCommandFilterCtx *fctx, int pos)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CommandFilterArgInsert)(
+    ValkeyModuleCommandFilterCtx *fctx, int pos,
+    ValkeyModuleString *arg) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CommandFilterArgReplace)(
+    ValkeyModuleCommandFilterCtx *fctx, int pos,
+    ValkeyModuleString *arg) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_CommandFilterArgDelete)(
+    ValkeyModuleCommandFilterCtx *fctx, int pos) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_Fork)(ValkeyModuleForkDoneHandler cb,
+                                          void *user_data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SendChildHeartbeat)(double progress)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ExitFromChild)(int retcode)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_KillForkChild)(int child_pid)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API float (*ValkeyModule_GetUsedMemoryRatio)() VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_MallocSize)(void *ptr) VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_MallocUsableSize)(void *ptr)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_MallocSizeString)(
+    ValkeyModuleString *str) VALKEYMODULE_ATTR;
+VALKEYMODULE_API size_t (*ValkeyModule_MallocSizeDict)(ValkeyModuleDict *dict)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleUser *(*ValkeyModule_CreateModuleUser)(
+    const char *name)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_FreeModuleUser)(ValkeyModuleUser *user)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_SetContextUser)(
+    ValkeyModuleCtx *ctx, const ValkeyModuleUser *user) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetModuleUserACL)(
+    ValkeyModuleUser *user, const char *acl) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_SetModuleUserACLString)(
+    ValkeyModuleCtx *ctx, ValkeyModuleUser *user, const char *acl,
+    ValkeyModuleString **error) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetModuleUserACLString)(
+    ValkeyModuleUser *user)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetCurrentUserName)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleUser *(*ValkeyModule_GetModuleUserFromUserName)(
+    ValkeyModuleString *name)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ACLCheckCommandPermissions)(
+    ValkeyModuleUser *user, ValkeyModuleString **argv,
+    int argc) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ACLCheckKeyPermissions)(
+    ValkeyModuleUser *user, ValkeyModuleString *key,
+    int flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ACLCheckChannelPermissions)(
+    ValkeyModuleUser *user, ValkeyModuleString *ch,
+    int literal) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ACLAddLogEntry)(
+    ValkeyModuleCtx *ctx, ValkeyModuleUser *user, ValkeyModuleString *object,
+    ValkeyModuleACLLogEntryReason reason) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_ACLAddLogEntryByUserName)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString *user, ValkeyModuleString *object,
+    ValkeyModuleACLLogEntryReason reason) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AuthenticateClientWithACLUser)(
+    ValkeyModuleCtx *ctx, const char *name, size_t len,
+    ValkeyModuleUserChangedFunc callback, void *privdata,
+    uint64_t *client_id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_AuthenticateClientWithUser)(
+    ValkeyModuleCtx *ctx, ValkeyModuleUser *user,
+    ValkeyModuleUserChangedFunc callback, void *privdata,
+    uint64_t *client_id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DeauthenticateAndCloseClient)(
+    ValkeyModuleCtx *ctx, uint64_t client_id) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RedactClientCommandArgument)(
+    ValkeyModuleCtx *ctx, int pos) VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_GetClientCertificate)(
+    ValkeyModuleCtx *ctx, uint64_t id)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int *(*ValkeyModule_GetCommandKeys)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
+    int *num_keys)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int *(*ValkeyModule_GetCommandKeysWithFlags)(
+    ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc, int *num_keys,
+    int **out_flags)VALKEYMODULE_ATTR;
+VALKEYMODULE_API const char *(*ValkeyModule_GetCurrentCommandName)(
+    ValkeyModuleCtx *ctx)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterDefragFunc)(
+    ValkeyModuleCtx *ctx, ValkeyModuleDefragFunc func) VALKEYMODULE_ATTR;
+VALKEYMODULE_API void *(*ValkeyModule_DefragAlloc)(ValkeyModuleDefragCtx *ctx,
+                                                   void *ptr)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleString *(*ValkeyModule_DefragValkeyModuleString)(
+    ValkeyModuleDefragCtx *ctx, ValkeyModuleString *str)VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DefragShouldStop)(
+    ValkeyModuleDefragCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DefragCursorSet)(
+    ValkeyModuleDefragCtx *ctx, unsigned long cursor) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_DefragCursorGet)(
+    ValkeyModuleDefragCtx *ctx, unsigned long *cursor) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_GetDbIdFromDefragCtx)(
+    ValkeyModuleDefragCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API const ValkeyModuleString *(
+    *ValkeyModule_GetKeyNameFromDefragCtx)(ValkeyModuleDefragCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_EventLoopAdd)(
+    int fd, int mask, ValkeyModuleEventLoopFunc func,
+    void *user_data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_EventLoopDel)(int fd,
+                                                  int mask) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_EventLoopAddOneShot)(
+    ValkeyModuleEventLoopOneShotFunc func, void *user_data) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterBoolConfig)(
+    ValkeyModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
+    ValkeyModuleConfigGetBoolFunc getfn, ValkeyModuleConfigSetBoolFunc setfn,
+    ValkeyModuleConfigApplyFunc applyfn, void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterNumericConfig)(
+    ValkeyModuleCtx *ctx, const char *name, long long default_val,
     unsigned int flags, long long min, long long max,
-    RedisModuleConfigGetNumericFunc getfn,
-    RedisModuleConfigSetNumericFunc setfn, RedisModuleConfigApplyFunc applyfn,
-    void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterStringConfig)(
-    RedisModuleCtx *ctx, const char *name, const char *default_val,
-    unsigned int flags, RedisModuleConfigGetStringFunc getfn,
-    RedisModuleConfigSetStringFunc setfn, RedisModuleConfigApplyFunc applyfn,
-    void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RegisterEnumConfig)(
-    RedisModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
+    ValkeyModuleConfigGetNumericFunc getfn,
+    ValkeyModuleConfigSetNumericFunc setfn, ValkeyModuleConfigApplyFunc applyfn,
+    void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterStringConfig)(
+    ValkeyModuleCtx *ctx, const char *name, const char *default_val,
+    unsigned int flags, ValkeyModuleConfigGetStringFunc getfn,
+    ValkeyModuleConfigSetStringFunc setfn, ValkeyModuleConfigApplyFunc applyfn,
+    void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RegisterEnumConfig)(
+    ValkeyModuleCtx *ctx, const char *name, int default_val, unsigned int flags,
     const char **enum_values, const int *int_values, int num_enum_vals,
-    RedisModuleConfigGetEnumFunc getfn, RedisModuleConfigSetEnumFunc setfn,
-    RedisModuleConfigApplyFunc applyfn, void *privdata) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_LoadConfigs)(RedisModuleCtx *ctx)
-    REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleRdbStream *(*RedisModule_RdbStreamCreateFromFile)(
-    const char *filename)REDISMODULE_ATTR;
-REDISMODULE_API RedisModuleRdbStream *(
-    *RedisModule_RdbStreamCreateFromRioHandler)(
-    const RedisModuleRIOHandler *handler)REDISMODULE_ATTR;
-REDISMODULE_API void (*RedisModule_RdbStreamFree)(RedisModuleRdbStream *stream)
-    REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RdbLoad)(RedisModuleCtx *ctx,
-                                           RedisModuleRdbStream *stream,
-                                           int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_RdbSave)(RedisModuleCtx *ctx,
-                                           RedisModuleRdbStream *stream,
-                                           int flags) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplicationSetMasterCrossCluster)(
-    RedisModuleCtx *ctx, const char *ip, const int port) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplicationUnsetMasterCrossCluster)(
-    RedisModuleCtx *ctx) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_ReplicationSetSecondaryCluster)(
-    RedisModuleCtx *ctx, bool is_secondary_cluster) REDISMODULE_ATTR;
-REDISMODULE_API int (*RedisModule_HashExternalize)(
-    RedisModuleKey *key, RedisModuleString *field, RedisModuleHashExternCB fn,
-    void *privdata) REDISMODULE_ATTR;
+    ValkeyModuleConfigGetEnumFunc getfn, ValkeyModuleConfigSetEnumFunc setfn,
+    ValkeyModuleConfigApplyFunc applyfn, void *privdata) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_LoadConfigs)(ValkeyModuleCtx *ctx)
+    VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleRdbStream *(*ValkeyModule_RdbStreamCreateFromFile)(
+    const char *filename)VALKEYMODULE_ATTR;
+VALKEYMODULE_API ValkeyModuleRdbStream *(
+    *ValkeyModule_RdbStreamCreateFromRioHandler)(
+    const ValkeyModuleRIOHandler *handler)VALKEYMODULE_ATTR;
+VALKEYMODULE_API void (*ValkeyModule_RdbStreamFree)(
+    ValkeyModuleRdbStream *stream) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RdbLoad)(ValkeyModuleCtx *ctx,
+                                             ValkeyModuleRdbStream *stream,
+                                             int flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_RdbSave)(ValkeyModuleCtx *ctx,
+                                             ValkeyModuleRdbStream *stream,
+                                             int flags) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplicationSetMasterCrossCluster)(
+    ValkeyModuleCtx *ctx, const char *ip, const int port) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplicationUnsetMasterCrossCluster)(
+    ValkeyModuleCtx *ctx) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_ReplicationSetSecondaryCluster)(
+    ValkeyModuleCtx *ctx, bool is_secondary_cluster) VALKEYMODULE_ATTR;
+VALKEYMODULE_API int (*ValkeyModule_HashExternalize)(
+    ValkeyModuleKey *key, ValkeyModuleString *field,
+    ValkeyModuleHashExternCB fn, void *privdata) VALKEYMODULE_ATTR;
 
-#define RedisModule_IsAOFClient(id) ((id) == UINT64_MAX)
+#define ValkeyModule_IsAOFClient(id) ((id) == UINT64_MAX)
 
-/* This is included inline inside each Redis module. */
-static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
-                            int apiver) REDISMODULE_ATTR_UNUSED;
-static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
-                            int apiver) {
+/* This is included inline inside each Valkey module. */
+static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver,
+                             int apiver) VALKEYMODULE_ATTR_UNUSED;
+static int ValkeyModule_Init(ValkeyModuleCtx *ctx, const char *name, int ver,
+                             int apiver) {
   void *getapifuncptr = ((void **)ctx)[0];
-  RedisModule_GetApi =
+  ValkeyModule_GetApi =
       (int (*)(const char *, void *))(unsigned long)getapifuncptr;
-  REDISMODULE_GET_API(Alloc);
-  REDISMODULE_GET_API(TryAlloc);
-  REDISMODULE_GET_API(Calloc);
-  REDISMODULE_GET_API(Free);
-  REDISMODULE_GET_API(Realloc);
-  REDISMODULE_GET_API(Strdup);
-  REDISMODULE_GET_API(CreateCommand);
-  REDISMODULE_GET_API(GetCommand);
-  REDISMODULE_GET_API(CreateSubcommand);
-  REDISMODULE_GET_API(SetCommandInfo);
-  REDISMODULE_GET_API(SetModuleAttribs);
-  REDISMODULE_GET_API(IsModuleNameBusy);
-  REDISMODULE_GET_API(WrongArity);
-  REDISMODULE_GET_API(ReplyWithLongLong);
-  REDISMODULE_GET_API(SetConnectionProperties);
-  REDISMODULE_GET_API(SetShardId);
-  REDISMODULE_GET_API(ReplyWithError);
-  REDISMODULE_GET_API(ReplyWithSimpleString);
-  REDISMODULE_GET_API(ReplyWithArray);
-  REDISMODULE_GET_API(ReplyWithMap);
-  REDISMODULE_GET_API(ReplyWithSet);
-  REDISMODULE_GET_API(ReplyWithAttribute);
-  REDISMODULE_GET_API(ReplyWithNullArray);
-  REDISMODULE_GET_API(ReplyWithEmptyArray);
-  REDISMODULE_GET_API(ReplySetArrayLength);
-  REDISMODULE_GET_API(ReplySetMapLength);
-  REDISMODULE_GET_API(ReplySetSetLength);
-  REDISMODULE_GET_API(ReplySetAttributeLength);
-  REDISMODULE_GET_API(ReplySetPushLength);
-  REDISMODULE_GET_API(ReplyWithStringBuffer);
-  REDISMODULE_GET_API(ReplyWithCString);
-  REDISMODULE_GET_API(ReplyWithString);
-  REDISMODULE_GET_API(ReplyWithEmptyString);
-  REDISMODULE_GET_API(ReplyWithVerbatimString);
-  REDISMODULE_GET_API(ReplyWithVerbatimStringType);
-  REDISMODULE_GET_API(ReplyWithNull);
-  REDISMODULE_GET_API(ReplyWithBool);
-  REDISMODULE_GET_API(ReplyWithCallReply);
-  REDISMODULE_GET_API(ReplyWithDouble);
-  REDISMODULE_GET_API(ReplyWithBigNumber);
-  REDISMODULE_GET_API(ReplyWithLongDouble);
-  REDISMODULE_GET_API(GetSelectedDb);
-  REDISMODULE_GET_API(SelectDb);
-  REDISMODULE_GET_API(KeyExists);
-  REDISMODULE_GET_API(OpenKey);
-  REDISMODULE_GET_API(GetOpenKeyModesAll);
-  REDISMODULE_GET_API(CloseKey);
-  REDISMODULE_GET_API(KeyType);
-  REDISMODULE_GET_API(ValueLength);
-  REDISMODULE_GET_API(ListPush);
-  REDISMODULE_GET_API(ListPop);
-  REDISMODULE_GET_API(ListGet);
-  REDISMODULE_GET_API(ListSet);
-  REDISMODULE_GET_API(ListInsert);
-  REDISMODULE_GET_API(ListDelete);
-  REDISMODULE_GET_API(StringToLongLong);
-  REDISMODULE_GET_API(StringToULongLong);
-  REDISMODULE_GET_API(StringToDouble);
-  REDISMODULE_GET_API(StringToLongDouble);
-  REDISMODULE_GET_API(StringToStreamID);
-  REDISMODULE_GET_API(Call);
-  REDISMODULE_GET_API(CallReplyProto);
-  REDISMODULE_GET_API(FreeCallReply);
-  REDISMODULE_GET_API(CallReplyInteger);
-  REDISMODULE_GET_API(CallReplyDouble);
-  REDISMODULE_GET_API(CallReplyBool);
-  REDISMODULE_GET_API(CallReplyBigNumber);
-  REDISMODULE_GET_API(CallReplyVerbatim);
-  REDISMODULE_GET_API(CallReplySetElement);
-  REDISMODULE_GET_API(CallReplyMapElement);
-  REDISMODULE_GET_API(CallReplyAttributeElement);
-  REDISMODULE_GET_API(CallReplyAttribute);
-  REDISMODULE_GET_API(CallReplyType);
-  REDISMODULE_GET_API(CallReplyLength);
-  REDISMODULE_GET_API(CallReplyArrayElement);
-  REDISMODULE_GET_API(CallReplyStringPtr);
-  REDISMODULE_GET_API(CreateStringFromCallReply);
-  REDISMODULE_GET_API(CreateString);
-  REDISMODULE_GET_API(CreateStringFromLongLong);
-  REDISMODULE_GET_API(CreateStringFromULongLong);
-  REDISMODULE_GET_API(CreateStringFromDouble);
-  REDISMODULE_GET_API(CreateStringFromLongDouble);
-  REDISMODULE_GET_API(CreateStringFromString);
-  REDISMODULE_GET_API(CreateStringFromStreamID);
-  REDISMODULE_GET_API(CreateStringPrintf);
-  REDISMODULE_GET_API(FreeString);
-  REDISMODULE_GET_API(StringPtrLen);
-  REDISMODULE_GET_API(AutoMemory);
-  REDISMODULE_GET_API(Replicate);
-  REDISMODULE_GET_API(ReplicateVerbatim);
-  REDISMODULE_GET_API(DeleteKey);
-  REDISMODULE_GET_API(UnlinkKey);
-  REDISMODULE_GET_API(StringSet);
-  REDISMODULE_GET_API(StringDMA);
-  REDISMODULE_GET_API(StringTruncate);
-  REDISMODULE_GET_API(GetExpire);
-  REDISMODULE_GET_API(SetExpire);
-  REDISMODULE_GET_API(GetAbsExpire);
-  REDISMODULE_GET_API(SetAbsExpire);
-  REDISMODULE_GET_API(ResetDataset);
-  REDISMODULE_GET_API(DbSize);
-  REDISMODULE_GET_API(RandomKey);
-  REDISMODULE_GET_API(ZsetAdd);
-  REDISMODULE_GET_API(ZsetIncrby);
-  REDISMODULE_GET_API(ZsetScore);
-  REDISMODULE_GET_API(ZsetRem);
-  REDISMODULE_GET_API(ZsetRangeStop);
-  REDISMODULE_GET_API(ZsetFirstInScoreRange);
-  REDISMODULE_GET_API(ZsetLastInScoreRange);
-  REDISMODULE_GET_API(ZsetFirstInLexRange);
-  REDISMODULE_GET_API(ZsetLastInLexRange);
-  REDISMODULE_GET_API(ZsetRangeCurrentElement);
-  REDISMODULE_GET_API(ZsetRangeNext);
-  REDISMODULE_GET_API(ZsetRangePrev);
-  REDISMODULE_GET_API(ZsetRangeEndReached);
-  REDISMODULE_GET_API(HashSet);
-  REDISMODULE_GET_API(HashGet);
-  REDISMODULE_GET_API(StreamAdd);
-  REDISMODULE_GET_API(StreamDelete);
-  REDISMODULE_GET_API(StreamIteratorStart);
-  REDISMODULE_GET_API(StreamIteratorStop);
-  REDISMODULE_GET_API(StreamIteratorNextID);
-  REDISMODULE_GET_API(StreamIteratorNextField);
-  REDISMODULE_GET_API(StreamIteratorDelete);
-  REDISMODULE_GET_API(StreamTrimByLength);
-  REDISMODULE_GET_API(StreamTrimByID);
-  REDISMODULE_GET_API(IsKeysPositionRequest);
-  REDISMODULE_GET_API(KeyAtPos);
-  REDISMODULE_GET_API(KeyAtPosWithFlags);
-  REDISMODULE_GET_API(IsChannelsPositionRequest);
-  REDISMODULE_GET_API(ChannelAtPosWithFlags);
-  REDISMODULE_GET_API(GetClientId);
-  REDISMODULE_GET_API(GetClientUserNameById);
-  REDISMODULE_GET_API(GetContextFlags);
-  REDISMODULE_GET_API(AvoidReplicaTraffic);
-  REDISMODULE_GET_API(PoolAlloc);
-  REDISMODULE_GET_API(CreateDataType);
-  REDISMODULE_GET_API(ModuleTypeSetValue);
-  REDISMODULE_GET_API(ModuleTypeReplaceValue);
-  REDISMODULE_GET_API(ModuleTypeGetType);
-  REDISMODULE_GET_API(ModuleTypeGetValue);
-  REDISMODULE_GET_API(IsIOError);
-  REDISMODULE_GET_API(SetModuleOptions);
-  REDISMODULE_GET_API(SetModuleExtendedOptions);
-  REDISMODULE_GET_API(SignalModifiedKey);
-  REDISMODULE_GET_API(SaveUnsigned);
-  REDISMODULE_GET_API(LoadUnsigned);
-  REDISMODULE_GET_API(SaveSigned);
-  REDISMODULE_GET_API(LoadSigned);
-  REDISMODULE_GET_API(SaveString);
-  REDISMODULE_GET_API(SaveStringBuffer);
-  REDISMODULE_GET_API(LoadString);
-  REDISMODULE_GET_API(LoadStringBuffer);
-  REDISMODULE_GET_API(SaveDouble);
-  REDISMODULE_GET_API(LoadDouble);
-  REDISMODULE_GET_API(SaveFloat);
-  REDISMODULE_GET_API(LoadFloat);
-  REDISMODULE_GET_API(SaveLongDouble);
-  REDISMODULE_GET_API(LoadLongDouble);
-  REDISMODULE_GET_API(SaveDataTypeToString);
-  REDISMODULE_GET_API(LoadDataTypeFromString);
-  REDISMODULE_GET_API(LoadDataTypeFromStringEncver);
-  REDISMODULE_GET_API(EmitAOF);
-  REDISMODULE_GET_API(Log);
-  REDISMODULE_GET_API(LogIOError);
-  REDISMODULE_GET_API(_Assert);
-  REDISMODULE_GET_API(LatencyAddSample);
-  REDISMODULE_GET_API(StringAppendBuffer);
-  REDISMODULE_GET_API(TrimStringAllocation);
-  REDISMODULE_GET_API(RetainString);
-  REDISMODULE_GET_API(HoldString);
-  REDISMODULE_GET_API(StringCompare);
-  REDISMODULE_GET_API(GetContextFromIO);
-  REDISMODULE_GET_API(GetKeyNameFromIO);
-  REDISMODULE_GET_API(GetKeyNameFromModuleKey);
-  REDISMODULE_GET_API(GetDbIdFromModuleKey);
-  REDISMODULE_GET_API(GetDbIdFromIO);
-  REDISMODULE_GET_API(GetKeyNameFromOptCtx);
-  REDISMODULE_GET_API(GetToKeyNameFromOptCtx);
-  REDISMODULE_GET_API(GetDbIdFromOptCtx);
-  REDISMODULE_GET_API(GetToDbIdFromOptCtx);
-  REDISMODULE_GET_API(Milliseconds);
-  REDISMODULE_GET_API(MonotonicMicroseconds);
-  REDISMODULE_GET_API(DigestAddStringBuffer);
-  REDISMODULE_GET_API(DigestAddLongLong);
-  REDISMODULE_GET_API(DigestEndSequence);
-  REDISMODULE_GET_API(GetKeyNameFromDigest);
-  REDISMODULE_GET_API(GetDbIdFromDigest);
-  REDISMODULE_GET_API(CreateDict);
-  REDISMODULE_GET_API(FreeDict);
-  REDISMODULE_GET_API(DictSize);
-  REDISMODULE_GET_API(DictSetC);
-  REDISMODULE_GET_API(DictReplaceC);
-  REDISMODULE_GET_API(DictSet);
-  REDISMODULE_GET_API(DictReplace);
-  REDISMODULE_GET_API(DictGetC);
-  REDISMODULE_GET_API(DictGet);
-  REDISMODULE_GET_API(DictDelC);
-  REDISMODULE_GET_API(DictDel);
-  REDISMODULE_GET_API(DictIteratorStartC);
-  REDISMODULE_GET_API(DictIteratorStart);
-  REDISMODULE_GET_API(DictIteratorStop);
-  REDISMODULE_GET_API(DictIteratorReseekC);
-  REDISMODULE_GET_API(DictIteratorReseek);
-  REDISMODULE_GET_API(DictNextC);
-  REDISMODULE_GET_API(DictPrevC);
-  REDISMODULE_GET_API(DictNext);
-  REDISMODULE_GET_API(DictPrev);
-  REDISMODULE_GET_API(DictCompare);
-  REDISMODULE_GET_API(DictCompareC);
-  REDISMODULE_GET_API(RegisterInfoFunc);
-  REDISMODULE_GET_API(AddACLCategory);
-  REDISMODULE_GET_API(SetCommandACLCategories);
-  REDISMODULE_GET_API(SetCommandACLCategories);
-  REDISMODULE_GET_API(RegisterAuthCallback);
-  REDISMODULE_GET_API(InfoAddSection);
-  REDISMODULE_GET_API(InfoBeginDictField);
-  REDISMODULE_GET_API(InfoEndDictField);
-  REDISMODULE_GET_API(InfoAddFieldString);
-  REDISMODULE_GET_API(InfoAddFieldCString);
-  REDISMODULE_GET_API(InfoAddFieldDouble);
-  REDISMODULE_GET_API(InfoAddFieldLongLong);
-  REDISMODULE_GET_API(InfoAddFieldULongLong);
-  REDISMODULE_GET_API(GetServerInfo);
-  REDISMODULE_GET_API(FreeServerInfo);
-  REDISMODULE_GET_API(ServerInfoGetField);
-  REDISMODULE_GET_API(ServerInfoGetFieldC);
-  REDISMODULE_GET_API(ServerInfoGetFieldSigned);
-  REDISMODULE_GET_API(ServerInfoGetFieldUnsigned);
-  REDISMODULE_GET_API(ServerInfoGetFieldDouble);
-  REDISMODULE_GET_API(GetClusterInfo);
-  REDISMODULE_GET_API(GetClientInfoById);
-  REDISMODULE_GET_API(GetClientNameById);
-  REDISMODULE_GET_API(SetClientNameById);
-  REDISMODULE_GET_API(PublishMessage);
-  REDISMODULE_GET_API(PublishMessageShard);
-  REDISMODULE_GET_API(SubscribeToServerEvent);
-  REDISMODULE_GET_API(SetLRU);
-  REDISMODULE_GET_API(GetLRU);
-  REDISMODULE_GET_API(SetLFU);
-  REDISMODULE_GET_API(GetLFU);
-  REDISMODULE_GET_API(BlockClientOnKeys);
-  REDISMODULE_GET_API(SignalKeyAsReady);
-  REDISMODULE_GET_API(GetBlockedClientReadyKey);
-  REDISMODULE_GET_API(ScanCursorCreate);
-  REDISMODULE_GET_API(ScanCursorRestart);
-  REDISMODULE_GET_API(ScanCursorDestroy);
-  REDISMODULE_GET_API(Scan);
-  REDISMODULE_GET_API(ScanKey);
-  REDISMODULE_GET_API(GetContextFlagsAll);
-  REDISMODULE_GET_API(GetKeyspaceNotificationFlagsAll);
-  REDISMODULE_GET_API(IsSubEventSupported);
-  REDISMODULE_GET_API(GetServerVersion);
-  REDISMODULE_GET_API(GetTypeMethodVersion);
-  REDISMODULE_GET_API(Yield);
-  REDISMODULE_GET_API(GetThreadSafeContext);
-  REDISMODULE_GET_API(GetDetachedThreadSafeContext);
-  REDISMODULE_GET_API(FreeThreadSafeContext);
-  REDISMODULE_GET_API(ThreadSafeContextLock);
-  REDISMODULE_GET_API(ThreadSafeContextTryLock);
-  REDISMODULE_GET_API(ThreadSafeContextUnlock);
-  REDISMODULE_GET_API(BlockClient);
-  REDISMODULE_GET_API(BlockClientOnAuth);
-  REDISMODULE_GET_API(UnblockClient);
-  REDISMODULE_GET_API(IsBlockedReplyRequest);
-  REDISMODULE_GET_API(IsBlockedTimeoutRequest);
-  REDISMODULE_GET_API(GetBlockedClientPrivateData);
-  REDISMODULE_GET_API(GetBlockedClientHandle);
-  REDISMODULE_GET_API(AbortBlock);
-  REDISMODULE_GET_API(BlockedClientMeasureTimeStart);
-  REDISMODULE_GET_API(BlockedClientMeasureTimeEnd);
-  REDISMODULE_GET_API(SetDisconnectCallback);
-  REDISMODULE_GET_API(SubscribeToKeyspaceEvents);
-  REDISMODULE_GET_API(NotifyKeyspaceEvent);
-  REDISMODULE_GET_API(GetNotifyKeyspaceEvents);
-  REDISMODULE_GET_API(BlockedClientDisconnected);
-  REDISMODULE_GET_API(RegisterClusterMessageReceiver);
-  REDISMODULE_GET_API(SendClusterMessage);
-  REDISMODULE_GET_API(GetClusterNodeInfo);
-  REDISMODULE_GET_API(GetClusterNodesList);
-  REDISMODULE_GET_API(FreeClusterNodesList);
-  REDISMODULE_GET_API(CreateTimer);
-  REDISMODULE_GET_API(StopTimer);
-  REDISMODULE_GET_API(GetTimerInfo);
-  REDISMODULE_GET_API(GetCrossClusterReplicasList);
-  REDISMODULE_GET_API(FreeCrossClusterReplicasList);
-  REDISMODULE_GET_API(GetMyClusterID);
-  REDISMODULE_GET_API(GetMyShardID);
-  REDISMODULE_GET_API(GetClusterSize);
-  REDISMODULE_GET_API(GetRandomBytes);
-  REDISMODULE_GET_API(GetRandomHexChars);
-  REDISMODULE_GET_API(SetClusterFlags);
-  REDISMODULE_GET_API(ExportSharedAPI);
-  REDISMODULE_GET_API(GetSharedAPI);
-  REDISMODULE_GET_API(RegisterCommandFilter);
-  REDISMODULE_GET_API(UnregisterCommandFilter);
-  REDISMODULE_GET_API(CommandFilterArgsCount);
-  REDISMODULE_GET_API(CommandFilterArgGet);
-  REDISMODULE_GET_API(CommandFilterArgInsert);
-  REDISMODULE_GET_API(CommandFilterArgReplace);
-  REDISMODULE_GET_API(CommandFilterArgDelete);
-  REDISMODULE_GET_API(Fork);
-  REDISMODULE_GET_API(SendChildHeartbeat);
-  REDISMODULE_GET_API(ExitFromChild);
-  REDISMODULE_GET_API(KillForkChild);
-  REDISMODULE_GET_API(GetUsedMemoryRatio);
-  REDISMODULE_GET_API(MallocSize);
-  REDISMODULE_GET_API(MallocUsableSize);
-  REDISMODULE_GET_API(MallocSizeString);
-  REDISMODULE_GET_API(MallocSizeDict);
-  REDISMODULE_GET_API(CreateModuleUser);
-  REDISMODULE_GET_API(FreeModuleUser);
-  REDISMODULE_GET_API(SetContextUser);
-  REDISMODULE_GET_API(SetModuleUserACL);
-  REDISMODULE_GET_API(SetModuleUserACLString);
-  REDISMODULE_GET_API(GetModuleUserACLString);
-  REDISMODULE_GET_API(GetCurrentUserName);
-  REDISMODULE_GET_API(GetModuleUserFromUserName);
-  REDISMODULE_GET_API(ACLCheckCommandPermissions);
-  REDISMODULE_GET_API(ACLCheckKeyPermissions);
-  REDISMODULE_GET_API(ACLCheckChannelPermissions);
-  REDISMODULE_GET_API(ACLAddLogEntry);
-  REDISMODULE_GET_API(ACLAddLogEntryByUserName);
-  REDISMODULE_GET_API(DeauthenticateAndCloseClient);
-  REDISMODULE_GET_API(AuthenticateClientWithACLUser);
-  REDISMODULE_GET_API(AuthenticateClientWithUser);
-  REDISMODULE_GET_API(RedactClientCommandArgument);
-  REDISMODULE_GET_API(GetClientCertificate);
-  REDISMODULE_GET_API(GetCommandKeys);
-  REDISMODULE_GET_API(GetCommandKeysWithFlags);
-  REDISMODULE_GET_API(GetCurrentCommandName);
-  REDISMODULE_GET_API(RegisterDefragFunc);
-  REDISMODULE_GET_API(DefragAlloc);
-  REDISMODULE_GET_API(DefragRedisModuleString);
-  REDISMODULE_GET_API(DefragShouldStop);
-  REDISMODULE_GET_API(DefragCursorSet);
-  REDISMODULE_GET_API(DefragCursorGet);
-  REDISMODULE_GET_API(GetKeyNameFromDefragCtx);
-  REDISMODULE_GET_API(GetDbIdFromDefragCtx);
-  REDISMODULE_GET_API(EventLoopAdd);
-  REDISMODULE_GET_API(EventLoopDel);
-  REDISMODULE_GET_API(EventLoopAddOneShot);
-  REDISMODULE_GET_API(RegisterBoolConfig);
-  REDISMODULE_GET_API(RegisterNumericConfig);
-  REDISMODULE_GET_API(RegisterStringConfig);
-  REDISMODULE_GET_API(RegisterEnumConfig);
-  REDISMODULE_GET_API(LoadConfigs);
-  REDISMODULE_GET_API(RdbStreamCreateFromFile);
-  REDISMODULE_GET_API(RdbStreamCreateFromRioHandler);
-  REDISMODULE_GET_API(RdbStreamFree);
-  REDISMODULE_GET_API(RdbLoad);
-  REDISMODULE_GET_API(RdbSave);
-  REDISMODULE_GET_API(ReplicationSetMasterCrossCluster);
-  REDISMODULE_GET_API(ReplicationUnsetMasterCrossCluster);
-  REDISMODULE_GET_API(ReplicationSetSecondaryCluster);
-  REDISMODULE_GET_API(HashExternalize);
+  VALKEYMODULE_GET_API(Alloc);
+  VALKEYMODULE_GET_API(TryAlloc);
+  VALKEYMODULE_GET_API(Calloc);
+  VALKEYMODULE_GET_API(Free);
+  VALKEYMODULE_GET_API(Realloc);
+  VALKEYMODULE_GET_API(Strdup);
+  VALKEYMODULE_GET_API(CreateCommand);
+  VALKEYMODULE_GET_API(GetCommand);
+  VALKEYMODULE_GET_API(CreateSubcommand);
+  VALKEYMODULE_GET_API(SetCommandInfo);
+  VALKEYMODULE_GET_API(SetModuleAttribs);
+  VALKEYMODULE_GET_API(IsModuleNameBusy);
+  VALKEYMODULE_GET_API(WrongArity);
+  VALKEYMODULE_GET_API(ReplyWithLongLong);
+  VALKEYMODULE_GET_API(SetConnectionProperties);
+  VALKEYMODULE_GET_API(SetShardId);
+  VALKEYMODULE_GET_API(ReplyWithError);
+  VALKEYMODULE_GET_API(ReplyWithSimpleString);
+  VALKEYMODULE_GET_API(ReplyWithArray);
+  VALKEYMODULE_GET_API(ReplyWithMap);
+  VALKEYMODULE_GET_API(ReplyWithSet);
+  VALKEYMODULE_GET_API(ReplyWithAttribute);
+  VALKEYMODULE_GET_API(ReplyWithNullArray);
+  VALKEYMODULE_GET_API(ReplyWithEmptyArray);
+  VALKEYMODULE_GET_API(ReplySetArrayLength);
+  VALKEYMODULE_GET_API(ReplySetMapLength);
+  VALKEYMODULE_GET_API(ReplySetSetLength);
+  VALKEYMODULE_GET_API(ReplySetAttributeLength);
+  VALKEYMODULE_GET_API(ReplySetPushLength);
+  VALKEYMODULE_GET_API(ReplyWithStringBuffer);
+  VALKEYMODULE_GET_API(ReplyWithCString);
+  VALKEYMODULE_GET_API(ReplyWithString);
+  VALKEYMODULE_GET_API(ReplyWithEmptyString);
+  VALKEYMODULE_GET_API(ReplyWithVerbatimString);
+  VALKEYMODULE_GET_API(ReplyWithVerbatimStringType);
+  VALKEYMODULE_GET_API(ReplyWithNull);
+  VALKEYMODULE_GET_API(ReplyWithBool);
+  VALKEYMODULE_GET_API(ReplyWithCallReply);
+  VALKEYMODULE_GET_API(ReplyWithDouble);
+  VALKEYMODULE_GET_API(ReplyWithBigNumber);
+  VALKEYMODULE_GET_API(ReplyWithLongDouble);
+  VALKEYMODULE_GET_API(GetSelectedDb);
+  VALKEYMODULE_GET_API(SelectDb);
+  VALKEYMODULE_GET_API(KeyExists);
+  VALKEYMODULE_GET_API(OpenKey);
+  VALKEYMODULE_GET_API(GetOpenKeyModesAll);
+  VALKEYMODULE_GET_API(CloseKey);
+  VALKEYMODULE_GET_API(KeyType);
+  VALKEYMODULE_GET_API(ValueLength);
+  VALKEYMODULE_GET_API(ListPush);
+  VALKEYMODULE_GET_API(ListPop);
+  VALKEYMODULE_GET_API(ListGet);
+  VALKEYMODULE_GET_API(ListSet);
+  VALKEYMODULE_GET_API(ListInsert);
+  VALKEYMODULE_GET_API(ListDelete);
+  VALKEYMODULE_GET_API(StringToLongLong);
+  VALKEYMODULE_GET_API(StringToULongLong);
+  VALKEYMODULE_GET_API(StringToDouble);
+  VALKEYMODULE_GET_API(StringToLongDouble);
+  VALKEYMODULE_GET_API(StringToStreamID);
+  VALKEYMODULE_GET_API(Call);
+  VALKEYMODULE_GET_API(CallReplyProto);
+  VALKEYMODULE_GET_API(FreeCallReply);
+  VALKEYMODULE_GET_API(CallReplyInteger);
+  VALKEYMODULE_GET_API(CallReplyDouble);
+  VALKEYMODULE_GET_API(CallReplyBool);
+  VALKEYMODULE_GET_API(CallReplyBigNumber);
+  VALKEYMODULE_GET_API(CallReplyVerbatim);
+  VALKEYMODULE_GET_API(CallReplySetElement);
+  VALKEYMODULE_GET_API(CallReplyMapElement);
+  VALKEYMODULE_GET_API(CallReplyAttributeElement);
+  VALKEYMODULE_GET_API(CallReplyAttribute);
+  VALKEYMODULE_GET_API(CallReplyType);
+  VALKEYMODULE_GET_API(CallReplyLength);
+  VALKEYMODULE_GET_API(CallReplyArrayElement);
+  VALKEYMODULE_GET_API(CallReplyStringPtr);
+  VALKEYMODULE_GET_API(CreateStringFromCallReply);
+  VALKEYMODULE_GET_API(CreateString);
+  VALKEYMODULE_GET_API(CreateStringFromLongLong);
+  VALKEYMODULE_GET_API(CreateStringFromULongLong);
+  VALKEYMODULE_GET_API(CreateStringFromDouble);
+  VALKEYMODULE_GET_API(CreateStringFromLongDouble);
+  VALKEYMODULE_GET_API(CreateStringFromString);
+  VALKEYMODULE_GET_API(CreateStringFromStreamID);
+  VALKEYMODULE_GET_API(CreateStringPrintf);
+  VALKEYMODULE_GET_API(FreeString);
+  VALKEYMODULE_GET_API(StringPtrLen);
+  VALKEYMODULE_GET_API(AutoMemory);
+  VALKEYMODULE_GET_API(Replicate);
+  VALKEYMODULE_GET_API(ReplicateVerbatim);
+  VALKEYMODULE_GET_API(DeleteKey);
+  VALKEYMODULE_GET_API(UnlinkKey);
+  VALKEYMODULE_GET_API(StringSet);
+  VALKEYMODULE_GET_API(StringDMA);
+  VALKEYMODULE_GET_API(StringTruncate);
+  VALKEYMODULE_GET_API(GetExpire);
+  VALKEYMODULE_GET_API(SetExpire);
+  VALKEYMODULE_GET_API(GetAbsExpire);
+  VALKEYMODULE_GET_API(SetAbsExpire);
+  VALKEYMODULE_GET_API(ResetDataset);
+  VALKEYMODULE_GET_API(DbSize);
+  VALKEYMODULE_GET_API(RandomKey);
+  VALKEYMODULE_GET_API(ZsetAdd);
+  VALKEYMODULE_GET_API(ZsetIncrby);
+  VALKEYMODULE_GET_API(ZsetScore);
+  VALKEYMODULE_GET_API(ZsetRem);
+  VALKEYMODULE_GET_API(ZsetRangeStop);
+  VALKEYMODULE_GET_API(ZsetFirstInScoreRange);
+  VALKEYMODULE_GET_API(ZsetLastInScoreRange);
+  VALKEYMODULE_GET_API(ZsetFirstInLexRange);
+  VALKEYMODULE_GET_API(ZsetLastInLexRange);
+  VALKEYMODULE_GET_API(ZsetRangeCurrentElement);
+  VALKEYMODULE_GET_API(ZsetRangeNext);
+  VALKEYMODULE_GET_API(ZsetRangePrev);
+  VALKEYMODULE_GET_API(ZsetRangeEndReached);
+  VALKEYMODULE_GET_API(HashSet);
+  VALKEYMODULE_GET_API(HashGet);
+  VALKEYMODULE_GET_API(StreamAdd);
+  VALKEYMODULE_GET_API(StreamDelete);
+  VALKEYMODULE_GET_API(StreamIteratorStart);
+  VALKEYMODULE_GET_API(StreamIteratorStop);
+  VALKEYMODULE_GET_API(StreamIteratorNextID);
+  VALKEYMODULE_GET_API(StreamIteratorNextField);
+  VALKEYMODULE_GET_API(StreamIteratorDelete);
+  VALKEYMODULE_GET_API(StreamTrimByLength);
+  VALKEYMODULE_GET_API(StreamTrimByID);
+  VALKEYMODULE_GET_API(IsKeysPositionRequest);
+  VALKEYMODULE_GET_API(KeyAtPos);
+  VALKEYMODULE_GET_API(KeyAtPosWithFlags);
+  VALKEYMODULE_GET_API(IsChannelsPositionRequest);
+  VALKEYMODULE_GET_API(ChannelAtPosWithFlags);
+  VALKEYMODULE_GET_API(GetClientId);
+  VALKEYMODULE_GET_API(GetClientUserNameById);
+  VALKEYMODULE_GET_API(GetContextFlags);
+  VALKEYMODULE_GET_API(AvoidReplicaTraffic);
+  VALKEYMODULE_GET_API(PoolAlloc);
+  VALKEYMODULE_GET_API(CreateDataType);
+  VALKEYMODULE_GET_API(ModuleTypeSetValue);
+  VALKEYMODULE_GET_API(ModuleTypeReplaceValue);
+  VALKEYMODULE_GET_API(ModuleTypeGetType);
+  VALKEYMODULE_GET_API(ModuleTypeGetValue);
+  VALKEYMODULE_GET_API(IsIOError);
+  VALKEYMODULE_GET_API(SetModuleOptions);
+  VALKEYMODULE_GET_API(SetModuleExtendedOptions);
+  VALKEYMODULE_GET_API(SignalModifiedKey);
+  VALKEYMODULE_GET_API(SaveUnsigned);
+  VALKEYMODULE_GET_API(LoadUnsigned);
+  VALKEYMODULE_GET_API(SaveSigned);
+  VALKEYMODULE_GET_API(LoadSigned);
+  VALKEYMODULE_GET_API(SaveString);
+  VALKEYMODULE_GET_API(SaveStringBuffer);
+  VALKEYMODULE_GET_API(LoadString);
+  VALKEYMODULE_GET_API(LoadStringBuffer);
+  VALKEYMODULE_GET_API(SaveDouble);
+  VALKEYMODULE_GET_API(LoadDouble);
+  VALKEYMODULE_GET_API(SaveFloat);
+  VALKEYMODULE_GET_API(LoadFloat);
+  VALKEYMODULE_GET_API(SaveLongDouble);
+  VALKEYMODULE_GET_API(LoadLongDouble);
+  VALKEYMODULE_GET_API(SaveDataTypeToString);
+  VALKEYMODULE_GET_API(LoadDataTypeFromString);
+  VALKEYMODULE_GET_API(LoadDataTypeFromStringEncver);
+  VALKEYMODULE_GET_API(EmitAOF);
+  VALKEYMODULE_GET_API(Log);
+  VALKEYMODULE_GET_API(LogIOError);
+  VALKEYMODULE_GET_API(_Assert);
+  VALKEYMODULE_GET_API(LatencyAddSample);
+  VALKEYMODULE_GET_API(StringAppendBuffer);
+  VALKEYMODULE_GET_API(TrimStringAllocation);
+  VALKEYMODULE_GET_API(RetainString);
+  VALKEYMODULE_GET_API(HoldString);
+  VALKEYMODULE_GET_API(StringCompare);
+  VALKEYMODULE_GET_API(GetContextFromIO);
+  VALKEYMODULE_GET_API(GetKeyNameFromIO);
+  VALKEYMODULE_GET_API(GetKeyNameFromModuleKey);
+  VALKEYMODULE_GET_API(GetDbIdFromModuleKey);
+  VALKEYMODULE_GET_API(GetDbIdFromIO);
+  VALKEYMODULE_GET_API(GetKeyNameFromOptCtx);
+  VALKEYMODULE_GET_API(GetToKeyNameFromOptCtx);
+  VALKEYMODULE_GET_API(GetDbIdFromOptCtx);
+  VALKEYMODULE_GET_API(GetToDbIdFromOptCtx);
+  VALKEYMODULE_GET_API(Milliseconds);
+  VALKEYMODULE_GET_API(MonotonicMicroseconds);
+  VALKEYMODULE_GET_API(DigestAddStringBuffer);
+  VALKEYMODULE_GET_API(DigestAddLongLong);
+  VALKEYMODULE_GET_API(DigestEndSequence);
+  VALKEYMODULE_GET_API(GetKeyNameFromDigest);
+  VALKEYMODULE_GET_API(GetDbIdFromDigest);
+  VALKEYMODULE_GET_API(CreateDict);
+  VALKEYMODULE_GET_API(FreeDict);
+  VALKEYMODULE_GET_API(DictSize);
+  VALKEYMODULE_GET_API(DictSetC);
+  VALKEYMODULE_GET_API(DictReplaceC);
+  VALKEYMODULE_GET_API(DictSet);
+  VALKEYMODULE_GET_API(DictReplace);
+  VALKEYMODULE_GET_API(DictGetC);
+  VALKEYMODULE_GET_API(DictGet);
+  VALKEYMODULE_GET_API(DictDelC);
+  VALKEYMODULE_GET_API(DictDel);
+  VALKEYMODULE_GET_API(DictIteratorStartC);
+  VALKEYMODULE_GET_API(DictIteratorStart);
+  VALKEYMODULE_GET_API(DictIteratorStop);
+  VALKEYMODULE_GET_API(DictIteratorReseekC);
+  VALKEYMODULE_GET_API(DictIteratorReseek);
+  VALKEYMODULE_GET_API(DictNextC);
+  VALKEYMODULE_GET_API(DictPrevC);
+  VALKEYMODULE_GET_API(DictNext);
+  VALKEYMODULE_GET_API(DictPrev);
+  VALKEYMODULE_GET_API(DictCompare);
+  VALKEYMODULE_GET_API(DictCompareC);
+  VALKEYMODULE_GET_API(RegisterInfoFunc);
+  VALKEYMODULE_GET_API(AddACLCategory);
+  VALKEYMODULE_GET_API(SetCommandACLCategories);
+  VALKEYMODULE_GET_API(SetCommandACLCategories);
+  VALKEYMODULE_GET_API(RegisterAuthCallback);
+  VALKEYMODULE_GET_API(InfoAddSection);
+  VALKEYMODULE_GET_API(InfoBeginDictField);
+  VALKEYMODULE_GET_API(InfoEndDictField);
+  VALKEYMODULE_GET_API(InfoAddFieldString);
+  VALKEYMODULE_GET_API(InfoAddFieldCString);
+  VALKEYMODULE_GET_API(InfoAddFieldDouble);
+  VALKEYMODULE_GET_API(InfoAddFieldLongLong);
+  VALKEYMODULE_GET_API(InfoAddFieldULongLong);
+  VALKEYMODULE_GET_API(GetServerInfo);
+  VALKEYMODULE_GET_API(FreeServerInfo);
+  VALKEYMODULE_GET_API(ServerInfoGetField);
+  VALKEYMODULE_GET_API(ServerInfoGetFieldC);
+  VALKEYMODULE_GET_API(ServerInfoGetFieldSigned);
+  VALKEYMODULE_GET_API(ServerInfoGetFieldUnsigned);
+  VALKEYMODULE_GET_API(ServerInfoGetFieldDouble);
+  VALKEYMODULE_GET_API(GetClusterInfo);
+  VALKEYMODULE_GET_API(GetClientInfoById);
+  VALKEYMODULE_GET_API(GetClientNameById);
+  VALKEYMODULE_GET_API(SetClientNameById);
+  VALKEYMODULE_GET_API(PublishMessage);
+  VALKEYMODULE_GET_API(PublishMessageShard);
+  VALKEYMODULE_GET_API(SubscribeToServerEvent);
+  VALKEYMODULE_GET_API(SetLRU);
+  VALKEYMODULE_GET_API(GetLRU);
+  VALKEYMODULE_GET_API(SetLFU);
+  VALKEYMODULE_GET_API(GetLFU);
+  VALKEYMODULE_GET_API(BlockClientOnKeys);
+  VALKEYMODULE_GET_API(SignalKeyAsReady);
+  VALKEYMODULE_GET_API(GetBlockedClientReadyKey);
+  VALKEYMODULE_GET_API(ScanCursorCreate);
+  VALKEYMODULE_GET_API(ScanCursorRestart);
+  VALKEYMODULE_GET_API(ScanCursorDestroy);
+  VALKEYMODULE_GET_API(Scan);
+  VALKEYMODULE_GET_API(ScanKey);
+  VALKEYMODULE_GET_API(GetContextFlagsAll);
+  VALKEYMODULE_GET_API(GetKeyspaceNotificationFlagsAll);
+  VALKEYMODULE_GET_API(IsSubEventSupported);
+  VALKEYMODULE_GET_API(GetServerVersion);
+  VALKEYMODULE_GET_API(GetTypeMethodVersion);
+  VALKEYMODULE_GET_API(Yield);
+  VALKEYMODULE_GET_API(GetThreadSafeContext);
+  VALKEYMODULE_GET_API(GetDetachedThreadSafeContext);
+  VALKEYMODULE_GET_API(FreeThreadSafeContext);
+  VALKEYMODULE_GET_API(ThreadSafeContextLock);
+  VALKEYMODULE_GET_API(ThreadSafeContextTryLock);
+  VALKEYMODULE_GET_API(ThreadSafeContextUnlock);
+  VALKEYMODULE_GET_API(BlockClient);
+  VALKEYMODULE_GET_API(BlockClientOnAuth);
+  VALKEYMODULE_GET_API(UnblockClient);
+  VALKEYMODULE_GET_API(IsBlockedReplyRequest);
+  VALKEYMODULE_GET_API(IsBlockedTimeoutRequest);
+  VALKEYMODULE_GET_API(GetBlockedClientPrivateData);
+  VALKEYMODULE_GET_API(GetBlockedClientHandle);
+  VALKEYMODULE_GET_API(AbortBlock);
+  VALKEYMODULE_GET_API(BlockedClientMeasureTimeStart);
+  VALKEYMODULE_GET_API(BlockedClientMeasureTimeEnd);
+  VALKEYMODULE_GET_API(SetDisconnectCallback);
+  VALKEYMODULE_GET_API(SubscribeToKeyspaceEvents);
+  VALKEYMODULE_GET_API(NotifyKeyspaceEvent);
+  VALKEYMODULE_GET_API(GetNotifyKeyspaceEvents);
+  VALKEYMODULE_GET_API(BlockedClientDisconnected);
+  VALKEYMODULE_GET_API(RegisterClusterMessageReceiver);
+  VALKEYMODULE_GET_API(SendClusterMessage);
+  VALKEYMODULE_GET_API(GetClusterNodeInfo);
+  VALKEYMODULE_GET_API(GetClusterNodesList);
+  VALKEYMODULE_GET_API(FreeClusterNodesList);
+  VALKEYMODULE_GET_API(CreateTimer);
+  VALKEYMODULE_GET_API(StopTimer);
+  VALKEYMODULE_GET_API(GetTimerInfo);
+  VALKEYMODULE_GET_API(GetCrossClusterReplicasList);
+  VALKEYMODULE_GET_API(FreeCrossClusterReplicasList);
+  VALKEYMODULE_GET_API(GetMyClusterID);
+  VALKEYMODULE_GET_API(GetMyShardID);
+  VALKEYMODULE_GET_API(GetClusterSize);
+  VALKEYMODULE_GET_API(GetRandomBytes);
+  VALKEYMODULE_GET_API(GetRandomHexChars);
+  VALKEYMODULE_GET_API(SetClusterFlags);
+  VALKEYMODULE_GET_API(ExportSharedAPI);
+  VALKEYMODULE_GET_API(GetSharedAPI);
+  VALKEYMODULE_GET_API(RegisterCommandFilter);
+  VALKEYMODULE_GET_API(UnregisterCommandFilter);
+  VALKEYMODULE_GET_API(CommandFilterArgsCount);
+  VALKEYMODULE_GET_API(CommandFilterArgGet);
+  VALKEYMODULE_GET_API(CommandFilterArgInsert);
+  VALKEYMODULE_GET_API(CommandFilterArgReplace);
+  VALKEYMODULE_GET_API(CommandFilterArgDelete);
+  VALKEYMODULE_GET_API(Fork);
+  VALKEYMODULE_GET_API(SendChildHeartbeat);
+  VALKEYMODULE_GET_API(ExitFromChild);
+  VALKEYMODULE_GET_API(KillForkChild);
+  VALKEYMODULE_GET_API(GetUsedMemoryRatio);
+  VALKEYMODULE_GET_API(MallocSize);
+  VALKEYMODULE_GET_API(MallocUsableSize);
+  VALKEYMODULE_GET_API(MallocSizeString);
+  VALKEYMODULE_GET_API(MallocSizeDict);
+  VALKEYMODULE_GET_API(CreateModuleUser);
+  VALKEYMODULE_GET_API(FreeModuleUser);
+  VALKEYMODULE_GET_API(SetContextUser);
+  VALKEYMODULE_GET_API(SetModuleUserACL);
+  VALKEYMODULE_GET_API(SetModuleUserACLString);
+  VALKEYMODULE_GET_API(GetModuleUserACLString);
+  VALKEYMODULE_GET_API(GetCurrentUserName);
+  VALKEYMODULE_GET_API(GetModuleUserFromUserName);
+  VALKEYMODULE_GET_API(ACLCheckCommandPermissions);
+  VALKEYMODULE_GET_API(ACLCheckKeyPermissions);
+  VALKEYMODULE_GET_API(ACLCheckChannelPermissions);
+  VALKEYMODULE_GET_API(ACLAddLogEntry);
+  VALKEYMODULE_GET_API(ACLAddLogEntryByUserName);
+  VALKEYMODULE_GET_API(DeauthenticateAndCloseClient);
+  VALKEYMODULE_GET_API(AuthenticateClientWithACLUser);
+  VALKEYMODULE_GET_API(AuthenticateClientWithUser);
+  VALKEYMODULE_GET_API(RedactClientCommandArgument);
+  VALKEYMODULE_GET_API(GetClientCertificate);
+  VALKEYMODULE_GET_API(GetCommandKeys);
+  VALKEYMODULE_GET_API(GetCommandKeysWithFlags);
+  VALKEYMODULE_GET_API(GetCurrentCommandName);
+  VALKEYMODULE_GET_API(RegisterDefragFunc);
+  VALKEYMODULE_GET_API(DefragAlloc);
+  VALKEYMODULE_GET_API(DefragValkeyModuleString);
+  VALKEYMODULE_GET_API(DefragShouldStop);
+  VALKEYMODULE_GET_API(DefragCursorSet);
+  VALKEYMODULE_GET_API(DefragCursorGet);
+  VALKEYMODULE_GET_API(GetKeyNameFromDefragCtx);
+  VALKEYMODULE_GET_API(GetDbIdFromDefragCtx);
+  VALKEYMODULE_GET_API(EventLoopAdd);
+  VALKEYMODULE_GET_API(EventLoopDel);
+  VALKEYMODULE_GET_API(EventLoopAddOneShot);
+  VALKEYMODULE_GET_API(RegisterBoolConfig);
+  VALKEYMODULE_GET_API(RegisterNumericConfig);
+  VALKEYMODULE_GET_API(RegisterStringConfig);
+  VALKEYMODULE_GET_API(RegisterEnumConfig);
+  VALKEYMODULE_GET_API(LoadConfigs);
+  VALKEYMODULE_GET_API(RdbStreamCreateFromFile);
+  VALKEYMODULE_GET_API(RdbStreamCreateFromRioHandler);
+  VALKEYMODULE_GET_API(RdbStreamFree);
+  VALKEYMODULE_GET_API(RdbLoad);
+  VALKEYMODULE_GET_API(RdbSave);
+  VALKEYMODULE_GET_API(ReplicationSetMasterCrossCluster);
+  VALKEYMODULE_GET_API(ReplicationUnsetMasterCrossCluster);
+  VALKEYMODULE_GET_API(ReplicationSetSecondaryCluster);
+  VALKEYMODULE_GET_API(HashExternalize);
 
-  if (RedisModule_IsModuleNameBusy && RedisModule_IsModuleNameBusy(name))
-    return REDISMODULE_ERR;
-  RedisModule_SetModuleAttribs(ctx, name, ver, apiver);
-  return REDISMODULE_OK;
+  if (ValkeyModule_IsModuleNameBusy && ValkeyModule_IsModuleNameBusy(name))
+    return VALKEYMODULE_ERR;
+  ValkeyModule_SetModuleAttribs(ctx, name, ver, apiver);
+  return VALKEYMODULE_OK;
 }
 
-#define RedisModule_Assert(_e) \
-  ((_e) ? (void)0 : (RedisModule__Assert(#_e, __FILE__, __LINE__), exit(1)))
+#define ValkeyModule_Assert(_e) \
+  ((_e) ? (void)0 : (ValkeyModule__Assert(#_e, __FILE__, __LINE__), exit(1)))
 
 #define RMAPI_FUNC_SUPPORTED(func) (func != NULL)
 
@@ -2233,7 +2254,7 @@ static int RedisModule_Init(RedisModuleCtx *ctx, const char *name, int ver,
 
 /* Things only defined for the modules core, not exported to modules
  * including this file. */
-#define RedisModuleString robj
+#define ValkeyModuleString robj
 
-#endif /* REDISMODULE_CORE */
+#endif /* VALKEYMODULE_CORE */
 #endif /* VMSDK_SRC_VALKEY_MODULE_API_VALKEY_MODULE_H */

--- a/vmsdk/testing/blocked_client_test.cc
+++ b/vmsdk/testing/blocked_client_test.cc
@@ -44,7 +44,7 @@ struct BlockedClientTestCase {
 };
 
 class BlockedClientTest
-    : public vmsdk::RedisTestWithParam<BlockedClientTestCase> {
+    : public vmsdk::ValkeyTestWithParam<BlockedClientTestCase> {
  protected:
 };
 
@@ -58,19 +58,19 @@ std::vector<size_t> FetchTrackedBlockedClients() {
 
 TEST_P(BlockedClientTest, EngineVersion) {
   const BlockedClientTestCase &test_case = GetParam();
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   EXPECT_TRUE(FetchTrackedBlockedClients().empty());
   std::vector<unsigned long long> client_ids(test_case.client_id_cnt);
-  std::vector<RedisModuleBlockedClient> bc_ptr(test_case.client_id_cnt);
+  std::vector<ValkeyModuleBlockedClient> bc_ptr(test_case.client_id_cnt);
   {
     std::vector<BlockedClient> blocked_clients;
     if (test_case.tracked_blocked_clients.empty()) {
-      EXPECT_CALL(*kMockRedisModule, UnblockClient(testing::_, nullptr))
+      EXPECT_CALL(*kMockValkeyModule, UnblockClient(testing::_, nullptr))
           .Times(0);
     } else {
       for (size_t i = 0; i < test_case.client_id_cnt; ++i) {
         if (i == 0 || !test_case.use_same_client_id) {
-          EXPECT_CALL(*kMockRedisModule, UnblockClient(&bc_ptr[i], nullptr))
+          EXPECT_CALL(*kMockValkeyModule, UnblockClient(&bc_ptr[i], nullptr))
               .Times(1);
         }
       }
@@ -78,26 +78,26 @@ TEST_P(BlockedClientTest, EngineVersion) {
     for (size_t i = 0; i < test_case.client_id_cnt; ++i) {
       auto ctx = test_case.use_same_client_id ? &client_ids[0] : &client_ids[i];
       if (test_case.tracked_blocked_clients.empty()) {
-        EXPECT_CALL(*kMockRedisModule,
+        EXPECT_CALL(*kMockValkeyModule,
                     BlockClient(&fake_ctx, nullptr, nullptr, nullptr, 0))
             .Times(0);
 
       } else {
         if (test_case.use_same_client_id) {
-          EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+          EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
               .WillOnce(testing::Return(1));
         } else {
-          EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+          EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
               .WillOnce(testing::Return(i + 1));
         }
         if (i == 0 || !test_case.use_same_client_id) {
-          EXPECT_CALL(*kMockRedisModule,
+          EXPECT_CALL(*kMockValkeyModule,
                       BlockClient(&fake_ctx, nullptr, nullptr, nullptr, 0))
               .WillOnce(
-                  [&bc_ptr, i](RedisModuleCtx *ctx,
-                               RedisModuleCmdFunc reply_callback,
-                               RedisModuleCmdFunc timeout_callback,
-                               void (*free_privdata)(RedisModuleCtx *, void *),
+                  [&bc_ptr, i](ValkeyModuleCtx *ctx,
+                               ValkeyModuleCmdFunc reply_callback,
+                               ValkeyModuleCmdFunc timeout_callback,
+                               void (*free_privdata)(ValkeyModuleCtx *, void *),
                                long long timeout_ms) { return &bc_ptr[i]; });
         }
       }

--- a/vmsdk/testing/command_parser_test.cc
+++ b/vmsdk/testing/command_parser_test.cc
@@ -110,7 +110,7 @@ class CBTestCommandParser {
   }
   virtual ~CBTestCommandParser() = default;
 
-  absl::StatusOr<TestParameters> Parse(RedisModuleString **argv, int argc) {
+  absl::StatusOr<TestParameters> Parse(ValkeyModuleString **argv, int argc) {
     TestParameters test_params;
     ArgsIterator itr{argv, argc};
     VMSDK_RETURN_IF_ERROR(param_parsers_.Parse(test_params, itr));
@@ -123,12 +123,12 @@ class CBTestCommandParser {
 };
 
 class KeyValueParserTest
-    : public vmsdk::RedisTestWithParam<KeyValueParseTestCase> {};
+    : public vmsdk::ValkeyTestWithParam<KeyValueParseTestCase> {};
 
 TEST_P(KeyValueParserTest, ParseParams) {
   const KeyValueParseTestCase &test_case = GetParam();
   static CBTestCommandParser parser;
-  auto args = ToRedisStringVector(test_case.params_str);
+  auto args = ToValkeyStringVector(test_case.params_str);
   auto params = parser.Parse(&args[0], args.size());
   EXPECT_EQ(params.ok(), test_case.success);
   if (params.ok()) {
@@ -147,7 +147,7 @@ TEST_P(KeyValueParserTest, ParseParams) {
     }
   }
   for (const auto &arg : args) {
-    TestRedisModule_FreeString(nullptr, arg);
+    TestValkeyModule_FreeString(nullptr, arg);
   }
 }
 
@@ -223,14 +223,14 @@ struct ParseParamsTestCase {
   bool expected_iterator_last{false};
 };
 
-class ParseParamsTest : public vmsdk::RedisTestWithParam<ParseParamsTestCase> {
+class ParseParamsTest : public vmsdk::ValkeyTestWithParam<ParseParamsTestCase> {
 };
 
 template <typename T>
 void DoTest(bool expected_success, const std::string &expected_err_msg,
             const T expected_parsed_value, const ParseParamsTestCase &test_case,
             auto parse_func) {
-  auto args = ToRedisStringVector(test_case.args_str);
+  auto args = ToValkeyStringVector(test_case.args_str);
   ArgsIterator itr{args.data(), static_cast<int>(args.size())};
   T parsed_value;
   auto res = parse_func(test_case.parse_key, test_case.is_mandatory, itr,
@@ -246,10 +246,10 @@ void DoTest(bool expected_success, const std::string &expected_err_msg,
       EXPECT_EQ(expected_err_msg, res.status().message());
     }
   }
-  auto redis_str = itr.Get();
-  EXPECT_EQ(!test_case.expected_iterator_last, redis_str.ok());
+  auto valkey_str = itr.Get();
+  EXPECT_EQ(!test_case.expected_iterator_last, valkey_str.ok());
   for (const auto &arg : args) {
-    TestRedisModule_FreeString(nullptr, arg);
+    TestValkeyModule_FreeString(nullptr, arg);
   }
 }
 

--- a/vmsdk/testing/memory_allocation_test.cc
+++ b/vmsdk/testing/memory_allocation_test.cc
@@ -62,10 +62,10 @@ namespace vmsdk {
 
 namespace {
 #ifndef TESTING_TMP_DISABLED
-class MemoryAllocationTest : public RedisTest {
+class MemoryAllocationTest : public ValkeyTest {
  protected:
   void SetUp() override {
-    RedisTest::SetUp();
+    ValkeyTest::SetUp();
     kMockSystemAlloc = new MockSystemAlloc();
     SetRealAllocators(
         [](size_t size) { return kMockSystemAlloc->_malloc(size); },
@@ -88,7 +88,7 @@ class MemoryAllocationTest : public RedisTest {
   void TearDown() override {
     SetRealAllocators(malloc, free, calloc, realloc, aligned_alloc,
                       posix_memalign, valloc);
-    RedisTest::TearDown();
+    ValkeyTest::TearDown();
     delete kMockSystemAlloc;
     vmsdk::ResetValkeyAlloc();
   }
@@ -99,7 +99,7 @@ TEST_F(MemoryAllocationTest, SystemAllocIsDefault) {
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _malloc(size))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, Alloc(size)).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, Alloc(size)).Times(0);
   void* ptr = __wrap_malloc(size);
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
@@ -114,7 +114,7 @@ TEST_F(MemoryAllocationTest, SystemCallocIsDefault) {
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _calloc(size, sizeof(int)))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, Calloc(size, sizeof(int))).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, Calloc(size, sizeof(int))).Times(0);
   void* ptr = __wrap_calloc(size, sizeof(int));
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
@@ -130,7 +130,7 @@ TEST_F(MemoryAllocationTest, SystemAlignedAllocIsDefault) {
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _aligned_alloc(align, size))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, Alloc(align)).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, Alloc(align)).Times(0);
   void* ptr = __wrap_aligned_alloc(align, size);
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
@@ -144,9 +144,9 @@ TEST_F(MemoryAllocationTest, MallocUsableSize) {
   vmsdk::UseValkeyAlloc();
   size_t valkey_size = 20;
   void* valkey_test_ptr = reinterpret_cast<void*>(0xBADF00D1);
-  EXPECT_CALL(*kMockRedisModule, Alloc(valkey_size))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(valkey_size))
       .WillOnce(testing::Return(valkey_test_ptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(valkey_test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(valkey_test_ptr))
       .Times(3)
       .WillRepeatedly(testing::Return(valkey_size));
 
@@ -155,7 +155,7 @@ TEST_F(MemoryAllocationTest, MallocUsableSize) {
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), valkey_size);
   EXPECT_EQ(__wrap_malloc_usable_size(valkey_ptr), valkey_size);
 
-  EXPECT_CALL(*kMockRedisModule, Free(valkey_test_ptr)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(valkey_test_ptr)).Times(1);
   __wrap_free(valkey_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -166,9 +166,9 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyAlloc) {
   size_t size = 10;
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _malloc(size)).Times(0);
-  EXPECT_CALL(*kMockRedisModule, Alloc(size))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(size))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr))
       .Times(2)
       .WillRepeatedly(testing::Return(size));
 
@@ -176,7 +176,7 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyAlloc) {
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), size);
 
-  EXPECT_CALL(*kMockRedisModule, Free(test_ptr)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(test_ptr)).Times(1);
   __wrap_free(test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -185,9 +185,9 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyCalloc) {
   size_t size = 10;
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _calloc(size, sizeof(int))).Times(0);
-  EXPECT_CALL(*kMockRedisModule, Calloc(size, sizeof(int)))
+  EXPECT_CALL(*kMockValkeyModule, Calloc(size, sizeof(int)))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr))
       .Times(2)
       .WillRepeatedly(testing::Return(size * sizeof(int)));
 
@@ -196,7 +196,7 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyCalloc) {
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), size * sizeof(int));
 
-  EXPECT_CALL(*kMockRedisModule, Free(test_ptr)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(test_ptr)).Times(1);
   __wrap_free(test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -206,9 +206,9 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyAlignedAlloc) {
   size_t align = 1024;
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
   EXPECT_CALL(*kMockSystemAlloc, _aligned_alloc(align, size)).Times(0);
-  EXPECT_CALL(*kMockRedisModule, Alloc(align))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(align))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr))
       .Times(2)
       .WillRepeatedly(testing::Return(align));
 
@@ -217,7 +217,7 @@ TEST_F(MemoryAllocationTest, SwitchToValkeyAlignedAlloc) {
   EXPECT_EQ(ptr, test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), align);
 
-  EXPECT_CALL(*kMockRedisModule, Free(test_ptr)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(test_ptr)).Times(1);
   __wrap_free(test_ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -246,8 +246,8 @@ TEST_F(MemoryAllocationTest, SystemFreeNullptr) {
 
 TEST_F(MemoryAllocationTest, ValkeyFreeNullptr) {
   vmsdk::UseValkeyAlloc();
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(testing::_)).Times(0);
-  EXPECT_CALL(*kMockRedisModule, Free(testing::_)).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(testing::_)).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, Free(testing::_)).Times(0);
   __wrap_free(nullptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -265,9 +265,9 @@ TEST_F(MemoryAllocationTest, SystemAllocReturnsNullptr) {
 TEST_F(MemoryAllocationTest, ValkeyAllocReturnsNullptr) {
   size_t size = 10;
   vmsdk::UseValkeyAlloc();
-  EXPECT_CALL(*kMockRedisModule, Alloc(size))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(size))
       .WillOnce(testing::Return(nullptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(testing::_)).Times(0);
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(testing::_)).Times(0);
   void* ptr = __wrap_malloc(size);
   EXPECT_EQ(ptr, nullptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
@@ -338,16 +338,16 @@ TEST_F(MemoryAllocationTest, ValkeyReallocBasic) {
   size_t initial_size = 10;
   size_t realloc_size = 20;
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
-  EXPECT_CALL(*kMockRedisModule, Alloc(initial_size))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(initial_size))
       .WillOnce(testing::Return(test_ptr));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr))
       .Times(2)
       .WillRepeatedly(testing::Return(initial_size));
 
   void* test_ptr_2 = reinterpret_cast<void*>(0xBADF00D1);
-  EXPECT_CALL(*kMockRedisModule, Realloc(test_ptr, realloc_size))
+  EXPECT_CALL(*kMockValkeyModule, Realloc(test_ptr, realloc_size))
       .WillOnce(testing::Return(test_ptr_2));
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr_2))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr_2))
       .Times(2)
       .WillRepeatedly(testing::Return(realloc_size));
 
@@ -361,17 +361,17 @@ TEST_F(MemoryAllocationTest, ValkeyReallocBasic) {
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), realloc_size);
   EXPECT_EQ(ptr_2, test_ptr_2);
 
-  EXPECT_CALL(*kMockRedisModule, Free(test_ptr_2)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(test_ptr_2)).Times(1);
   __wrap_free(ptr_2);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
 TEST_F(MemoryAllocationTest, ValkeyReallocNullptr) {
   size_t realloc_size = 20;
   void* test_ptr = reinterpret_cast<void*>(0xBAADF00D);
-  EXPECT_CALL(*kMockRedisModule, MallocUsableSize(test_ptr))
+  EXPECT_CALL(*kMockValkeyModule, MallocUsableSize(test_ptr))
       .Times(2)
       .WillRepeatedly(testing::Return(realloc_size));
-  EXPECT_CALL(*kMockRedisModule, Realloc(nullptr, realloc_size))
+  EXPECT_CALL(*kMockValkeyModule, Realloc(nullptr, realloc_size))
       .WillOnce(testing::Return(test_ptr));
 
   vmsdk::UseValkeyAlloc();
@@ -379,7 +379,7 @@ TEST_F(MemoryAllocationTest, ValkeyReallocNullptr) {
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), realloc_size);
   EXPECT_EQ(ptr, test_ptr);
 
-  EXPECT_CALL(*kMockRedisModule, Free(ptr)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(ptr)).Times(1);
   __wrap_free(ptr);
   EXPECT_EQ(vmsdk::GetUsedMemoryCnt(), 0);
 }
@@ -394,10 +394,10 @@ TEST_F(MemoryAllocationTest, SystemFreeUntracksPointer) {
 
   vmsdk::UseValkeyAlloc();
 
-  EXPECT_CALL(*kMockRedisModule, Alloc(testing::_))
+  EXPECT_CALL(*kMockValkeyModule, Alloc(testing::_))
       .WillOnce(testing::Return(test_ptr));
   __wrap_malloc(size);
-  EXPECT_CALL(*kMockRedisModule, Free(testing::_)).Times(1);
+  EXPECT_CALL(*kMockValkeyModule, Free(testing::_)).Times(1);
   __wrap_free(test_ptr);
 }
 TEST_F(MemoryAllocationTest, SystemFreeDefaultsDuringBootstrap) {

--- a/vmsdk/testing/module_test.cc
+++ b/vmsdk/testing/module_test.cc
@@ -42,41 +42,43 @@ namespace vmsdk {
 namespace {
 #define INSTALLED_MODULES 3
 
-class ModuleTest : public vmsdk::RedisTest {
+class ModuleTest : public vmsdk::ValkeyTest {
  protected:
-  RedisModuleCtx fake_ctx;
-  RedisModuleCallReply json_key;
-  RedisModuleCallReply json_value;
-  RedisModuleCallReply some_key;
-  RedisModuleCallReply reply_internal[INSTALLED_MODULES];
+  ValkeyModuleCtx fake_ctx;
+  ValkeyModuleCallReply json_key;
+  ValkeyModuleCallReply json_value;
+  ValkeyModuleCallReply some_key;
+  ValkeyModuleCallReply reply_internal[INSTALLED_MODULES];
   void InstallCheckers();
 };
 
 void ModuleTest::InstallCheckers() {
-  auto reply = new RedisModuleCallReply;
-  EXPECT_CALL(*kMockRedisModule,
+  auto reply = new ValkeyModuleCallReply;
+  EXPECT_CALL(*kMockValkeyModule,
               Call(&fake_ctx, testing::StrEq("MODULE"), testing::StrEq("c"),
                    testing::StrEq("LIST")))
-      .WillOnce(
-          [reply](RedisModuleCtx* ctx, const char* cmd, const char* fmt,
-                  const char* arg1) -> RedisModuleCallReply* { return reply; });
-  EXPECT_CALL(*kMockRedisModule, FreeCallReply(reply))
-      .WillOnce([](RedisModuleCallReply* reply) { delete reply; });
+      .WillOnce([reply](ValkeyModuleCtx* ctx, const char* cmd, const char* fmt,
+                        const char* arg1) -> ValkeyModuleCallReply* {
+        return reply;
+      });
+  EXPECT_CALL(*kMockValkeyModule, FreeCallReply(reply))
+      .WillOnce([](ValkeyModuleCallReply* reply) { delete reply; });
 
-  EXPECT_CALL(*kMockRedisModule, CallReplyType(testing::_))
-      .WillRepeatedly(
-          [](RedisModuleCallReply* reply) { return REDISMODULE_REPLY_ARRAY; });
-  EXPECT_CALL(*kMockRedisModule, CallReplyLength(testing::_))
-      .WillRepeatedly([reply](RedisModuleCallReply* in_reply) -> size_t {
+  EXPECT_CALL(*kMockValkeyModule, CallReplyType(testing::_))
+      .WillRepeatedly([](ValkeyModuleCallReply* reply) {
+        return VALKEYMODULE_REPLY_ARRAY;
+      });
+  EXPECT_CALL(*kMockValkeyModule, CallReplyLength(testing::_))
+      .WillRepeatedly([reply](ValkeyModuleCallReply* in_reply) -> size_t {
         if (reply == in_reply) {
           return INSTALLED_MODULES;
         }
         return 10;
       });
 
-  EXPECT_CALL(*kMockRedisModule, CallReplyArrayElement(testing::_, testing::_))
-      .WillRepeatedly([reply, this](RedisModuleCallReply* in_reply,
-                                    size_t indx) -> RedisModuleCallReply* {
+  EXPECT_CALL(*kMockValkeyModule, CallReplyArrayElement(testing::_, testing::_))
+      .WillRepeatedly([reply, this](ValkeyModuleCallReply* in_reply,
+                                    size_t indx) -> ValkeyModuleCallReply* {
         if (reply == in_reply) {
           return &reply_internal[indx];
         }
@@ -90,9 +92,9 @@ void ModuleTest::InstallCheckers() {
         return &some_key;
       });
 
-  EXPECT_CALL(*kMockRedisModule, CallReplyStringPtr(testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, CallReplyStringPtr(testing::_, testing::_))
       .WillRepeatedly(
-          [&](RedisModuleCallReply* in_reply, size_t* len) -> const char* {
+          [&](ValkeyModuleCallReply* in_reply, size_t* len) -> const char* {
             if (in_reply == &json_key) {
               static const std::string str("name");
               *len = str.length();

--- a/vmsdk/testing/module_type_test.cc
+++ b/vmsdk/testing/module_type_test.cc
@@ -44,44 +44,45 @@ namespace vmsdk {
 namespace {
 
 // Test fixture for module_type tests
-class ModuleTypeTest : public vmsdk::RedisTest {
+class ModuleTypeTest : public vmsdk::ValkeyTest {
  protected:
-  // Helper function to create RedisModuleString
-  RedisModuleString* CreateRedisModuleString(const std::string& str) {
-    return RedisModule_CreateString(nullptr, str.c_str(), str.size());
+  // Helper function to create ValkeyModuleString
+  ValkeyModuleString* CreateValkeyModuleString(const std::string& str) {
+    return ValkeyModule_CreateString(nullptr, str.c_str(), str.size());
   }
 };
 
 TEST_F(ModuleTypeTest, FailOpenRegisterKey) {
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(
-          testing::Return(reinterpret_cast<RedisModuleKey*>(REDISMODULE_OK)));
+          testing::Return(reinterpret_cast<ValkeyModuleKey*>(VALKEYMODULE_OK)));
 
   std::string key = "test_key";
-  RedisModuleType* module_type = reinterpret_cast<RedisModuleType*>(2);
+  ValkeyModuleType* module_type = reinterpret_cast<ValkeyModuleType*>(2);
   void* ptr = reinterpret_cast<void*>(3);
 
   // Call the Register function
   absl::Status result = ModuleType::Register(nullptr, key, ptr, module_type);
 
-  EXPECT_EQ(result.message(), "failed to open Redis module key: test_key");
+  EXPECT_EQ(result.message(), "failed to open Valkey module key: test_key");
   EXPECT_TRUE(result.code() != absl::StatusCode::kOk);
 }
 
 TEST_F(ModuleTypeTest, SuccessfullyRegistersKey) {
-  auto fake_key = reinterpret_cast<RedisModuleKey*>(1);
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  auto fake_key = reinterpret_cast<ValkeyModuleKey*>(1);
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(fake_key));
-  EXPECT_CALL(*kMockRedisModule, CloseKey(fake_key))
+  EXPECT_CALL(*kMockValkeyModule, CloseKey(fake_key))
       .WillOnce(testing::Return());
-  EXPECT_CALL(*kMockRedisModule, KeyType(fake_key))
-      .WillOnce(testing::Return(REDISMODULE_KEYTYPE_EMPTY));
+  EXPECT_CALL(*kMockValkeyModule, KeyType(fake_key))
+      .WillOnce(testing::Return(VALKEYMODULE_KEYTYPE_EMPTY));
 
   std::string key = "test_key";
-  RedisModuleType* module_type = reinterpret_cast<RedisModuleType*>(2);
+  ValkeyModuleType* module_type = reinterpret_cast<ValkeyModuleType*>(2);
   void* ptr = reinterpret_cast<void*>(3);
-  EXPECT_CALL(*kMockRedisModule, ModuleTypeSetValue(fake_key, module_type, ptr))
-      .WillOnce(testing::Return(REDISMODULE_OK));
+  EXPECT_CALL(*kMockValkeyModule,
+              ModuleTypeSetValue(fake_key, module_type, ptr))
+      .WillOnce(testing::Return(VALKEYMODULE_OK));
 
   // Call the Register function
   absl::Status result = ModuleType::Register(nullptr, key, ptr, module_type);
@@ -91,16 +92,16 @@ TEST_F(ModuleTypeTest, SuccessfullyRegistersKey) {
 }
 
 TEST_F(ModuleTypeTest, RegisterKeyAlreadyExistsError) {
-  auto fake_key = reinterpret_cast<RedisModuleKey*>(1);
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  auto fake_key = reinterpret_cast<ValkeyModuleKey*>(1);
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(fake_key));
-  EXPECT_CALL(*kMockRedisModule, CloseKey(fake_key))
+  EXPECT_CALL(*kMockValkeyModule, CloseKey(fake_key))
       .WillOnce(testing::Return());
-  EXPECT_CALL(*kMockRedisModule, KeyType(testing::_))
-      .WillOnce(testing::Return(REDISMODULE_KEYTYPE_STRING));
+  EXPECT_CALL(*kMockValkeyModule, KeyType(testing::_))
+      .WillOnce(testing::Return(VALKEYMODULE_KEYTYPE_STRING));
 
   std::string key = "test_key";
-  RedisModuleType* module_type = reinterpret_cast<RedisModuleType*>(2);
+  ValkeyModuleType* module_type = reinterpret_cast<ValkeyModuleType*>(2);
   void* ptr = reinterpret_cast<void*>(3);
 
   // Call the Register function
@@ -111,22 +112,22 @@ TEST_F(ModuleTypeTest, RegisterKeyAlreadyExistsError) {
 }
 
 TEST_F(ModuleTypeTest, RegisterInternalError) {
-  auto fake_key = reinterpret_cast<RedisModuleKey*>(1);
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  auto fake_key = reinterpret_cast<ValkeyModuleKey*>(1);
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(fake_key));
-  EXPECT_CALL(*kMockRedisModule, CloseKey(fake_key))
+  EXPECT_CALL(*kMockValkeyModule, CloseKey(fake_key))
       .WillOnce(testing::Return());
-  EXPECT_CALL(*kMockRedisModule, KeyType(fake_key))
-      .WillOnce(testing::Return(REDISMODULE_KEYTYPE_EMPTY));
-  EXPECT_CALL(*kMockRedisModule, DeleteKey(fake_key))
-      .WillOnce(testing::Return(REDISMODULE_OK));
+  EXPECT_CALL(*kMockValkeyModule, KeyType(fake_key))
+      .WillOnce(testing::Return(VALKEYMODULE_KEYTYPE_EMPTY));
+  EXPECT_CALL(*kMockValkeyModule, DeleteKey(fake_key))
+      .WillOnce(testing::Return(VALKEYMODULE_OK));
 
-  EXPECT_CALL(*kMockRedisModule,
+  EXPECT_CALL(*kMockValkeyModule,
               ModuleTypeSetValue(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(1));
 
   std::string key = "test_key";
-  RedisModuleType* module_type = reinterpret_cast<RedisModuleType*>(2);
+  ValkeyModuleType* module_type = reinterpret_cast<ValkeyModuleType*>(2);
   void* ptr = reinterpret_cast<void*>(3);
 
   // Call the Register function
@@ -136,15 +137,15 @@ TEST_F(ModuleTypeTest, RegisterInternalError) {
 }
 
 TEST_F(ModuleTypeTest, DeregisterSuccessfully) {
-  auto fake_key = reinterpret_cast<RedisModuleKey*>(1);
-  EXPECT_CALL(*kMockRedisModule, KeyExists(testing::_, testing::_))
+  auto fake_key = reinterpret_cast<ValkeyModuleKey*>(1);
+  EXPECT_CALL(*kMockValkeyModule, KeyExists(testing::_, testing::_))
       .WillOnce(testing::Return(1));
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(fake_key));
-  EXPECT_CALL(*kMockRedisModule, CloseKey(fake_key))
+  EXPECT_CALL(*kMockValkeyModule, CloseKey(fake_key))
       .WillOnce(testing::Return());
-  EXPECT_CALL(*kMockRedisModule, DeleteKey(fake_key))
-      .WillOnce(testing::Return(REDISMODULE_OK));
+  EXPECT_CALL(*kMockValkeyModule, DeleteKey(fake_key))
+      .WillOnce(testing::Return(VALKEYMODULE_OK));
 
   // Call the Deregister function
   absl::Status result = ModuleType::Deregister(nullptr, "test_key");
@@ -154,7 +155,7 @@ TEST_F(ModuleTypeTest, DeregisterSuccessfully) {
 }
 
 TEST_F(ModuleTypeTest, DeregisterUnregisteredKey) {
-  EXPECT_CALL(*kMockRedisModule, KeyExists(testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, KeyExists(testing::_, testing::_))
       .WillOnce(testing::Return(0));
 
   // Call the Deregister function
@@ -165,10 +166,10 @@ TEST_F(ModuleTypeTest, DeregisterUnregisteredKey) {
 }
 
 #ifdef NDEBUG
-TEST_F(ModuleTypeTest, DeregisterFailOpenRedisKey) {
-  EXPECT_CALL(*kMockRedisModule, KeyExists(testing::_, testing::_))
+TEST_F(ModuleTypeTest, DeregisterFailOpenValkeyKey) {
+  EXPECT_CALL(*kMockValkeyModule, KeyExists(testing::_, testing::_))
       .WillOnce(testing::Return(1));
-  EXPECT_CALL(*kMockRedisModule, OpenKey(testing::_, testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, OpenKey(testing::_, testing::_, testing::_))
       .WillOnce(testing::Return(nullptr));
   // Call the Deregister function
   absl::Status result = ModuleType::Deregister(nullptr, "test_key");

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -43,16 +43,16 @@ namespace vmsdk {
 
 namespace {
 
-class UtilsTest : public vmsdk::RedisTest {};
+class UtilsTest : public vmsdk::ValkeyTest {};
 
 TEST_F(UtilsTest, RunByMain) {
   absl::BlockingCounter blocking_refcount(1);
   ThreadPool thread_pool("test-pool", 1);
   thread_pool.StartWorkers();
-  RedisModuleEventLoopOneShotFunc captured_callback;
+  ValkeyModuleEventLoopOneShotFunc captured_callback;
   void* captured_data;
-  EXPECT_CALL(*kMockRedisModule, EventLoopAddOneShot(testing::_, testing::_))
-      .WillOnce([&](RedisModuleEventLoopOneShotFunc callback, void* data) {
+  EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
+      .WillOnce([&](ValkeyModuleEventLoopOneShotFunc callback, void* data) {
         captured_callback = callback;
         captured_data = data;
         blocking_refcount.DecrementCount();
@@ -75,7 +75,7 @@ TEST_F(UtilsTest, RunByMain) {
 
 TEST_F(UtilsTest, RunByMainWhileInMain) {
   absl::BlockingCounter blocking_refcount(1);
-  EXPECT_CALL(*kMockRedisModule, EventLoopAddOneShot(testing::_, testing::_))
+  EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
       .Times(0);
   bool run = false;
   RunByMain([&blocking_refcount, &run] {
@@ -105,43 +105,43 @@ TEST_F(UtilsTest, ParseTag) {
 }
 
 TEST_F(UtilsTest, MultiOrLua) {
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   {
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx))
         .WillRepeatedly(testing::Return(0));
     EXPECT_FALSE(MultiOrLua(&fake_ctx));
   }
   {
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx))
-        .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_MULTI));
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx))
+        .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_MULTI));
     EXPECT_TRUE(MultiOrLua(&fake_ctx));
   }
   {
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx))
-        .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_LUA));
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx))
+        .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LUA));
     EXPECT_TRUE(MultiOrLua(&fake_ctx));
   }
 }
 
 TEST_F(UtilsTest, IsRealUserClient) {
-  RedisModuleCtx fake_ctx;
+  ValkeyModuleCtx fake_ctx;
   {
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
         .WillRepeatedly(testing::Return(1));
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx))
         .WillRepeatedly(testing::Return(0));
     EXPECT_TRUE(IsRealUserClient(&fake_ctx));
   }
   {
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
         .WillRepeatedly(testing::Return(0));
     EXPECT_FALSE(IsRealUserClient(&fake_ctx));
   }
   {
-    EXPECT_CALL(*kMockRedisModule, GetClientId(&fake_ctx))
+    EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
         .WillRepeatedly(testing::Return(1));
-    EXPECT_CALL(*kMockRedisModule, GetContextFlags(&fake_ctx))
-        .WillRepeatedly(testing::Return(REDISMODULE_CTX_FLAGS_REPLICATED));
+    EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx))
+        .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_REPLICATED));
     EXPECT_FALSE(IsRealUserClient(&fake_ctx));
   }
 }

--- a/vmsdk/versionscript.lds
+++ b/vmsdk/versionscript.lds
@@ -1,7 +1,7 @@
 {
   global:
-    # Only expose the RedisModule APIs
-    RedisModule_OnLoad;
-    RedisModule_OnUnload;
+    # Only expose the ValkeyModule APIs
+    ValkeyModule_OnLoad;
+    ValkeyModule_OnUnload;
   local: *;  # hide everything else
 };


### PR DESCRIPTION
As of today, the module uses module API commands and function names with Redis instead of Valkey.

Rebranded the module to use only Valkey.
For example, changed: `REDISMODULE_API` -> `VALKEYMODULE_API` etc.