### PR TITLE
Implement lexical scanner

### DIFF
--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -95,7 +95,11 @@ target_link_libraries(vector_flat PUBLIC status_macros)
 target_link_libraries(vector_flat PUBLIC valkey_module)
 
 set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text/posting.cc
-              ${CMAKE_CURRENT_LIST_DIR}/text/posting.h)
+              ${CMAKE_CURRENT_LIST_DIR}/text/posting.h
+              ${CMAKE_CURRENT_LIST_DIR}/text.cc
+              ${CMAKE_CURRENT_LIST_DIR}/text.h
+              ${CMAKE_CURRENT_LIST_DIR}/text/lexer.cc
+              ${CMAKE_CURRENT_LIST_DIR}/text/lexer.h)
 
 valkey_search_add_static_library(text "${SRCS_TEXT}")
 target_include_directories(text PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text.h"
+#include "src/indexes/text_index.h"
+#include "src/indexes/text/lexer.h"
+#include "vmsdk/src/log.h"
+
+namespace valkey_search::indexes {
+
+Text::Text(const data_model::TextIndex& text_index_proto, 
+           const data_model::IndexSchema* index_schema_proto)
+    : IndexBase(IndexerType::kText),
+      text_impl_(std::make_unique<text::TextFieldIndex>(
+          text_index_proto,
+          index_schema_proto,
+          // Pass field identifier if available, otherwise empty string
+          (index_schema_proto && !index_schema_proto->name().empty()) 
+              ? index_schema_proto->name() : "")) {}
+
+absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
+                                     absl::string_view data) {
+  absl::MutexLock lock(&index_mutex_);
+  // TODO: stub
+  return text_impl_->AddRecord(key, data);
+}
+
+absl::StatusOr<bool> Text::RemoveRecord(const InternedStringPtr& key,
+                                        DeletionType deletion_type) {
+  absl::MutexLock lock(&index_mutex_);
+  // TODO: stub
+  return text_impl_->RemoveRecord(key, deletion_type);
+}
+
+absl::StatusOr<bool> Text::ModifyRecord(const InternedStringPtr& key,
+                                        absl::string_view data) {
+  absl::MutexLock lock(&index_mutex_);
+  // TODO: stub
+  return text_impl_->ModifyRecord(key, data);
+}
+
+int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
+  // TODO: stub
+  return text_impl_->RespondWithInfo(ctx);
+}
+
+bool Text::IsTracked(const InternedStringPtr& key) const {
+  // TODO: stub
+  return text_impl_->IsTracked(key);
+}
+
+uint64_t Text::GetRecordCount() const {
+  // TODO: stub
+  return text_impl_->GetRecordCount();
+}
+
+std::unique_ptr<data_model::Index> Text::ToProto() const {
+  // TODO: stub
+  return text_impl_->ToProto();
+}
+
+InternedStringPtr Text::GetRawValue(const InternedStringPtr& key) const {
+  // TODO:stub
+  static InternedStringPtr empty;
+  return empty;
+}
+
+// EntriesFetcherIterator implementations
+bool Text::EntriesFetcherIterator::Done() const {
+  // TODO:stub
+  return true;
+}
+
+void Text::EntriesFetcherIterator::Next() {
+  // TODO:stub
+}
+
+const InternedStringPtr& Text::EntriesFetcherIterator::operator*() const {
+  // TODO:stub
+  static InternedStringPtr empty;
+  return empty;
+}
+
+// EntriesFetcher implementations
+size_t Text::EntriesFetcher::Size() const {
+  // TODO:stub
+  return 0;
+}
+
+std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
+  // TODO:stub
+  return std::make_unique<EntriesFetcherIterator>();
+}
+
+std::unique_ptr<Text::EntriesFetcher> Text::Search(
+    const query::TextPredicate& predicate, bool negate) const {
+  // TODO: stub
+  return std::make_unique<EntriesFetcher>();
+}
+
+} // namespace valkey_search::indexes
+
+namespace valkey_search {
+namespace text {
+
+absl::StatusOr<bool> TextFieldIndex::AddRecord(const InternedStringPtr& key,
+                                               absl::string_view data) {
+  auto lexer_result = lexer_.ProcessString(data);
+  if (!lexer_result.ok()) {
+    // Use debug logging for non-parseable data (very rare, not actionable)
+    // Increased interval to once per minute to prevent log spam
+    VMSDK_LOG_EVERY_N_SEC(DEBUG, nullptr, 60)
+        << "Text field analysis failed for key " << key->Str() << ": " 
+        << lexer_result.status().message();
+    return lexer_result.status();
+  }
+  
+  // Get the processed terms
+  const auto& terms = lexer_result->GetProcessedTerms();
+  
+  // Use info-level logging for normal operation, with rate limiting
+  // TODO: This logging is for testing purpose, will be removed or updated to
+  // DEBUG level as we have other change below working as anticipated
+  VMSDK_LOG_EVERY_N_SEC(NOTICE, nullptr, 1) 
+      << "Text field [" 
+      << (field_identifier_.empty() ? "unknown" : field_identifier_)
+      // Access field configuration flags safely
+      << (text_index_proto_.nostem() ? " NOSTEM" : "")
+      << (text_index_proto_.suffix_tree() ? " SUFFIX" : "")
+      // Include language information if index_schema_proto_ is available and not using NOSTEM
+      << (!text_index_proto_.nostem() && index_schema_proto_ && index_schema_proto_->language() != data_model::LANGUAGE_UNSPECIFIED ? 
+            (" LANG:" + data_model::Language_Name(index_schema_proto_->language())) : "")
+      << "] processed document '" << key->Str() 
+      << "' into " << terms.size() << " terms";
+  
+  // TODO: Once RadixTree and Postings are implemented:
+  // 1. Store terms in prefix tree (text_->prefix_) with appropriate locking
+  // 2. Store terms in suffix tree if text_index_proto_.suffix_tree() is enabled with appropriate locking
+  // 3. Update postings for each term to track key and positions (if with_offsets_ is true)
+  // Note: Updates to prefix/suffix tree data structures must be coordinated
+  // with their respective locking mechanisms to ensure thread safety
+  
+  // For now, return success regardless of word count
+  // Empty documents and documents with no indexable words are valid cases
+  // This is consistent with other index types that can have empty records
+  return true;
+}
+
+}  // namespace text
+}  // namespace valkey_search

--- a/src/indexes/text/lexer.cc
+++ b/src/indexes/text/lexer.cc
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text/lexer.h"
+
+#include <bitset>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/ascii.h"
+#include "absl/strings/string_view.h"
+
+namespace valkey_search::text {
+
+namespace {
+// ASCII character bitmap for fast punctuation lookup
+using PunctuationBitmap = std::bitset<256>;
+
+// Check if a character is valid UTF-8 continuation byte
+bool IsUtf8Continuation(char c) {
+  return (static_cast<unsigned char>(c) & 0xC0) == 0x80;
+}
+
+// Get the length of a UTF-8 character from its first byte
+int GetUtf8CharLength(char c) {
+  unsigned char byte = static_cast<unsigned char>(c);
+  if (byte < 0x80) return 1;  // ASCII
+  if ((byte & 0xE0) == 0xC0) return 2;  // 110xxxxx
+  if ((byte & 0xF0) == 0xE0) return 3;  // 1110xxxx
+  if ((byte & 0xF8) == 0xF0) return 4;  // 11110xxx
+  return -1;  // Invalid UTF-8
+}
+
+// Validate UTF-8 sequence starting at position
+bool IsValidUtf8Sequence(absl::string_view text, size_t pos, int expected_len) {
+  if (pos + expected_len > text.size()) return false;
+  
+  for (int i = 1; i < expected_len; ++i) {
+    if (!IsUtf8Continuation(text[pos + i])) {
+      return false;
+    }
+  }
+  return true;
+}
+
+// Check if entire string is valid UTF-8
+bool IsValidUtf8(absl::string_view text) {
+  size_t pos = 0;
+  while (pos < text.size()) {
+    int char_len = GetUtf8CharLength(text[pos]);
+    if (char_len < 0 || !IsValidUtf8Sequence(text, pos, char_len)) {
+      return false;
+    }
+    pos += char_len;
+  }
+  return true;
+}
+
+// Create punctuation bitmap from string
+PunctuationBitmap CreatePunctuationBitmap(const std::string& punctuation) {
+  PunctuationBitmap bitmap;
+  for (char c : punctuation) {
+    bitmap.set(static_cast<unsigned char>(c));
+  }
+  return bitmap;
+}
+
+// No defaults here - parser is the source of truth
+
+}  // namespace
+
+// Initialize lexer from schema proto
+Lexer::Lexer(const data_model::IndexSchema& schema_proto) {
+  ConfigureFromSchemaProto(schema_proto);
+}
+
+// Initialize lexer from text index and schema protos
+Lexer::Lexer(const data_model::TextIndex& text_index_proto,
+             const data_model::IndexSchema& schema_proto) {
+  // First configure from schema-level settings
+  ConfigureFromSchemaProto(schema_proto);
+  
+  // Then apply field-specific overrides
+  ApplyFieldOverrides(text_index_proto);
+}
+
+// Configure lexer from schema proto
+void Lexer::ConfigureFromSchemaProto(const data_model::IndexSchema& schema_proto) {
+  // Get schema-level text parameters - with no fallbacks
+  punctuation_ = schema_proto.punctuation();
+  bool nostem = schema_proto.nostem();
+  case_conversion_enabled_ = !nostem;
+  stemming_enabled_ = !nostem;
+  min_stem_size_ = schema_proto.min_stem_size();
+  language_ = schema_proto.language();
+  
+  // Initialize stop words from schema parameters
+  SetStopWords(std::vector<std::string>(schema_proto.stop_words().begin(), schema_proto.stop_words().end()));
+}
+
+// Apply field-specific overrides
+void Lexer::ApplyFieldOverrides(const data_model::TextIndex& text_index_proto) {
+  // Field-specific parameters override schema parameters
+  if (text_index_proto.nostem()) {
+    case_conversion_enabled_ = false;
+    stemming_enabled_ = false;
+  }
+  
+  // Field-specific min stem size overrides schema if non-zero
+  if (text_index_proto.min_stem_size() > 0) {
+    min_stem_size_ = text_index_proto.min_stem_size();
+  }
+}
+      
+// TODO: Add these methods once we implement stop words functionality
+void Lexer::SetStopWords(const std::vector<std::string>& stop_words) {
+  // No-op for now, will be implemented in future
+  stop_words_.clear();
+  for (const auto& word : stop_words) {
+    stop_words_.insert(absl::AsciiStrToLower(word));
+  }
+}
+
+const std::unordered_set<std::string>& Lexer::GetStopWords() const {
+  return stop_words_;
+}
+
+// TODO: Add these methods once we implement stemming functionality
+void Lexer::SetStemmingEnabled(bool enabled) {
+  stemming_enabled_ = enabled;
+}
+
+bool Lexer::IsStemmingEnabled() const {
+  return stemming_enabled_;
+}
+
+void Lexer::SetMinStemSize(uint32_t size) {
+  min_stem_size_ = size;
+}
+
+uint32_t Lexer::GetMinStemSize() const {
+  return min_stem_size_;
+}
+
+void Lexer::SetLanguage(data_model::Language language) {
+  language_ = language;
+}
+
+data_model::Language Lexer::GetLanguage() const {
+  return language_;
+}
+
+void Lexer::SetCaseConversionEnabled(bool enabled) {
+  case_conversion_enabled_ = enabled;
+}
+
+bool Lexer::IsCaseConversionEnabled() const {
+  return case_conversion_enabled_;
+}
+
+void Lexer::ApplyCaseConversion(std::vector<std::string>& words) const {
+  for (auto& word : words) {
+    word = absl::AsciiStrToLower(word);
+  }
+}
+
+// TODO: Implement stop word removal
+void Lexer::ApplyStopWordRemoval(std::vector<std::string>& words, std::vector<size_t>& positions) const {
+  // No-op for now - will be implemented in future stages
+  // This function should remove common words (like "the", "a", "is") that don't contribute to search relevance
+}
+
+// TODO: Implement stemming using Snowball stemmer library
+void Lexer::ApplyStemming(std::vector<std::string>& words) const {
+  // No-op for now - will be implemented in future stages
+  // This function should reduce words to their root form (e.g., "running" -> "run")
+}
+
+// TODO: Implement Porter stemming algorithm
+std::string Lexer::ApplyPorterStemming(const std::string& word) const {
+  // No-op for now - will be implemented in future stages
+  // Returns the word unchanged until stemming is implemented
+  return word;
+}
+
+absl::Status Lexer::SetPunctuation(const std::string& new_punctuation) {
+  // Validate that all characters are ASCII
+  for (char c : new_punctuation) {
+    if (static_cast<unsigned char>(c) >= 128) {
+      return absl::InvalidArgumentError(
+          "Punctuation characters must be ASCII");
+    }
+  }
+  
+  punctuation_ = new_punctuation;
+  return absl::OkStatus();
+}
+
+std::string Lexer::GetPunctuation() const {
+  return punctuation_;
+}
+
+absl::StatusOr<LexerOutput> Lexer::ProcessString(absl::string_view s) const {
+  // Validate UTF-8
+  if (!IsValidUtf8(s)) {
+    return absl::InvalidArgumentError("Invalid UTF-8 sequence in input");
+  }
+  
+  LexerOutput output;
+  PunctuationBitmap punct_bitmap = CreatePunctuationBitmap(punctuation_);
+  
+  // Track positions for all words
+  output.has_positions_ = true;
+  
+  size_t pos = 0;
+  while (pos < s.size()) {
+    // Skip punctuation/whitespace, but handle escape sequences
+    while (pos < s.size()) {
+      char current = s[pos];
+      
+      // Handle escape sequences - don't skip them as punctuation
+      if (current == '\\' && pos + 1 < s.size()) {
+        break;  // This is the start of a word with escaped characters
+      }
+      
+      // If not punctuation, we've found the start of a word
+      if (!punct_bitmap[static_cast<unsigned char>(current)]) {
+        break;  // Found non-punctuation character - start of word
+      }
+      
+      // Skip regular punctuation
+      pos++;
+    }
+    
+    if (pos >= s.size()) break;
+    
+    // Found start of a word
+    size_t word_start = pos;
+    std::string escaped_word;
+    bool has_escaped_chars = false;
+    
+    // Process the word
+    while (pos < s.size()) {
+      char current = s[pos];
+      
+      // Handle escape sequences
+      if (current == '\\' && pos + 1 < s.size()) {
+        // Next character is escaped - treat as literal
+        has_escaped_chars = true;
+        if (escaped_word.empty()) {
+          // First escaped char - copy everything so far
+          escaped_word = std::string(s.substr(word_start, pos - word_start));
+        }
+        escaped_word += s[pos + 1];  // Add the escaped character
+        pos += 2;  // Skip both '\' and the escaped character
+        continue;
+      }
+      
+      // Check if current character is punctuation
+      if (punct_bitmap[static_cast<unsigned char>(current)]) {
+        break;  // End of word
+      }
+      
+      // Regular character - add to escaped word if we're building one
+      if (has_escaped_chars) {
+        escaped_word += current;
+      }
+      
+      pos++;
+    }
+    
+    // Create word entry
+    LexerOutput::Word word;
+    word.location.start = word_start;
+    word.location.end = pos;
+    
+    if (has_escaped_chars) {
+      // Store escaped word and reference it
+      output.escaped_words_.push_back(std::move(escaped_word));
+      word.word = output.escaped_words_.back();
+    } else {
+      // Use string_view of original text
+      word.word = s.substr(word_start, pos - word_start);
+    }
+    
+    output.words_.push_back(word);
+  }
+  
+  // Process words for case conversion and other operations
+  if (!output.words_.empty()) {
+    // Extract words as strings for further processing
+    std::vector<std::string> word_strings;
+    word_strings.reserve(output.words_.size());
+    
+    // Set up positions if tracking is enabled
+    if (output.has_positions_) {
+      output.positions_.reserve(output.words_.size());
+    }
+    
+    for (size_t i = 0; i < output.words_.size(); ++i) {
+      word_strings.push_back(std::string(output.words_[i].word));
+      if (output.has_positions_) {
+        output.positions_.push_back(i);
+      }
+    }
+    
+    // Apply case conversion if enabled
+    if (case_conversion_enabled_) {
+      ApplyCaseConversion(word_strings);
+    }
+    
+    // TODO: Apply stop word removal (when implemented)
+    // if (!stop_words_.empty()) {
+    //   ApplyStopWordRemoval(word_strings, output.positions_);
+    // }
+    
+    // TODO: Apply stemming (when implemented)
+    // if (stemming_enabled_) {
+    //   ApplyStemming(word_strings);
+    // }
+    
+    // Store processed terms
+    output.processed_terms_ = std::move(word_strings);
+  }
+  
+  return output;
+}
+
+const std::vector<LexerOutput::Word>& LexerOutput::GetWords() const {
+  return words_;
+}
+
+const std::vector<std::string>& LexerOutput::GetProcessedTerms() const {
+  return processed_terms_;
+}
+
+const std::vector<size_t>& LexerOutput::GetPositions() const {
+  return positions_;
+}
+
+bool LexerOutput::HasPositions() const {
+  return has_positions_;
+}
+
+}  // namespace valkey_search::text

--- a/src/indexes/text/lexer.h
+++ b/src/indexes/text/lexer.h
@@ -3,28 +3,39 @@
 
 /*
 
-The Lexer takes in a UTF-8 string and outputs a vector of words.
+The Lexer takes in a UTF-8 string and outputs a vector of processed terms.
 Each word output is decorated with metadata like it's physical location, etc.
 
 1. The lexer treats configurable punctuation as whitespace.
 2. The lexer supports escaping of punctuation to force its treatment as a
-natural character that is part of a word.
+   natural character that is part of a word.
 3. Words are defined as sequences of utf-8 characters separated by whitespace.
+4. The lexer converts text to lowercase (configurable).
+5. The lexer provides APIs for stop word removal and stemming (future implementation).
 
 */
 
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "absl/status/statusor.h"
-#include "src/text/text.h"
+#include "absl/strings/string_view.h"
+#include "src/index_schema.pb.h"
 
-namespace valkey_search::text {
+namespace valkey_search {
+namespace text {
+
+// Forward declaration
+struct LexerOutput;
 
 /*
 
 Configuration for Lexer operation. Typically, there's one of these for each
-index-field.
+index-field. The lexer handles the text processing pipeline:
+1. Tokenization (breaking text into words)
+2. Case conversion (converting to lowercase, configurable) 
+3. APIs for advanced processing (stemming, stop words) for future implementation
 
 */
 
@@ -42,15 +53,69 @@ struct Lexer {
 
   std::string GetPunctuation() const;
 
-  // Instantiate with default Punctuation
-  Lexer();
+  // Enable/disable case conversion (enabled by default)
+  void SetCaseConversionEnabled(bool enabled);
+  
+  bool IsCaseConversionEnabled() const;
+  
+  // Set/get stop words
+  void SetStopWords(const std::vector<std::string>& stop_words);
+  const std::unordered_set<std::string>& GetStopWords() const;
+  
+  // Enable/disable stemming (enabled by default)
+  void SetStemmingEnabled(bool enabled);
+  bool IsStemmingEnabled() const;
+  
+  // Set/get minimum stem size
+  void SetMinStemSize(uint32_t size);
+  uint32_t GetMinStemSize() const;
+
+  // Set/get language for stemming
+  void SetLanguage(data_model::Language language);
+  data_model::Language GetLanguage() const;
+
+  // Instantiate with schema proto parameters
+  explicit Lexer(const data_model::IndexSchema& schema_proto);
+  
+  // Instantiate with text index and schema protos (field-specific configuration)
+  Lexer(const data_model::TextIndex& text_index_proto,
+        const data_model::IndexSchema& schema_proto);
 
   //
-  // Process an input string
+  // Process an input string - performs text processing:
+  // 1. Tokenization
+  // 2. Case conversion (if enabled)
+  // 3. Future: Stop word removal and stemming (when implemented)
   //
   // May fail if there are non-UTF-8 characters present.
   //
   absl::StatusOr<LexerOutput> ProcessString(absl::string_view s) const;
+
+ private:
+  // Apply case conversion to words (convert to lowercase)
+  void ApplyCaseConversion(std::vector<std::string>& words) const;
+  
+  // Apply stop word removal - filters out common words
+  void ApplyStopWordRemoval(std::vector<std::string>& words, std::vector<size_t>& positions) const;
+  
+  // Apply stemming - reduces words to their root form
+  void ApplyStemming(std::vector<std::string>& words) const;
+  
+  // Helper to apply Porter stemming algorithm
+  std::string ApplyPorterStemming(const std::string& word) const;
+  
+  // Configure lexer from schema proto
+  void ConfigureFromSchemaProto(const data_model::IndexSchema& schema_proto);
+  
+  // Apply field-specific overrides
+  void ApplyFieldOverrides(const data_model::TextIndex& text_index_proto);
+  
+  std::string punctuation_;
+  bool case_conversion_enabled_;
+  std::unordered_set<std::string> stop_words_;
+  bool stemming_enabled_;
+  uint32_t min_stem_size_;
+  data_model::Language language_;
 };
 
 //
@@ -69,12 +134,36 @@ struct LexerOutput {
   };
 
   const std::vector<Word>& GetWords() const;
+  
+  // Get the processed terms after all text processing steps
+  const std::vector<std::string>& GetProcessedTerms() const;
+  
+  // Get term positions, only valid if positions are tracked
+  const std::vector<size_t>& GetPositions() const;
+  
+  // Check if positions are tracked
+  bool HasPositions() const;
 
  private:
+  friend struct Lexer;
+  
   // Storage for escaped words
   std::vector<std::string> escaped_words_;
-}
+  
+  // Vector of words
+  std::vector<Word> words_;
+  
+  // Final processed terms after all processing steps
+  std::vector<std::string> processed_terms_;
+  
+  // Term positions
+  std::vector<size_t> positions_;
+  
+  // Whether positions are tracked
+  bool has_positions_ = false;
+};
 
-}  // namespace valkey_search::text
+}  // namespace text
+}  // namespace valkey_search
 
 #endif

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -76,9 +76,11 @@ finalize_test_flags(commands_test)
 # 2. Indexes Test Suite - consolidates index-related tests
 set(INDEXES_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/index_schema_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/lexer_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/numeric_index_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/posting_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/tag_index_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/text_field_index_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/vector_test.cc
 )
 

--- a/testing/lexer_test.cc
+++ b/testing/lexer_test.cc
@@ -1,0 +1,388 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text/lexer.h"
+
+#include <string>
+#include <vector>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+
+namespace valkey_search::text {
+
+class LexerTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create schema proto with test values
+    data_model::IndexSchema schema_proto;
+    schema_proto.set_punctuation(" \t\n\r!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+    schema_proto.set_with_offsets(true);
+    schema_proto.set_nostem(false);
+    schema_proto.set_language(data_model::LANGUAGE_ENGLISH);
+    schema_proto.set_min_stem_size(4);
+    
+    // For stop words, use common English stop words
+    // Properly add each stop word to the repeated field
+    std::vector<std::string> stop_words = {
+      "a", "is", "the", "an", "and", "are", "as", "at", "be", "but", "by", "for",
+      "if", "in", "into", "it", "no", "not", "of", "on", "or", "such", "that", "their",
+      "then", "there", "these", "they", "this", "to", "was", "will", "with"
+    };
+    for (const auto& word : stop_words) {
+      schema_proto.add_stop_words(word);
+    }
+    
+    // Create lexer with the schema proto
+    lexer_ = std::make_unique<Lexer>(schema_proto);
+  }
+
+  std::unique_ptr<Lexer> lexer_;
+};
+
+TEST_F(LexerTest, BasicTokenization) {
+  auto result = lexer_->ProcessString("hello world");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[0].location.start, 0);
+  EXPECT_EQ(words[0].location.end, 5);
+  
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[1].location.start, 6);
+  EXPECT_EQ(words[1].location.end, 11);
+}
+
+TEST_F(LexerTest, EmptyStringReturnsNoWords) {
+  auto result = lexer_->ProcessString("");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  EXPECT_EQ(words.size(), 0);
+}
+
+TEST_F(LexerTest, OnlyPunctuationReturnsNoWords) {
+  auto result = lexer_->ProcessString("   \t\n!@#$%^&*()   ");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  EXPECT_EQ(words.size(), 0);
+}
+
+TEST_F(LexerTest, DefaultPunctuationHandling) {
+  auto result = lexer_->ProcessString("hello,world!this-is_a.test");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 6);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[2].word, "this");
+  EXPECT_EQ(words[3].word, "is");
+  EXPECT_EQ(words[4].word, "a");
+  EXPECT_EQ(words[5].word, "test");
+}
+
+TEST_F(LexerTest, CustomPunctuation) {
+  ASSERT_TRUE(lexer_->SetPunctuation(" ,").ok());
+  
+  auto result = lexer_->ProcessString("hello,world!this-is_a.test");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "world!this-is_a.test");
+}
+
+TEST_F(LexerTest, EscapeSequences) {
+  auto result = lexer_->ProcessString("hello\\,world test\\!ing");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "hello,world");
+  EXPECT_EQ(words[1].word, "test!ing");
+}
+
+TEST_F(LexerTest, EscapeAtEndOfString) {
+  auto result = lexer_->ProcessString("hello\\");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, "hello");
+}
+
+TEST_F(LexerTest, EscapeBackslash) {
+  auto result = lexer_->ProcessString("hello\\\\world");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, "hello\\world");
+}
+
+TEST_F(LexerTest, MultipleEscapesInWord) {
+  auto result = lexer_->ProcessString("a\\,b\\!c\\@d");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, "a,b!c@d");
+}
+
+TEST_F(LexerTest, EscapeNonPunctuation) {
+  auto result = lexer_->ProcessString("hello\\aworld");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, "helloaworld");
+}
+
+TEST_F(LexerTest, UTF8Support) {
+  auto result = lexer_->ProcessString("hello 世界 test café");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 4);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "世界");
+  EXPECT_EQ(words[2].word, "test");
+  EXPECT_EQ(words[3].word, "café");
+  
+  // Check processed terms (with case conversion)
+  const auto& terms = result->GetProcessedTerms();
+  ASSERT_EQ(terms.size(), 4);
+  EXPECT_EQ(terms[0], "hello");
+  EXPECT_EQ(terms[1], "世界");  // Non-ASCII should remain unchanged
+  EXPECT_EQ(terms[2], "test");
+  EXPECT_EQ(terms[3], "café");  // Accented characters should remain unchanged
+}
+
+TEST_F(LexerTest, InvalidUTF8) {
+  // Invalid UTF-8 sequence
+  std::string invalid_utf8 = "hello \xFF\xFE world";
+  auto result = lexer_->ProcessString(invalid_utf8);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(LexerTest, CaseConversion) {
+  // Test with case conversion enabled (default)
+  auto result = lexer_->ProcessString("HELLO World miXeD");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 3);
+  // Original words should be unchanged
+  EXPECT_EQ(words[0].word, "HELLO");
+  EXPECT_EQ(words[1].word, "World");
+  EXPECT_EQ(words[2].word, "miXeD");
+  
+  // Processed terms should be lowercase
+  const auto& terms = result->GetProcessedTerms();
+  ASSERT_EQ(terms.size(), 3);
+  EXPECT_EQ(terms[0], "hello");
+  EXPECT_EQ(terms[1], "world");
+  EXPECT_EQ(terms[2], "mixed");
+}
+
+TEST_F(LexerTest, DisableCaseConversion) {
+  // Disable case conversion
+  lexer_->SetCaseConversionEnabled(false);
+  EXPECT_FALSE(lexer_->IsCaseConversionEnabled());
+  
+  auto result = lexer_->ProcessString("HELLO World miXeD");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  // Processed terms should preserve original case
+  const auto& terms = result->GetProcessedTerms();
+  ASSERT_EQ(terms.size(), 3);
+  EXPECT_EQ(terms[0], "HELLO");
+  EXPECT_EQ(terms[1], "World");
+  EXPECT_EQ(terms[2], "miXeD");
+  
+  // Re-enable for subsequent tests
+  lexer_->SetCaseConversionEnabled(true);
+}
+
+TEST_F(LexerTest, PositionTracking) {
+  auto result = lexer_->ProcessString("hello world");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  // Check that positions are tracked
+  EXPECT_TRUE(result->HasPositions());
+  
+  const auto& positions = result->GetPositions();
+  ASSERT_EQ(positions.size(), 2);
+  EXPECT_EQ(positions[0], 0);
+  EXPECT_EQ(positions[1], 1);
+}
+
+TEST_F(LexerTest, LeadingAndTrailingWhitespace) {
+  auto result = lexer_->ProcessString("   hello world   ");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[0].location.start, 3);
+  EXPECT_EQ(words[0].location.end, 8);
+  
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[1].location.start, 9);
+  EXPECT_EQ(words[1].location.end, 14);
+}
+
+TEST_F(LexerTest, MultipleSpacesBetweenWords) {
+  auto result = lexer_->ProcessString("hello    world");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[1].location.start, 9);
+}
+
+TEST_F(LexerTest, GetAndSetPunctuation) {
+  // Test default punctuation
+  std::string default_punct = lexer_->GetPunctuation();
+  EXPECT_FALSE(default_punct.empty());
+  
+  // Test setting custom punctuation
+  ASSERT_TRUE(lexer_->SetPunctuation(".,!?").ok());
+  EXPECT_EQ(lexer_->GetPunctuation(), ".,!?");
+  
+  // Test that setting works
+  auto result = lexer_->ProcessString("hello,world.test!now?please");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 5);
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[2].word, "test");
+  EXPECT_EQ(words[3].word, "now");
+  EXPECT_EQ(words[4].word, "please");
+}
+
+TEST_F(LexerTest, FieldSpecificOverrides) {
+  // Create a text index with field-specific overrides
+  data_model::TextIndex text_index_proto;
+  text_index_proto.set_nostem(true);  // Override schema-level setting
+  text_index_proto.set_min_stem_size(6);  // Override schema-level setting
+  
+  // Create schema proto with defaults
+  data_model::IndexSchema schema_proto;
+  schema_proto.set_punctuation(" \t\n\r!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~");
+  schema_proto.set_nostem(false);  // Will be overridden by field
+  schema_proto.set_min_stem_size(4);  // Will be overridden by field
+  
+  // Create lexer with both protos
+  Lexer field_lexer(text_index_proto, schema_proto);
+  
+  // Test that field-specific overrides were applied
+  EXPECT_FALSE(field_lexer.IsCaseConversionEnabled());  // nostem=true disables case conversion
+  EXPECT_FALSE(field_lexer.IsStemmingEnabled());
+  EXPECT_EQ(field_lexer.GetMinStemSize(), 6);
+}
+
+TEST_F(LexerTest, NonASCIIPunctuationRejected) {
+  auto status = lexer_->SetPunctuation(".,!?🙂");
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(LexerTest, SingleCharacterWords) {
+  auto result = lexer_->ProcessString("a b c");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 3);
+  
+  EXPECT_EQ(words[0].word, "a");
+  EXPECT_EQ(words[1].word, "b");
+  EXPECT_EQ(words[2].word, "c");
+}
+
+TEST_F(LexerTest, LongWord) {
+  std::string long_word(1000, 'a');
+  auto result = lexer_->ProcessString(long_word);
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, long_word);
+  EXPECT_EQ(words[0].location.start, 0);
+  EXPECT_EQ(words[0].location.end, 1000);
+}
+
+TEST_F(LexerTest, MixedEscapedAndNormalWords) {
+  auto result = lexer_->ProcessString("normal esc\\,aped normal2");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 3);
+  
+  EXPECT_EQ(words[0].word, "normal");
+  EXPECT_EQ(words[1].word, "esc,aped");
+  EXPECT_EQ(words[2].word, "normal2");
+}
+
+TEST_F(LexerTest, OnlyEscapedCharacters) {
+  auto result = lexer_->ProcessString("\\,\\!\\@\\#");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 1);
+  EXPECT_EQ(words[0].word, ",!@#");
+}
+
+TEST_F(LexerTest, TabsAndNewlines) {
+  auto result = lexer_->ProcessString("hello\tworld\ntest");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 3);
+  
+  EXPECT_EQ(words[0].word, "hello");
+  EXPECT_EQ(words[1].word, "world");
+  EXPECT_EQ(words[2].word, "test");
+}
+
+// Test position tracking with escaped characters
+TEST_F(LexerTest, EscapedCharacterPositions) {
+  auto result = lexer_->ProcessString("abc\\,def ghi");
+  ASSERT_TRUE(result.ok()) << result.status();
+  
+  const auto& words = result->GetWords();
+  ASSERT_EQ(words.size(), 2);
+  
+  EXPECT_EQ(words[0].word, "abc,def");
+  EXPECT_EQ(words[0].location.start, 0);
+  EXPECT_EQ(words[0].location.end, 8);  // Position after 'def'
+  
+  EXPECT_EQ(words[1].word, "ghi");
+  EXPECT_EQ(words[1].location.start, 9);
+  EXPECT_EQ(words[1].location.end, 12);
+}
+
+}  // namespace valkey_search::text

--- a/testing/text_field_index_test.cc
+++ b/testing/text_field_index_test.cc
@@ -1,0 +1,306 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text.h"
+#include "src/indexes/text/lexer.h"
+
+#include <memory>
+#include <string>
+
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+#include "src/utils/string_interning.h"
+
+namespace valkey_search::text {
+
+class TextFieldIndexTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Create a text index prototype with various settings
+    default_text_index_proto_ = std::make_unique<data_model::TextIndex>();
+    
+    // Create a text index prototype with suffix tree enabled
+    suffix_tree_text_index_proto_ = std::make_unique<data_model::TextIndex>();
+    suffix_tree_text_index_proto_->set_suffix_tree(true);
+    
+    // Create a text index prototype with no stemming
+    nostem_text_index_proto_ = std::make_unique<data_model::TextIndex>();
+    nostem_text_index_proto_->set_nostem(true);
+    
+    // Create a text index prototype with custom min stem size
+    min_stem_text_index_proto_ = std::make_unique<data_model::TextIndex>();
+    min_stem_text_index_proto_->set_min_stem_size(5);  // Different from default
+    
+    // Create TextFieldIndex instances
+    default_text_field_index_ = std::make_unique<TextFieldIndex>(*default_text_index_proto_);
+    suffix_tree_text_field_index_ = std::make_unique<TextFieldIndex>(*suffix_tree_text_index_proto_);
+    nostem_text_field_index_ = std::make_unique<TextFieldIndex>(*nostem_text_index_proto_);
+    min_stem_text_field_index_ = std::make_unique<TextFieldIndex>(*min_stem_text_index_proto_);
+  }
+
+  std::unique_ptr<data_model::TextIndex> default_text_index_proto_;
+  std::unique_ptr<data_model::TextIndex> suffix_tree_text_index_proto_;
+  std::unique_ptr<data_model::TextIndex> nostem_text_index_proto_;
+  std::unique_ptr<data_model::TextIndex> min_stem_text_index_proto_;
+  
+  std::unique_ptr<TextFieldIndex> default_text_field_index_;
+  std::unique_ptr<TextFieldIndex> suffix_tree_text_field_index_;
+  std::unique_ptr<TextFieldIndex> nostem_text_field_index_;
+  std::unique_ptr<TextFieldIndex> min_stem_text_field_index_;
+};
+
+TEST_F(TextFieldIndexTest, BasicAddRecord) {
+  auto key = valkey_search::StringInternStore::Intern("test_key");
+  std::string data = "Hello world, this is a test document.";
+  
+  // Add record should succeed
+  auto result = default_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+}
+
+TEST_F(TextFieldIndexTest, EmptyRecord) {
+  auto key = valkey_search::StringInternStore::Intern("empty_key");
+  std::string data = "";
+  
+  // Adding an empty record should still succeed
+  auto result = default_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+}
+
+TEST_F(TextFieldIndexTest, InvalidUTF8) {
+  auto key = valkey_search::StringInternStore::Intern("invalid_key");
+  std::string data = "Hello \xFF\xFE world";  // Invalid UTF-8 sequence
+  
+  // Adding invalid UTF-8 should fail with an InvalidArgument error
+  auto result = default_text_field_index_->AddRecord(key, data);
+  EXPECT_FALSE(result.ok());
+  EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
+}
+
+TEST_F(TextFieldIndexTest, SuffixTreeConfig) {
+  auto key = valkey_search::StringInternStore::Intern("test_key");
+  std::string data = "Hello world";
+  
+  // Add record should succeed for both default and suffix tree enabled indices
+  auto default_result = default_text_field_index_->AddRecord(key, data);
+  auto suffix_result = suffix_tree_text_field_index_->AddRecord(key, data);
+  
+  ASSERT_TRUE(default_result.ok()) << default_result.status();
+  ASSERT_TRUE(suffix_result.ok()) << suffix_result.status();
+  
+  EXPECT_TRUE(default_result.value());
+  EXPECT_TRUE(suffix_result.value());
+}
+
+TEST_F(TextFieldIndexTest, NostemConfig) {
+  auto key = valkey_search::StringInternStore::Intern("test_key");
+  std::string data = "Running jumps working";  // Words that could be stemmed
+  
+  // Add record should succeed for both default and no stemming indices
+  auto default_result = default_text_field_index_->AddRecord(key, data);
+  auto nostem_result = nostem_text_field_index_->AddRecord(key, data);
+  
+  ASSERT_TRUE(default_result.ok()) << default_result.status();
+  ASSERT_TRUE(nostem_result.ok()) << nostem_result.status();
+  
+  EXPECT_TRUE(default_result.value());
+  EXPECT_TRUE(nostem_result.value());
+}
+
+TEST_F(TextFieldIndexTest, MinStemSizeConfig) {
+  auto key = valkey_search::StringInternStore::Intern("test_key");
+  std::string data = "run running jump jumping walk walking";
+  
+  // Add record should succeed for both default and custom min stem size indices
+  auto default_result = default_text_field_index_->AddRecord(key, data);
+  auto min_stem_result = min_stem_text_field_index_->AddRecord(key, data);
+  
+  ASSERT_TRUE(default_result.ok()) << default_result.status();
+  ASSERT_TRUE(min_stem_result.ok()) << min_stem_result.status();
+  
+  EXPECT_TRUE(default_result.value());
+  EXPECT_TRUE(min_stem_result.value());
+}
+
+TEST_F(TextFieldIndexTest, LargeDocument) {
+  auto key = valkey_search::StringInternStore::Intern("large_doc_key");
+  std::string data(10000, 'a');  // 10KB document of just 'a's
+  
+  // Large document should still succeed
+  auto result = default_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+}
+
+TEST_F(TextFieldIndexTest, UnicodeSupport) {
+  auto key = valkey_search::StringInternStore::Intern("unicode_key");
+  std::string data = "こんにちは 世界 Привет мир Hello world";
+  
+  // Unicode text should be handled correctly
+  auto result = default_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+}
+
+TEST_F(TextFieldIndexTest, SchemaPunctuationConfig) {
+  // Create a text index with custom schema punctuation
+  data_model::TextIndex text_index_proto;
+  
+  // Create a schema with custom punctuation
+  auto schema_proto = std::make_unique<data_model::IndexSchema>();
+  schema_proto->set_punctuation("@#$");  // Only these characters will be treated as punctuation
+  
+  // Create TextFieldIndex with custom schema
+  TextFieldIndex custom_punct_index(text_index_proto, schema_proto.get());
+  
+  auto key = StringInternStore::Intern("punct_test_key");
+  // This string has default punctuation (spaces, commas) and custom punctuation (@#$)
+  std::string data = "hello,world this@is#a$test";
+  
+  // Add record should succeed
+  auto result = custom_punct_index.AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+  
+  // TODO: Team implements storage, add assertions to verify:
+  // 1. "hello,world" is stored as one token (comma isn't punctuation)
+  // 2. "this", "is", "a", "test" are separate tokens (@ # $ are punctuation)
+}
+
+TEST_F(TextFieldIndexTest, CaseConversionEnabled) {
+  auto key = valkey_search::StringInternStore::Intern("case_test_key");
+  std::string data = "HELLO World miXeD";
+  
+  // Default TextFieldIndex should have case conversion enabled
+  auto result = default_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+  
+  // With our enhanced Lexer, words should be processed to lowercase
+  // TODO: When storage is implemented, verify terms are stored as lowercase
+}
+
+TEST_F(TextFieldIndexTest, CaseConversionDisabled) {
+  auto key = valkey_search::StringInternStore::Intern("case_test_key");
+  std::string data = "HELLO World miXeD";
+  
+  // nostem_text_field_index_ should have case conversion disabled
+  auto result = nostem_text_field_index_->AddRecord(key, data);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_TRUE(result.value());
+  
+  // With nostem, case conversion should be disabled
+  // TODO: When storage is implemented, verify terms are stored with original case
+}
+
+TEST_F(TextFieldIndexTest, MultipleFieldsWithDifferentConfigs) {
+  // Create an index with two text fields having different configurations
+  data_model::TextIndex field1_proto;
+  field1_proto.set_suffix_tree(true);  // First field uses suffix tree
+  field1_proto.set_nostem(false);      // First field uses stemming
+
+  data_model::TextIndex field2_proto;
+  field2_proto.set_suffix_tree(false); // Second field doesn't use suffix tree
+  field2_proto.set_nostem(true);       // Second field has stemming disabled
+
+  // Create a common schema
+  auto schema_proto = std::make_unique<data_model::IndexSchema>();
+  schema_proto->set_with_offsets(true);
+  schema_proto->set_punctuation(",. ");  // Common punctuation
+
+  // Create TextFieldIndex instances for each field
+  TextFieldIndex field1_index(field1_proto, schema_proto.get());
+  TextFieldIndex field2_index(field2_proto, schema_proto.get());
+
+  // Test with same content for both fields
+  auto key1 = StringInternStore::Intern("key1");
+  auto key2 = StringInternStore::Intern("key2");
+  std::string data = "Running,Walking Quickly";
+
+  // Add records to both fields
+  auto result1 = field1_index.AddRecord(key1, data);
+  auto result2 = field2_index.AddRecord(key2, data);
+
+  ASSERT_TRUE(result1.ok()) << result1.status();
+  ASSERT_TRUE(result2.ok()) << result2.status();
+  EXPECT_TRUE(result1.value());
+  EXPECT_TRUE(result2.value());
+
+  // TODO: Once storage is implemented, verify:
+  // 1. field1 would stem "Running" to "run" and store in suffix tree
+  // 2. field2 would keep "Running" as is and not use suffix tree
+  // 3. Both fields would handle punctuation consistently
+}
+
+TEST_F(TextFieldIndexTest, FieldIdentifierCorrectlyStored) {
+  // Create text index prototypes
+  data_model::TextIndex text_index_proto;
+  
+  // Create schema prototypes with different names
+  auto title_schema_proto = std::make_unique<data_model::IndexSchema>();
+  title_schema_proto->set_name("title_field");
+  
+  auto desc_schema_proto = std::make_unique<data_model::IndexSchema>();
+  desc_schema_proto->set_name("description_field");
+  
+  // Create TextFieldIndex with field identifiers passed through constructor
+  TextFieldIndex title_index(text_index_proto, title_schema_proto.get(), "title_field");
+  TextFieldIndex desc_index(text_index_proto, desc_schema_proto.get(), "description_field");
+  TextFieldIndex no_id_index(text_index_proto);
+  
+  // Verify field identifiers are correctly stored
+  EXPECT_EQ(title_index.GetFieldIdentifier(), "title_field");
+  EXPECT_EQ(desc_index.GetFieldIdentifier(), "description_field");
+  EXPECT_EQ(no_id_index.GetFieldIdentifier(), ""); // Empty for default constructor
+  
+  // Test basic functionality with field identifiers
+  auto key = StringInternStore::Intern("test_key");
+  EXPECT_TRUE(title_index.AddRecord(key, "test content").ok());
+  EXPECT_TRUE(desc_index.AddRecord(key, "test description").ok());
+}
+
+TEST_F(TextFieldIndexTest, LanguageAndFieldPropagation) {
+  // Create text index prototypes
+  data_model::TextIndex text_index_proto;
+  
+  // Create schema prototypes with language and field name
+  auto schema_proto = std::make_unique<data_model::IndexSchema>();
+  schema_proto->set_name("content_field");
+  schema_proto->set_language(data_model::LANGUAGE_ENGLISH);
+  
+  // Create another schema with different language
+  auto schema_proto2 = std::make_unique<data_model::IndexSchema>();
+  schema_proto2->set_name("tag_field");
+  schema_proto2->set_language(data_model::LANGUAGE_ENGLISH); // Future: use different language once supported
+  schema_proto2->set_nostem(true); // Disable stemming
+  
+  // Create TextFieldIndex instances with field identifiers
+  TextFieldIndex content_index(text_index_proto, schema_proto.get(), "content_field");
+  TextFieldIndex tag_index(text_index_proto, schema_proto2.get(), "tag_field");
+  
+  // Verify field identifiers and language settings propagated
+  EXPECT_EQ(content_index.GetFieldIdentifier(), "content_field");
+  EXPECT_EQ(tag_index.GetFieldIdentifier(), "tag_field");
+  
+  // Basic functionality with different language settings
+  auto key = StringInternStore::Intern("test_key");
+  auto content_result = content_index.AddRecord(key, "running jumping swimming");
+  auto tag_result = tag_index.AddRecord(key, "run jump swim");
+  
+  ASSERT_TRUE(content_result.ok());
+  ASSERT_TRUE(tag_result.ok());
+  EXPECT_TRUE(content_result.value());
+  EXPECT_TRUE(tag_result.value());
+  
+  // Future: Add assertions for language-specific stemming once implemented
+}
+
+}  // namespace valkey_search::text


### PR DESCRIPTION
Implemented initial lexical scanner for text search that handles UTF-8 text tokenization with configurable punctuation boundaries and whitespace normalization, establishing the foundation for the text indexing pipeline as outlined in the text search RFC.

## Implementation Details

- Added core UTF-8 text tokenization functionality in the `text` namespace
- Implemented configurable punctuation character handling for word boundary detection
- Created a pipeline for text processing with whitespace normalization
- Added support for escaped punctuation characters using backslash syntax
- Implemented token position tracking to support future offset-based features
- Added utility functions for lexical analysis
- Includes test coverage for various tokenization scenarios


## Note to Reviewers

⚠️ __IMPORTANT__: This PR depends on Nivesh's FT.CREATE support PR which has not been merged yet. As a result:

1. __The build will fail until the dependency is merged.__
2. This PR is provided for early review of just the lexical scanner implementation.
3. Once the dependency is merged, this PR will be rebased on top of it.

Please focus your review on the lexical scanner implementation, especially the tokenization approach, UTF-8 handling, and the overall design of the text processing pipeline. The integration with the text index implementation will be part of future PRs.

## Working Implementation for Review

While this PR depends on Nivesh's FT.CREATE support which hasn't been merged yet, I've created a fully working end-to-end implementation in my personal fork for reviewers who want to see the complete functionality:

__Full working implementation__: [](https://github.com/VoletiRam/valkey-search/tree/lexical_scanner)<https://github.com/VoletiRam/valkey-search/tree/lexical_scanner> Compare changes: [](https://github.com/valkey-io/valkey-search/compare/fulltext...VoletiRam:valkey-search:lexical_scanner)<https://github.com/valkey-io/valkey-search/compare/fulltext...VoletiRam:valkey-search:lexical_scanner>

This branch contains my implementation of both:

1. The necessary FT.CREATE foundation (temporary implementation until Nivesh's PR is merged)
2. The lexical scanner implementation (the focus of this PR)

Reviewers can check out this branch to see and test the full text search tokenization pipeline in action. This should provide better context for how the lexical scanner fits into the overall text search functionality.

