### PR TITLE
Global memory metrics by type

### DIFF
--- a/integration/test_global_metrics.py
+++ b/integration/test_global_metrics.py
@@ -1,0 +1,358 @@
+import struct
+from valkey.client import Valkey
+from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+
+class TestGlobalMetrics(ValkeySearchTestCaseBase):
+    """    
+    This test suite validates the fields within the search_global_metrics section.
+    """
+
+    def test_global_metrics(self):
+        """
+        Test search_global_metrics section fields only.
+        
+        This test validates only the fields within the search_global_metrics section
+        from INFO SEARCH output, including:
+        """
+
+        client: Valkey = self.server.get_new_client()
+        
+        # Create an index with vector, tag, and numeric fields
+        index_name = "test_idx"
+        client.execute_command(
+            "FT.CREATE", index_name,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA",
+            "vector", "VECTOR", "HNSW", "6",
+            "TYPE", "FLOAT32",
+            "DIM", "4",
+            "DISTANCE_METRIC", "L2",
+            "price", "NUMERIC",
+            "category", "TAG"
+        )
+        
+        # Get initial global metrics
+        info_data = client.info("SEARCH")
+        
+        # Validate initial search_global_metrics fields
+        assert int(info_data["search_flat_nodes"]) == 0
+        assert int(info_data["search_hnsw_edges"]) == 0
+        assert int(info_data["search_hnsw_edges_marked_deleted"]) == 0
+        assert int(info_data["search_hnsw_nodes"]) == 0
+        assert int(info_data["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data["search_interned_strings"]) >= 0
+        assert int(info_data["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data["search_interned_strings_memory"]) >= 0
+        assert int(info_data["search_keys_memory"]) >= 0
+        assert int(info_data["search_numeric_records"]) == 0
+        assert int(info_data["search_tags"]) >= 0
+        assert int(info_data["search_tags_memory"]) >= 0
+        assert int(info_data["search_vectors_memory"]) == 0
+        assert int(info_data["search_vectors_memory_marked_deleted"]) == 0
+        
+        # Insert a document with all field types
+        doc_key = "doc:1"
+        embedding_vector = [0.1, 0.2, 0.3, 0.4]
+        vector_bytes = struct.pack('<4f', *embedding_vector)
+        
+        client.hset(doc_key, mapping={
+            "vector": vector_bytes,
+            "category": "electronics",
+            "price": 999
+        })
+        
+        # Get metrics after insertion
+        info_data = client.info("SEARCH")
+        
+        # Validate search_global_metrics fields after document insertion
+        assert int(info_data["search_flat_nodes"]) == 0
+        assert int(info_data["search_hnsw_edges"]) >= 0  # May vary based on HNSW implementation
+        assert int(info_data["search_hnsw_edges_marked_deleted"]) == 0
+        assert int(info_data["search_hnsw_nodes"]) == 1
+        assert int(info_data["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data["search_interned_strings"]) >= 1
+        assert int(info_data["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data["search_interned_strings_memory"]) > 0
+        assert int(info_data["search_keys_memory"]) > 0
+        assert int(info_data["search_numeric_records"]) == 1
+        assert int(info_data["search_tags"]) >= 1  # "electronics"
+        assert int(info_data["search_tags_memory"]) > 0
+        assert int(info_data["search_vectors_memory"]) == 16  # 4 floats * 4 bytes = 16 bytes
+        assert int(info_data["search_vectors_memory_marked_deleted"]) == 0
+        
+        # Clean up
+        client.execute_command("FT.DROPINDEX", index_name)
+
+    def test_deleted_key_memory_marked_as_deleted(self):
+        """
+        Test that after deleting a key, memory is still allocated but marked as deleted.
+        
+        This test validates that when a document is deleted, the memory is not immediately
+        freed but instead marked as deleted, as shown in the search_global_metrics.
+        """
+        
+        client: Valkey = self.server.get_new_client()
+
+        # Create an index with vector, tag, and numeric fields
+        index_name = "test_idx"
+        client.execute_command(
+            "FT.CREATE", index_name,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA",
+            "vector", "VECTOR", "HNSW", "6",
+            "TYPE", "FLOAT32",
+            "DIM", "4",
+            "DISTANCE_METRIC", "L2",
+            "price", "NUMERIC",
+            "category", "TAG", "SEPARATOR", "|"
+        )
+        
+        # Insert a document with all field types
+        doc_key = "doc:1"
+        embedding_vector = [0.1, 0.2, 0.3, 0.4]
+        vector_bytes = struct.pack('<4f', *embedding_vector)
+        
+        client.hset(doc_key, mapping={
+            "vector": vector_bytes,
+            "category": "aaaa|bbbb",
+            "price": 999
+        })
+        
+        # Get metrics after insertion
+        info_data_after_insert = client.info("SEARCH")
+        
+        # Validate that data is present and not marked as deleted
+        assert int(info_data_after_insert["search_hnsw_nodes"]) == 1
+        assert int(info_data_after_insert["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_vectors_memory"]) == 16  # 4 floats * 4 bytes
+        assert int(info_data_after_insert["search_vectors_memory_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_interned_strings"]) >= 1
+        assert int(info_data_after_insert["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_interned_strings_memory"]) > 0
+        # Store values before deletion for comparison
+        hnsw_edges_before = int(info_data_after_insert["search_hnsw_edges"])
+        hnsw_nodes_before = int(info_data_after_insert["search_hnsw_nodes"])
+        vectors_memory_before = int(info_data_after_insert["search_vectors_memory"])
+
+        # Delete the document
+        result = client.delete(doc_key)
+        assert result == 1  # Confirm deletion was successful
+        
+        # Get metrics after deletion
+        info_data_after_delete = client.info("SEARCH")
+        
+        # Validate that memory is still allocated but marked as deleted
+        # HNSW edges should be marked as deleted but memory still allocated
+        assert int(info_data_after_delete["search_hnsw_edges"]) == hnsw_edges_before
+        assert int(info_data_after_delete["search_hnsw_edges_marked_deleted"]) == hnsw_edges_before
+        
+        # HNSW nodes should be marked as deleted but still counted
+        assert int(info_data_after_delete["search_hnsw_nodes"]) == hnsw_nodes_before
+        assert int(info_data_after_delete["search_hnsw_nodes_marked_deleted"]) == hnsw_nodes_before
+        
+        # Interned strings only the vector string remains
+        assert int(info_data_after_delete["search_interned_strings"]) == 1 
+        assert int(info_data_after_delete["search_interned_strings_marked_deleted"]) == 1
+        assert int(info_data_after_delete["search_interned_strings_memory"]) == 16
+        
+        # Vector memory should be marked as deleted but still allocated
+        assert int(info_data_after_delete["search_vectors_memory"]) == vectors_memory_before
+        assert int(info_data_after_delete["search_vectors_memory_marked_deleted"]) == vectors_memory_before
+        
+        # Keys memory should now be 0 since the key is deleted
+        assert int(info_data_after_delete["search_keys_memory"]) == 0
+        
+        # Numeric and tag data should also be marked as deleted
+        assert int(info_data_after_delete["search_numeric_records"]) == 0
+        assert int(info_data_after_delete["search_tags"]) == 0
+        
+        # Clean up
+        client.execute_command("FT.DROPINDEX", index_name)
+
+    def test_shared_vector_across_indices_drop_one_index(self):
+        """
+        Test that when the same vector is added to 2 indices tracking the same keys,
+        after dropping one index the string is not marked as deleted since it is 
+        alive in the second index.
+        
+        This test validates that interned strings are properly reference counted
+        across multiple indices and are deleted when no index references them.
+        """
+        client: Valkey = self.server.get_new_client()
+        # Create first index
+        index_name1 = "test_idx1"
+        client.execute_command(
+            "FT.CREATE", index_name1,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA",
+            "vector", "VECTOR", "HNSW", "6",
+            "TYPE", "FLOAT32",
+            "DIM", "4",
+            "DISTANCE_METRIC", "L2",
+            "category", "TAG"
+        )
+        
+        # Create second index with same prefix (tracking same keys)
+        index_name2 = "test_idx2"
+        client.execute_command(
+            "FT.CREATE", index_name2,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA",
+            "vector", "VECTOR", "HNSW", "6",
+            "TYPE", "FLOAT32",
+            "DIM", "4",
+            "DISTANCE_METRIC", "L2",
+            "price", "NUMERIC"
+        )
+        
+        # Insert a document that will be indexed by both indices
+        doc_key = "doc:1"
+        embedding_vector = [0.1, 0.2, 0.3, 0.4]
+        vector_bytes = struct.pack('<4f', *embedding_vector)
+        
+        client.hset(doc_key, mapping={
+            "vector": vector_bytes,
+            "category": "electronics",
+            "price": 999
+        })
+        
+        # Get metrics after insertion (both indices should reference the same vector)
+        info_data_after_insert = client.info("SEARCH")
+
+        # Validate that data is present and not marked as deleted
+        # Both indices should reference the same interned string for the vector
+        assert int(info_data_after_insert["search_hnsw_nodes"]) == 2  # One node per index
+        assert int(info_data_after_insert["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_vectors_memory"]) == 16  # Both indices using the same vector string
+        assert int(info_data_after_insert["search_vectors_memory_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_interned_strings"]) >= 1  # At least the vector string
+        assert int(info_data_after_insert["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data_after_insert["search_interned_strings_memory"]) > 16
+
+        # Drop the first index
+        client.execute_command("FT.DROPINDEX", index_name1)
+        
+        # Get metrics after dropping first index
+        info_data_after_drop = client.info("SEARCH")
+        
+        # Validate that the interned strings are NOT marked as deleted
+        # because they are still referenced by the second index
+        assert int(info_data_after_drop["search_hnsw_nodes"]) == 1  # Only second index remains
+        assert int(info_data_after_drop["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data_after_drop["search_vectors_memory"]) == 16
+        assert int(info_data_after_drop["search_vectors_memory_marked_deleted"]) == 0
+        assert int(info_data_after_drop["search_interned_strings"]) >= 1
+        assert int(info_data_after_drop["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data_after_drop["search_interned_strings_memory"]) >= 16
+
+        # Now drop the second index - this should make the strings to be deleted
+        client.execute_command("FT.DROPINDEX", index_name2)
+        info_data_final = client.info("SEARCH")
+        
+        # Now the interned strings should be clean
+        assert int(info_data_final["search_hnsw_nodes"]) == 0
+        assert int(info_data_final["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data_final["search_vectors_memory"]) == 0
+        assert int(info_data_final["search_vectors_memory_marked_deleted"]) == 0
+        assert int(info_data_final["search_interned_strings"]) == 0
+        assert int(info_data_final["search_interned_strings_marked_deleted"]) == 0
+        assert int(info_data_final["search_interned_strings_memory"]) == 0
+
+    def test_two_keys_same_vector_string_reference_counting(self):
+        """
+        Test that when 2 keys have the same vector string, validate using vector memory
+        that only one string was created. After deleting one key, the vector string 
+        is not marked as deleted. After deleting the second key, the vector string 
+        is marked as deleted.
+        
+        This test validates vector string deduplication by tracking vector memory.
+        """
+        
+        client: Valkey = self.server.get_new_client()
+        # Create an index
+        index_name = "test_idx"
+        client.execute_command(
+            "FT.CREATE", index_name,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA",
+            "vector", "VECTOR", "HNSW", "6",
+            "TYPE", "FLOAT32",
+            "DIM", "4",
+            "DISTANCE_METRIC", "L2"
+        )
+        
+        # Create the same vector for both keys
+        embedding_vector = [0.1, 0.2, 0.3, 0.4]
+        vector_bytes = struct.pack('<4f', *embedding_vector)
+        
+        # Insert first document with the vector
+        doc_key1 = "doc:1"
+        client.hset(doc_key1, mapping={
+            "vector": vector_bytes
+        })
+        
+        # Get metrics after first insertion
+        info_data_after_first = client.info("SEARCH")
+
+        # Validate initial state - one vector
+        assert int(info_data_after_first["search_hnsw_nodes"]) == 1
+        assert int(info_data_after_first["search_hnsw_nodes_marked_deleted"]) == 0
+        assert int(info_data_after_first["search_vectors_memory"]) == 16  # 4 floats * 4 bytes
+        assert int(info_data_after_first["search_vectors_memory_marked_deleted"]) == 0
+        
+        # Insert second document with the SAME vector
+        doc_key2 = "doc:2"
+        client.hset(doc_key2, mapping={
+            "vector": vector_bytes  # Same vector bytes
+        })
+        
+        # Get metrics after second insertion
+        info_data_after_second = client.info("SEARCH")
+        
+        # Key validation: Track only vector memory to validate deduplication
+        # We should have 2 HNSW nodes but vector memory should show deduplication
+        assert int(info_data_after_second["search_hnsw_nodes"]) == 2
+        assert int(info_data_after_second["search_hnsw_nodes_marked_deleted"]) == 0
+        
+        # Validate only one string was created using vector memory
+        assert int(info_data_after_second["search_vectors_memory"]) == 16
+        assert int(info_data_after_second["search_vectors_memory_marked_deleted"]) == 0
+        
+        # Delete the first key
+        assert client.delete(doc_key1) == 1
+        
+        # Get metrics after deleting first key
+        info_data_after_first_delete = client.info("SEARCH")
+        
+        # Validate using vector memory that the string is NOT marked as deleted
+        # because the second key still references it
+        assert int(info_data_after_first_delete["search_hnsw_nodes"]) == 2  # Both nodes remains
+        assert int(info_data_after_first_delete["search_hnsw_nodes_marked_deleted"]) == 1  # One is marked as deleted
+        assert int(info_data_after_first_delete["search_vectors_memory"]) == 16  # Memory still allocated
+        assert int(info_data_after_first_delete["search_vectors_memory_marked_deleted"]) == 0  # Vector is still in use at one index
+        # Delete the second key
+        assert client.delete(doc_key2) == 1
+        
+        # Get metrics after deleting second key
+        info_data_after_second_delete = client.info("SEARCH")
+        
+        assert int(info_data_after_second_delete["search_hnsw_nodes"]) == 2  # Nodes are still active
+        assert int(info_data_after_second_delete["search_hnsw_nodes_marked_deleted"]) == 2  # Nodes are marked as deleted
+        assert int(info_data_after_second_delete["search_vectors_memory"]) == 16  # Memory still allocated
+        assert int(info_data_after_second_delete["search_vectors_memory_marked_deleted"]) == 16  # All marked as deleted
+        
+        # Drop index - assert memory cleanup
+        client.execute_command("FT.DROPINDEX", index_name)
+
+        info_data_after_drop = client.info("SEARCH")
+        assert int(info_data_after_drop["search_hnsw_nodes"]) == 0  # Nodes are still active
+        assert int(info_data_after_drop["search_hnsw_nodes_marked_deleted"]) == 0  # Nodes are marked as deleted
+        assert int(info_data_after_drop["search_vectors_memory"]) == 0  # Memory still allocated
+        assert int(info_data_after_drop["search_vectors_memory_marked_deleted"]) == 0  # All marked as deleted

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -342,7 +342,7 @@ void IndexSchema::ProcessKeyspaceNotification(ValkeyModuleCtx *ctx,
   }
   MutatedAttributes mutated_attributes;
   bool added = false;
-  auto interned_key = StringInternStore::Intern(key_cstr);
+  auto interned_key = StringInternStore::Intern(key_cstr, nullptr, indexes::MetricType::kKeysMemory);
   for (const auto &attribute_itr : attributes_) {
     auto &attribute = attribute_itr.second;
     if (!key_obj) {

--- a/src/indexes/global_metrics.h
+++ b/src/indexes/global_metrics.h
@@ -1,0 +1,197 @@
+ /*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_GLOBAL_METRICS_H
+#define VALKEYSEARCH_SRC_INDEXES_GLOBAL_METRICS_H
+
+#include <atomic>
+#include <cassert>
+#include <cstdint>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/strings/string_view.h"
+#include "src/utils/string_interning.h"
+#include "src/indexes/metric_types.h"
+#include "vmsdk/src/info.h"
+
+namespace valkey_search::indexes {
+
+// Packed metadata structure for InternedString (32 bits total)
+struct MetaData {
+  uint32_t metric_type : 7;          // 7 bits for metric type
+  uint32_t use_count : 16;           // 16 bits for use count
+  uint32_t ever_used : 1;            // 1 bit to track if ever been used
+  uint32_t reserved : 8;             // 8 bits reserved for future use
+};
+
+struct MetricData {
+  std::atomic<uint64_t> count{0};           
+};
+
+const absl::flat_hash_map<MetricType, absl::string_view> kMetricTypeToStr = {
+  {MetricType::kVectorsMemory, "vectors_memory"},
+  {MetricType::kVectorsMemoryMarkedDeleted, "vectors_memory_marked_deleted"},
+  {MetricType::kHnswNodes, "hnsw_nodes"},
+  {MetricType::kHnswNodesMarkedDeleted, "hnsw_nodes_marked_deleted"},
+  {MetricType::kHnswEdges, "hnsw_edges"},
+  {MetricType::kHnswEdgesMarkedDeleted, "hnsw_edges_marked_deleted"},
+  {MetricType::kFlatNodes, "flat_nodes"},
+  {MetricType::kTags, "tags"},
+  {MetricType::kTagsMemory, "tags_memory"},
+  {MetricType::kNumericRecords, "numeric_records"},
+  {MetricType::kInternedStrings, "interned_strings"},
+  {MetricType::kInternedStringsMarkedDeleted, "interned_strings_marked_deleted"},
+  {MetricType::kInternedStringsMemory, "interned_strings_memory"},
+  {MetricType::kKeysMemory, "keys_memory"}
+};
+
+class GlobalIndexStats {
+ public:
+  static GlobalIndexStats& Instance() {
+    static GlobalIndexStats instance;
+    return instance;
+  }
+  
+  void Incr(MetricType metric_type, uint64_t value = 1) {
+    GetOrCreateMetric(metric_type).count.fetch_add(value, std::memory_order_relaxed);
+  }
+  
+  void Decr(MetricType metric_type, uint64_t value = 1) {
+    GetOrCreateMetric(metric_type).count.fetch_sub(value, std::memory_order_relaxed);
+  }
+  
+  uint64_t GetCount(MetricType metric_type) const {
+    auto it = metrics_.find(metric_type);
+    return it != metrics_.end() ? it->second->count.load(std::memory_order_relaxed) : 0;
+  }
+  
+  absl::flat_hash_map<MetricType, uint64_t> GetAllMetrics() const {
+    absl::flat_hash_map<MetricType, uint64_t> result;
+    for (const auto& [type, metric] : metrics_) {
+      result[type] = metric->count.load(std::memory_order_relaxed);
+    }
+    return result;
+  }
+  
+ private:
+  GlobalIndexStats() = default;
+  
+  MetricData& GetOrCreateMetric(MetricType metric_type) {
+    auto [it, inserted] = metrics_.try_emplace(metric_type, nullptr);
+    if (inserted) {
+      it->second = std::make_unique<MetricData>();
+    }
+    return *it->second;
+  }
+
+  absl::flat_hash_map<MetricType, std::unique_ptr<MetricData>> metrics_;
+};
+
+inline void OnInternedStringAlloc(::valkey_search::InternedString* interned_str, MetricType metric_type) {
+  if (!interned_str) return;
+  size_t bytes = interned_str->Str().length();
+  GlobalIndexStats::Instance().Incr(MetricType::kInternedStringsMemory, bytes);
+  GlobalIndexStats::Instance().Incr(MetricType::kInternedStrings, 1);
+
+  if (metric_type == MetricType::kNone) return;
+
+  MetaData metadata{};
+  metadata.metric_type = static_cast<uint8_t>(metric_type);
+  metadata.use_count = 0;             // Start with 0
+  metadata.ever_used = 0;             // Not used yet
+  metadata.reserved = 0;
+  interned_str->SetMetadataFlags(*reinterpret_cast<uint32_t*>(&metadata));
+
+  GlobalIndexStats::Instance().Incr(metric_type, bytes);
+}
+
+inline void OnInternedStringDealloc(::valkey_search::InternedString* interned_str) {
+  size_t bytes = interned_str->Str().length();
+  GlobalIndexStats::Instance().Decr(MetricType::kInternedStringsMemory, bytes);
+  GlobalIndexStats::Instance().Decr(MetricType::kInternedStrings, 1);
+  uint32_t metadata_flags = interned_str->GetMetadataFlags();
+  if (metadata_flags == 0) return;
+
+  MetaData* metadata = reinterpret_cast<MetaData*>(&metadata_flags);
+  assert(metadata->use_count == 0);  // Assert use_count is 0 when deallocating
+  MetricType type = static_cast<MetricType>(metadata->metric_type);
+  if (type != MetricType::kNone) {
+    GlobalIndexStats::Instance().Decr(type, bytes);
+  }
+}
+
+inline bool OnInternedStringMarkUnused(const std::shared_ptr<::valkey_search::InternedString>& interned_str) {
+  if (!interned_str) return false;
+  
+  uint32_t* flags_ptr = interned_str->GetMetadataFlagsPtr();
+  MetaData* metadata = reinterpret_cast<MetaData*>(flags_ptr);
+  assert(metadata->use_count > 0);
+  metadata->use_count--;
+
+  if (metadata->use_count == 0 && metadata->ever_used) {
+    // Only mark as deleted if it was actually used and now back to 0
+    MetricType type = static_cast<MetricType>(metadata->metric_type);
+    // Only intern strings that may be marked as deleted are kVectorsMemory 
+    assert(type == MetricType::kVectorsMemory);
+    GlobalIndexStats::Instance().Incr(MetricType::kVectorsMemoryMarkedDeleted, interned_str->Str().length());
+    GlobalIndexStats::Instance().Incr(MetricType::kInternedStringsMarkedDeleted, 1);
+  }
+
+  return true;
+}
+
+inline bool OnInternedStringIncrUsed(const std::shared_ptr<::valkey_search::InternedString>& interned_str) {
+  if (!interned_str) return false;
+  
+  uint32_t* flags_ptr = interned_str->GetMetadataFlagsPtr();
+  if (*flags_ptr == 0) return false;
+  
+  MetaData* metadata = reinterpret_cast<MetaData*>(flags_ptr);
+  
+  if (metadata->use_count == 0 && metadata->ever_used) {
+    // This was marked as deleted, now used again
+    MetricType type = static_cast<MetricType>(metadata->metric_type);
+    assert(type == MetricType::kVectorsMemory);
+    GlobalIndexStats::Instance().Decr(MetricType::kVectorsMemoryMarkedDeleted, interned_str->Str().length());
+    GlobalIndexStats::Instance().Decr(MetricType::kInternedStringsMarkedDeleted, 1);
+  }
+
+  // Mark as ever used on first increment
+  if (!metadata->ever_used) {
+    metadata->ever_used = 1;
+  }
+
+  metadata->use_count++;
+
+  return true;
+}
+
+template<typename InfoFieldInteger>
+inline void CreateGlobalMetricsInfoFields() {
+  static auto global_metrics_fields = []() {
+    std::vector<std::unique_ptr<InfoFieldInteger>> fields;
+    
+    for (const auto& [metric_type, metric_name] : kMetricTypeToStr) {
+      auto count_field = std::make_unique<InfoFieldInteger>(
+          "global_metrics", std::string(metric_name),
+          vmsdk::info_field::IntegerBuilder()
+              .App()
+              .Computed([metric_type]() -> long long {
+                return static_cast<long long>(GlobalIndexStats::Instance().GetCount(metric_type));
+              })
+              .CrashSafe());
+      
+      fields.push_back(std::move(count_field));
+    }
+    
+    return fields;
+  }();
+}
+
+}  // namespace valkey_search::indexes
+
+#endif  // VALKEYSEARCH_SRC_INDEXES_GLOBAL_METRICS_H

--- a/src/indexes/metric_types.h
+++ b/src/indexes/metric_types.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_METRIC_TYPES_H
+#define VALKEYSEARCH_SRC_INDEXES_METRIC_TYPES_H
+
+namespace valkey_search::indexes {
+
+enum class MetricType {
+  kNone,  // Indicates no metric type set
+  kVectorsMemory,
+  kVectorsMemoryMarkedDeleted,
+  
+  kHnswNodes,
+  kHnswNodesMarkedDeleted,
+  kHnswEdges,
+  kHnswEdgesMarkedDeleted,
+  
+  kFlatNodes,
+  
+  kTags,
+  kTagsMemory,
+  
+  kNumericRecords,
+  
+  kInternedStrings,
+  kInternedStringsMarkedDeleted,
+  kInternedStringsMemory,
+  
+  kKeysMemory,
+  
+  kMetricTypeCount
+};
+
+}  // namespace valkey_search::indexes
+
+#endif  // VALKEYSEARCH_SRC_INDEXES_METRIC_TYPES_H

--- a/src/indexes/numeric.h
+++ b/src/indexes/numeric.h
@@ -82,6 +82,7 @@ class BTreeNumeric {
 class Numeric : public IndexBase {
  public:
   explicit Numeric(const data_model::NumericIndex& numeric_index_proto);
+  ~Numeric() override;
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -32,6 +32,7 @@ namespace valkey_search::indexes {
 class Tag : public IndexBase {
  public:
   explicit Tag(const data_model::TagIndex& tag_index_proto);
+  ~Tag() override;
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -29,6 +29,7 @@
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "src/attribute_data_type.h"
+#include "src/indexes/global_metrics.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/vector_base.h"
 #include "src/metrics.h"
@@ -158,6 +159,7 @@ absl::Status VectorFlat<T>::AddRecordImpl(uint64_t internal_id,
       absl::ReaderMutexLock lock(&resize_mutex_);
 
       algo_->addPoint((T *)record.data(), internal_id);
+      GlobalIndexStats::Instance().Incr(MetricType::kFlatNodes);
     } catch (const std::exception &e) {
       ++Metrics::GetStats().flat_add_exceptions_cnt;
       std::string error_msg = e.what();
@@ -196,6 +198,7 @@ absl::Status VectorFlat<T>::RemoveRecordImpl(uint64_t internal_id) {
   try {
     absl::ReaderMutexLock lock(&resize_mutex_);
     algo_->removePoint(internal_id);
+    GlobalIndexStats::Instance().Decr(MetricType::kFlatNodes);
   } catch (const std::exception &e) {
     ++Metrics::GetStats().flat_remove_exceptions_cnt;
     return absl::InternalError(

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -30,6 +30,7 @@
 #include "absl/synchronization/mutex.h"
 #include "absl/time/time.h"
 #include "src/attribute_data_type.h"
+#include "src/indexes/global_metrics.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/vector_base.h"
 #include "src/metrics.h"
@@ -111,6 +112,7 @@ void VectorHNSW<T>::TrackVector(uint64_t internal_id,
                                 const InternedStringPtr &vector) {
   absl::MutexLock lock(&tracked_vectors_mutex_);
   tracked_vectors_.push_back(vector);
+  OnInternedStringIncrUsed(vector);
 }
 
 template <typename T>
@@ -179,6 +181,31 @@ VectorHNSW<T>::VectorHNSW(int dimensions,
                  attribute_identifier) {}
 
 template <typename T>
+VectorHNSW<T>::~VectorHNSW() {
+  if (algo_) {
+    // Call UnmarkDelete for vector strings of all deleted elements
+    for (hnswlib::tableint i = 0; i < algo_->cur_element_count_; i++) {
+      if (algo_->isMarkedDeleted(i)) {
+        char* vector_data = algo_->getDataByInternalId(i);
+        absl::string_view record(vector_data, algo_->vector_size_);
+        valkey_search::StringInternStore::Instance().UnmarkDelete(record);
+      }
+    }
+    
+    // Decrement node count for all current elements (including deleted ones)
+    size_t current_nodes = algo_->getCurrentElementCount();
+    if (current_nodes > 0) {
+      GlobalIndexStats::Instance().Decr(MetricType::kHnswNodes, current_nodes);
+    }
+    
+    size_t total_edges = current_nodes * algo_->M_;
+    if (total_edges > 0) {
+      GlobalIndexStats::Instance().Decr(MetricType::kHnswEdges, total_edges);
+    }
+  }
+}
+
+template <typename T>
 absl::Status VectorHNSW<T>::AddRecordImpl(uint64_t internal_id,
                                           absl::string_view record) {
   do {
@@ -186,6 +213,7 @@ absl::Status VectorHNSW<T>::AddRecordImpl(uint64_t internal_id,
       absl::ReaderMutexLock lock(&resize_mutex_);
 
       algo_->addPoint((T *)record.data(), internal_id);
+      GlobalIndexStats::Instance().Incr(MetricType::kHnswNodes);
       return absl::OkStatus();
     } catch (const std::exception &e) {
       std::string error_msg = e.what();

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -42,7 +42,7 @@ class VectorHNSW : public VectorBase {
       const data_model::VectorIndex& vector_index_proto,
       absl::string_view attribute_identifier,
       SupplementalContentChunkIter&& iter) ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  ~VectorHNSW() override = default;
+  ~VectorHNSW() override;
   size_t GetDataTypeSize() const override { return sizeof(T); }
 
   const hnswlib::SpaceInterface<float>* GetSpace() const {

--- a/src/utils/string_interning.cc
+++ b/src/utils/string_interning.cc
@@ -13,23 +13,28 @@
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "src/utils/allocator.h"
+#include "src/indexes/global_metrics.h"
 
 namespace valkey_search {
 
-InternedString::InternedString(absl::string_view str, bool shared)
-    : length_(str.length()), is_shared_(shared), is_data_owner_(true) {
+InternedString::InternedString(absl::string_view str, bool shared, indexes::MetricType metric_type)
+    : length_(str.length()), is_shared_(shared), is_data_owner_(true), metadata_flags_(0) {
   data_ = new char[length_ + 1];
   memcpy(data_, str.data(), length_);
   data_[length_] = '\0';
+  indexes::OnInternedStringAlloc(this, metric_type);
 }
 
-InternedString::InternedString(char* data, size_t length)
-    : data_(data), length_(length), is_shared_(true), is_data_owner_(false) {}
+InternedString::InternedString(char* data, size_t length, indexes::MetricType metric_type)
+    : data_(data), length_(length), is_shared_(true), is_data_owner_(false), metadata_flags_(0) {
+  indexes::OnInternedStringAlloc(this, metric_type);
+}
 
 InternedString::~InternedString() {
   if (is_shared_) {
     StringInternStore::Instance().Release(this);
   }
+  indexes::OnInternedStringDealloc(this);
   if (is_data_owner_) {
     delete[] data_;
   } else {
@@ -53,12 +58,40 @@ void StringInternStore::Release(InternedString* str) {
 }
 
 std::shared_ptr<InternedString> StringInternStore::Intern(
-    absl::string_view str, Allocator* allocator) {
-  return Instance().InternImpl(str, allocator);
+    absl::string_view str, Allocator* allocator, indexes::MetricType metric_type) {
+  return Instance().InternImpl(str, allocator, metric_type);
+}
+
+bool StringInternStore::MarkDelete(absl::string_view str) {
+  absl::MutexLock lock(&mutex_);
+  auto it = str_to_interned_.find(str);
+  if (it == str_to_interned_.end()) {
+    return false;
+  }
+  auto locked = it->second.lock();
+  if (!locked) {
+    return false;
+  }
+
+  return indexes::OnInternedStringMarkUnused(locked);
+}
+
+bool StringInternStore::UnmarkDelete(absl::string_view str) {
+  absl::MutexLock lock(&mutex_);
+  auto it = str_to_interned_.find(str);
+  if (it == str_to_interned_.end()) {
+    return false;
+  }
+  auto locked = it->second.lock();
+  if (!locked) {
+    return false;
+  }
+  
+  return indexes::OnInternedStringIncrUsed(locked);
 }
 
 std::shared_ptr<InternedString> StringInternStore::InternImpl(
-    absl::string_view str, Allocator* allocator) {
+    absl::string_view str, Allocator* allocator, indexes::MetricType metric_type) {
   absl::MutexLock lock(&mutex_);
   auto it = str_to_interned_.find(str);
   if (it != str_to_interned_.end()) {
@@ -72,10 +105,10 @@ std::shared_ptr<InternedString> StringInternStore::InternImpl(
     memcpy(buffer, str.data(), str.size());
     buffer[str.size()] = '\0';
     interned_string =
-        std::shared_ptr<InternedString>(new InternedString(buffer, str.size()));
+        std::shared_ptr<InternedString>(new InternedString(buffer, str.size(), metric_type));
   } else {
     interned_string =
-        std::shared_ptr<InternedString>(new InternedString(str, true));
+        std::shared_ptr<InternedString>(new InternedString(str, true, metric_type));
   }
   str_to_interned_.insert({*interned_string, interned_string});
   return interned_string;

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -29,6 +29,8 @@
 #include "src/coordinator/server.h"
 #include "src/coordinator/util.h"
 #include "src/index_schema.h"
+#include "src/indexes/index_base.h"
+#include "src/indexes/global_metrics.h"
 #include "src/metrics.h"
 #include "src/rdb_serialization.h"
 #include "src/schema_manager.h"
@@ -683,6 +685,12 @@ static vmsdk::info_field::String flat_vector_index_search_latency_usec(
           return Metrics::GetStats()
               .flat_vector_index_search_latency.HasSamples();
         }));
+
+// Global metrics info fields
+static auto global_metrics_fields = []() {
+  indexes::CreateGlobalMetricsInfoFields<vmsdk::info_field::Integer>();
+  return true;
+}();
 
 #ifdef DEBUG_INFO
 // Helper function to create subscription info fields with maximum deduplication

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -98,6 +98,7 @@ set(CORE_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/vector_externalizer_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/acl_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/rdb_serialization_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/global_metrics_test.cc
 )
 
 add_executable(core_test ${CORE_TEST_SOURCES})

--- a/testing/global_metrics_test.cc
+++ b/testing/global_metrics_test.cc
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include <algorithm>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "src/commands/ft_create_parser.h"
+#include "src/indexes/global_metrics.h"
+#include "src/indexes/metric_types.h"
+#include "src/utils/string_interning.h"
+#include "testing/common.h"
+#include "vmsdk/src/testing_infra/module.h"
+
+namespace valkey_search {
+
+class GlobalMetricsTest : public ValkeySearchTest {
+ protected:
+  void SetUp() override {
+    ValkeySearchTest::SetUp();
+    // Reset global metrics to ensure clean state
+    auto& stats = indexes::GlobalIndexStats::Instance();
+    // Clear any existing metrics by getting all and resetting
+    auto all_metrics = stats.GetAllMetrics();
+    for (const auto& [type, count] : all_metrics) {
+      // Reset counters to 0
+      while (stats.GetCount(type) > 0) {
+        stats.Decr(type, 1);
+      }
+    }
+  }
+};
+
+// Sanity test to verify basic global metrics functionality
+TEST_F(GlobalMetricsTest, BasicMetricsIncrement) {
+  auto& stats = indexes::GlobalIndexStats::Instance();
+  
+  // Test basic increment/decrement
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStrings), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+  
+  stats.Incr(indexes::MetricType::kInternedStrings, 5);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStrings), 5);
+  
+  stats.Incr(indexes::MetricType::kVectorsMemoryMarkedDeleted, 2);
+  stats.Incr(indexes::MetricType::kInternedStringsMarkedDeleted, 1);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 2);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 1);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStrings), 5); // Count unchanged
+  
+  stats.Decr(indexes::MetricType::kVectorsMemoryMarkedDeleted, 1);
+  stats.Decr(indexes::MetricType::kInternedStringsMarkedDeleted, 1);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 1);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+  
+  stats.Decr(indexes::MetricType::kInternedStrings, 3);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStrings), 2);
+}
+
+// Test interned string allocation and deallocation metrics
+TEST_F(GlobalMetricsTest, InternedStringAllocationMetrics) {
+  auto& stats = indexes::GlobalIndexStats::Instance();
+
+  std::string test_str = "test_vector_key_123";
+  auto interned_str = StringInternStore::Intern(test_str, nullptr, indexes::MetricType::kVectorsMemory);
+  
+  // Verify metrics were updated
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStrings), 1);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMemory), test_str.length());
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemory), test_str.length());
+  
+  // Increment use count to set it to 1 (from initial 0xFFFF)
+  indexes::OnInternedStringIncrUsed(interned_str);
+  
+  // Mark as unused (should trigger mark_deleted when use_count reaches 0)
+  bool marked = indexes::OnInternedStringMarkUnused(interned_str);
+  EXPECT_TRUE(marked);
+  
+  // Verify mark_deleted metrics
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), test_str.length());
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 1);
+  
+  // Unmark deleted (reuse)
+  bool unmarked = indexes::OnInternedStringIncrUsed(interned_str);
+  EXPECT_TRUE(unmarked);
+
+  // Verify mark_deleted metrics are reduced
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+}
+
+// Test use count behavior for shared interned strings
+TEST_F(GlobalMetricsTest, SharedInternedStringUseCount) {
+  auto& stats = indexes::GlobalIndexStats::Instance();
+  
+  std::string shared_key = "shared_vector_key";
+  auto interned_str = StringInternStore::Intern(shared_key, nullptr, indexes::MetricType::kVectorsMemory);
+  
+  // Increment use count multiple times (simulate multiple indexes using the same key)
+  // First call sets use_count from 0xFFFF to 1, subsequent calls increment it
+  indexes::OnInternedStringIncrUsed(interned_str);  // use_count = 1
+  indexes::OnInternedStringIncrUsed(interned_str);  // use_count = 2
+  indexes::OnInternedStringIncrUsed(interned_str);  // use_count = 3
+  
+  // Mark unused once - should not trigger mark_deleted yet (use_count = 2)
+  indexes::OnInternedStringMarkUnused(interned_str);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+  
+  // Mark unused again - should not trigger mark_deleted yet (use_count = 1)
+  indexes::OnInternedStringMarkUnused(interned_str);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+  
+  // Mark unused one more time - now use_count should reach 0 and trigger mark_deleted
+  indexes::OnInternedStringMarkUnused(interned_str);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), shared_key.length());
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 1);
+
+  // Test unmarking deleted (reuse)
+  indexes::OnInternedStringIncrUsed(interned_str);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kVectorsMemoryMarkedDeleted), 0);
+  EXPECT_EQ(stats.GetCount(indexes::MetricType::kInternedStringsMarkedDeleted), 0);
+}
+
+// Test GetAllMetrics functionality
+TEST_F(GlobalMetricsTest, GetAllMetrics) {
+  auto& stats = indexes::GlobalIndexStats::Instance();
+  
+  // Add some metrics
+  stats.Incr(indexes::MetricType::kInternedStrings, 10);
+  stats.Incr(indexes::MetricType::kHnswNodes, 5);
+  stats.Incr(indexes::MetricType::kVectorsMemoryMarkedDeleted, 3);
+  stats.Incr(indexes::MetricType::kInternedStringsMarkedDeleted, 1);
+  stats.Incr(indexes::MetricType::kHnswNodesMarkedDeleted, 2);
+  
+  auto all_metrics = stats.GetAllMetrics();
+  
+  // Verify the metrics are correctly returned
+  EXPECT_EQ(all_metrics[indexes::MetricType::kInternedStrings], 10);
+  EXPECT_EQ(all_metrics[indexes::MetricType::kHnswNodes], 5);
+  EXPECT_EQ(all_metrics[indexes::MetricType::kVectorsMemoryMarkedDeleted], 3);
+  EXPECT_EQ(all_metrics[indexes::MetricType::kInternedStringsMarkedDeleted], 1);
+  EXPECT_EQ(all_metrics[indexes::MetricType::kHnswNodesMarkedDeleted], 2);
+}
+
+
+}  // namespace valkey_search


### PR DESCRIPTION
Adds detailed memory usage tracking for different index types in valkey-search, for better visibility into memory usage patterns.

### Main Changes
• **Global Metrics System**: Tracks memory usage across vectors, HNSW nodes/edges, tags, numeric records, and interned strings
• **INFO Command Integration**: Metrics exposed through INFO SEARCH
• **Lifecycle Tracking**: Separates active vs marked-deleted memory

### Key Metrics Added
• Vector memory (active + marked deleted)
• HNSW nodes and edges (active + marked deleted) 
• Flat index nodes
• Tag memory and count
• Numeric records
• Interned strings memory
• Keys memory

### Technical Details
• Uses atomic counters for thread safety
• Updated all index implementations to report metrics
• Enhanced string interning with metadata tracking

### Files Modified
• Core: global_metrics.h, metric_types.h
• Indexes: vector, tag, numeric implementations
• Utils: string interning enhancements
• Tests: unit and integration coverage

