### PR TITLE
Fix WrongArity function to wrap command names with single quotes for Valkey consistency

### DIFF
--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -331,8 +331,8 @@ INSTANTIATE_TEST_SUITE_P(
                     {
                         .argv = {"FT.Info"},
                         .expect_return_failure = true,
-                        .expected_output = "$49\r\nERR wrong number of "
-                                           "arguments for FT.INFO command\r\n",
+                        .expected_output = "$51\r\nERR wrong number of "
+                                           "arguments for 'FT.INFO' command\r\n",
                     },
                 },
         },

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -70,7 +70,7 @@ int RunByMain(absl::AnyInvocable<void()> fn, bool force_async) {
 }
 
 std::string WrongArity(absl::string_view cmd) {
-  return absl::StrCat("ERR wrong number of arguments for ", cmd, " command");
+  return absl::StrCat("ERR wrong number of arguments for '", cmd, "' command");
 }
 
 bool IsRealUserClient(ValkeyModuleCtx *ctx) {

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -145,6 +145,30 @@ TEST_F(UtilsTest, DisplayAsSIBytes) {
   }
 }
 
+TEST_F(UtilsTest, WrongArity) {
+  // Test standard FT commands
+  EXPECT_EQ(WrongArity("FT.INFO"), 
+            "ERR wrong number of arguments for 'FT.INFO' command");
+  EXPECT_EQ(WrongArity("FT.SEARCH"), 
+            "ERR wrong number of arguments for 'FT.SEARCH' command");
+  EXPECT_EQ(WrongArity("FT.DROPINDEX"), 
+            "ERR wrong number of arguments for 'FT.DROPINDEX' command");
+  EXPECT_EQ(WrongArity("FT._LIST"), 
+            "ERR wrong number of arguments for 'FT._LIST' command");
+  
+  // Test edge cases
+  EXPECT_EQ(WrongArity(""), 
+            "ERR wrong number of arguments for '' command");
+  EXPECT_EQ(WrongArity("SINGLE"), 
+            "ERR wrong number of arguments for 'SINGLE' command");
+  
+  // Test with special characters
+  EXPECT_EQ(WrongArity("CMD.WITH-DASH"), 
+            "ERR wrong number of arguments for 'CMD.WITH-DASH' command");
+  EXPECT_EQ(WrongArity("CMD_WITH_UNDERSCORE"), 
+            "ERR wrong number of arguments for 'CMD_WITH_UNDERSCORE' command");
+}
+
 }  // namespace
 
 }  // namespace vmsdk


### PR DESCRIPTION

Fix WrongArity function to wrap command names with single quotes for Valkey consistency

### **Problem**
The `WrongArity` function in `vmsdk/src/utils.cc` generates error messages that don't match Valkey's standard formatting. Command names should be wrapped in single quotes to be consistent with Valkey's `commandCheckArity` function.

**Current behavior:**
```
ERR wrong number of arguments for FT.INFO command
```

**Expected behavior (matching Valkey standard):**
```
ERR wrong number of arguments for 'FT.INFO' command
```

### **Solution**
Updated the `WrongArity` function to include single quotes around command names:

```cpp
// Before
std::string WrongArity(absl::string_view cmd) {
  return absl::StrCat("ERR wrong number of arguments for ", cmd, " command");
}

// After  
std::string WrongArity(absl::string_view cmd) {
  return absl::StrCat("ERR wrong number of arguments for '", cmd, "' command");
}
```

### **Impact**
This change affects all commands using the `WrongArity` helper:
- `FT.INFO` (src/commands/ft_info.cc)
- `FT.DROPINDEX` (src/commands/ft_dropindex.cc)  
- `FT._LIST` (src/commands/ft_list.cc)
- Any future commands using this utility

### **Testing**
Added comprehensive test coverage in `vmsdk/testing/utils_test.cc`:
- ✅ Standard FT commands formatting
- ✅ Edge cases (empty strings, single words)
- ✅ Special characters (dots, dashes, underscores)
- ✅ Proper quote formatting verification

### **Files Changed**
- `vmsdk/src/utils.cc` - Updated WrongArity function
- `vmsdk/testing/utils_test.cc` - Added comprehensive test cases
- `vmsdk/testing/ft_info_test.cc` - Fix test

This ensures error message consistency across the valkey-search module and alignment with Valkey's core error formatting standards.

---