### PR TITLE
Add support to retrieving JSON values via the JSON shared API

### DIFF
--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -16,6 +16,8 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
+#include "src/valkey_search.h"
+#include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/module.h"
 #include "vmsdk/src/type_conversions.h"
@@ -23,6 +25,10 @@
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search {
+static JsonSharedAPIGetValueFn json_get;
+static std::optional<bool> is_json_loaded;
+void ResetJsonLoadedCache() { is_json_loaded = std::nullopt; }
+
 absl::StatusOr<vmsdk::UniqueValkeyString> HashAttributeDataType::GetRecord(
     [[maybe_unused]] ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
     [[maybe_unused]] absl::string_view key,
@@ -72,7 +78,7 @@ bool HashHasRecord(ValkeyModuleKey *key, absl::string_view identifier) {
 
 absl::StatusOr<RecordsMap> HashAttributeDataType::FetchAllRecords(
     ValkeyModuleCtx *ctx, const std::string &vector_identifier,
-    absl::string_view key,
+    [[maybe_unused]] ValkeyModuleKey *open_key, absl::string_view key,
     const absl::flat_hash_set<absl::string_view> &identifiers) const {
   vmsdk::VerifyMainThread();
   auto key_str = vmsdk::MakeUniqueValkeyString(key);
@@ -103,8 +109,8 @@ absl::string_view TrimBrackets(absl::string_view record) {
   return record;
 }
 
-absl::StatusOr<vmsdk::UniqueValkeyString> NormalizeJsonRecord(
-    absl::string_view record) {
+absl::Status NormalizeJsonRecord(absl::string_view record,
+                                 vmsdk::UniqueValkeyString &out_record) {
   if (!record.empty() && record[0] != '[') {
     return absl::NotFoundError("Invalid record");
   }
@@ -117,14 +123,39 @@ absl::StatusOr<vmsdk::UniqueValkeyString> NormalizeJsonRecord(
   if (record.empty()) {
     return absl::NotFoundError("Empty record");
   }
-  return vmsdk::MakeUniqueValkeyString(record);
+  auto record_ptr = vmsdk::MakeUniqueValkeyString(record);
+  out_record.swap(record_ptr);
+  return absl::OkStatus();
 }
-
-absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetRecord(
-    ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleKey *open_key,
-    absl::string_view key, absl::string_view identifier) const {
+// GetJsonRecord is the actual implementation for retrieving a JSON value.
+// If the JSON module is not loaded, it returns an error.
+// It prefers using the JSON shared API, and falls back to VM_Call if the API is
+// unavailable. On success, the result is stored in the `record` input
+// parameter. The caller may only check for the existence of the identifier
+// by passing nullptr as the `record` value.
+absl::Status GetJsonRecord(ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
+                           absl::string_view key, absl::string_view identifier,
+                           vmsdk::UniqueValkeyString *record) {
   vmsdk::VerifyMainThread();
-
+  if (!IsJsonModuleSupported(ctx)) {
+    return absl::UnavailableError("The JSON module is not supported");
+  }
+  if (json_get) {
+    if (!open_key) {
+      return absl::NotFoundError(absl::StrCat("Key not found: `", key, "`"));
+    }
+    ValkeyModuleString *record_str = nullptr;
+    if (json_get(open_key, identifier.data(), &record_str) ==
+        VALKEYMODULE_ERR) {
+      return absl::NotFoundError(
+          absl::StrCat("No such record with identifier: `", identifier, "`"));
+    }
+    if (!record) {
+      return absl::OkStatus();
+    }
+    auto record_tmp = vmsdk::UniqueValkeyString(record_str);
+    return NormalizeJsonRecord(vmsdk::ToStringView(record_tmp.get()), *record);
+  }
   auto reply = vmsdk::UniquePtrValkeyCallReply(ValkeyModule_Call(
       ctx, kJsonCmd.data(), "cc", key.data(), identifier.data()));
   if (reply == nullptr) {
@@ -132,31 +163,37 @@ absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetRecord(
         absl::StrCat("No such record with identifier: `", identifier, "`"));
   }
   auto reply_type = ValkeyModule_CallReplyType(reply.get());
-  if (reply_type == VALKEYMODULE_REPLY_STRING) {
-    auto reply_str = vmsdk::UniqueValkeyString(
-        ValkeyModule_CreateStringFromCallReply(reply.get()));
-    return NormalizeJsonRecord(vmsdk::ToStringView(reply_str.get()));
+  if (reply_type != VALKEYMODULE_REPLY_STRING) {
+    return absl::NotFoundError(
+        absl::StrCat(kJsonCmd.data(), " returned a non string value"));
   }
-  return absl::NotFoundError("Json.get returned a non string value");
+  if (!record) {
+    return absl::OkStatus();
+  }
+  auto reply_str = vmsdk::UniqueValkeyString(
+      ValkeyModule_CreateStringFromCallReply(reply.get()));
+  return NormalizeJsonRecord(vmsdk::ToStringView(reply_str.get()), *record);
+}
+
+absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetRecord(
+    ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
+    absl::string_view identifier) const {
+  vmsdk::UniqueValkeyString record;
+  VMSDK_RETURN_IF_ERROR(GetJsonRecord(ctx, open_key, key, identifier, &record));
+  return record;
 }
 
 absl::StatusOr<RecordsMap> JsonAttributeDataType::FetchAllRecords(
     ValkeyModuleCtx *ctx, const std::string &vector_identifier,
-    absl::string_view key,
+    ValkeyModuleKey *open_key, absl::string_view key,
     const absl::flat_hash_set<absl::string_view> &identifiers) const {
-  vmsdk::VerifyMainThread();
-  // Validating that a JSON object with the key exists with the vector
-  // identifier
-  auto reply = vmsdk::UniquePtrValkeyCallReply(ValkeyModule_Call(
-      ctx, kJsonCmd.data(), "cc", key.data(), vector_identifier.c_str()));
-  if (reply == nullptr ||
-      ValkeyModule_CallReplyType(reply.get()) != VALKEYMODULE_REPLY_STRING) {
-    return absl::NotFoundError(absl::StrCat("No such record with identifier: `",
-                                            vector_identifier, "`"));
-  }
+  // First, validate that a JSON object exists for the given key using the
+  // vector identifier.
+  VMSDK_RETURN_IF_ERROR(
+      GetJsonRecord(ctx, open_key, key, vector_identifier, nullptr));
   RecordsMap key_value_content;
   for (const auto &identifier : identifiers) {
-    auto str = GetRecord(ctx, nullptr, key, identifier);
+    auto str = GetRecord(ctx, open_key, key, identifier);
     if (!str.ok()) {
       continue;
     }
@@ -167,7 +204,26 @@ absl::StatusOr<RecordsMap> JsonAttributeDataType::FetchAllRecords(
   return key_value_content;
 }
 
-bool IsJsonModuleLoaded(ValkeyModuleCtx *ctx) {
-  return vmsdk::IsModuleLoaded(ctx, "json");
+bool IsJsonModuleSupported(ValkeyModuleCtx *ctx) {
+  // Use positive caching only. Note: the JSON module may be loaded after
+  // initialization.
+  if (is_json_loaded.has_value() && is_json_loaded.value()) {
+    return is_json_loaded.value();
+  }
+  is_json_loaded = vmsdk::IsModuleLoaded(ctx, "json");
+  if (!is_json_loaded.value()) {
+    return false;
+  }
+  json_get = (int (*)(ValkeyModuleKey *, const char *, ValkeyModuleString **))
+      ValkeyModule_GetSharedAPI(ctx, "JSON_GetValue");
+  // Note: In cluster mode, replicas must have the JSON module loaded to access
+  // the JSON shared API. Otherwise, invoking commands via ValkeyModule_Call
+  // from a replica will result in a MOVED response.
+  if (!json_get && ValkeySearch::Instance().IsCluster()) {
+    VMSDK_LOG(WARNING, ctx)
+        << "Note: When cluster mode is enabled, valkey-search requires "
+           "valkey-json version 1.02 or higher for proper JSON support.";
+  }
+  return true;
 }
 }  // namespace valkey_search

--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -214,8 +214,8 @@ bool IsJsonModuleSupported(ValkeyModuleCtx *ctx) {
   if (!is_json_loaded.value()) {
     return false;
   }
-  json_get = (int (*)(ValkeyModuleKey *, const char *, ValkeyModuleString **))
-      ValkeyModule_GetSharedAPI(ctx, "JSON_GetValue");
+  json_get =
+      (JsonSharedAPIGetValueFn)ValkeyModule_GetSharedAPI(ctx, "JSON_GetValue");
   // Note: In cluster mode, replicas must have the JSON module loaded to access
   // the JSON shared API. Otherwise, invoking commands via ValkeyModule_Call
   // from a replica will result in a MOVED response.

--- a/src/attribute_data_type.h
+++ b/src/attribute_data_type.h
@@ -119,7 +119,6 @@ class JsonAttributeDataType : public AttributeDataType {
 bool IsJsonModuleSupported(ValkeyModuleCtx *ctx);
 using JsonSharedAPIGetValueFn = int (*)(ValkeyModuleKey *key, const char *path,
                                         ValkeyModuleString **result);
-absl::string_view TrimBrackets(absl::string_view record);
 // Used just for testing
 void ResetJsonLoadedCache();
 }  // namespace valkey_search

--- a/src/attribute_data_type.h
+++ b/src/attribute_data_type.h
@@ -57,7 +57,7 @@ class AttributeDataType {
   };
   virtual absl::StatusOr<RecordsMap> FetchAllRecords(
       ValkeyModuleCtx *ctx, const std::string &vector_identifier,
-      absl::string_view key,
+      ValkeyModuleKey *open_key, absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const = 0;
   virtual data_model::AttributeDataType ToProto() const = 0;
   virtual std::string ToString() const = 0;
@@ -82,7 +82,7 @@ class HashAttributeDataType : public AttributeDataType {
   inline std::string ToString() const override { return "HASH"; }
   absl::StatusOr<RecordsMap> FetchAllRecords(
       ValkeyModuleCtx *ctx, const std::string &vector_identifier,
-      absl::string_view key,
+      ValkeyModuleKey *open_key, absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const override;
   bool IsProperType(ValkeyModuleKey *key) const override {
     return ValkeyModule_KeyType(key) == VALKEYMODULE_KEYTYPE_HASH;
@@ -108,7 +108,7 @@ class JsonAttributeDataType : public AttributeDataType {
   inline std::string ToString() const override { return "JSON"; }
   absl::StatusOr<RecordsMap> FetchAllRecords(
       ValkeyModuleCtx *ctx, const std::string &vector_identifier,
-      absl::string_view key,
+      ValkeyModuleKey *open_key, absl::string_view key,
       const absl::flat_hash_set<absl::string_view> &identifiers) const override;
   bool IsProperType(ValkeyModuleKey *key) const override {
     return ValkeyModule_KeyType(key) == VALKEYMODULE_KEYTYPE_MODULE;
@@ -116,7 +116,11 @@ class JsonAttributeDataType : public AttributeDataType {
   bool RecordsProvidedAsString() const override { return true; }
 };
 
-bool IsJsonModuleLoaded(ValkeyModuleCtx *ctx);
+bool IsJsonModuleSupported(ValkeyModuleCtx *ctx);
+using JsonSharedAPIGetValueFn = int (*)(ValkeyModuleKey *key, const char *path,
+                                        ValkeyModuleString **result);
 absl::string_view TrimBrackets(absl::string_view record);
+// Used just for testing
+void ResetJsonLoadedCache();
 }  // namespace valkey_search
 #endif  // VALKEYSEARCH_SRC_ATTRIBUTE_DATA_TYPE_H_

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -437,7 +437,7 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
   VMSDK_ASSIGN_OR_RETURN(auto res, ParseParam(kOnParam, false, itr,
                                               on_data_type, *kOnDataTypeByStr));
   if (on_data_type == data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON &&
-      !IsJsonModuleLoaded(ctx)) {
+      !IsJsonModuleSupported(ctx)) {
     return absl::InvalidArgumentError("JSON module is not loaded.");
   }
   index_schema_proto.set_attribute_data_type(on_data_type);

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -154,7 +154,7 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::Create(
       attribute_data_type = std::make_unique<HashAttributeDataType>();
       break;
     case data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON:
-      if (!IsJsonModuleLoaded(ctx)) {
+      if (!IsJsonModuleSupported(ctx)) {
         return absl::InvalidArgumentError("JSON module is not loaded");
       }
       attribute_data_type = std::make_unique<JsonAttributeDataType>();

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -132,9 +132,12 @@ absl::StatusOr<RecordsMap> GetContentNoReturnJson(
        parameters.filter_parse_results.filter_identifiers) {
     identifiers.insert(filter_identifier);
   }
-  VMSDK_ASSIGN_OR_RETURN(
-      auto content, attribute_data_type.FetchAllRecords(ctx, vector_identifier,
-                                                        key, identifiers));
+  auto key_str = vmsdk::MakeUniqueValkeyString(key);
+  auto key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+      ctx, key_str.get(), VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
+  VMSDK_ASSIGN_OR_RETURN(auto content, attribute_data_type.FetchAllRecords(
+                                           ctx, vector_identifier,
+                                           key_obj.get(), key, identifiers));
   if (parameters.filter_parse_results.filter_identifiers.empty()) {
     return content;
   }
@@ -173,9 +176,12 @@ absl::StatusOr<RecordsMap> GetContent(
       identifiers.insert(filter_identifier);
     }
   }
-  VMSDK_ASSIGN_OR_RETURN(
-      auto content, attribute_data_type.FetchAllRecords(ctx, vector_identifier,
-                                                        key, identifiers));
+  auto key_str = vmsdk::MakeUniqueValkeyString(key);
+  auto key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+      ctx, key_str.get(), VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
+  VMSDK_ASSIGN_OR_RETURN(auto content, attribute_data_type.FetchAllRecords(
+                                           ctx, vector_identifier,
+                                           key_obj.get(), key, identifiers));
   if (parameters.filter_parse_results.filter_identifiers.empty()) {
     return content;
   }

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -1055,9 +1055,9 @@ absl::Status ValkeySearch::OnLoad(ValkeyModuleCtx *ctx,
       ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS |
                VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
                VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED);
-  VMSDK_LOG(NOTICE, ctx) << "Json module is "
-                         << (IsJsonModuleLoaded(ctx) ? "" : "not ")
-                         << "loaded!";
+  VMSDK_LOG(NOTICE, ctx) << "Json "
+                         << (IsJsonModuleSupported(ctx) ? "" : "not ")
+                         << "supported!";
   VectorExternalizer::Instance().Init(ctx_);
   ValkeyModule_Assert(vmsdk::info_field::Validate(ctx));
   VMSDK_LOG(DEBUG, ctx) << "Search module completed initialization!";

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -124,5 +124,6 @@ class ValkeySearch {
 void ModuleInfo(ValkeyModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search
 
-int (*JSON_GetValue)(ValkeyModuleKey *key, const char *path, ValkeyModuleString **result);
+int (*JSON_GetValue)(ValkeyModuleKey *key, const char *path,
+                     ValkeyModuleString **result);
 #endif  // VALKEYSEARCH_SRC_VALKEY_SEARCH_H_

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -124,4 +124,5 @@ class ValkeySearch {
 void ModuleInfo(ValkeyModuleInfoCtx *ctx, int for_crash_report);
 }  // namespace valkey_search
 
+int (*JSON_GetValue)(ValkeyModuleKey *key, const char *path, ValkeyModuleString **result);
 #endif  // VALKEYSEARCH_SRC_VALKEY_SEARCH_H_

--- a/testing/attribute_data_type_test.cc
+++ b/testing/attribute_data_type_test.cc
@@ -290,6 +290,13 @@ class JsonAttributeDataTypeTest
         VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
     vmsdk::SetModuleLoaded("json");
   }
+
+  void TearDown() override {
+    key_str.reset();
+    key_obj.reset();
+    ValkeySearchTestWithParam::TearDown();
+  }
+  
   ValkeyModuleCtx fake_ctx;
   JsonAttributeDataType json_attribute_data_type;
   vmsdk::UniqueValkeyString key_str;

--- a/testing/attribute_data_type_test.cc
+++ b/testing/attribute_data_type_test.cc
@@ -296,7 +296,7 @@ class JsonAttributeDataTypeTest
     key_obj.reset();
     ValkeySearchTestWithParam::TearDown();
   }
-  
+
   ValkeyModuleCtx fake_ctx;
   JsonAttributeDataType json_attribute_data_type;
   vmsdk::UniqueValkeyString key_str;
@@ -370,7 +370,7 @@ absl::string_view NormalizeValue(absl::string_view record) {
     absl::ConsumeSuffix(&record, "]");
   }
   if (absl::ConsumePrefix(&record, "\"")) {
-      absl::ConsumeSuffix(&record, "\"");
+    absl::ConsumeSuffix(&record, "\"");
   }
   return record;
 }
@@ -502,7 +502,8 @@ TEST_P(JsonAttributeDataTypeTest, JsonFetchAllRecords) {
         vmsdk::ToStringView(key_str.get()).data(), identifiers);
     if (records.ok()) {
       EXPECT_EQ(module_reply_type, VALKEYMODULE_REPLY_STRING);
-      EXPECT_EQ(ToStringMap(records.value()), NormalizeExpected(test_case.expected_records_map));
+      EXPECT_EQ(ToStringMap(records.value()),
+                NormalizeExpected(test_case.expected_records_map));
       return;
     }
     EXPECT_FALSE(expect_exists_key &&

--- a/testing/attribute_data_type_test.cc
+++ b/testing/attribute_data_type_test.cc
@@ -21,6 +21,7 @@
 #include "gtest/gtest.h"
 #include "testing/common.h"
 #include "vmsdk/src/managed_pointers.h"
+#include "vmsdk/src/module.h"
 #include "vmsdk/src/testing_infra/module.h"
 #include "vmsdk/src/type_conversions.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
@@ -165,7 +166,8 @@ TEST_P(HashAttributeDataTypeTest, HashFetchAllRecords) {
   const FetchAllRecordsTestCase &test_case = std::get<2>(params);
   auto key = expect_exists_key ? exists_key.get() : not_exists_key.get();
   EXPECT_CALL(*kMockValkeyModule, OpenKey(&fake_ctx, testing::_, testing::_))
-      .WillOnce([&](ValkeyModuleCtx *ctx, ValkeyModuleString *key, int flags) {
+      .WillRepeatedly([&](ValkeyModuleCtx *ctx, ValkeyModuleString *key,
+                          int flags) {
         return vmsdk::ToStringView(key) == vmsdk::ToStringView(exists_key.get())
                    ? TestValkeyModule_OpenKeyDefaultImpl(&fake_ctx,
                                                          exists_key.get(), 0)
@@ -213,9 +215,13 @@ TEST_P(HashAttributeDataTypeTest, HashFetchAllRecords) {
   }
   auto identifiers = ToStringViewSet(test_case.identifiers);
   EXPECT_EQ(identifiers.size(), test_case.identifiers.size());
+  auto key_str = vmsdk::MakeUniqueValkeyString(vmsdk::ToStringView(key));
+  auto key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+      &fake_ctx, key_str.get(),
+      VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
   auto records = hash_attribute_data_type.FetchAllRecords(
-      &fake_ctx, std::string(identifier), vmsdk::ToStringView(key),
-      identifiers);
+      &fake_ctx, std::string(identifier), key_obj.get(),
+      vmsdk::ToStringView(key), identifiers);
   if (expect_exists_key && expect_exists_identifier) {
     VMSDK_EXPECT_OK(records);
     if (records.ok()) {
@@ -272,11 +278,29 @@ INSTANTIATE_TEST_SUITE_P(
 
 class JsonAttributeDataTypeTest
     : public ValkeySearchTestWithParam<
-          ::testing::tuple<bool, FetchAllRecordsTestCase>> {
- protected:
+          ::testing::tuple<bool, bool, FetchAllRecordsTestCase>> {
+ public:
+  void SetUp() override {
+    ValkeySearchTestWithParam::SetUp();
+    key_str = vmsdk::MakeUniqueValkeyString("key");
+    key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+        &fake_ctx, key_str.get(),
+        VALKEYMODULE_OPEN_KEY_NOEFFECTS | VALKEYMODULE_READ);
+    vmsdk::SetModuleLoaded("json");
+  }
   ValkeyModuleCtx fake_ctx;
   JsonAttributeDataType json_attribute_data_type;
+  vmsdk::UniqueValkeyString key_str;
+  vmsdk::UniqueValkeyOpenKey key_obj;
+  const std::string query_attribute_name = "vector_json_path";
+  absl::flat_hash_map<std::string, std::string> json_path_results = {
+      {"$", "[res0]"},
+      {"json_path_results1", "[res1]"},
+      {"json_path_results2", "[res2]"}};
+  ;
 };
+
+static JsonAttributeDataTypeTest *current_test;
 
 TEST_F(JsonAttributeDataTypeTest, JsonBasic) {
   EXPECT_EQ(json_attribute_data_type.GetValkeyEventTypes(),
@@ -321,25 +345,60 @@ void CheckJsonGetRecord(
       });
 }
 
-TEST_F(JsonAttributeDataTypeTest, JsonGetRecord) {
-  absl::flat_hash_map<std::string, std::string> json_path_results{
-      {"$", "[res0]"},
-      {"json_path_results1", "res1"},
-      {"json_path_results2", "res2"}};
-  absl::flat_hash_set<std::string> identifiers{"$", "false"};
+int MyJsonSharedAPIGetValue(ValkeyModuleKey *key, const char *path,
+                            ValkeyModuleString **result) {
+  auto itr = current_test->json_path_results.find(path);
+  if (itr == current_test->json_path_results.end()) {
+    return VALKEYMODULE_ERR;
+  }
+  *result =
+      vmsdk::MakeUniqueValkeyString(absl::string_view(itr->second)).release();
+  return VALKEYMODULE_OK;
+}
+
+TEST_P(JsonAttributeDataTypeTest, JsonGetRecord) {
+  auto &params = GetParam();
+  auto use_shared_api = std::get<1>(params);
+  const FetchAllRecordsTestCase &test_case = std::get<2>(params);
+  const auto identifiers = ToStringViewSet(test_case.identifiers);
+  current_test = this;
   for (const auto &identifier : identifiers) {
+    if (use_shared_api) {
+      ResetJsonLoadedCache();
+      EXPECT_CALL(*kMockValkeyModule,
+                  GetSharedAPI(&fake_ctx, testing::StrEq("JSON_GetValue")))
+          .WillOnce([&](ValkeyModuleCtx *ctx, const char *cmd) {
+            return (void *)MyJsonSharedAPIGetValue;
+          });
+      auto record = json_attribute_data_type.GetRecord(
+          &fake_ctx, key_obj.get(), vmsdk::ToStringView(key_str.get()).data(),
+          identifier);
+      if (record.ok()) {
+        EXPECT_TRUE(json_path_results.contains(identifier));
+        auto res_str = std::string(json_path_results.find(identifier)->second);
+        EXPECT_EQ(vmsdk::ToStringView(record.value().get()),
+                  TrimBrackets(res_str));
+      } else {
+        EXPECT_FALSE(json_path_results.contains(identifier));
+        EXPECT_EQ(record.status().code(), absl::StatusCode::kNotFound);
+      }
+      continue;
+    }
+    ResetJsonLoadedCache();
     for (int module_reply_type = VALKEYMODULE_REPLY_UNKNOWN;
          module_reply_type < VALKEYMODULE_REPLY_ATTRIBUTE * 2;
          module_reply_type++) {
       CheckJsonGetRecord(fake_ctx, identifier, module_reply_type,
                          json_path_results);
-      auto record = json_attribute_data_type.GetRecord(&fake_ctx, nullptr,
-                                                       "key", identifier);
+      auto record = json_attribute_data_type.GetRecord(
+          &fake_ctx, key_obj.get(), vmsdk::ToStringView(key_str.get()).data(),
+          identifier);
       if (record.ok()) {
         EXPECT_TRUE(json_path_results.contains(identifier));
         EXPECT_EQ(module_reply_type, VALKEYMODULE_REPLY_STRING);
+        auto res_str = std::string(json_path_results.find(identifier)->second);
         EXPECT_EQ(vmsdk::ToStringView(record.value().get()),
-                  TrimBrackets(json_path_results[identifier]));
+                  TrimBrackets(res_str));
       } else {
         EXPECT_FALSE(json_path_results.contains(identifier) &&
                      module_reply_type == VALKEYMODULE_REPLY_STRING);
@@ -350,22 +409,38 @@ TEST_F(JsonAttributeDataTypeTest, JsonGetRecord) {
 }
 
 TEST_P(JsonAttributeDataTypeTest, JsonFetchAllRecords) {
-  absl::flat_hash_map<std::string, std::string> json_path_results{
-      {"$", "[res0]"},
-      {"json_path_results1", "[res1]"},
-      {"json_path_results2", "[res2]"}};
   ValkeyModuleCallReply reply;
   auto &params = GetParam();
   auto expect_exists_key = std::get<0>(params);
-  const FetchAllRecordsTestCase &test_case = std::get<1>(params);
-  std::string query_attribute_name = "vector_json_path";
+  auto use_shared_api = std::get<1>(params);
+  const FetchAllRecordsTestCase &test_case = std::get<2>(params);
+  const auto identifiers = ToStringViewSet(test_case.identifiers);
+  current_test = this;
+  if (use_shared_api) {
+    ResetJsonLoadedCache();
+    EXPECT_CALL(*kMockValkeyModule,
+                GetSharedAPI(&fake_ctx, testing::StrEq("JSON_GetValue")))
+        .WillOnce([&](ValkeyModuleCtx *ctx, const char *cmd) {
+          return (void *)MyJsonSharedAPIGetValue;
+        });
+    auto records = json_attribute_data_type.FetchAllRecords(
+        &fake_ctx, query_attribute_name, key_obj.get(),
+        vmsdk::ToStringView(key_str.get()).data(), identifiers);
+    if (records.ok()) {
+      EXPECT_EQ(ToStringMap(records.value()), test_case.expected_records_map);
+      return;
+    }
+    EXPECT_EQ(records.status().code(), absl::StatusCode::kNotFound);
+    return;
+  }
+  ResetJsonLoadedCache();
   for (int module_reply_type = VALKEYMODULE_REPLY_UNKNOWN;
        module_reply_type < VALKEYMODULE_REPLY_ATTRIBUTE * 2;
        module_reply_type++) {
-    EXPECT_CALL(
-        *kMockValkeyModule,
-        Call(&fake_ctx, testing::StrEq(kJsonCmd), testing::StrEq("cc"),
-             testing::StrEq("key"), testing::StrEq(query_attribute_name)))
+    EXPECT_CALL(*kMockValkeyModule,
+                Call(&fake_ctx, testing::StrEq(kJsonCmd), testing::StrEq("cc"),
+                     testing::StrEq(vmsdk::ToStringView(key_str.get()).data()),
+                     testing::StrEq(query_attribute_name)))
         .WillOnce([&](ValkeyModuleCtx *ctx, const char *cmd, const char *fmt,
                       const char *arg1,
                       const char *arg2) -> ValkeyModuleCallReply * {
@@ -392,28 +467,28 @@ TEST_P(JsonAttributeDataTypeTest, JsonFetchAllRecords) {
         }
       }
     }
-    auto identifiers = ToStringViewSet(test_case.identifiers);
     auto records = json_attribute_data_type.FetchAllRecords(
-        &fake_ctx, query_attribute_name, "key", identifiers);
+        &fake_ctx, query_attribute_name, key_obj.get(),
+        vmsdk::ToStringView(key_str.get()).data(), identifiers);
     if (records.ok()) {
       EXPECT_EQ(module_reply_type, VALKEYMODULE_REPLY_STRING);
       EXPECT_EQ(ToStringMap(records.value()), test_case.expected_records_map);
-    } else {
-      EXPECT_FALSE(expect_exists_key &&
-                   module_reply_type == VALKEYMODULE_REPLY_STRING);
-      EXPECT_EQ(records.status().code(), absl::StatusCode::kNotFound);
+      return;
     }
+    EXPECT_FALSE(expect_exists_key &&
+                 module_reply_type == VALKEYMODULE_REPLY_STRING);
+    EXPECT_EQ(records.status().code(), absl::StatusCode::kNotFound);
   }
 }
 
 INSTANTIATE_TEST_SUITE_P(
     JsonHashAttributeDataTypeTests, JsonAttributeDataTypeTest,
     testing::Combine(
-        testing::Bool(),
+        testing::Bool(), testing::Bool(),
         testing::ValuesIn<FetchAllRecordsTestCase>({
             {
                 .test_name = "single_identifier",
-                .identifiers = {"$"},
+                .identifiers = {"$", "false"},
                 .expected_records_map = {{"$", "res0"}},
             },
             {
@@ -423,12 +498,14 @@ INSTANTIATE_TEST_SUITE_P(
                                          {"json_path_results2", "res2"}},
             },
         })),
-    [](const TestParamInfo<::testing::tuple<bool, FetchAllRecordsTestCase>>
-           &info) {
+    [](const TestParamInfo<
+        ::testing::tuple<bool, bool, FetchAllRecordsTestCase>> &info) {
       auto expect_exists_key = std::get<0>(info.param);
-      return std::get<1>(info.param).test_name + "_" +
+      auto use_shared_api = std::get<1>(info.param);
+      return std::get<2>(info.param).test_name + "_" +
              (expect_exists_key ? "expect_exists_key"
-                                : "expect_not_exists_key");
+                                : "expect_not_exists_key") +
+             "_" + (use_shared_api ? "use_shared_api" : "use_call_api");
     });
 
 }  // namespace

--- a/testing/common.h
+++ b/testing/common.h
@@ -125,7 +125,7 @@ class MockAttributeDataType : public AttributeDataType {
   MOCK_METHOD(int, GetValkeyEventTypes, (), (override, const));
   MOCK_METHOD((absl::StatusOr<RecordsMap>), FetchAllRecords,
               (ValkeyModuleCtx * ctx, const std::string& query_attribute_name,
-               absl::string_view key,
+               ValkeyModuleKey* open_key, absl::string_view key,
                const absl::flat_hash_set<absl::string_view>& identifiers),
               (override, const));
   MOCK_METHOD((data_model::AttributeDataType), ToProto, (), (override, const));

--- a/testing/query/response_generator_test.cc
+++ b/testing/query/response_generator_test.cc
@@ -122,14 +122,15 @@ TEST_P(ResponseGeneratorTest, ProcessNeighborsForReply) {
     expected_fetched_identifiers.insert(id);
   }
   for (const auto &neighbor : expected_neighbors) {
-    EXPECT_CALL(data_type,
-                FetchAllRecords(&fake_ctx, parameters.attribute_alias,
-                                absl::string_view(*neighbor.external_id),
-                                expected_fetched_identifiers))
+    EXPECT_CALL(
+        data_type,
+        FetchAllRecords(&fake_ctx, parameters.attribute_alias, testing::_,
+                        absl::string_view(*neighbor.external_id),
+                        expected_fetched_identifiers))
         .WillOnce([&params](
                       ValkeyModuleCtx *ctx,
                       const std::string &query_attribute_alias,
-                      absl::string_view key,
+                      ValkeyModuleKey *open_key, absl::string_view key,
                       const absl::flat_hash_set<absl::string_view> &identifiers)
                       -> absl::StatusOr<RecordsMap> {
           if (params.missing_keys.contains(key)) {
@@ -193,12 +194,12 @@ TEST_F(ResponseGeneratorTest, ProcessNeighborsForReplyContentLimits) {
   });
 
   // Mock FetchAllRecords to return different sized content
-  EXPECT_CALL(data_type, FetchAllRecords(&fake_ctx, parameters.attribute_alias,
-                                         absl::string_view("small_content_id"),
-                                         testing::_))
+  EXPECT_CALL(data_type, FetchAllRecords(
+                             &fake_ctx, parameters.attribute_alias, testing::_,
+                             absl::string_view("small_content_id"), testing::_))
       .WillOnce([](ValkeyModuleCtx *ctx,
                    const std::string &query_attribute_alias,
-                   absl::string_view key,
+                   ValkeyModuleKey *open_key, absl::string_view key,
                    const absl::flat_hash_set<absl::string_view> &identifiers)
                     -> absl::StatusOr<RecordsMap> {
         // Return small content (within both size and field limits)
@@ -212,13 +213,13 @@ TEST_F(ResponseGeneratorTest, ProcessNeighborsForReplyContentLimits) {
         return small_content;
       });
 
-  EXPECT_CALL(data_type, FetchAllRecords(&fake_ctx, parameters.attribute_alias,
-                                         absl::string_view("large_content_id"),
-                                         testing::_))
+  EXPECT_CALL(data_type, FetchAllRecords(
+                             &fake_ctx, parameters.attribute_alias, testing::_,
+                             absl::string_view("large_content_id"), testing::_))
       .WillOnce([test_size_limit](
                     ValkeyModuleCtx *ctx,
                     const std::string &query_attribute_alias,
-                    absl::string_view key,
+                    ValkeyModuleKey *open_key, absl::string_view key,
                     const absl::flat_hash_set<absl::string_view> &identifiers)
                     -> absl::StatusOr<RecordsMap> {
         // Return large content (exceeds size limit)
@@ -233,11 +234,11 @@ TEST_F(ResponseGeneratorTest, ProcessNeighborsForReplyContentLimits) {
       });
 
   EXPECT_CALL(data_type,
-              FetchAllRecords(&fake_ctx, parameters.attribute_alias,
+              FetchAllRecords(&fake_ctx, parameters.attribute_alias, testing::_,
                               absl::string_view("many_fields_id"), testing::_))
       .WillOnce([](ValkeyModuleCtx *ctx,
                    const std::string &query_attribute_alias,
-                   absl::string_view key,
+                   ValkeyModuleKey *open_key, absl::string_view key,
                    const absl::flat_hash_set<absl::string_view> &identifiers)
                     -> absl::StatusOr<RecordsMap> {
         // Return content with many fields (exceeds field count limit)

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -58,6 +58,7 @@ class LoadTest : public ValkeySearchTestWithParam<LoadTestCase> {
   void SetUp() override {
     ValkeySearchTestWithParam<LoadTestCase>::SetUp();
     CHECK(options::Reset().ok());
+    vmsdk::SetModuleLoaded("json", true);
   }
 };
 

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -114,9 +114,16 @@ int OnLoadDone(absl::Status status, ValkeyModuleCtx *ctx,
   return VALKEYMODULE_ERR;
 }
 }  // namespace module
+static absl::flat_hash_set<std::string> loaded_modules;
+void SetModuleLoaded(const std::string &name, bool remove) {
+  if (remove) {
+    loaded_modules.erase(name);
+    return;
+  }
+  loaded_modules.insert(name);
+}
 
 bool IsModuleLoaded(ValkeyModuleCtx *ctx, const std::string &name) {
-  static absl::flat_hash_set<std::string> loaded_modules;
   if (loaded_modules.contains(name)) {
     return true;
   }
@@ -138,7 +145,6 @@ bool IsModuleLoaded(ValkeyModuleCtx *ctx, const std::string &name) {
     }
 
     size_t len = ValkeyModule_CallReplyLength(mod_info);
-
     for (size_t j = 0; j + 1 < len; j += 2) {
       ValkeyModuleCallReply *key =
           ValkeyModule_CallReplyArrayElement(mod_info, j);

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -97,6 +97,8 @@ int CreateCommand(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {
   return VALKEYMODULE_OK;
 }
 bool IsModuleLoaded(ValkeyModuleCtx *ctx, const std::string &name);
+// Used only for testing
+void SetModuleLoaded(const std::string &name, bool remove = false);
 }  // namespace vmsdk
 
 #endif  // VMSDK_SRC_MODULE_H_

--- a/vmsdk/src/testing_infra/module.h
+++ b/vmsdk/src/testing_infra/module.h
@@ -230,6 +230,7 @@ class MockValkeyModule {
   MOCK_METHOD(ValkeyModuleCallReply *, Call,
               (ValkeyModuleCtx * ctx, const char *cmd, const char *fmt,
                const char *arg1, const char *arg2));
+  MOCK_METHOD(void *, GetSharedAPI, (ValkeyModuleCtx * ctx, const char *arg1));
   MOCK_METHOD(ValkeyModuleCallReply *, Call,
               (ValkeyModuleCtx * ctx, const char *cmd, const char *fmt,
                const char *arg1));
@@ -1176,7 +1177,10 @@ inline size_t TestValkeyModule_MallocUsableSize(void *ptr) {
 inline size_t TestValkeyModule_GetClusterSize() {
   return kMockValkeyModule->GetClusterSize();
 }
-
+inline void *TestValkeyModule_GetSharedAPI(ValkeyModuleCtx *ctx,
+                                           const char *arg1) {
+  return kMockValkeyModule->GetSharedAPI(ctx, arg1);
+}
 inline int TestValkeyModule_WrongArity(ValkeyModuleCtx *ctx) {
   return kMockValkeyModule->WrongArity(ctx);
 }
@@ -1543,6 +1547,7 @@ inline void TestValkeyModule_Init() {
   ValkeyModule_Calloc = &TestValkeyModule_Calloc;
   ValkeyModule_MallocUsableSize = &TestValkeyModule_MallocUsableSize;
   ValkeyModule_GetClusterSize = &TestValkeyModule_GetClusterSize;
+  ValkeyModule_GetSharedAPI = &TestValkeyModule_GetSharedAPI;
   ValkeyModule_Call = &TestValkeyModule_Call;
   ValkeyModule_CallReplyArrayElement = &TestValkeyModule_CallReplyArrayElement;
   ValkeyModule_CallReplyMapElement = &TestValkeyModule_CallReplyMapElement;


### PR DESCRIPTION
This change addresses the issue reported in [issue #255](https://github.com/valkey-io/valkey-search/issues/255).

Support for the JSON shared API is WIP and introduced in [this PR](https://github.com/valkey-io/valkey-json/pull/71).

To avoid introducing a hard dependency on a specific valkey-json release, the implementation is backward compatible: it prefers the new shared API if available, and falls back to VM_Call otherwise.

Once the valkey-json changes are included in an official release, we plan to deprecate the fallback logic and enforce valkey-json version that includes the new JSON shared API.