### PR TITLE
Fix ACL bug where commands where allowed when user has no permissions for one of the index prefixes

### DIFF
--- a/src/acl.cc
+++ b/src/acl.cc
@@ -341,17 +341,20 @@ absl::Status AclPrefixCheck(
 
   // If no index prefixes are given from the module, it should have permission
   // to access ALL keys.
-  if (module_prefixes.empty() && IsPrefixAllowed("", acl_keys)) {
-    return absl::OkStatus();
+  if (module_prefixes.empty() && !IsPrefixAllowed("", acl_keys)) {
+    return absl::PermissionDeniedError(
+          "The user doesn't have a permission to execute a command");
   }
 
+  // We allow the user to execute command only if the user has permissions for
+  // ALL of the prefixes of the index
   for (const auto &module_prefix : module_prefixes) {
-    if (IsPrefixAllowed(module_prefix, acl_keys)) {
-      return absl::OkStatus();
+    if (!IsPrefixAllowed(module_prefix, acl_keys)) {
+      return absl::PermissionDeniedError(
+          "The user doesn't have a permission to execute a command");
     }
   }
-  return absl::PermissionDeniedError(
-      "The user doesn't have a permission to execute a command");
+  return absl::OkStatus();
 }
 
 absl::Status AclPrefixCheck(

--- a/testing/acl_test.cc
+++ b/testing/acl_test.cc
@@ -362,6 +362,27 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_return = absl::PermissionDeniedError(
                 "The user doesn't have a permission to execute a command"),
         },
+        {
+            .test_name = "several_prefixes_allowed_only_one",
+            .module_allowed_commands = {"@search"},
+            .prefixes = {"abc:", "xyz:"},
+            .acls = {{
+                .cmds = "+@all",
+                .keys = "~abc:*",
+            }},
+            .expected_return = absl::PermissionDeniedError(
+                "The user doesn't have a permission to execute a command"),
+        },
+        {
+            .test_name = "several_prefixes_allowed_all",
+            .module_allowed_commands = {"@search"},
+            .prefixes = {"abc:", "xyz:"},
+            .acls = {{
+                .cmds = "+@all",
+                .keys = "~abc:* ~xyz:*",
+            }},
+            .expected_return = absl::OkStatus(),
+        },
     }),
     [](const TestParamInfo<AclPrefixCheckTestCase> &info) {
       return info.param.test_name;


### PR DESCRIPTION
As of today, if an index vector is created with several prefixes, and a user can access at least one of them, the user can run search command and view results of keys which he does not have access to. 
For example:
```
127.0.0.1:6378> ft.info vector_index_3
...
 6) 1) key_type
    2) HASH
    3) prefixes
    4) 1) vec:
       2) vector:
...

127.0.0.1:6378> acl list
...
 4) "user user-1 on sanitize-payload #0000000000000000000000000000000000000000000000000000000000000000 ~vector:* &* +@all"
...
127.0.0.1:6378> auth user-1 [redacted]
127.0.0.1:6378> acl whoami
"user-1"
127.0.0.1:6378> ft.search vector_index_3 "*=>[knn 2 @vec $query_vec]" params 2 query_vec "\x00\x00\x00\x00\x00\x00\x00\x00" dialect 2
1) (integer) 2
2) "vec:69"
3) 1) "__vec_score"
   2) "0"
   3) "vector"
   4) "\x01\x00\x00\x00\x00\x00\x00\x00"
   5) "foo"
   6) "bar"
4) "vec:32"
5) 1) "__vec_score"
   2) "0"
   3) "vector"
   4) "\x03\x00\x00\x00\x00\x00\x00\x00"
   5) "foo"
   6) "bar"
127.0.0.1:6378> hgetall vec:69
(error) NOPERM No permissions to access a key
```

In the example above, user `user-1` has permissions only for keys with prefix `~vector:*`. The index has two prefixes:
- `vec:`
- `vector:`

In theory, the user should not be able to view keys with prefix `vec:`, but the current implementation allows it.
This PR fixes this bug.