### PR TITLE
Bridge some gaps in ingestion pipeline

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -6,6 +6,7 @@
  */
 
 #include "src/index_schema.h"
+#include "src/indexes/text/text_index.h"
 
 #include <algorithm>
 #include <atomic>
@@ -84,13 +85,15 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
       return std::make_shared<indexes::Numeric>(index.numeric_index());
     }
     case data_model::Index::IndexTypeCase::kTextIndex: {
-      // TODO: make this TextIndex a proper schema-level object
-      std::shared_ptr<indexes::text::TextIndex> index_structure =
-          std::make_shared<indexes::text::TextIndex>(
-              indexes::text::TextIndex());
-      // TODO: pass in a unique text field ID number
+      // Create or reuse shared TextIndexSchema
+      if (!index_schema->GetTextIndexSchema()) {
+        index_schema->SetTextIndexSchema(std::make_shared<indexes::TextIndexSchema>());
+      }
+      //TODO : Increment logic 
+      //index_schema->text_index_schema_->num_text_fields_++;
+      // TODO: pass in a unique text field ID number 
       return std::make_shared<indexes::Text>(index.text_index(),
-                                             index_structure);
+                                             index_schema->GetTextIndexSchema(), 0);
     }
     case data_model::Index::IndexTypeCase::kVectorIndex: {
       switch (index.vector_index().algorithm_case()) {

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -87,7 +87,7 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
     case data_model::Index::IndexTypeCase::kTextIndex: {
       // Create or reuse shared TextIndexSchema
       if (!index_schema->GetTextIndexSchema()) {
-        index_schema->SetTextIndexSchema(std::make_shared<indexes::TextIndexSchema>());
+        index_schema->CreateTextIndexSchema();
       }
       //TODO : Increment logic 
       //index_schema->text_index_schema_->num_text_fields_++;

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -92,7 +92,9 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
       //TODO : Increment logic 
       //index_schema->text_index_schema_->num_text_fields_++;
       // TODO: pass in a unique text field ID number 
+      auto index_schema_proto = index_schema->ToProto();
       return std::make_shared<indexes::Text>(index.text_index(),
+                                             *index_schema_proto,
                                              index_schema->GetTextIndexSchema(), 0);
     }
     case data_model::Index::IndexTypeCase::kVectorIndex: {

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -87,8 +87,8 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
     case data_model::Index::IndexTypeCase::kTextIndex: {
       // Create or reuse shared TextIndexSchema
       if (!index_schema->GetTextIndexSchema()) {
-        auto index_schema_proto = index_schema->ToProto();
-        index_schema->CreateTextIndexSchema(*index_schema_proto);
+        // TODO : get the index_schema_proto the right way here to pass schema level properties
+        index_schema->CreateTextIndexSchema();
       }
       //TODO : Increment logic 
       //index_schema->text_index_schema_->num_text_fields_++;

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -87,14 +87,13 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
     case data_model::Index::IndexTypeCase::kTextIndex: {
       // Create or reuse shared TextIndexSchema
       if (!index_schema->GetTextIndexSchema()) {
-        index_schema->CreateTextIndexSchema();
+        auto index_schema_proto = index_schema->ToProto();
+        index_schema->CreateTextIndexSchema(*index_schema_proto);
       }
       //TODO : Increment logic 
       //index_schema->text_index_schema_->num_text_fields_++;
       // TODO: pass in a unique text field ID number 
-      auto index_schema_proto = index_schema->ToProto();
       return std::make_shared<indexes::Text>(index.text_index(),
-                                             *index_schema_proto,
                                              index_schema->GetTextIndexSchema(), 0);
     }
     case data_model::Index::IndexTypeCase::kVectorIndex: {

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -31,6 +31,7 @@
 #include "src/index_schema.pb.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/vector_base.h"
+#include "src/indexes/text/text_index.h"
 #include "src/keyspace_event_manager.h"
 #include "src/rdb_serialization.h"
 #include "src/utils/string_interning.h"
@@ -97,13 +98,8 @@ class IndexSchema : public KeyspaceEventSubscription,
   inline const std::string &GetName() const { return name_; }
   inline std::uint32_t GetDBNum() const { return db_num_; }
 
-  bool GetSavePositions() const { return save_positions_; }
-  size_t GetNumTextFields() const { return num_text_fields_; }
-  // TODO: Change this after query support is added for full text search
-  void SetTextConfiguration(bool save_positions, size_t num_text_fields) {
-    save_positions_ = save_positions;
-    num_text_fields_ = num_text_fields;
-  }
+  std::shared_ptr<indexes::TextIndexSchema> GetTextIndexSchema() const { return text_index_schema_; }
+  void SetTextIndexSchema(std::shared_ptr<indexes::TextIndexSchema> schema) { text_index_schema_ = schema; }
 
   void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type, const char *event,
                               ValkeyModuleString *key) override;
@@ -176,6 +172,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   uint32_t db_num_{0};
   bool save_positions_{true};
   size_t num_text_fields_{0};
+  std::shared_ptr<indexes::TextIndexSchema> text_index_schema_;
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};
   InternedStringMap<DocumentMutation> tracked_mutated_records_

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -99,8 +99,12 @@ class IndexSchema : public KeyspaceEventSubscription,
   inline std::uint32_t GetDBNum() const { return db_num_; }
 
   std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const { return text_index_schema_; }
-  void CreateTextIndexSchema(const data_model::IndexSchema& index_schema_proto) { 
-    text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(index_schema_proto); 
+  void CreateTextIndexSchema(const data_model::IndexSchema* index_schema_proto = nullptr) { 
+    if (index_schema_proto) {
+      text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(*index_schema_proto); 
+    } else {
+      text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(); 
+    }
   }
 
   void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type, const char *event,

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -99,7 +99,9 @@ class IndexSchema : public KeyspaceEventSubscription,
   inline std::uint32_t GetDBNum() const { return db_num_; }
 
   std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const { return text_index_schema_; }
-  void CreateTextIndexSchema() { text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(); }
+  void CreateTextIndexSchema(const data_model::IndexSchema& index_schema_proto) { 
+    text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(index_schema_proto); 
+  }
 
   void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type, const char *event,
                               ValkeyModuleString *key) override;
@@ -170,8 +172,6 @@ class IndexSchema : public KeyspaceEventSubscription,
   std::unique_ptr<AttributeDataType> attribute_data_type_;
   std::string name_;
   uint32_t db_num_{0};
-  bool save_positions_{true};
-  size_t num_text_fields_{0};
   std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema_;
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -98,8 +98,8 @@ class IndexSchema : public KeyspaceEventSubscription,
   inline const std::string &GetName() const { return name_; }
   inline std::uint32_t GetDBNum() const { return db_num_; }
 
-  std::shared_ptr<indexes::TextIndexSchema> GetTextIndexSchema() const { return text_index_schema_; }
-  void SetTextIndexSchema(std::shared_ptr<indexes::TextIndexSchema> schema) { text_index_schema_ = schema; }
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const { return text_index_schema_; }
+  void CreateTextIndexSchema() { text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(); }
 
   void OnKeyspaceNotification(ValkeyModuleCtx *ctx, int type, const char *event,
                               ValkeyModuleString *key) override;
@@ -172,7 +172,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   uint32_t db_num_{0};
   bool save_positions_{true};
   size_t num_text_fields_{0};
-  std::shared_ptr<indexes::TextIndexSchema> text_index_schema_;
+  std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema_;
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};
   InternedStringMap<DocumentMutation> tracked_mutated_records_

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -96,7 +96,9 @@ target_link_libraries(vector_flat PUBLIC valkey_module)
 
 set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text/text_index.h
               ${CMAKE_CURRENT_LIST_DIR}/text.cc
-              ${CMAKE_CURRENT_LIST_DIR}/text.h)
+              ${CMAKE_CURRENT_LIST_DIR}/text.h
+              ${CMAKE_CURRENT_LIST_DIR}/text/posting.cc
+              ${CMAKE_CURRENT_LIST_DIR}/text/posting.h)
 
 valkey_search_add_static_library(text "${SRCS_TEXT}")
 target_include_directories(text PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -94,14 +94,17 @@ target_link_libraries(vector_flat PUBLIC memory_allocation_overrides)
 target_link_libraries(vector_flat PUBLIC status_macros)
 target_link_libraries(vector_flat PUBLIC valkey_module)
 
-set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text.cc
+set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text/text_index.h
+              ${CMAKE_CURRENT_LIST_DIR}/text.cc
               ${CMAKE_CURRENT_LIST_DIR}/text.h
+              ${CMAKE_CURRENT_LIST_DIR}/text/radix_tree.h 
               ${CMAKE_CURRENT_LIST_DIR}/text/posting.cc
               ${CMAKE_CURRENT_LIST_DIR}/text/posting.h)
 
 valkey_search_add_static_library(text "${SRCS_TEXT}")
 target_include_directories(text PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(text PUBLIC index_base)
+target_link_libraries(text PUBLIC index_schema_cc_proto)
 target_link_libraries(text PUBLIC rdb_serialization)
 target_link_libraries(text PUBLIC string_interning)
 target_link_libraries(text PUBLIC valkey_module)

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -96,10 +96,7 @@ target_link_libraries(vector_flat PUBLIC valkey_module)
 
 set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text/text_index.h
               ${CMAKE_CURRENT_LIST_DIR}/text.cc
-              ${CMAKE_CURRENT_LIST_DIR}/text.h
-              ${CMAKE_CURRENT_LIST_DIR}/text/radix_tree.h 
-              ${CMAKE_CURRENT_LIST_DIR}/text/posting.cc
-              ${CMAKE_CURRENT_LIST_DIR}/text/posting.h)
+              ${CMAKE_CURRENT_LIST_DIR}/text.h)
 
 valkey_search_add_static_library(text "${SRCS_TEXT}")
 target_include_directories(text PUBLIC ${CMAKE_CURRENT_LIST_DIR})

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -17,7 +17,6 @@
 namespace valkey_search::indexes {
 
 Text::Text(const data_model::TextIndex& text_index_proto,
-           const data_model::IndexSchema& index_schema_proto,
            std::shared_ptr<text::TextIndexSchema> text_index_schema,
            size_t text_field_number)
     : IndexBase(IndexerType::kText), 
@@ -25,11 +24,7 @@ Text::Text(const data_model::TextIndex& text_index_proto,
       text_index_schema_(text_index_schema),
       with_suffix_trie_(text_index_proto.with_suffix_trie()),
       no_stem_(text_index_proto.no_stem()),
-      min_stem_size_(text_index_proto.min_stem_size()),
-      language_(index_schema_proto.language()),
-      punctuation_(index_schema_proto.punctuation()),
-      with_offsets_(index_schema_proto.with_offsets()),
-      stop_words_(index_schema_proto.stop_words().begin(), index_schema_proto.stop_words().end()) {   
+      min_stem_size_(text_index_proto.min_stem_size()) {   
 }
 
 absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
@@ -85,7 +80,7 @@ int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
 }
 
 bool Text::IsTracked(const InternedStringPtr& key) const {
-  throw std::runtime_error("Text::IsTracked not implemented");
+  return false;
 }
 
 uint64_t Text::GetRecordCount() const {

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -17,7 +17,7 @@
 namespace valkey_search::indexes {
 
 Text::Text(const data_model::TextIndex& text_index_proto,
-           std::shared_ptr<TextIndexSchema> text_index_schema,
+           std::shared_ptr<text::TextIndexSchema> text_index_schema,
            size_t text_field_number)
     : IndexBase(IndexerType::kText), 
       text_index_schema_(text_index_schema),

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -17,11 +17,19 @@
 namespace valkey_search::indexes {
 
 Text::Text(const data_model::TextIndex& text_index_proto,
+           const data_model::IndexSchema& index_schema_proto,
            std::shared_ptr<text::TextIndexSchema> text_index_schema,
            size_t text_field_number)
     : IndexBase(IndexerType::kText), 
+      text_field_number_(text_field_number),
       text_index_schema_(text_index_schema),
-      text_field_number_(text_field_number) {   
+      with_suffix_trie_(text_index_proto.with_suffix_trie()),
+      no_stem_(text_index_proto.no_stem()),
+      min_stem_size_(text_index_proto.min_stem_size()),
+      language_(index_schema_proto.language()),
+      punctuation_(index_schema_proto.punctuation()),
+      with_offsets_(index_schema_proto.with_offsets()),
+      stop_words_(index_schema_proto.stop_words().begin(), index_schema_proto.stop_words().end()) {   
 }
 
 absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
@@ -50,7 +58,7 @@ absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
                 postings = std::make_shared<text::Postings>(save_positions, num_text_fields);
               }
               
-              // Add the key and position to postings using correct API
+              // Add the key and position to postings
               postings->InsertPosting(key, text_field_number_, position);
               return postings;
             });
@@ -85,7 +93,13 @@ uint64_t Text::GetRecordCount() const {
 }
 
 std::unique_ptr<data_model::Index> Text::ToProto() const {
-  throw std::runtime_error("Text::ToProto not implemented");
+  auto index_proto = std::make_unique<data_model::Index>();
+  auto text_index = std::make_unique<data_model::TextIndex>();
+  text_index->set_with_suffix_trie(with_suffix_trie_);
+  text_index->set_no_stem(no_stem_);
+  text_index->set_min_stem_size(min_stem_size_);
+  index_proto->set_allocated_text_index(text_index.release());
+  return index_proto;
 }
 
 std::unique_ptr<Text::EntriesFetcher> Text::Search(

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -23,10 +23,6 @@
 #include "src/utils/string_interning.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
-// Forward declarations
-namespace valkey_search::query {
-class TextPredicate;
-}
 
 namespace valkey_search::indexes {
 

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -29,7 +29,7 @@ namespace valkey_search::indexes {
 class Text : public IndexBase {
  public:
   explicit Text(const data_model::TextIndex& text_index_proto,
-                std::shared_ptr<TextIndexSchema> text_index_schema,
+                std::shared_ptr<text::TextIndexSchema> text_index_schema,
                 size_t text_field_number);
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
@@ -84,17 +84,15 @@ class Text : public IndexBase {
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  private:
-  // Each text field is assigned a unique number within the containing index, this is used
+  // Each text field index within the schema is assigned a unique number, this is used
   // by the Postings object to identify fields.
   size_t text_field_number_;
   
   // Reference to the shared text index schema
-  std::shared_ptr<TextIndexSchema> text_index_schema_;
+  std::shared_ptr<text::TextIndexSchema> text_index_schema_;
   
-  // Map to track which keys are indexed and their raw data
-  absl::flat_hash_map<InternedStringPtr, InternedStringPtr> tracked_tags_by_keys_
-      ABSL_GUARDED_BY(index_mutex_);
-  
+  // TODO: Map to track which keys are indexed and their raw data
+
   mutable absl::Mutex index_mutex_;
 };
 }  // namespace valkey_search::indexes

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -8,19 +8,33 @@
 #ifndef VALKEYSEARCH_SRC_INDEXES_TEXT_H_
 #define VALKEYSEARCH_SRC_INDEXES_TEXT_H_
 
+#include <memory>
+#include <optional>
+#include "absl/base/thread_annotations.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/functional/any_invocable.h"
+#include "absl/status/status.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/text/text_index.h"
-#include "src/query/predicate.h"
+#include "src/index_schema.pb.h"
+#include "src/utils/string_interning.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
+
+// Forward declarations
+namespace valkey_search::query {
+class TextPredicate;
+}
 
 namespace valkey_search::indexes {
 
 class Text : public IndexBase {
  public:
   explicit Text(const data_model::TextIndex& text_index_proto,
-                std::shared_ptr<text::TextIndex> text_index);
+                std::shared_ptr<TextIndexSchema> text_index_schema,
+                size_t text_field_number);
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
@@ -36,13 +50,6 @@ class Text : public IndexBase {
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
   }
-
- private:
-  // Each text field is assigned a unique number within the containing index,
-  // this is used by the Postings object to identify fields.
-  // size_t text_field_number_; - TODO
-  // 
-  std::shared_ptr<text::TextIndex> text_index_;
 
   inline void ForEachTrackedKey(
       absl::AnyInvocable<void(const InternedStringPtr&)> fn) const override {
@@ -81,6 +88,17 @@ class Text : public IndexBase {
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  private:
+  // Each text field is assigned a unique number within the containing index, this is used
+  // by the Postings object to identify fields.
+  size_t text_field_number_;
+  
+  // Reference to the shared text index schema
+  std::shared_ptr<TextIndexSchema> text_index_schema_;
+  
+  // Map to track which keys are indexed and their raw data
+  absl::flat_hash_map<InternedStringPtr, InternedStringPtr> tracked_tags_by_keys_
+      ABSL_GUARDED_BY(index_mutex_);
+  
   mutable absl::Mutex index_mutex_;
 };
 }  // namespace valkey_search::indexes

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -29,7 +29,6 @@ namespace valkey_search::indexes {
 class Text : public IndexBase {
  public:
   explicit Text(const data_model::TextIndex& text_index_proto,
-                const data_model::IndexSchema& index_schema_proto,
                 std::shared_ptr<text::TextIndexSchema> text_index_schema,
                 size_t text_field_number);
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
@@ -96,12 +95,6 @@ class Text : public IndexBase {
   bool with_suffix_trie_;
   bool no_stem_;
   int32_t min_stem_size_;
-  
-  // IndexSchema proto-derived configuration fields
-  data_model::Language language_;
-  std::string punctuation_;
-  bool with_offsets_;
-  std::vector<std::string> stop_words_;
   
   // TODO: Map to track which keys are indexed and their raw data
 

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -29,6 +29,7 @@ namespace valkey_search::indexes {
 class Text : public IndexBase {
  public:
   explicit Text(const data_model::TextIndex& text_index_proto,
+                const data_model::IndexSchema& index_schema_proto,
                 std::shared_ptr<text::TextIndexSchema> text_index_schema,
                 size_t text_field_number);
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
@@ -90,6 +91,17 @@ class Text : public IndexBase {
   
   // Reference to the shared text index schema
   std::shared_ptr<text::TextIndexSchema> text_index_schema_;
+  
+  // TextIndex proto-derived configuration fields
+  bool with_suffix_trie_;
+  bool no_stem_;
+  int32_t min_stem_size_;
+  
+  // IndexSchema proto-derived configuration fields
+  data_model::Language language_;
+  std::string punctuation_;
+  bool with_offsets_;
+  std::vector<std::string> stop_words_;
   
   // TODO: Map to track which keys are indexed and their raw data
 

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -186,8 +186,8 @@ public:
       : save_positions_(save_positions), num_text_fields_(num_text_fields) {}
 };
 
-Postings::Postings(const valkey_search::IndexSchema& index_schema) 
-    : impl_(std::make_unique<Impl>(index_schema.GetSavePositions(), index_schema.GetNumTextFields())) {
+Postings::Postings(bool save_positions, size_t num_text_fields) 
+    : impl_(std::make_unique<Impl>(save_positions, num_text_fields)) {
   CHECK(impl_ != nullptr) << "Failed to create Postings implementation";
 }
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -39,7 +39,7 @@ A PositionIterator is provided to iterate over the positions of an individual Ke
 #include <vector>
 #include <map>
 
-#include "src/index_schema.h"
+#include "src/utils/string_interning.h"
 
 namespace valkey_search::indexes::text {
 
@@ -63,7 +63,7 @@ struct Postings {
   // are inserted have an assumed single position of 0.
   // The "num_text_fields" entry identifies how many bits of the field-mask are required
   // and is used to select the representation.
-  explicit Postings(const valkey_search::IndexSchema& index_schema);
+  explicit Postings(bool save_positions, size_t num_text_fields);
   
   // Destructor
   ~Postings();

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -26,7 +26,7 @@ Conceptually, this object holds an ordered list of Keys and for each Key there i
 an ordered list of Positions. Each position is tagged with a bitmask of fields.
 
 A KeyIterator is provided to iterate over the keys within this object.
-A PositionIterator is provided to iterate over the positions of an individual Key.
+A PositionIterator is provided to iterate over the positions of an individual Key. 
 
 */
 

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -1,3 +1,10 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
 #ifndef VALKEY_SEARCH_INDEXES_TEXT_INDEX_H_
 #define VALKEY_SEARCH_INDEXES_TEXT_INDEX_H_
 
@@ -11,18 +18,12 @@
 #include "src/indexes/text/posting.h"
 #include "src/index_schema.pb.h"
 
-namespace valkey_search::indexes {
+namespace valkey_search::indexes::text {
 
 using Key = valkey_search::InternedStringPtr;
 using Position = uint32_t;
 
-// Forward declaration from text namespace
-namespace text {
-  struct Postings;
-}
-
-class TextIndex {
- public:
+struct TextIndex {
   TextIndex() = default;
   ~TextIndex() = default;
   //
@@ -38,22 +39,21 @@ class TextIndex {
   //
 
   // Prefix tree
-  text::RadixTree<std::shared_ptr<text::Postings>, false> prefix_;
+  RadixTree<std::shared_ptr<Postings>, false> prefix_;
   
   // Suffix tree
-  std::optional<text::RadixTree<std::shared_ptr<text::Postings>, true>> suffix_;
+  std::optional<RadixTree<std::shared_ptr<Postings>, true>> suffix_;
 };
 
-class TextIndexSchema {
- public:
-  //
-  // This is the main index of all Text fields in this index schema
-  //
+struct TextIndexSchema {
   TextIndexSchema() : num_text_fields_(0), text_index_(std::make_shared<TextIndex>()) {}
   ~TextIndexSchema() = default;
 
   uint8_t num_text_fields_;
-  std::shared_ptr<indexes::TextIndex> text_index_;
+  //
+  // This is the main index of all Text fields in this index schema
+  //
+  std::shared_ptr<TextIndex> text_index_;
   //
   // To support the Delete record and the post-filtering case, there is a
   // separate table of postings that are indexed by Key.

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -46,9 +46,9 @@ struct TextIndex {
 };
 
 struct TextIndexSchema {
-  TextIndexSchema() : num_text_fields_(0), text_index_(std::make_shared<TextIndex>()) {}
+  TextIndexSchema() : num_text_fields_(1), text_index_(std::make_shared<TextIndex>()) {}
   TextIndexSchema(const data_model::IndexSchema& index_schema_proto) 
-      : num_text_fields_(0), 
+      : num_text_fields_(1), 
         text_index_(std::make_shared<TextIndex>()),
         language_(index_schema_proto.language()),
         punctuation_(index_schema_proto.punctuation()),

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -64,6 +64,6 @@ struct TextIndexSchema {
   absl::flat_hash_map<Key, TextIndex> by_key_;
 };
 
-}  // namespace valkey_search::indexes
+}  // namespace valkey_search::indexes::text
 
 #endif

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -47,6 +47,13 @@ struct TextIndex {
 
 struct TextIndexSchema {
   TextIndexSchema() : num_text_fields_(0), text_index_(std::make_shared<TextIndex>()) {}
+  TextIndexSchema(const data_model::IndexSchema& index_schema_proto) 
+      : num_text_fields_(0), 
+        text_index_(std::make_shared<TextIndex>()),
+        language_(index_schema_proto.language()),
+        punctuation_(index_schema_proto.punctuation()),
+        with_offsets_(index_schema_proto.with_offsets()),
+        stop_words_(index_schema_proto.stop_words().begin(), index_schema_proto.stop_words().end()) {}
   ~TextIndexSchema() = default;
 
   uint8_t num_text_fields_;
@@ -62,6 +69,12 @@ struct TextIndexSchema {
   // safe.
   //
   absl::flat_hash_map<Key, TextIndex> by_key_;
+
+  // IndexSchema proto-derived configuration fields
+  data_model::Language language_ = data_model::LANGUAGE_UNSPECIFIED;
+  std::string punctuation_;
+  bool with_offsets_ = false;
+  std::vector<std::string> stop_words_;
 };
 
 }  // namespace valkey_search::indexes::text

--- a/testing/posting_test.cc
+++ b/testing/posting_test.cc
@@ -23,16 +23,14 @@ class PostingTest : public ValkeySearchTest {
     boolean_schema_ = MockIndexSchema::Create(&fake_ctx_, "boolean_schema", key_prefixes,
                                             std::make_unique<MockAttributeDataType>(),
                                             nullptr).value();
-    boolean_schema_->SetTextConfiguration(false, 3);  // Boolean search, 3 fields
     
     positional_schema_ = MockIndexSchema::Create(&fake_ctx_, "positional_schema", key_prefixes,
                                                std::make_unique<MockAttributeDataType>(),
                                                nullptr).value();
-    positional_schema_->SetTextConfiguration(true, 5);  // Positional search, 5 fields
     
     // Create postings with different configurations for testing using IndexSchema
-    boolean_postings_ = new Postings(*boolean_schema_);  // Boolean search, 3 fields
-    positional_postings_ = new Postings(*positional_schema_); // Positional search, 5 fields
+    boolean_postings_ = new Postings(false, 3);  // Boolean search, 3 fields
+    positional_postings_ = new Postings(true, 5); // Positional search, 5 fields
   }
   
   // Helper function to create InternedStringPtr from string
@@ -149,8 +147,7 @@ TEST_F(PostingTest, SingleFieldOptimization) {
   auto single_field_schema = MockIndexSchema::Create(&fake_ctx_, "single_field_schema", single_key_prefixes,
                                                     std::make_unique<MockAttributeDataType>(),
                                                     nullptr).value();
-  single_field_schema->SetTextConfiguration(true, 1);  // 1 field only
-  Postings single_field_posting(*single_field_schema);
+  Postings single_field_posting(true, 1);
   
   // Add some postings - all will use field 0
   single_field_posting.InsertPosting(InternKey("doc1"), 0, 10);


### PR DESCRIPTION
Building on top of #289 

```
class Text 
├── Inherits IndexBase
├── Implemented AddRecord API , placeholder for rest.
├── Text takes the whole index_schema_proto, text_index_proto, shared reference to the TextIndexSchema class, text field number as parameters

class TextIndex
├── Holds the prefix tree and optional suffix tree. (postings are shared between prefix and suffix tree
├── wrapper around the trees, we need to go via TextIndex to mutate on the tree , get word iterator, get path iterator
├── resides in the TextIndexSchema, One TextIndex per Schema. 

class TextIndexSchema
├── wrapper between IndexSchema and TextIndex. 
├── While initializing IndexBases per field/attribute if we encounter a text field and if TextIndexSchema reference doesn't already exist we initialize a Shared Instance of TextIndexSchema. This happens in Initialized in IndexSchema -> IndexFactory. We have one TextIndexSchema per IndexSchema. 
├── We have one TextIndex for one TextIndexSchema, num_text_fields and a hashmap<Key, TextIndex> to support the Delete record and the post-filtering case
├── this TextIndexSchema is passed in Text class as a parameter, help reach TextIndex which leads to prefix/suffix trees. also passes num_text_fields #295
```

- updated posting to take only properties needed, rather than whole index_schema
- Implemented ToProto() method as well

Note : Actively adding more to this PR, and open to suggestions. End goal to make ingestion pipeline work end-to-end