### PR TITLE
Fix DisplayAsSIBytes test

### DIFF
--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -141,7 +141,7 @@ TEST_F(UtilsTest, DisplayAsSIBytes) {
     std::memset(buffer, -1, sizeof(buffer));
     bytes = DisplayAsSIBytes(value, buffer, 1);
     EXPECT_EQ(buffer[0], 0);
-    EXPECT_EQ(buffer[1], -1); // untouched.
+    EXPECT_EQ(buffer[1], '\xff'); // untouched.
   }
 }
 


### PR DESCRIPTION
The test fails on AARCH architecture, this should work for all architectures.