### PR TITLE
Add query string bytes limit using a module config

### DIFF
--- a/integration/test_query_parser.py
+++ b/integration/test_query_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from valkey import ResponseError
 from valkey.client import Valkey
 from valkey_search_test_case import ValkeySearchTestCaseBase
@@ -6,7 +7,32 @@ from valkeytestframework.conftest import resource_port_tracker
 
 class TestQueryParser(ValkeySearchTestCaseBase):
 
-    def test_query_string_limit(self):
+    def test_query_string_bytes_limit(self):
+        """
+            Test the query string bytes depth limit in Valkey Search using Vector based queries.
+        """
+        client: Valkey = self.server.get_new_client()
+        # Test that the default query string limit is 10240
+        assert client.execute_command("CONFIG GET search.query-string-bytes") == [b"search.query-string-bytes", b"10240"]
+        assert client.execute_command("FT.CREATE my_index ON HASH PREFIX 1 doc: SCHEMA price NUMERIC category TAG SEPARATOR | doc_embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 128 DISTANCE_METRIC COSINE") == b"OK"
+        query = "@price:[10 20] =>[KNN 10 @doc_embedding $BLOB]"
+        assert client.execute_command(f"CONFIG SET search.query-string-bytes {len(query) - 1}") == b"OK"
+        with pytest.raises(Exception, match="Query string is too long, max length is 45 bytes"):
+            client.execute_command(
+                "FT.SEARCH", "my_index",
+                query,
+                "PARAMS", 2, "BLOB", "<your_vector_blob>",
+                "RETURN", 1, "doc_embedding"
+            )
+        assert client.execute_command(f"CONFIG SET search.query-string-bytes {len(query)}") == b"OK"
+        assert client.execute_command(
+            "FT.SEARCH", "my_index",
+            query,
+            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "RETURN", 1, "doc_embedding"
+        ) == [0]
+
+    def test_query_string_depth_limit(self):
         """
             Test the query string recursive depth limit in Valkey Search using Vector based queries.
         """

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -29,6 +29,7 @@
 #include "src/metrics.h"
 #include "src/query/search.h"
 #include "src/schema_manager.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/command_parser.h"
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/status/status_macros.h"
@@ -372,6 +373,13 @@ ParseVectorSearchParameters(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                                                parameters->index_schema_name));
   VMSDK_RETURN_IF_ERROR(
       vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));
+  // Validate the query string's length.
+  if (parameters->parse_vars.query_string.length() >
+      options::GetQueryStringBytes()) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Query string is too long, max length is ",
+                     options::GetQueryStringBytes(), " bytes."));
+  }
   VMSDK_RETURN_IF_ERROR(SearchParser.Parse(*parameters, itr));
   if (itr.DistanceEnd() > 0) {
     return absl::InvalidArgumentError(

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -64,6 +64,18 @@ static auto query_string_depth =
                           UINT_MAX)                  // max size
         .Build();
 
+/// Register the "--query-string-bytes" flag. Controls the depth of the query
+/// string parsing from the FT.SEARCH cmd.
+constexpr absl::string_view kQueryStringBytesConfig{"query-string-bytes"};
+constexpr uint32_t kDefaultQueryStringBytes{10240};
+constexpr uint32_t kMinimumQueryStringBytes{1};
+static auto query_string_bytes =
+    config::NumberBuilder(kQueryStringBytesConfig,   // name
+                          kDefaultQueryStringBytes,  // default size
+                          kMinimumQueryStringBytes,  // min size
+                          UINT_MAX)                  // max size
+        .Build();
+
 constexpr absl::string_view kHNSWBlockSizeConfig{"hnsw-block-size"};
 static auto hnsw_block_size =
     config::NumberBuilder(kHNSWBlockSizeConfig,   // name
@@ -152,6 +164,10 @@ static auto log_level =
 
 uint32_t GetQueryStringDepth() {
   return query_string_depth->GetValue();
+}
+
+uint32_t GetQueryStringBytes() {
+  return query_string_bytes->GetValue();
 }
 
 vmsdk::config::Number& GetHNSWBlockSize() {

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -64,8 +64,8 @@ static auto query_string_depth =
                           UINT_MAX)                  // max size
         .Build();
 
-/// Register the "--query-string-bytes" flag. Controls the depth of the query
-/// string parsing from the FT.SEARCH cmd.
+/// Register the "--query-string-bytes" flag. Controls the length of the query
+/// string of the FT.SEARCH cmd.
 constexpr absl::string_view kQueryStringBytesConfig{"query-string-bytes"};
 constexpr uint32_t kDefaultQueryStringBytes{10240};
 constexpr uint32_t kMinimumQueryStringBytes{1};

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -16,6 +16,9 @@ namespace config = vmsdk::config;
 /// Return the value of the Query String Depth configuration
 uint32_t GetQueryStringDepth();
 
+/// Return the value of the Query String Bytes configuration
+uint32_t GetQueryStringBytes();
+
 /// Return a mutable reference to the HNSW resize configuration parameter
 config::Number& GetHNSWBlockSize();
 


### PR DESCRIPTION
Add query string bytes limit using a module config. This control the size of the query string used in the FT.SEARCH command.
