### PR TITLE
valkey-test-framework: support creating cluster

### DIFF
--- a/integration/run.sh
+++ b/integration/run.sh
@@ -150,6 +150,7 @@ export MODULE_PATH=${MODULE_PATH}
 export VALKEY_SERVER_PATH=${VALKEY_SERVER_PATH}
 export PYTHONPATH=${WD}/valkeytestframework:${WD}
 export JSON_MODULE_PATH=${JSON_MODULE_PATH}
+export SKIPLOGCLEAN=1
 
 FILTER_ARGS=""
 if [ ! -z "${TEST_PATTERN}" ]; then
@@ -159,4 +160,4 @@ else
     LOG_INFO "TEST_PATTERN is not set. Running all integration tests."
 fi
 LOG_INFO "Running: ${PYTHON_PATH} -m pytest ${FILTER_ARGS} --capture=sys --cache-clear -v ${ROOT_DIR}/integration/"
-${PYTHON_PATH} -m pytest ${FILTER_ARGS} --capture=sys --cache-clear -v ${ROOT_DIR}/integration/
+${PYTHON_PATH} -m pytest ${FILTER_ARGS} --log-cli-level=INFO --capture=sys --cache-clear -v ${ROOT_DIR}/integration/

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -91,6 +91,15 @@ function setup_python() {
     fi
 }
 
+function zap() {
+    echo "Zapping $1...";
+    pids=$(ps -ef|grep $1|grep -v grep |awk '{print $2;}');
+    for pid in $pids;
+    do
+        kill -9 $pid;
+    done
+}
+
 function install_test_framework() {
     local test_framework_url="https://github.com/valkey-io/valkey-test-framework"
     local test_framework_path="${WD}/valkey-test-framework"
@@ -159,5 +168,7 @@ if [ ! -z "${TEST_PATTERN}" ]; then
 else
     LOG_INFO "TEST_PATTERN is not set. Running all integration tests."
 fi
+
+zap valkey-server
 LOG_INFO "Running: ${PYTHON_PATH} -m pytest ${FILTER_ARGS} --capture=sys --cache-clear -v ${ROOT_DIR}/integration/"
 ${PYTHON_PATH} -m pytest ${FILTER_ARGS} --log-cli-level=INFO --capture=sys --cache-clear -v ${ROOT_DIR}/integration/

--- a/integration/test_vss_basic.py
+++ b/integration/test_vss_basic.py
@@ -1,8 +1,11 @@
 import time
+import logging
 from valkeytestframework.util.waiters import *
 from valkey import ResponseError
 from valkey.client import Valkey
+from valkey.cluster import ValkeyCluster
 from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkey_search_test_case import ValkeySearchClusterTestCase
 from valkeytestframework.conftest import resource_port_tracker
 
 
@@ -23,3 +26,15 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
             elif module[b"name"] == b"json":
                 json_loaded = True
         assert module_loaded
+
+
+class TestVSSClusterBasic(ValkeySearchClusterTestCase):
+
+    def test_cluster_starting(self):
+        client: Valkey = self.new_client_for_primary(0)
+        module_list_data = client.execute_command("MODULE LIST")
+        module_list_count = len(module_list_data)
+        # We expect JSON & Search to be loaded
+        assert module_list_count == 2
+        cluster_client: ValkeyCluster = self.new_cluster_client()
+        assert cluster_client.set("hello", "world") == True

--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -2,6 +2,9 @@ import os
 import pytest
 from valkeytestframework.valkey_test_case import ValkeyTestCase
 from valkey import ResponseError
+from valkey.cluster import ValkeyCluster, ClusterNode
+from valkey.client import Valkey
+from valkey.connection import Connection
 import random
 import string
 import logging
@@ -54,3 +57,157 @@ class ValkeySearchTestCaseBase(ValkeyTestCase):
                 key, value = line.split(":", 1)
                 stats_dict[key.strip()] = value.strip()
         return stats_dict
+
+
+class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
+    def dict_to_space_delimited(self, d):
+        result = []
+        for key, value in d.items():
+            result.append(f"--{key}")
+            result.append(str(value))
+        return " ".join(result)
+
+    def _start_server(self, port):
+        server_path = os.getenv("VALKEY_SERVER_PATH")
+        pid = os.getpid()
+        testdir = f"/tmp/valkey-search-clusters/{pid}/shard-{port}"
+        os.makedirs(testdir, exist_ok=True)
+        curdir = os.getcwd()
+        os.chdir(testdir)
+        lines = [
+            "enable-debug-command yes",
+            f"loadmodule {os.getenv('JSON_MODULE_PATH')}",
+            f"loadmodule {os.getenv('MODULE_PATH')} --use-coordinator",
+            f"dir {testdir}",
+            "cluster-enabled yes",
+        ]
+        with open(f"{testdir}/valkey.conf", "w+") as f:
+            for line in lines:
+                f.write(f"{line}\n")
+            f.write("\n")
+            f.close()
+
+        server, client = self.create_server(
+            testdir=testdir,
+            server_path=server_path,
+            args="",
+            port=port,
+            conf_file=f"{testdir}/valkey.conf",
+        )
+        os.chdir(curdir)
+        logfile = f"{testdir}/logfile_{port}"
+        return server, client, logfile
+
+    def _split_range_pairs(self, start, end, n):
+        points = [start + i * (end - start) // n for i in range(n + 1)]
+        return list(zip(points[:-1], points[1:]))
+
+    def add_slots(self, node_idx, first_slot, last_slot):
+        client: Valkey = self.client_for_primary(node_idx)
+        slots_to_add = list(range(int(first_slot), int(last_slot)))
+        try:
+            client.execute_command("CLUSTERADMIN ADDSLOTS", *slots_to_add)
+        except Exception as e:
+            client.execute_command("CLUSTER ADDSLOTS", *slots_to_add)
+
+    def cluster_meet(self, node_idx, primaries_count):
+        client: Valkey = self.client_for_primary(node_idx)
+
+        for node_to_meet in range(0, primaries_count):
+            if node_to_meet == node_idx:
+                continue
+            meet_command = (
+                f"MEET 127.0.0.1 {self.get_primary_port(node_to_meet)}"
+            )
+            try:
+                client.execute_command(
+                    " ".join(
+                        [
+                            "CLUSTERADMIN",
+                            "MEET",
+                            "127.0.0.1",
+                            f"{self.get_primary_port(node_to_meet)}",
+                        ]
+                    )
+                )
+            except Exception as e:
+                client.execute_command(
+                    " ".join(
+                        [
+                            "CLUSTER",
+                            "MEET",
+                            "127.0.0.1",
+                            f"{self.get_primary_port(node_to_meet)}",
+                        ]
+                    )
+                )
+
+    @pytest.fixture(autouse=True)
+    def setup_test(self, setup):
+        self.servers = []
+        ports = [
+            self.get_bind_port(),
+            self.get_bind_port(),
+            self.get_bind_port(),
+        ]
+
+        for port in ports:
+            server, client, logfile = self._start_server(port)
+            self.servers.append(
+                {
+                    "server": server,
+                    "client": client,
+                    "port": port,
+                    "logfile": logfile,
+                }
+            )
+
+        # Split the slots
+        ranges = self._split_range_pairs(0, 16384, len(ports))
+        node_idx = 0
+        for start, end in ranges:
+            self.add_slots(node_idx, start, end)
+            node_idx = node_idx + 1
+
+        # Perform cluster meet
+        for node_idx in range(0, 3):
+            self.cluster_meet(node_idx, 3)
+
+        # Wait for the cluster to be up
+        logging.info("Waiting for cluster to change state...")
+        for server in self.servers:
+            self.wait_for_logfile(
+                server["logfile"], "Cluster state changed: ok"
+            )
+        logging.info("Cluster is up and running!")
+
+    def get_primary(self, index):
+        return self.servers[index]["server"]
+
+    def get_primary_port(self, index):
+        return self.servers[index]["port"]
+
+    def new_client_for_primary(self, index):
+        return self.servers[index]["server"].get_new_client()
+
+    def client_for_primary(self, index):
+        return self.servers[index]["client"]
+
+    def new_cluster_client(self):
+        """Return a cluster client"""
+        startup_nodes = [
+            ClusterNode("127.0.0.1", self.get_primary_port(0)),
+            ClusterNode("127.0.0.1", self.get_primary_port(1)),
+            ClusterNode("127.0.0.1", self.get_primary_port(2)),
+        ]
+
+        valkey_conn = ValkeyCluster.from_url(
+            url="valkey://{}:{}".format(
+                startup_nodes[0].host, startup_nodes[0].port
+            ),
+            connection_class=Connection,
+            startup_nodes=startup_nodes,
+            require_full_coverage=True,
+        )
+        valkey_conn.ping()
+        return valkey_conn

--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -61,10 +61,11 @@ class ValkeySearchTestCaseBase(ValkeyTestCase):
 
 
 class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
+    CLUSTER_SIZE = 3
+
     def _start_server(self, port, test_name):
         server_path = os.getenv("VALKEY_SERVER_PATH")
-        testdir_base = f"/tmp/valkey-search-clusters/{test_name}"
-        testdir = f"{testdir_base}/{port}"
+        testdir = f"/tmp/valkey-search-clusters/{test_name}"
 
         os.makedirs(testdir, exist_ok=True)
         curdir = os.getcwd()
@@ -75,9 +76,10 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
             f"loadmodule {os.getenv('MODULE_PATH')} --use-coordinator",
             f"dir {testdir}",
             "cluster-enabled yes",
+            f"cluster-config-file nodes_{port}.conf",
         ]
 
-        conf_file = f"{testdir}/valkey.conf"
+        conf_file = f"{testdir}/valkey_{port}.conf"
         with open(conf_file, "w+") as f:
             for line in lines:
                 f.write(f"{line}\n")
@@ -102,10 +104,7 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
     def add_slots(self, node_idx, first_slot, last_slot):
         client: Valkey = self.client_for_primary(node_idx)
         slots_to_add = list(range(int(first_slot), int(last_slot)))
-        try:
-            client.execute_command("CLUSTERADMIN ADDSLOTS", *slots_to_add)
-        except Exception as e:
-            client.execute_command("CLUSTER ADDSLOTS", *slots_to_add)
+        client.execute_command("CLUSTER ADDSLOTS", *slots_to_add)
 
     def cluster_meet(self, node_idx, primaries_count):
         client: Valkey = self.client_for_primary(node_idx)
@@ -113,37 +112,24 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
         for node_to_meet in range(0, primaries_count):
             if node_to_meet == node_idx:
                 continue
-            try:
-                client.execute_command(
-                    " ".join(
-                        [
-                            "CLUSTERADMIN",
-                            "MEET",
-                            "127.0.0.1",
-                            f"{self.get_primary_port(node_to_meet)}",
-                        ]
-                    )
+
+            client.execute_command(
+                " ".join(
+                    [
+                        "CLUSTER",
+                        "MEET",
+                        "127.0.0.1",
+                        f"{self.get_primary_port(node_to_meet)}",
+                    ]
                 )
-            except Exception as e:
-                client.execute_command(
-                    " ".join(
-                        [
-                            "CLUSTER",
-                            "MEET",
-                            "127.0.0.1",
-                            f"{self.get_primary_port(node_to_meet)}",
-                        ]
-                    )
-                )
+            )
 
     @pytest.fixture(autouse=True)
     def setup_test(self, request):
         self.servers = []
-        ports = [
-            self.get_bind_port(),
-            self.get_bind_port(),
-            self.get_bind_port(),
-        ]
+        ports = []
+        for i in range(0, self.CLUSTER_SIZE):
+            ports.append(self.get_bind_port())
 
         testdir_base = f"/tmp/valkey-search-clusters/{request.node.name}"
         if os.path.exists(testdir_base):
@@ -170,8 +156,8 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
             node_idx = node_idx + 1
 
         # Perform cluster meet
-        for node_idx in range(0, 3):
-            self.cluster_meet(node_idx, 3)
+        for node_idx in range(0, self.CLUSTER_SIZE):
+            self.cluster_meet(node_idx, self.CLUSTER_SIZE)
 
         # Wait for the cluster to be up
         for server in self.servers:
@@ -195,11 +181,11 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseBase):
 
     def new_cluster_client(self):
         """Return a cluster client"""
-        startup_nodes = [
-            ClusterNode("127.0.0.1", self.get_primary_port(0)),
-            ClusterNode("127.0.0.1", self.get_primary_port(1)),
-            ClusterNode("127.0.0.1", self.get_primary_port(2)),
-        ]
+        startup_nodes = []
+        for index in range(0, self.CLUSTER_SIZE):
+            startup_nodes.append(
+                ClusterNode("127.0.0.1", self.get_primary_port(index))
+            )
 
         valkey_conn = ValkeyCluster.from_url(
             url="valkey://{}:{}".format(


### PR DESCRIPTION
With this change:

- Added support for CME in valkey-test-framework
- Each test creates its own test folder under `/tmp/valkey-search-clusters/<TEST_NAME>/<PORT>`

