### PR TITLE
Add a limit on the number of terms in a search query

### DIFF
--- a/integration/test_query_parser.py
+++ b/integration/test_query_parser.py
@@ -94,3 +94,65 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             assert False
         except ResponseError as e:
             assert "argument must be between 1 and 4294967295 inclusive" in str(e)
+            
+    def test_query_string_terms_count_limit(self):
+        """
+            Test the query string terms count limit in Valkey Search using Vector based queries.
+        """
+        client: Valkey = self.server.get_new_client()
+        # Test that the default query string terms count limit is 16
+        assert client.execute_command("CONFIG GET search.query-string-terms-count") == [b"search.query-string-terms-count", b"16"]
+        # Create an index for testing
+        assert client.execute_command("FT.CREATE my_index ON HASH PREFIX 1 doc: SCHEMA price NUMERIC category TAG SEPARATOR | doc_embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 128 DISTANCE_METRIC COSINE") == b"OK"
+        
+        # Test that we can set the query string terms count limit to 5
+        assert client.execute_command("CONFIG SET search.query-string-terms-count 5") == b"OK"
+        
+        # Validate the success case with a query having 5 terms (3 predicates + 2 composed predicates)
+        assert client.execute_command(
+            "FT.SEARCH", "my_index",
+            "@price:[10 20] @price:[30 40] @price:[50 60] =>[KNN 10 @doc_embedding $BLOB]",
+            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "RETURN", 1, "doc_embedding"
+        ) == [0]
+        
+        # Validate the failure case with a query having 7 terms (4 predicates + 3 composed predicates)
+        try:
+            client.execute_command(
+                "FT.SEARCH", "my_index",
+                "@price:[10 20] @price:[30 40] @price:[50 60] @price:[70 80] =>[KNN 10 @doc_embedding $BLOB]",
+                "PARAMS", 2, "BLOB", "<your_vector_blob>",
+                "RETURN", 1, "doc_embedding"
+            )
+            assert False
+        except ResponseError as e:
+            assert str(e) == "Invalid filter expression: `@price:[10 20] @price:[30 40] @price:[50 60] @price:[70 80]`. Invalid range: Value above maximum; Query string is too complex: max number of terms can't exceed 5"
+        
+        # Test with a higher limit
+        assert client.execute_command("CONFIG SET search.query-string-terms-count 10") == b"OK"
+        assert client.execute_command(
+            "FT.SEARCH", "my_index",
+            "@price:[10 20] @price:[30 40] @price:[50 60] @price:[70 80] =>[KNN 10 @doc_embedding $BLOB]",
+            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "RETURN", 1, "doc_embedding"
+        ) == [0]
+        
+        # Test with OR operators (each OR adds a composed predicate)
+        assert client.execute_command(
+            "FT.SEARCH", "my_index",
+            "@price:[10 20] | @price:[30 40] | @price:[50 60] =>[KNN 10 @doc_embedding $BLOB]",
+            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "RETURN", 1, "doc_embedding"
+        ) == [0]
+        
+        # Test that the config ranges from 1 to 32
+        try:
+            client.execute_command("CONFIG SET search.query-string-terms-count 0")
+            assert False
+        except ResponseError as e:
+            assert "argument must be between 1 and 32 inclusive" in str(e)
+        try:
+            client.execute_command("CONFIG SET search.query-string-terms-count 33")
+            assert False
+        except ResponseError as e:
+            assert "argument must be between 1 and 32 inclusive" in str(e)

--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -21,15 +21,57 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "src/valkey_search_options.h"
 #include "src/index_schema.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/numeric.h"
 #include "src/indexes/tag.h"
 #include "src/query/predicate.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/status/status_macros.h"
 
 namespace valkey_search {
+
+namespace options {
+
+/// Register the "--query-string-depth" flag. Controls the depth of the query
+/// string parsing from the FT.SEARCH cmd.
+constexpr absl::string_view kQueryStringDepthConfig{"query-string-depth"};
+constexpr uint32_t kDefaultQueryStringDepth{1000};
+constexpr uint32_t kMinimumQueryStringDepth{1};
+static auto query_string_depth =
+    config::NumberBuilder(kQueryStringDepthConfig,   // name
+                          kDefaultQueryStringDepth,  // default size
+                          kMinimumQueryStringDepth,  // min size
+                          UINT_MAX)                  // max size
+        .WithValidationCallback(CHECK_RANGE(kMinimumQueryStringDepth, UINT_MAX,
+                                            kQueryStringDepthConfig))
+        .Build();
+
+/// Register the "query-string-terms-count" flag. Controls the size of the
+/// query string parsing from the FT.SEARCH cmd. The number of nodes in the
+/// predicate tree.
+constexpr absl::string_view kQueryStringTermsCountConfig{
+    "query-string-terms-count"};
+constexpr uint32_t kDefaultQueryTermsCount{16};
+constexpr uint32_t kMaxQueryTermsCount{32};
+static auto query_terms_count =
+    config::NumberBuilder(kQueryStringTermsCountConfig,  // name
+                          kDefaultQueryTermsCount,       // default size
+                          1,                             // min size
+                          kMaxQueryTermsCount)           // max size
+        .WithValidationCallback(
+            CHECK_RANGE(1, kMaxQueryTermsCount, kQueryStringTermsCountConfig))
+        .Build();
+
+vmsdk::config::Number& GetQueryStringDepth() {
+  return dynamic_cast<vmsdk::config::Number&>(*query_string_depth);
+}
+
+vmsdk::config::Number& GetQueryStringTermsCount() {
+  return dynamic_cast<vmsdk::config::Number&>(*query_terms_count);
+}
+
+}  // namespace options
 
 namespace {
 #if defined(__clang__)
@@ -300,9 +342,9 @@ std::unique_ptr<query::Predicate> WrapPredicate(
 // than 100 is expressed as [(100 inf].
 // 10. Numeric filters are inclusive. Exclusive min or max are expressed with (
 // prepended to the number, for example, [(100 (200].
-absl::StatusOr<std::unique_ptr<query::Predicate>>
-FilterParser::ParseExpression(uint32_t level) {
-  if (level++ >= options::GetQueryStringDepth()) {
+absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::ParseExpression(
+    uint32_t level) {
+  if (level++ >= options::GetQueryStringDepth().GetValue()) {
     return absl::InvalidArgumentError("Query string is too complex");
   }
   std::unique_ptr<query::Predicate> prev_predicate;
@@ -322,6 +364,9 @@ FilterParser::ParseExpression(uint32_t level) {
             absl::StrCat("Expected ')' after expression got '",
                          expression_.substr(pos_, 1), "'. Position: ", pos_));
       }
+      if (prev_predicate) {
+        node_count_++;  // Count the ComposedPredicate Node
+      }
       prev_predicate =
           WrapPredicate(std::move(prev_predicate), std::move(predicate), negate,
                         query::LogicalOperator::kAnd);
@@ -330,25 +375,38 @@ FilterParser::ParseExpression(uint32_t level) {
         return UnexpectedChar(expression_, pos_ - 1);
       }
       VMSDK_ASSIGN_OR_RETURN(predicate, ParseExpression(level));
+      if (prev_predicate) {
+        node_count_++;  // Count the ComposedPredicate Node
+      }
       prev_predicate =
           WrapPredicate(std::move(prev_predicate), std::move(predicate), negate,
                         query::LogicalOperator::kOr);
     } else {
       VMSDK_ASSIGN_OR_RETURN(auto field_name, ParseFieldName());
       if (Match('[')) {
+        node_count_++;  // Count the NumericPredicate Node
         VMSDK_ASSIGN_OR_RETURN(predicate, ParseNumericPredicate(field_name));
       } else if (Match('{')) {
+        node_count_++;  // Count the TagPredicate Node
         VMSDK_ASSIGN_OR_RETURN(predicate, ParseTagPredicate(field_name));
       } else {
         return absl::InvalidArgumentError(
             absl::StrCat("Expected '[', '{', got '",
                          expression_.substr(pos_, 1), "'. Position: ", pos_));
       }
+      if (prev_predicate) {
+        node_count_++;  // Count the ComposedPredicate Node
+      }
       prev_predicate =
           WrapPredicate(std::move(prev_predicate), std::move(predicate), negate,
                         query::LogicalOperator::kAnd);
     }
     SkipWhitespace();
+    auto max_node_count = options::GetQueryStringTermsCount().GetValue();
+    VMSDK_RETURN_IF_ERROR(
+        vmsdk::VerifyRange(node_count_, std::nullopt, max_node_count))
+        << "Query string is too complex: max number of terms can't exceed "
+        << max_node_count;
   }
   return prev_predicate;
 }

--- a/src/commands/filter_parser.h
+++ b/src/commands/filter_parser.h
@@ -17,6 +17,7 @@
 #include "src/index_schema.h"
 #include "src/indexes/tag.h"
 #include "src/query/predicate.h"
+#include "vmsdk/src/module_config.h"
 
 namespace valkey_search {
 namespace indexes {
@@ -36,10 +37,12 @@ class FilterParser {
   const IndexSchema& index_schema_;
   absl::string_view expression_;
   size_t pos_{0};
+  size_t node_count_{0};
   absl::flat_hash_set<std::string> filter_identifiers_;
 
   absl::StatusOr<bool> IsMatchAllExpression();
-  absl::StatusOr<std::unique_ptr<query::Predicate>> ParseExpression(uint32_t level);
+  absl::StatusOr<std::unique_ptr<query::Predicate>> ParseExpression(
+      uint32_t level);
   absl::StatusOr<std::unique_ptr<query::NumericPredicate>>
   ParseNumericPredicate(const std::string& attribute_alias);
   absl::StatusOr<std::unique_ptr<query::TagPredicate>> ParseTagPredicate(
@@ -60,6 +63,16 @@ class FilterParser {
   absl::StatusOr<absl::flat_hash_set<absl::string_view>> ParseTags(
       absl::string_view tag_string, indexes::Tag* tag_index) const;
 };
+
+namespace options {
+
+/// Return the value of the Query String Depth configuration
+vmsdk::config::Number& GetQueryStringDepth();
+
+/// Return the value of the Query String Terms Count configuration
+vmsdk::config::Number& GetQueryStringTermsCount();
+
+}  // namespace options
 
 }  // namespace valkey_search
 #endif  // VALKEYSEARCH_SRC_COMMANDS_FILTER_PARSER_H_

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -52,18 +52,6 @@ absl::Status ValidateLogLevel(const int value) {
 // Configuration entries
 namespace config = vmsdk::config;
 
-/// Register the "--query-string-depth" flag. Controls the depth of the query
-/// string parsing from the FT.SEARCH cmd.
-constexpr absl::string_view kQueryStringDepthConfig{"query-string-depth"};
-constexpr uint32_t kDefaultQueryStringDepth{1000};
-constexpr uint32_t kMinimumQueryStringDepth{1};
-static auto query_string_depth =
-    config::NumberBuilder(kQueryStringDepthConfig,   // name
-                          kDefaultQueryStringDepth,  // default size
-                          kMinimumQueryStringDepth,  // min size
-                          UINT_MAX)                  // max size
-        .Build();
-
 /// Register the "--query-string-bytes" flag. Controls the length of the query
 /// string of the FT.SEARCH cmd.
 constexpr absl::string_view kQueryStringBytesConfig{"query-string-bytes"};
@@ -162,13 +150,7 @@ static auto log_level =
         .WithValidationCallback(ValidateLogLevel)
         .Build();
 
-uint32_t GetQueryStringDepth() {
-  return query_string_depth->GetValue();
-}
-
-uint32_t GetQueryStringBytes() {
-  return query_string_bytes->GetValue();
-}
+uint32_t GetQueryStringBytes() { return query_string_bytes->GetValue(); }
 
 vmsdk::config::Number& GetHNSWBlockSize() {
   return dynamic_cast<vmsdk::config::Number&>(*hnsw_block_size);

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -13,9 +13,6 @@ namespace options {
 
 namespace config = vmsdk::config;
 
-/// Return the value of the Query String Depth configuration
-uint32_t GetQueryStringDepth();
-
 /// Return the value of the Query String Bytes configuration
 uint32_t GetQueryStringBytes();
 


### PR DESCRIPTION
When using the FT.SEARCH we provide a query, aw we already implemented a depth limit on the query syntax tree we also want to limit the number of terms in the query i.e the number of nodes in the syntax tree.

In this PR I added the terms count limit and refactored the depth limit