### PR TITLE
Add text field number to the text field index

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -90,11 +90,8 @@ absl::StatusOr<std::shared_ptr<indexes::IndexBase>> IndexFactory(
         // TODO : get the index_schema_proto the right way here to pass schema level properties
         index_schema->CreateTextIndexSchema();
       }
-      //TODO : Increment logic 
-      //index_schema->text_index_schema_->num_text_fields_++;
-      // TODO: pass in a unique text field ID number 
       return std::make_shared<indexes::Text>(index.text_index(),
-                                             index_schema->GetTextIndexSchema(), 0);
+                                             index_schema->GetTextIndexSchema());
     }
     case data_model::Index::IndexTypeCase::kVectorIndex: {
       switch (index.vector_index().algorithm_case()) {

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -17,14 +17,13 @@
 namespace valkey_search::indexes {
 
 Text::Text(const data_model::TextIndex& text_index_proto,
-           std::shared_ptr<text::TextIndexSchema> text_index_schema,
-           size_t text_field_number)
+           std::shared_ptr<text::TextIndexSchema> text_index_schema)
     : IndexBase(IndexerType::kText), 
-      text_field_number_(text_field_number),
       text_index_schema_(text_index_schema),
+      text_field_number_(text_index_schema->AllocateTextFieldNumber()),
       with_suffix_trie_(text_index_proto.with_suffix_trie()),
       no_stem_(text_index_proto.no_stem()),
-      min_stem_size_(text_index_proto.min_stem_size()) {   
+      min_stem_size_(text_index_proto.min_stem_size()) {
 }
 
 absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -29,8 +29,7 @@ namespace valkey_search::indexes {
 class Text : public IndexBase {
  public:
   explicit Text(const data_model::TextIndex& text_index_proto,
-                std::shared_ptr<text::TextIndexSchema> text_index_schema,
-                size_t text_field_number);
+                std::shared_ptr<valkey_search::indexes::text::TextIndexSchema> text_index_schema);
   absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                  absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -46,9 +46,9 @@ struct TextIndex {
 };
 
 struct TextIndexSchema {
-  TextIndexSchema() : num_text_fields_(1), text_index_(std::make_shared<TextIndex>()) {}
+  TextIndexSchema() : num_text_fields_(0), text_index_(std::make_shared<TextIndex>()) {}
   TextIndexSchema(const data_model::IndexSchema& index_schema_proto) 
-      : num_text_fields_(1), 
+      : num_text_fields_(0), 
         text_index_(std::make_shared<TextIndex>()),
         language_(index_schema_proto.language()),
         punctuation_(index_schema_proto.punctuation()),
@@ -75,6 +75,11 @@ struct TextIndexSchema {
   std::string punctuation_;
   bool with_offsets_ = false;
   std::vector<std::string> stop_words_;
+
+  uint8_t AllocateTextFieldNumber() {
+    return num_text_fields_++;
+  }
+
 };
 
 }  // namespace valkey_search::indexes::text

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -172,7 +172,10 @@ target_link_libraries(valkey_utils_test PRIVATE segment_tree)
 finalize_test_flags(valkey_utils_test)
 
 # 7. Text Index Test Suite
-add_executable(text_index_test ${CMAKE_CURRENT_LIST_DIR}/radix_test.cc)
+add_executable(text_index_test 
+    ${CMAKE_CURRENT_LIST_DIR}/radix_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/text_index_schema_test.cc)
 target_include_directories(text_index_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(text_index_test PRIVATE testing_common_base)
+target_link_libraries(text_index_test PRIVATE text)
 finalize_test_flags(text_index_test)

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/indexes/text/text_index.h"
+#include "src/indexes/text.h"
+
+namespace valkey_search {
+namespace indexes {
+namespace {
+
+class TextIndexSchemaTest : public ::testing::Test {
+ protected:
+  void SetUp() override {}
+  void TearDown() override {}
+};
+
+TEST_F(TextIndexSchemaTest, BasicFieldNumbering) {
+  // Create a TextIndexSchema instance
+  auto text_index_schema = std::make_shared<text::TextIndexSchema>();
+  
+  // Initially, no text fields allocated
+  EXPECT_EQ(text_index_schema->num_text_fields_, 0);
+
+  // Manually allocate field numbers and verify sequential allocation
+  EXPECT_EQ(0, text_index_schema->AllocateTextFieldNumber());
+  EXPECT_EQ(1, text_index_schema->AllocateTextFieldNumber());
+  EXPECT_EQ(2, text_index_schema->AllocateTextFieldNumber());
+  EXPECT_EQ(3, text_index_schema->num_text_fields_);
+}
+
+TEST_F(TextIndexSchemaTest, TextConstructorAllocation) {
+  // Create a TextIndexSchema instance
+  auto text_index_schema = std::make_shared<text::TextIndexSchema>();
+  
+  // Create text indexes and verify they get unique field numbers
+  data_model::TextIndex text_proto1;
+  auto text_index1 = std::make_shared<Text>(text_proto1, text_index_schema);
+  EXPECT_EQ(1, text_index_schema->num_text_fields_);
+  
+  data_model::TextIndex text_proto2;
+  auto text_index2 = std::make_shared<Text>(text_proto2, text_index_schema);
+  EXPECT_EQ(2, text_index_schema->num_text_fields_);
+  
+  data_model::TextIndex text_proto3;
+  auto text_index3 = std::make_shared<Text>(text_proto3, text_index_schema);
+  EXPECT_EQ(3, text_index_schema->num_text_fields_);
+}
+
+}  // namespace
+}  // namespace indexes
+}  // namespace valkey_search

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -7,12 +7,12 @@
 
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "src/indexes/text/text_index.h"
 #include "src/indexes/text.h"
+#include "src/indexes/text/text_index.h"
 
 namespace valkey_search {
 namespace indexes {
-namespace {
+namespace text {
 
 class TextIndexSchemaTest : public ::testing::Test {
  protected:
@@ -20,38 +20,21 @@ class TextIndexSchemaTest : public ::testing::Test {
   void TearDown() override {}
 };
 
-TEST_F(TextIndexSchemaTest, BasicFieldNumbering) {
-  // Create a TextIndexSchema instance
-  auto text_index_schema = std::make_shared<text::TextIndexSchema>();
-  
-  // Initially, no text fields allocated
-  EXPECT_EQ(text_index_schema->num_text_fields_, 0);
-
-  // Manually allocate field numbers and verify sequential allocation
-  EXPECT_EQ(0, text_index_schema->AllocateTextFieldNumber());
-  EXPECT_EQ(1, text_index_schema->AllocateTextFieldNumber());
-  EXPECT_EQ(2, text_index_schema->AllocateTextFieldNumber());
-  EXPECT_EQ(3, text_index_schema->num_text_fields_);
-}
-
 TEST_F(TextIndexSchemaTest, TextConstructorAllocation) {
   // Create a TextIndexSchema instance
   auto text_index_schema = std::make_shared<text::TextIndexSchema>();
-  
-  // Create text indexes and verify they get unique field numbers
-  data_model::TextIndex text_proto1;
-  auto text_index1 = std::make_shared<Text>(text_proto1, text_index_schema);
+
+  // Create text indexes and verify the number of text fields is incremented in
+  // the text index schema
+  data_model::TextIndex text_proto;
+  std::make_shared<Text>(text_proto, text_index_schema);
   EXPECT_EQ(1, text_index_schema->num_text_fields_);
-  
-  data_model::TextIndex text_proto2;
-  auto text_index2 = std::make_shared<Text>(text_proto2, text_index_schema);
+  std::make_shared<Text>(text_proto, text_index_schema);
   EXPECT_EQ(2, text_index_schema->num_text_fields_);
-  
-  data_model::TextIndex text_proto3;
-  auto text_index3 = std::make_shared<Text>(text_proto3, text_index_schema);
+  std::make_shared<Text>(text_proto, text_index_schema);
   EXPECT_EQ(3, text_index_schema->num_text_fields_);
 }
 
-}  // namespace
+}  // namespace text
 }  // namespace indexes
 }  // namespace valkey_search


### PR DESCRIPTION
 Provide a text field identifier number to the Text field objects on creation. update the total in text index schema level.

### tested:
```
42827:M 08 Aug 2025 20:29:20.707 # <module> [notice], tid: 140734468454144, /local/home/ramvolet/Workspace/valkey-search/src/indexes/text/posting.cc:205: InsertPosting: field_index=0, total_fields=4
[New Thread 0x7ffeb7dff700 (LWP 43743)]
42827:M 08 Aug 2025 20:30:19.264 # <module> [notice], tid: 140734818658048, /local/home/ramvolet/Workspace/valkey-search/src/indexes/text/posting.cc:205: InsertPosting: field_index=2, total_fields=4