### PR TITLE
Updated parsing and protobuff population with a clean git push

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,6 +125,8 @@ target_link_libraries(index_schema PUBLIC vector_externalizer)
 target_link_libraries(index_schema PUBLIC index_base)
 target_link_libraries(index_schema PUBLIC numeric)
 target_link_libraries(index_schema PUBLIC tag)
+target_link_libraries(index_schema PUBLIC text)
+
 target_link_libraries(index_schema PUBLIC vector_base)
 target_link_libraries(index_schema PUBLIC vector_flat)
 target_link_libraries(index_schema PUBLIC vector_hnsw)

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -11,6 +11,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>  // For std::once_flag
 #include <set>
 #include <string>
 
@@ -36,6 +37,14 @@
 
 namespace valkey_search {
 namespace {
+
+// Default stop words set
+const std::vector<std::string> kDefaultStopWords{
+    "a", "is", "the", "an", "and", "are", "as", "at", "be", "but", "by", "for",
+    "if", "in", "into", "it", "no", "not", "of", "on", "or", "such", "that", "their",
+    "then", "there", "these", "they", "this", "to", "was", "will", "with"
+};
+
 constexpr absl::string_view kInitialCapParam{"INITIAL_CAP"};
 constexpr absl::string_view kBlockSizeParam{"BLOCK_SIZE"};
 constexpr absl::string_view kMParam{"M"};
@@ -80,6 +89,18 @@ constexpr absl::string_view kMaxMConfig{"max-vector-m"};
 constexpr absl::string_view kMaxEfConstructionConfig{
     "max-vector-ef-construction"};
 constexpr absl::string_view kMaxEfRuntimeConfig{"max-vector-ef-runtime"};
+
+// FullText variables
+constexpr absl::string_view kTextParam{"TEXT"};
+constexpr absl::string_view kPunctuationParam{"PUNCTUATION"};
+constexpr absl::string_view kWithOffsetsParam{"WITHOFFSETS"};
+constexpr absl::string_view kNoOffsetsParam{"NOOFFSETS"};
+constexpr absl::string_view kWithSuffixTrieParam{"WITHSUFFIXTRIE"};
+constexpr absl::string_view kNoSuffixTrieParam{"NOSUFFIXTRIE"};
+constexpr absl::string_view kNoStopWordsParam{"NOSTOPWORDS"};
+constexpr absl::string_view kStopWordsParam{"STOPWORDS"};
+constexpr absl::string_view kNoStemParam{"NOSTEM"};
+constexpr absl::string_view kMinStemSizeParam{"MINSTEMSIZE"};
 
 /// Register the "--max-prefixes" flag. Controls the max number of prefixes per
 /// index.
@@ -359,6 +380,141 @@ absl::Status ParseTag(vmsdk::ArgsIterator &itr, data_model::Index &index_proto,
   index_proto.set_allocated_tag_index(tag_index_proto.release());
   return absl::OkStatus();
 }
+
+
+vmsdk::KeyValueParser<FTCreateTextParameters> CreateTextFieldParser() {
+  vmsdk::KeyValueParser<FTCreateTextParameters> parser;
+  // Field-level parameters only: WITHSUFFIXTRIE, NOSUFFIXTRIE, NOSTEM, MINSTEMSIZE
+  parser.AddParamParser(
+      kWithSuffixTrieParam, GENERATE_FLAG_PARSER(FTCreateTextParameters, with_suffix_trie));
+  parser.AddParamParser(
+      kNoSuffixTrieParam, 
+      std::make_unique<vmsdk::ParamParser<FTCreateTextParameters>>(
+          [](FTCreateTextParameters &params, vmsdk::ArgsIterator &itr) -> absl::Status {
+            params.with_suffix_trie = false;
+            return absl::OkStatus();
+          }));
+  parser.AddParamParser(
+      kNoStemParam, GENERATE_FLAG_PARSER(FTCreateTextParameters, no_stem));
+  parser.AddParamParser(
+      kMinStemSizeParam, 
+      std::make_unique<vmsdk::ParamParser<FTCreateTextParameters>>(
+          [](FTCreateTextParameters &params, vmsdk::ArgsIterator &itr) -> absl::Status {
+            int value;
+            VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, value));
+            if (value <= 0) {
+              return absl::InvalidArgumentError("MINSTEMSIZE must be positive");
+            }
+            params.min_stem_size = value;
+            return absl::OkStatus();
+          }));
+  return parser;
+}
+
+absl::Status ParseStopWords(vmsdk::ArgsIterator &itr, GlobalTextParameters &params) {
+  uint32_t count;
+  VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, count));
+  if (count == 0) {
+    params.no_stop_words = true;
+    return absl::OkStatus();
+  }
+  
+  // Check if we have enough arguments remaining
+  if (static_cast<uint32_t>(itr.DistanceEnd()) < count) {
+    return absl::OutOfRangeError("Missing argument");
+  }
+  
+  params.stop_words.clear();
+  for (uint32_t i = 0; i < count; ++i) {
+    if (!itr.HasNext()) {
+      return absl::OutOfRangeError("Missing argument");
+    }
+    
+    // Check if the next argument is a reserved keyword that should not be consumed
+    VMSDK_ASSIGN_OR_RETURN(auto next_arg, itr.Get());
+    absl::string_view next_word = vmsdk::ToStringView(next_arg);
+    if (absl::EqualsIgnoreCase(next_word, kSchemaParam)) {
+      return absl::OutOfRangeError("Missing argument");
+    }
+    
+    std::string word;
+    VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, word));
+    params.stop_words.push_back(word);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status ParseText(vmsdk::ArgsIterator &itr, data_model::Index &index_proto,
+                       const GlobalTextParameters &global_defaults) {
+  // Start with field-specific defaults, then parse field-level parameters
+  FTCreateTextParameters field_params;
+  field_params.with_suffix_trie = false;
+  field_params.no_stem = global_defaults.no_stem;  // Can be overridden
+  field_params.min_stem_size = global_defaults.min_stem_size;  // Can be overridden
+  
+  // Parse field-level parameters (WITHSUFFIXTRIE, NOSUFFIXTRIE, NOSTEM, MINSTEMSIZE)
+  static auto field_parser = CreateTextFieldParser();
+  VMSDK_RETURN_IF_ERROR(field_parser.Parse(field_params, itr, false));
+  
+  // Create and populate the TextIndex object (field-specific parameters only)
+  auto text_index_proto = std::make_unique<data_model::TextIndex>();
+  text_index_proto->set_with_suffix_trie(field_params.with_suffix_trie);
+  text_index_proto->set_no_stem(field_params.no_stem);
+  text_index_proto->set_min_stem_size(field_params.min_stem_size);
+  
+  // Set the text_index in the index_proto
+  index_proto.set_allocated_text_index(text_index_proto.release());
+  
+  return absl::OkStatus();
+}
+
+vmsdk::KeyValueParser<GlobalTextParameters> CreateGlobalTextParser() {
+  vmsdk::KeyValueParser<GlobalTextParameters> parser;
+  parser.AddParamParser(
+      kPunctuationParam, GENERATE_VALUE_PARSER(GlobalTextParameters, punctuation));
+  parser.AddParamParser(
+      kWithOffsetsParam, GENERATE_FLAG_PARSER(GlobalTextParameters, with_offsets));
+  parser.AddParamParser(
+      kNoOffsetsParam, 
+      std::make_unique<vmsdk::ParamParser<GlobalTextParameters>>(
+          [](GlobalTextParameters &params, vmsdk::ArgsIterator &itr) -> absl::Status {
+            params.with_offsets = false;
+            return absl::OkStatus();
+          }));
+  parser.AddParamParser(
+      kNoStemParam, GENERATE_FLAG_PARSER(GlobalTextParameters, no_stem));
+  parser.AddParamParser(
+      kNoStopWordsParam, GENERATE_FLAG_PARSER(GlobalTextParameters, no_stop_words));
+  return parser;
+}
+
+absl::Status ParseGlobalTextDefaults(vmsdk::ArgsIterator &itr, GlobalTextParameters &defaults) {
+  static auto parser = CreateGlobalTextParser();
+  VMSDK_RETURN_IF_ERROR(parser.Parse(defaults, itr, false));
+  
+  VMSDK_ASSIGN_OR_RETURN(auto res, vmsdk::IsParamKeyMatch(kStopWordsParam, false, itr));
+  if (res) {
+    VMSDK_RETURN_IF_ERROR(ParseStopWords(itr, defaults));
+  }
+  
+  // Handle LANGUAGE parameter for global text defaults
+  VMSDK_ASSIGN_OR_RETURN(res, vmsdk::ParseParam(kLanguageParam, false, itr,
+                                               defaults.language, *kLanguageByStr));
+  
+  // Validate punctuation is not empty after parsing
+  if (defaults.punctuation.length() >= 2 && 
+      ((defaults.punctuation.front() == '"' && defaults.punctuation.back() == '"') ||
+       (defaults.punctuation.front() == '\'' && defaults.punctuation.back() == '\''))) {
+    defaults.punctuation = defaults.punctuation.substr(1, defaults.punctuation.length() - 2);
+  }
+  
+  // Check if punctuation is empty after quote removal
+  if (defaults.punctuation.empty()) {
+    return absl::InvalidArgumentError("PUNCTUATION string cannot be empty");
+  }
+  
+  return absl::OkStatus();
+}
 absl::StatusOr<indexes::IndexerType> ParseIndexerType(
     vmsdk::ArgsIterator &itr) {
   absl::string_view index_type_str;
@@ -370,7 +526,8 @@ absl::StatusOr<indexes::IndexerType> ParseIndexerType(
 }
 absl::StatusOr<data_model::Attribute *> ParseAttributeArgs(
     vmsdk::ArgsIterator &itr, absl::string_view attribute_identifier,
-    data_model::IndexSchema &index_schema_proto) {
+    data_model::IndexSchema &index_schema_proto,
+    const GlobalTextParameters &global_text_defaults) {
   auto attribute_proto = index_schema_proto.add_attributes();
   attribute_proto->set_identifier(attribute_identifier);
   VMSDK_ASSIGN_OR_RETURN(auto res,
@@ -388,6 +545,8 @@ absl::StatusOr<data_model::Attribute *> ParseAttributeArgs(
   } else if (index_type == indexes::IndexerType::kNumeric) {
     VMSDK_RETURN_IF_ERROR(
         ParseNumeric(itr, *index_proto, attribute_identifier));
+  } else if (index_type == indexes::IndexerType::kText) {
+    VMSDK_RETURN_IF_ERROR(ParseText(itr, *index_proto, global_text_defaults));
   } else {
     CHECK(false);
   }
@@ -400,6 +559,17 @@ bool HasVectorIndex(const data_model::IndexSchema &index_schema_proto) {
     const auto &index = attribute.index();
     if (index.index_type_case() ==
         data_model::Index::IndexTypeCase::kVectorIndex) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasTextIndex(const data_model::IndexSchema &index_schema_proto) {
+  for (const auto &attribute : index_schema_proto.attributes()) {
+    const auto &index = attribute.index();
+    if (index.index_type_case() ==
+        data_model::Index::IndexTypeCase::kTextIndex) {
       return true;
     }
   }
@@ -441,6 +611,33 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
     return absl::InvalidArgumentError(
         NotSupportedParamErrorMsg(kPayloadFieldParam));
   }
+  
+  // Parse global text parameters before SCHEMA
+  GlobalTextParameters global_text_defaults;
+  // Initialize with defaults for each parse call
+  global_text_defaults.punctuation = ",.<>{}[]\"':;!@#$%^&*()-+=~/\\|";
+  global_text_defaults.min_stem_size = 4;
+  global_text_defaults.with_offsets = true;
+  global_text_defaults.no_stem = false;
+  global_text_defaults.no_stop_words = false;
+  global_text_defaults.language = data_model::LANGUAGE_ENGLISH;
+  global_text_defaults.stop_words = kDefaultStopWords;
+  
+  VMSDK_RETURN_IF_ERROR(ParseGlobalTextDefaults(itr, global_text_defaults));
+  
+  // Set global text parameters in IndexSchema
+  index_schema_proto.set_language(global_text_defaults.language);
+  index_schema_proto.set_punctuation(global_text_defaults.punctuation);
+  index_schema_proto.set_with_offsets(global_text_defaults.with_offsets);
+  index_schema_proto.set_no_stop_words(global_text_defaults.no_stop_words);
+  index_schema_proto.set_nostem(global_text_defaults.no_stem);
+  index_schema_proto.set_min_stem_size(global_text_defaults.min_stem_size);
+  
+  // Add stop words to the schema
+  for (const auto& word : global_text_defaults.stop_words) {
+    index_schema_proto.add_stop_words(word);
+  }
+  
   absl::string_view schema;
   VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, schema));
   if (!absl::EqualsIgnoreCase(schema, kSchemaParam)) {
@@ -457,7 +654,7 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
     VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, attribute_identifier));
     VMSDK_ASSIGN_OR_RETURN(
         auto attribute,
-        ParseAttributeArgs(itr, attribute_identifier, index_schema_proto),
+        ParseAttributeArgs(itr, attribute_identifier, index_schema_proto, global_text_defaults),
         _.SetPrepend() << "Invalid field type for field `"
                        << attribute_identifier << "`: ");
     if (identifier_names.find(attribute->identifier()) !=
@@ -472,9 +669,14 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
 
     identifier_names.insert(attribute->identifier());
   }
-  if (!HasVectorIndex(index_schema_proto)) {
+  
+  // Check if the schema has at least one required index type (vector or text)
+  bool has_vector = HasVectorIndex(index_schema_proto);
+  bool has_text = HasTextIndex(index_schema_proto);
+  
+  if (!has_vector && !has_text) {
     return absl::InvalidArgumentError(
-        "At least one attribute must be indexed as a vector");
+        "At least one attribute must be indexed as a vector or text field");
   }
   return index_schema_proto;
 }

--- a/src/commands/ft_create_parser.h
+++ b/src/commands/ft_create_parser.h
@@ -12,6 +12,8 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <string>
+#include <vector>
 
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -39,6 +41,25 @@ struct FTCreateVectorParameters {
   absl::Status Verify() const;
   std::unique_ptr<data_model::VectorIndex> ToProto() const;
 };
+
+// Global text parameters (per-index) - populated in IndexSchema
+struct GlobalTextParameters {
+  std::string punctuation{",.<>{}[]\"':;!@#$%^&*()-+=~/\\\\"};
+  bool with_offsets{true};
+  bool no_stem{false};
+  std::vector<std::string> stop_words;
+  bool no_stop_words{false};
+  data_model::Language language{data_model::LANGUAGE_ENGLISH};
+  int min_stem_size{4};
+};
+
+// Field-specific text parameters (per text field) - populated in TextIndex
+struct FTCreateTextParameters {
+  bool with_suffix_trie{false};
+  bool no_stem{false};  // Can be overridden per field
+  int min_stem_size{4};
+};
+
 
 constexpr int kDefaultBlockSize{1024};
 constexpr int kDefaultM{16};

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -36,6 +36,7 @@
 #include "src/indexes/index_base.h"
 #include "src/indexes/numeric.h"
 #include "src/indexes/tag.h"
+#include "src/indexes/text.h"
 #include "src/indexes/vector_base.h"
 #include "src/indexes/vector_flat.h"
 #include "src/indexes/vector_hnsw.h"
@@ -79,6 +80,9 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
     }
     case data_model::Index::IndexTypeCase::kNumericIndex: {
       return std::make_shared<indexes::Numeric>(index.numeric_index());
+    }
+    case data_model::Index::IndexTypeCase::kTextIndex: {
+      return std::make_shared<indexes::Text>(index.text_index());
     }
     case data_model::Index::IndexTypeCase::kVectorIndex: {
       switch (index.vector_index().algorithm_case()) {

--- a/src/index_schema.proto
+++ b/src/index_schema.proto
@@ -29,7 +29,22 @@ message IndexSchema {
   repeated Attribute attributes = 6;
   Stats stats = 7;
   optional uint32 db_num = 8;
+
+  string punctuation = 9;
+  bool with_offsets = 10;
+  repeated string stop_words = 11;
+  bool no_stop_words = 12;
+  bool nostem = 13;
+  int32 min_stem_size = 14;
 }
+
+
+message TextIndex {
+  bool with_suffix_trie = 1;
+  bool no_stem = 2;
+  int32 min_stem_size = 3;
+}
+
 
 enum AttributeIndexType {
   ATTRIBUTE_INDEX_TYPE_UNSPECIFIED = 0;
@@ -47,6 +62,7 @@ message Index {
     VectorIndex vector_index = 1;
     NumericIndex numeric_index = 2;
     TagIndex tag_index = 3;
+    TextIndex text_index = 4;
   }
 }
 

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -93,3 +93,12 @@ target_link_libraries(vector_flat PUBLIC log)
 target_link_libraries(vector_flat PUBLIC memory_allocation_overrides)
 target_link_libraries(vector_flat PUBLIC status_macros)
 target_link_libraries(vector_flat PUBLIC valkey_module)
+
+set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text.h)
+
+add_library(text INTERFACE ${SRCS_TEXT})
+target_include_directories(text INTERFACE ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(text INTERFACE index_base)
+target_link_libraries(text INTERFACE rdb_serialization)
+target_link_libraries(text INTERFACE string_interning)
+target_link_libraries(text INTERFACE valkey_module)

--- a/src/indexes/index_base.h
+++ b/src/indexes/index_base.h
@@ -25,7 +25,7 @@
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::indexes {
-enum class IndexerType { kHNSW, kFlat, kNumeric, kTag, kVector, kNone };
+enum class IndexerType { kHNSW, kFlat, kNumeric, kTag, kVector, kNone, kText };
 
 enum class DeletionType {
   kRecord,      // The record was deleted from the index.
@@ -36,7 +36,8 @@ enum class DeletionType {
 const absl::NoDestructor<absl::flat_hash_map<absl::string_view, IndexerType>>
     kIndexerTypeByStr({{"VECTOR", IndexerType::kVector},
                        {"TAG", IndexerType::kTag},
-                       {"NUMERIC", IndexerType::kNumeric}});
+                       {"NUMERIC", IndexerType::kNumeric},
+                       {"TEXT", IndexerType::kText}});
 
 class IndexBase {
  public:

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -30,65 +30,142 @@
 #ifndef VALKEYSEARCH_SRC_INDEXES_TEXT_H_
 #define VALKEYSEARCH_SRC_INDEXES_TEXT_H_
 
-#include "src/text/text.h"
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/base/thread_annotations.h"
+#include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "absl/synchronization/mutex.h"
+#include "src/index_schema.pb.h"
+#include "src/indexes/index_base.h"
+#include "src/rdb_serialization.h"
+#include "src/utils/string_interning.h"
+#include "vmsdk/src/valkey_module_api/valkey_module.h"
+
+// Forward declarations
+namespace valkey_search::query {
+class TextPredicate;
+}
 
 namespace valkey_search::indexes {
 
 class Text : public IndexBase {
  public:
-  explicit Text(const data_model::TextIndex& text_index_proto);
+  explicit Text(const data_model::TextIndex& text_index_proto) : IndexBase(IndexerType::kText) {
+    // TODO: Parse configuration from text_index_proto
+  }
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
-      ABSL_LOCKS_EXCLUDED(index_mutex_);
+      ABSL_LOCKS_EXCLUDED(index_mutex_) {
+    absl::MutexLock lock(&index_mutex_);
+    tracked_keys_[key] = std::string(data);
+    return true;
+  }
   absl::StatusOr<bool> RemoveRecord(
       const InternedStringPtr& key,
       DeletionType deletion_type = DeletionType::kNone) override
-      ABSL_LOCKS_EXCLUDED(index_mutex_);
+      ABSL_LOCKS_EXCLUDED(index_mutex_) {
+    absl::MutexLock lock(&index_mutex_);
+    auto it = tracked_keys_.find(key);
+    if (it == tracked_keys_.end()) {
+      return false;
+    }
+    tracked_keys_.erase(it);
+    return true;
+  }
   absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                     absl::string_view data) override
-      ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(RedisModuleCtx* ctx) const override;
-  bool IsTracked(const InternedStringPtr& key) const override;
-  absl::Status SaveIndex(RDBOutputStream& rdb_stream) const override {
+      ABSL_LOCKS_EXCLUDED(index_mutex_) {
+    absl::MutexLock lock(&index_mutex_);
+    auto it = tracked_keys_.find(key);
+    if (it == tracked_keys_.end()) {
+      return false;
+    }
+    it->second = std::string(data);
+    return true;
+  }
+  int RespondWithInfo(ValkeyModuleCtx* ctx) const override {
+    ValkeyModule_ReplyWithSimpleString(ctx, "index_type");
+    ValkeyModule_ReplyWithSimpleString(ctx, "TEXT");
+    return 2;
+  }
+  bool IsTracked(const InternedStringPtr& key) const override {
+    absl::MutexLock lock(&index_mutex_);
+    return tracked_keys_.find(key) != tracked_keys_.end();
+  }
+  absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
   }
 
   inline void ForEachTrackedKey(
       absl::AnyInvocable<void(const InternedStringPtr&)> fn) const override {
     absl::MutexLock lock(&index_mutex_);
-    for (const auto& [key, _] : tracked_tags_by_keys_) {
+    for (const auto& [key, _] : tracked_keys_) {
       fn(key);
     }
   }
-  uint64_t GetRecordCount() const override;
-  std::unique_ptr<data_model::Index> ToProto() const override;
+  uint64_t GetRecordCount() const override {
+    absl::MutexLock lock(&index_mutex_);
+    return tracked_keys_.size();
+  }
+  std::unique_ptr<data_model::Index> ToProto() const override {
+    auto index = std::make_unique<data_model::Index>();
+    auto text_index = std::make_unique<data_model::TextIndex>();
+    index->set_allocated_text_index(text_index.release());
+    return index;
+  }
 
   InternedStringPtr GetRawValue(const InternedStringPtr& key) const
-      ABSL_NO_THREAD_SAFETY_ANALYSIS;
+      ABSL_NO_THREAD_SAFETY_ANALYSIS {
+    auto it = tracked_keys_.find(key);
+    if (it == tracked_keys_.end()) {
+      return nullptr;
+    }
+    return StringInternStore::Intern(it->second);
+  }
 
   class EntriesFetcherIterator : public EntriesFetcherIteratorBase {
    public:
-    bool Done() const override;
-    void Next() override;
-    const InternedStringPtr& operator*() const override;
+    bool Done() const override {
+      return true;
+    }
+    void Next() override {
+      // TODO: Implement iterator logic
+    }
+    const InternedStringPtr& operator*() const override {
+      static InternedStringPtr empty_ptr;
+      return empty_ptr;
+    }
 
    private:
   };
 
   class EntriesFetcher : public EntriesFetcherBase {
    public:
-    size_t Size() const override;
-    std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
+    size_t Size() const override {
+      return 0;
+    }
+    std::unique_ptr<EntriesFetcherIteratorBase> Begin() override {
+      return std::make_unique<EntriesFetcherIterator>();
+    }
 
    private:
   };
 
   virtual std::unique_ptr<EntriesFetcher> Search(
       const query::TextPredicate& predicate,
-      bool negate) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
+      bool negate) const ABSL_NO_THREAD_SAFETY_ANALYSIS {
+    return std::make_unique<EntriesFetcher>();
+  }
 
  private:
   mutable absl::Mutex index_mutex_;
+  absl::flat_hash_map<InternedStringPtr, std::string> tracked_keys_;
 };
 }  // namespace valkey_search::indexes
 

--- a/src/indexes/text/text.cc
+++ b/src/indexes/text/text.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2025, ValkeySearch contributors
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *   * Neither the name of Redis nor the names of its contributors may be used
+ *     to endorse or promote products derived from this software without
+ *     specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Basic stub implementations for text subsystem types
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "src/utils/string_interning.h"
+#include <memory>
+
+namespace valkey_search {
+namespace text {
+
+// Forward declare types used in text.h
+template<typename T, bool suffix>
+class RadixTree {
+public:
+    RadixTree() = default;
+    ~RadixTree() = default;
+};
+
+class Postings {
+public:
+    Postings() = default;
+    ~Postings() = default;
+};
+
+// Basic stub classes to satisfy linker
+class TextIndex {
+public:
+    TextIndex() = default;
+    ~TextIndex() = default;
+};
+
+}  // namespace text
+}  // namespace valkey_search

--- a/src/indexes/text/text.h
+++ b/src/indexes/text/text.h
@@ -1,5 +1,5 @@
 #ifndef _VALKEY_SEARCH_INDEXES_TEXT_TEXT_H
-#define _VALKSY_SEARCH_INDEXES_TEXT_TEXT_H
+#define _VALKEY_SEARCH_INDEXES_TEXT_TEXT_H
 
 /*
 
@@ -7,9 +7,16 @@ External API for text subsystem
 
 */
 
-#include <concepts>
-#include <memory>
-
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "vmsdk/src/valkey_module_api/valkey_module.h"
+#include "src/attribute_data_type.h"
+#include "src/index_schema.pb.h"
+#include "src/indexes/index_base.h"
+#include "src/rdb_serialization.h"
 #include "src/utils/string_interning.h"
 
 namespace valkey_search {
@@ -46,8 +53,8 @@ struct TextFieldIndex : public indexes::IndexBase {
   // by the Postings object to identify fields.
   size_t text_field_number;
   // The per-index text index.
-  std::shared_ptr<TextIndex> text_
-}
+  std::shared_ptr<TextIndex> text_;
+};
 
 struct TextIndex {
   //
@@ -67,7 +74,7 @@ struct TextIndex {
 //
 // this is a logical extension of the index-schema. could easily be merged into that object.
 //
-struct IndexSchemaText
+struct IndexSchemaText {
   //
   // This is the main index of all Text fields in this index schema
   //
@@ -78,7 +85,7 @@ struct IndexSchemaText
   //
   // This object must also ensure that updates of this object are multi-thread safe.
   //
-  absl::flat_hash_map<Key, TextIndex>> by_key_;
+  absl::flat_hash_map<Key, TextIndex> by_key_;
 };
 
 }  // namespace text

--- a/src/indexes/text_index.h
+++ b/src/indexes/text_index.h
@@ -1,19 +1,56 @@
 #ifndef VALKEY_SEARCH_INDEXES_TEXT_TEXT_H_
-#define VALKEY_SEARCH_INDEXES_TEXT_TEST_H_
+#define VALKEY_SEARCH_INDEXES_TEXT_TEXT_H_
+
+#include <optional>
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "vmsdk/src/valkey_module_api/valkey_module.h"
+#include "src/attribute_data_type.h"
+#include "src/index_schema.pb.h"
+#include "src/indexes/index_base.h"
+#include "src/rdb_serialization.h"
+#include "src/utils/string_interning.h"
 
 namespace valkey_search {
+
+// Forward declare the types
+namespace text {
+class RadixTree {
+public:
+  RadixTree() = default;
+};
+}
+
+using Key = InternedStringPtr;
+
 namespace indexes {
 
 struct Text : public IndexBase {
   // Constructor
-  Text(const data_model& text_index_proto);
+  Text(const data_model::TextIndex& text_index_proto);
+
+  // Virtual methods from IndexBase
+  absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
+                                 absl::string_view data) override;
+  absl::StatusOr<bool> RemoveRecord(const InternedStringPtr& key,
+                                    DeletionType deletion_type) override;
+  absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
+                                    absl::string_view data) override;
+  int RespondWithInfo(ValkeyModuleCtx* ctx) const override;
+  bool IsTracked(const InternedStringPtr& key) const override;
+  absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override;
+  std::unique_ptr<data_model::Index> ToProto() const override;
+  uint64_t GetRecordCount() const override;
 
   text::RadixTree prefix_;
   std::optional<text::RadixTree> suffix_;
 
-  absl::hashmap<Key, text::RadixTree> reverse_;
+  absl::flat_hash_map<Key, text::RadixTree> reverse_;
 
-  absl::hashset<Key> untracked_keys_;
+  absl::flat_hash_set<Key> untracked_keys_;
 };
 
 }  // namespace indexes

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -53,8 +53,8 @@ struct FTCreateParserTestCase {
   std::vector<HNSWParameters> hnsw_parameters;
   std::vector<FlatParameters> flat_parameters;
   std::vector<FTCreateTagParameters> tag_parameters;
+  std::vector<FTCreateTextParameters> text_parameters;
   FTCreateParameters expected;
-
   std::string expected_error_message;
 };
 
@@ -103,6 +103,7 @@ TEST_P(FTCreateParserTest, ParseParams) {
     auto hnsw_index = 0;
     auto flat_index = 0;
     auto tag_index = 0;
+    auto text_index = 0;
     for (auto i = 0; i < index_schema_proto->attributes().size(); ++i) {
       EXPECT_EQ(index_schema_proto->attributes(i).identifier(),
                 test_case.expected.attributes[i].identifier);
@@ -156,6 +157,17 @@ TEST_P(FTCreateParserTest, ParseParams) {
         EXPECT_EQ(tag_proto.case_sensitive(),
                   test_case.tag_parameters[tag_index].case_sensitive);
         ++tag_index;
+      } else if (test_case.expected.attributes[i].indexer_type ==
+                 indexes::IndexerType::kText) {
+        EXPECT_TRUE(index_schema_proto->attributes(i).index().has_text_index());
+        if (text_index < test_case.text_parameters.size()) {
+          auto text_proto = index_schema_proto->attributes(i).index().text_index();
+          const auto& expected_text = test_case.text_parameters[text_index];
+          EXPECT_EQ(text_proto.with_suffix_trie(), expected_text.with_suffix_trie);
+          EXPECT_EQ(text_proto.no_stem(), expected_text.no_stem);
+          EXPECT_EQ(text_proto.min_stem_size(), expected_text.min_stem_size);
+        }
+        ++text_index;
       } else {
         EXPECT_FALSE(index_schema_proto->attributes(i)
                          .index()
@@ -182,8 +194,9 @@ TEST_P(FTCreateParserTest, ParseParams) {
 
 INSTANTIATE_TEST_SUITE_P(
     FTCreateParserTests, FTCreateParserTest,
-    ValuesIn<FTCreateParserTestCase>(
-        {{
+    ValuesIn(
+        std::vector<FTCreateParserTestCase>{
+         {
              .test_name = "happy_path_hnsw",
              .success = true,
              .command_str = " idx1 on HASH PREFIx 3 abc def ghi LANGUAGe "
@@ -556,7 +569,7 @@ INSTANTIATE_TEST_SUITE_P(
              .command_str = "idx1 on HASH SChema hash_field1 as "
                             "hash_field11 numeric ",
              .expected_error_message =
-                 "At least one attribute must be indexed as a vector",
+                 "At least one attribute must be indexed as a vector or text field",
          },
          {
              .test_name = "invalid_separator",
@@ -910,6 +923,588 @@ INSTANTIATE_TEST_SUITE_P(
              .command_str = "idx on hash prefix 1 a{b}",
              .expected_error_message =
                  "PREFIX argument(s) must not contain a hash tag",
+         },
+         // TEXT field tests
+         {
+             .test_name = "happy_path_text_basic",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "happy_path_text_with_field_parameters",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT WITHSUFFIXTRIE MINSTEMSIZE 2",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = true,
+                 .no_stem = false,
+                 .min_stem_size = 2,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "happy_path_text_with_global_parameters",
+             .success = true,
+             .command_str = "idx1 on HASH PUNCTUATION \",.;\" WITHOFFSETS NOSTEM STOPWORDS 3 the and or SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = true,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "happy_path_text_global_nostopwords",
+             .success = true,
+             .command_str = "idx1 on HASH NOSTOPWORDS SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "happy_path_text_global_stopwords_zero",
+             .success = true,
+             .command_str = "idx1 on HASH STOPWORDS 0 SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "happy_path_text_with_vector",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT vector_field VECTOR HNSW 6 TYPE FLOAT32 DIM 3 DISTANCE_METRIC IP",
+             .too_many_attributes = false,
+             .hnsw_parameters = {{
+                 {
+                     .dimensions = 3,
+                     .distance_metric = data_model::DISTANCE_METRIC_IP,
+                     .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
+                     .initial_cap = kDefaultInitialCap,
+                 },
+                 /* .m = */ kDefaultM,
+                 /* .ef_construction = */ kDefaultEFConstruction,
+                 /* .ef_runtime = */ kDefaultEFRuntime,
+             }},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {
+                     {
+                         .identifier = "text_field",
+                         .attribute_alias = "text_field",
+                         .indexer_type = indexes::IndexerType::kText,
+                     },
+                     {
+                         .identifier = "vector_field",
+                         .attribute_alias = "vector_field",
+                         .indexer_type = indexes::IndexerType::kHNSW,
+                     }
+                 }
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "text_only_schema_valid",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT NOSTOPWORDS",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+             .expected_error_message = "",
+         },
+         {
+             .test_name = "invalid_text_empty_punctuation_global",
+             .success = false,
+             .command_str = "idx1 on HASH PUNCTUATION \"\" SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {},
+             .expected = {},
+             .expected_error_message = "PUNCTUATION string cannot be empty",
+         },
+         {
+             .test_name = "invalid_text_negative_minstemsize",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT MINSTEMSIZE -1",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {},
+             .expected = {},
+             .expected_error_message = "Invalid field type for field `text_field`: Error parsing value for the parameter `MINSTEMSIZE` - MINSTEMSIZE must be positive",
+         },
+         {
+             .test_name = "invalid_text_zero_minstemsize",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT MINSTEMSIZE 0",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {},
+             .expected = {},
+             .expected_error_message = "Invalid field type for field `text_field`: Error parsing value for the parameter `MINSTEMSIZE` - MINSTEMSIZE must be positive",
+         },
+         {
+             .test_name = "invalid_global_stopwords_before_schema",
+             .success = false,
+             .command_str = "idx1 on HASH STOPWORDS -1 SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {},
+             .expected = {},
+             .expected_error_message = "`-1` is outside acceptable bounds",
+         },
+         {
+             .test_name = "invalid_global_stopwords_missing_words",
+             .success = false,
+             .command_str = "idx1 on HASH STOPWORDS 3 the and SCHEMA text_field TEXT",
+             .too_many_attributes = false,
+             .hnsw_parameters = {},
+             .flat_parameters = {},
+             .tag_parameters = {},
+             .text_parameters = {},
+             .expected = {},
+             .expected_error_message = "Missing argument",
+         },
+         // Additional TEXT field edge case tests
+         {
+             .test_name = "text_punctuation_single_quote",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT PUNCTUATION '.,;'",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_punctuation_unquoted",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT PUNCTUATION .,;",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+            .test_name = "text_nooffsets_flag",
+            .success = true,
+            .command_str = "idx1 on HASH NOOFFSETS SCHEMA text_field TEXT",
+            .text_parameters = {{
+                .with_suffix_trie = false,
+                .no_stem = false,
+                .min_stem_size = 4,
+            }},
+            .expected = {
+                .index_schema_name = "idx1",
+                .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                .attributes = {{
+                    .identifier = "text_field",
+                    .attribute_alias = "text_field",
+                    .indexer_type = indexes::IndexerType::kText,
+                }}
+            },
+        },
+         {
+             .test_name = "text_withsuffixtrie_flag",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT WITHSUFFIXTRIE",
+             .text_parameters = {{
+                 .with_suffix_trie = true,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_nosuffixtrie_flag",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT NOSUFFIXTRIE",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_combined_global_and_field_flags",
+             .success = true,
+             .command_str = "idx1 on HASH NOOFFSETS NOSTEM LANGUAGE ENGLISH SCHEMA text_field TEXT WITHSUFFIXTRIE MINSTEMSIZE 2",
+             .text_parameters = {{
+                 .with_suffix_trie = true,
+                 .no_stem = true,
+                 .min_stem_size = 2,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_large_stopwords_list_field",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT STOPWORDS 10 a an and are as at be but by for",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+            .test_name = "text_large_stopwords_list_global",
+            .success = true, 
+            .command_str = "idx1 on HASH STOPWORDS 10 a an and are as at be but by for SCHEMA text_field TEXT",
+            .text_parameters = {{
+                .with_suffix_trie = false,
+                .no_stem = false,
+                .min_stem_size = 4,
+            }},
+            .expected = {
+                .index_schema_name = "idx1",
+                .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                .attributes = {{
+                    .identifier = "text_field",
+                    .attribute_alias = "text_field",
+                    .indexer_type = indexes::IndexerType::kText,
+                }}
+            },
+        },
+         {
+             .test_name = "text_max_minstemsize",
+             .success = true,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT MINSTEMSIZE 100",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 100,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_special_characters_punctuation_field",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT PUNCTUATION \"!@#$%^&*()_+-=[]{}|;':,.<>?\"",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+            .test_name = "text_special_characters_punctuation_global",
+            .success = true,
+            .command_str = "idx1 on HASH PUNCTUATION \"!@#$%^&*()_+-=[]{}|;':,.<>?\" SCHEMA text_field TEXT",
+            .text_parameters = {{
+                .with_suffix_trie = false,
+                .no_stem = false,
+                .min_stem_size = 4,
+            }},
+            .expected = {
+                .index_schema_name = "idx1",
+                .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                .attributes = {{
+                    .identifier = "text_field",
+                    .attribute_alias = "text_field",
+                    .indexer_type = indexes::IndexerType::kText,
+                }}
+            },
+        },
+         {
+             .test_name = "text_multiple_fields_different_configs",
+             .success = true,
+             .command_str = "idx1 on HASH NOSTOPWORDS PUNCTUATION '.,;' SCHEMA text1 TEXT text2 TEXT MINSTEMSIZE 2",
+             .text_parameters = {
+                 {
+                     .with_suffix_trie = false,
+                     .no_stem = false,
+                     .min_stem_size = 4,
+                 },
+                 {
+                     .with_suffix_trie = false,
+                     .no_stem = false,
+                     .min_stem_size = 2,
+                 }
+             },
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {
+                     {
+                         .identifier = "text1",
+                         .attribute_alias = "text1",
+                         .indexer_type = indexes::IndexerType::kText,
+                     },
+                     {
+                         .identifier = "text2",
+                         .attribute_alias = "text2",
+                         .indexer_type = indexes::IndexerType::kText,
+                     }
+                 }
+             },
+         },
+         // Error cases for TEXT fields
+         {
+            .test_name = "invalid_text_single_quote_empty_global",
+            .success = false,
+            .command_str = "idx1 on HASH PUNCTUATION '' SCHEMA text_field TEXT",  // Moved PUNCTUATION before SCHEMA
+            .expected_error_message = "PUNCTUATION string cannot be empty",  // Simplified error message
+        },
+         {
+            .test_name = "invalid_text_stopwords_negative_count_global",
+            .success = false,
+            .command_str = "idx1 on HASH STOPWORDS -1 SCHEMA text_field TEXT",  // Moved STOPWORDS before SCHEMA
+            .expected_error_message = "`-1` is outside acceptable bounds",  // Simplified error message
+        },
+         {
+             .test_name = "invalid_text_stopwords_missing_words_field",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT STOPWORDS 3 the and",
+         },
+         {
+            .test_name = "invalid_text_stopwords_missing_words_global",
+            .success = false,
+            .command_str = "idx1 on HASH STOPWORDS 3 the and SCHEMA text_field TEXT",
+            .expected_error_message = "Missing argument",
+        },
+        {
+            .test_name = "invalid_text_field_parameters_global",
+            .success = false,
+            .command_str = "idx1 on HASH WITHSUFFIXTRIE MINSTEMSIZE 2 SCHEMA text_field TEXT",  // Moved parameters before SCHEMA
+            .expected_error_message = "Unexpected parameter `WITHSUFFIXTRIE`, expecting `SCHEMA`",  // Error for unsupported global parameter
+        },
+         {
+             .test_name = "invalid_text_minstemsize_too_large",
+             .success = true,  // Should succeed as there's no upper limit defined
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT MINSTEMSIZE 999999",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = false,
+                 .min_stem_size = 999999,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "invalid_text_unknown_parameter",
+             .success = false,
+             .command_str = "idx1 on HASH SCHEMA text_field TEXT UNKNOWN_PARAM value",
+             .expected_error_message = "Invalid field type for field `UNKNOWN_PARAM`: Unknown argument `value`",
+         },
+         {
+             .test_name = "text_case_insensitive_parameters",
+             .success = true,
+             .command_str = "idx1 on HASH punctuation '.,;' withoffsets nostem SCHEMA text_field text",
+             .text_parameters = {{
+                 .with_suffix_trie = false,
+                 .no_stem = true,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
+         },
+         {
+             .test_name = "text_global_and_field_parameters_mixed",
+             .success = true,
+             .command_str = "idx1 on HASH LANGUAGE english PUNCTUATION '.,;' SCHEMA text_field TEXT WITHSUFFIXTRIE",
+             .text_parameters = {{
+                 .with_suffix_trie = true,
+                 .no_stem = false,
+                 .min_stem_size = 4,
+             }},
+             .expected = {
+                 .index_schema_name = "idx1",
+                 .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                 .attributes = {{
+                     .identifier = "text_field",
+                     .attribute_alias = "text_field",
+                     .indexer_type = indexes::IndexerType::kText,
+                 }}
+             },
          }}),
     [](const TestParamInfo<FTCreateParserTestCase> &info) {
       return info.param.test_name;


### PR DESCRIPTION
This is a cleaner version of the code with using and changing of classes that are only affecting my work.

The parser is ready for FT_CREATE Function. It parses the create command and populates the protobuff with appropriately. There are unit tests covering both the parser and the whether the protobuff is correctly being populated.

An example of the correct FT.CREATE command would be as follows: FT.CREATE fullindex ON HASH PREFIX 1 doc: PUNCTUATION ",.;:!?" WITHOFFSETS STOPWORDS 2 the and LANGUAGE ENGLISH SCHEMA title TEXT WITHSUFFIXTRIE MINSTEMSIZE 3 body TEXT NOSTEM
and what we get return would be OK

If there is an incorrect command like: FT.CREATE badindex ON HASH SCHEMA content TEXT MINSTEMSIZE -1
We get the error tell what went wrong as follows: (error) Invalid field type for field content: Error parsing value for the parameter MINSTEMSIZE - MINSTEMSIZE must be positive

Currently we are testing the functionality using unit tests which is covering all different test cases.