### PR TITLE
feat: set command info for ft.create

### DIFF
--- a/integration/test_command_info.py
+++ b/integration/test_command_info.py
@@ -1,0 +1,412 @@
+import time
+from valkeytestframework.util.waiters import *
+from valkey import ResponseError
+from valkey.client import Valkey
+from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+class TestCommandInfo(ValkeySearchTestCaseBase):
+    """Integration tests for command metadata using COMMAND INFO and COMMAND DOCS"""
+
+    def test_ft_create_command_info(self):
+        """Test FT.CREATE command info"""
+        client: Valkey = self.server.get_new_client()
+        
+        info = client.execute_command("COMMAND", "INFO", "FT.CREATE")
+        assert info is not None
+        assert len(info) == 1
+        
+        ft_create_info = info[0]
+        
+        # Position 0: Command name
+        assert ft_create_info[0] == b"ft.create"
+        
+        # Position 1: Arity
+        assert ft_create_info[1] == -2
+        
+        # Position 2: Command flags
+        flags = ft_create_info[2]
+        assert isinstance(flags, list)
+        assert b"denyoom" in flags
+        
+        # Position 3: First key position
+        first_key = ft_create_info[3]
+        assert isinstance(first_key, int)
+        assert first_key == 0
+
+        # Position 4: Last key position
+        last_key = ft_create_info[4]
+        assert isinstance(last_key, int)
+        assert last_key == 0
+        
+        # Position 5: step
+        key_step = ft_create_info[5]
+        assert isinstance(key_step, int)
+        assert key_step == 0
+        
+        # Position 6: ACL Categories
+        acl_categories = ft_create_info[6]
+        assert isinstance(acl_categories, list)
+        expected_categories = [b"write", b"search", b"module"]
+        assert any(expected_category in acl_categories for expected_category in expected_categories)
+        
+        # Position 7: Command Tips
+        tips = ft_create_info[7]
+        assert tips is None
+        
+        # Position 8: Key Specifications
+        key_specs = ft_create_info[8]
+        assert key_specs is None
+        
+        # Position 9: Subcommands
+        subcommands = ft_create_info[9]
+        assert subcommands is None
+
+    def test_ft_create_command_docs(self):
+        """Test FT.CREATE command docs"""
+        client: Valkey = self.server.get_new_client()
+        
+        # Use RESP3 protocol
+        client.execute_command("HELLO", 3)
+        
+        docs = client.execute_command("COMMAND", "DOCS", "FT.CREATE")
+        assert docs is not None
+        assert isinstance(docs, dict)
+        
+        ft_create_docs = docs.get(b"ft.create")
+        assert ft_create_docs is not None
+        
+        # Verify summary
+        assert ft_create_docs[b"summary"] == b"Creates an empty search index and initiates the backfill process"
+        
+        # Verify complexity
+        assert ft_create_docs[b"complexity"] == b"O(N log N), where N is the number of indexed items"
+        
+        # Verify since version
+        assert ft_create_docs[b"since"] == b"1.0.0"
+        
+        # Verify arguments structure
+        arguments = ft_create_docs[b"arguments"]
+        assert isinstance(arguments, list)
+        assert len(arguments) == 4
+        
+        # Verify first argument (index_name)
+        index_name_arg = arguments[0]
+        assert index_name_arg[b"name"] == b"index_name"
+        assert index_name_arg[b"type"] == b"string"
+        assert index_name_arg[b"summary"] == b"Name of the index"
+        assert index_name_arg[b"since"] == b"1.0.0"
+        
+        # Verify second argument (on_data_type)
+        on_arg = arguments[1]
+        assert on_arg[b"name"] == b"on_data_type"
+        assert on_arg[b"type"] == b"oneof"
+        assert on_arg[b"token"] == b"ON"
+        assert on_arg[b"summary"] == b"Data type to index"
+        assert on_arg[b"since"] == b"1.0.0"
+        assert b"optional" in on_arg[b"flags"]
+        
+        # Verify ON subarguments (HASH and JSON)
+        on_subargs = on_arg[b"value"]
+        assert len(on_subargs) == 2
+        
+        hash_arg = on_subargs[0]
+        assert hash_arg[b"name"] == b"hash"
+        assert hash_arg[b"type"] == b"pure-token"
+        assert hash_arg[b"token"] == b"HASH"
+        assert hash_arg[b"summary"] == b"Index HASH data type"
+        
+        json_arg = on_subargs[1]
+        assert json_arg[b"name"] == b"json"
+        assert json_arg[b"type"] == b"pure-token"
+        assert json_arg[b"token"] == b"JSON"
+        assert json_arg[b"summary"] == b"Index JSON data type"
+        
+        # Verify third argument (prefix)
+        prefix_arg = arguments[2]
+        assert prefix_arg[b"name"] == b"prefix"
+        assert prefix_arg[b"type"] == b"block"
+        assert prefix_arg[b"token"] == b"PREFIX"
+        assert prefix_arg[b"summary"] == b"Key prefixes to index"
+        assert prefix_arg[b"since"] == b"1.0.0"
+        assert b"optional" in prefix_arg[b"flags"]
+        
+        # Verify PREFIX subarguments
+        prefix_subargs = prefix_arg[b"value"]
+        assert len(prefix_subargs) == 2
+        
+        count_arg = prefix_subargs[0]
+        assert count_arg[b"name"] == b"count"
+        assert count_arg[b"type"] == b"integer"
+        assert count_arg[b"summary"] == b"Number of prefixes"
+        assert count_arg[b"since"] == b"1.0.0"
+        
+        prefix_value_arg = prefix_subargs[1]
+        assert prefix_value_arg[b"name"] == b"prefix"
+        assert prefix_value_arg[b"type"] == b"string"
+        assert prefix_value_arg[b"summary"] == b"Key prefix to index"
+        assert prefix_value_arg[b"since"] == b"1.0.0"
+        assert b"multiple" in prefix_value_arg[b"flags"]
+        
+        # Verify fourth argument (schema)
+        schema_arg = arguments[3]
+        assert schema_arg[b"name"] == b"schema"
+        assert schema_arg[b"type"] == b"block"
+        assert schema_arg[b"token"] == b"SCHEMA"
+        assert schema_arg[b"summary"] == b"Schema definition"
+        assert schema_arg[b"since"] == b"1.0.0"
+        assert b"multiple" in schema_arg[b"flags"]
+        
+        # Verify SCHEMA subarguments
+        schema_subargs = schema_arg[b"value"]
+        assert len(schema_subargs) == 4
+        
+        field_id_arg = schema_subargs[0]
+        assert field_id_arg[b"name"] == b"field_identifier"
+        assert field_id_arg[b"type"] == b"string"
+        assert field_id_arg[b"summary"] == b"Field identifier"
+        assert field_id_arg[b"since"] == b"1.0.0"
+        
+        as_arg = schema_subargs[1]
+        assert as_arg[b"name"] == b"as"
+        assert as_arg[b"type"] == b"string"
+        assert as_arg[b"token"] == b"AS"
+        assert as_arg[b"summary"] == b"Field alias"
+        assert as_arg[b"since"] == b"1.0.0"
+        assert b"optional" in as_arg[b"flags"]
+        
+        field_type_arg = schema_subargs[2]
+        assert field_type_arg[b"name"] == b"field_type"
+        assert field_type_arg[b"type"] == b"oneof"
+        assert field_type_arg[b"summary"] == b"Field type (NUMERIC, TAG, VECTOR)"
+        assert field_type_arg[b"since"] == b"1.0.0"
+        
+        # Verify field types
+        field_types = field_type_arg[b"value"]
+        assert len(field_types) == 3
+        
+        numeric_type = field_types[0]
+        assert numeric_type[b"name"] == b"numeric"
+        assert numeric_type[b"type"] == b"pure-token"
+        assert numeric_type[b"token"] == b"NUMERIC"
+        assert numeric_type[b"summary"] == b"Numeric field type"
+        assert numeric_type[b"since"] == b"1.0.0"
+        
+        tag_type = field_types[1]
+        assert tag_type[b"name"] == b"tag"
+        assert tag_type[b"type"] == b"block"
+        assert tag_type[b"token"] == b"TAG"
+        assert tag_type[b"summary"] == b"Tag field type"
+        assert tag_type[b"since"] == b"1.0.0"
+        
+        vector_type = field_types[2]
+        assert vector_type[b"name"] == b"vector"
+        assert vector_type[b"type"] == b"block"
+        assert vector_type[b"token"] == b"VECTOR"
+        assert vector_type[b"summary"] == b"Vector field type"
+        assert vector_type[b"since"] == b"1.0.0"
+
+        # Verify TAG subarguments
+        tag_subargs = tag_type[b"value"]
+        assert len(tag_subargs) == 2
+        
+        separator_arg = tag_subargs[0]
+        assert separator_arg[b"name"] == b"separator"
+        assert separator_arg[b"type"] == b"string"
+        assert separator_arg[b"token"] == b"SEPARATOR"
+        assert separator_arg[b"summary"] == b"Tag separator character"
+        assert separator_arg[b"since"] == b"1.0.0"
+        assert b"optional" in separator_arg[b"flags"]
+        
+        casesensitive_arg = tag_subargs[1]
+        assert casesensitive_arg[b"name"] == b"casesensitive"
+        assert casesensitive_arg[b"type"] == b"pure-token"
+        assert casesensitive_arg[b"token"] == b"CASESENSITIVE"
+        assert casesensitive_arg[b"summary"] == b"Make tag matching case sensitive"
+        assert casesensitive_arg[b"since"] == b"1.0.0"
+        assert b"optional" in casesensitive_arg[b"flags"]
+        
+        # Verify VECTOR subarguments
+        vector_subargs = vector_type[b"value"]
+        assert len(vector_subargs) == 3
+        
+        algorithm_arg = vector_subargs[0]
+        assert algorithm_arg[b"name"] == b"algorithm"
+        assert algorithm_arg[b"type"] == b"oneof"
+        assert algorithm_arg[b"summary"] == b"Vector algorithm (HNSW or FLAT)"
+        assert algorithm_arg[b"since"] == b"1.0.0"
+        
+        # Verify algorithm options (HNSW and FLAT)
+        algorithms = algorithm_arg[b"value"]
+        assert len(algorithms) == 2
+        
+        # Test HNSW algorithm
+        hnsw_alg = algorithms[0]
+        assert hnsw_alg[b"name"] == b"hnsw"
+        assert hnsw_alg[b"type"] == b"block"
+        assert hnsw_alg[b"token"] == b"HNSW"
+        assert hnsw_alg[b"summary"] == b"HNSW vector algorithm"
+        assert hnsw_alg[b"since"] == b"1.0.0"
+        
+        # Verify HNSW parameters
+        hnsw_params = hnsw_alg[b"value"]
+        assert len(hnsw_params) == 7
+        
+        # Check all HNSW parameters
+        # 1. DIM parameter
+        dim_param = hnsw_params[0]
+        assert dim_param[b"name"] == b"dim"
+        assert dim_param[b"type"] == b"integer"
+        assert dim_param[b"token"] == b"DIM"
+        assert dim_param[b"summary"] == b"Vector dimensions (required)"
+        assert dim_param[b"since"] == b"1.0.0"
+        
+        # 2. TYPE parameter
+        type_param = hnsw_params[1]
+        assert type_param[b"name"] == b"type"
+        assert type_param[b"type"] == b"double"
+        assert type_param[b"token"] == b"TYPE"
+        assert type_param[b"summary"] == b"Vector data type (Currently Only for FLOAT32)"
+        assert type_param[b"since"] == b"1.0.0"
+        
+        # 3. DISTANCE_METRIC parameter
+        distance_param = hnsw_params[2]
+        assert distance_param[b"name"] == b"distance_metric"
+        assert distance_param[b"type"] == b"oneof"
+        assert distance_param[b"token"] == b"DISTANCE_METRIC"
+        assert distance_param[b"summary"] == b"Distance algorithm"
+        assert distance_param[b"since"] == b"1.0.0"
+        
+        # Check distance metric options (L2, IP, COSINE)
+        distance_options = distance_param[b"value"]
+        assert len(distance_options) == 3
+        
+        l2_option = distance_options[0]
+        assert l2_option[b"name"] == b"l2"
+        assert l2_option[b"type"] == b"pure-token"
+        assert l2_option[b"token"] == b"L2"
+        assert l2_option[b"summary"] == b"L2 (Euclidean) distance"
+        assert l2_option[b"since"] == b"1.0.0"
+        
+        ip_option = distance_options[1]
+        assert ip_option[b"name"] == b"ip"
+        assert ip_option[b"type"] == b"pure-token"
+        assert ip_option[b"token"] == b"IP"
+        assert ip_option[b"summary"] == b"Inner product distance"
+        assert ip_option[b"since"] == b"1.0.0"
+        
+        cosine_option = distance_options[2]
+        assert cosine_option[b"name"] == b"cosine"
+        assert cosine_option[b"type"] == b"pure-token"
+        assert cosine_option[b"token"] == b"COSINE"
+        assert cosine_option[b"summary"] == b"Cosine distance"
+        assert cosine_option[b"since"] == b"1.0.0"
+        
+        # 4. INITIAL_CAP parameter
+        initial_cap_param = hnsw_params[3]
+        assert initial_cap_param[b"name"] == b"initial_cap"
+        assert initial_cap_param[b"type"] == b"integer"
+        assert initial_cap_param[b"token"] == b"INITIAL_CAP"
+        assert initial_cap_param[b"summary"] == b"Initial index size (optional)"
+        assert initial_cap_param[b"since"] == b"1.0.0"
+        assert b"optional" in initial_cap_param[b"flags"]
+        
+        # 5. M parameter
+        m_param = hnsw_params[4]
+        assert m_param[b"name"] == b"m"
+        assert m_param[b"type"] == b"integer"
+        assert m_param[b"token"] == b"M"
+        assert m_param[b"summary"] == b"Maximum outgoing edges per node (default 16, max 512)"
+        assert m_param[b"since"] == b"1.0.0"
+        assert b"optional" in m_param[b"flags"]
+        
+        # 6. EF_CONSTRUCTION parameter
+        ef_construction_param = hnsw_params[5]
+        assert ef_construction_param[b"name"] == b"ef_construction"
+        assert ef_construction_param[b"type"] == b"integer"
+        assert ef_construction_param[b"token"] == b"EF_CONSTRUCTION"
+        assert ef_construction_param[b"summary"] == b"Vectors examined during index creation (default 200, max 4096)"
+        assert ef_construction_param[b"since"] == b"1.0.0"
+        assert b"optional" in ef_construction_param[b"flags"]
+        
+        # 7. EF_RUNTIME parameter
+        ef_runtime_param = hnsw_params[6]
+        assert ef_runtime_param[b"name"] == b"ef_runtime"
+        assert ef_runtime_param[b"type"] == b"integer"
+        assert ef_runtime_param[b"token"] == b"EF_RUNTIME"
+        assert ef_runtime_param[b"summary"] == b"Vectors examined during query (default 10, max 4096)"
+        assert ef_runtime_param[b"since"] == b"1.0.0"
+        assert b"optional" in ef_runtime_param[b"flags"]
+        
+        # Test FLAT algorithm
+        flat_alg = algorithms[1]
+        assert flat_alg[b"name"] == b"flat"
+        assert flat_alg[b"type"] == b"block"
+        assert flat_alg[b"token"] == b"FLAT"
+        assert flat_alg[b"summary"] == b"FLAT vector algorithm"
+        assert flat_alg[b"since"] == b"1.0.0"
+        
+        # Verify FLAT parameters
+        flat_params = flat_alg[b"value"]
+        assert len(flat_params) == 4
+        
+        # Check all FLAT parameters
+        # 1. DIM parameter
+        flat_dim_param = flat_params[0]
+        assert flat_dim_param[b"name"] == b"dim"
+        assert flat_dim_param[b"type"] == b"integer"
+        assert flat_dim_param[b"token"] == b"DIM"
+        assert flat_dim_param[b"summary"] == b"Vector dimensions (required)"
+        assert flat_dim_param[b"since"] == b"1.0.0"
+        
+        # 2. TYPE parameter
+        flat_type_param = flat_params[1]
+        assert flat_type_param[b"name"] == b"type"
+        assert flat_type_param[b"type"] == b"double"
+        assert flat_type_param[b"token"] == b"TYPE"
+        assert flat_type_param[b"summary"] == b"Vector data type (FLOAT32)"
+        assert flat_type_param[b"since"] == b"1.0.0"
+        
+        # 3. DISTANCE_METRIC parameter
+        flat_distance_param = flat_params[2]
+        assert flat_distance_param[b"name"] == b"distance_metric"
+        assert flat_distance_param[b"type"] == b"oneof"
+        assert flat_distance_param[b"token"] == b"DISTANCE_METRIC"
+        assert flat_distance_param[b"summary"] == b"Distance algorithm"
+        assert flat_distance_param[b"since"] == b"1.0.0"
+        
+        # Check distance metric options for FLAT (same as HNSW: L2, IP, COSINE)
+        assert b"value" in flat_distance_param
+        flat_distance_options = flat_distance_param[b"value"]
+        assert len(flat_distance_options) == 3
+        
+        flat_l2_option = flat_distance_options[0]
+        assert flat_l2_option[b"name"] == b"l2"
+        assert flat_l2_option[b"type"] == b"pure-token"
+        assert flat_l2_option[b"token"] == b"L2"
+        assert flat_l2_option[b"summary"] == b"L2 (Euclidean) distance"
+        assert flat_l2_option[b"since"] == b"1.0.0"
+        
+        flat_ip_option = flat_distance_options[1]
+        assert flat_ip_option[b"name"] == b"ip"
+        assert flat_ip_option[b"type"] == b"pure-token"
+        assert flat_ip_option[b"token"] == b"IP"
+        assert flat_ip_option[b"summary"] == b"Inner product distance"
+        assert flat_ip_option[b"since"] == b"1.0.0"
+        
+        flat_cosine_option = flat_distance_options[2]
+        assert flat_cosine_option[b"name"] == b"cosine"
+        assert flat_cosine_option[b"type"] == b"pure-token"
+        assert flat_cosine_option[b"token"] == b"COSINE"
+        assert flat_cosine_option[b"summary"] == b"Cosine distance"
+        assert flat_cosine_option[b"since"] == b"1.0.0"
+        
+        # 4. INITIAL_CAP parameter
+        flat_initial_cap_param = flat_params[3]
+        assert flat_initial_cap_param[b"name"] == b"initial_cap"
+        assert flat_initial_cap_param[b"type"] == b"integer"
+        assert flat_initial_cap_param[b"token"] == b"INITIAL_CAP"
+        assert flat_initial_cap_param[b"summary"] == b"Initial index size (optional)"
+        assert flat_initial_cap_param[b"since"] == b"1.0.0"
+        assert b"optional" in flat_initial_cap_param[b"flags"]
+        

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -51,6 +51,8 @@ const absl::flat_hash_set<absl::string_view> kListCmdPermissions{
 const absl::flat_hash_set<absl::string_view> kDebugCmdPermissions{
     kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
 
+extern ValkeyModuleCommandArg ftCreateArgs[];
+extern const ValkeyModuleCommandInfo ftCreateInfo;
 
 inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions,

--- a/src/commands/ft_create_info.cc
+++ b/src/commands/ft_create_info.cc
@@ -1,0 +1,468 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/commands/commands.h"
+
+namespace valkey_search {
+
+ValkeyModuleCommandArg ftCreateOnSubargs[] = {
+    {
+        .name = "hash",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "HASH",
+        .summary = "Index HASH data type",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "json",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "JSON",
+        .summary = "Index JSON data type",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreatePrefixSubargs[] = {
+    {
+        .name = "count",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Number of prefixes",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "prefix",
+        .type = VALKEYMODULE_ARG_TYPE_STRING,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Key prefix to index",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_MULTIPLE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreateTagSubargs[] = {
+    {
+        .name = "separator",
+        .type = VALKEYMODULE_ARG_TYPE_STRING,
+        .key_spec_index = -1,
+        .token = "SEPARATOR",
+        .summary = "Tag separator character",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "casesensitive",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "CASESENSITIVE",
+        .summary = "Make tag matching case sensitive",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+// Distance metric options for vector algorithms
+ValkeyModuleCommandArg ftCreateDistanceMetricOptions[] = {
+    {
+        .name = "l2",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "L2",
+        .summary = "L2 (Euclidean) distance",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "ip",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "IP",
+        .summary = "Inner product distance",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "cosine",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "COSINE",
+        .summary = "Cosine distance",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+// HNSW algorithm subargs
+ValkeyModuleCommandArg ftCreateHnswSubargs[] = {
+    {
+        .name = "dim",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "DIM",
+        .summary = "Vector dimensions (required)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "type",
+        .type = VALKEYMODULE_ARG_TYPE_DOUBLE,
+        .key_spec_index = -1,
+        .token = "TYPE",
+        .summary = "Vector data type (Currently Only for FLOAT32)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "distance_metric",
+        .type = VALKEYMODULE_ARG_TYPE_ONEOF,
+        .key_spec_index = -1,
+        .token = "DISTANCE_METRIC",
+        .summary = "Distance algorithm",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateDistanceMetricOptions,
+    },
+    {
+        .name = "initial_cap",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "INITIAL_CAP",
+        .summary = "Initial index size (optional)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "m",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "M",
+        .summary = "Maximum outgoing edges per node (default 16, max 512)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "ef_construction",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "EF_CONSTRUCTION",
+        .summary = "Vectors examined during index creation (default 200, max 4096)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "ef_runtime",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "EF_RUNTIME",
+        .summary = "Vectors examined during query (default 10, max 4096)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+// FLAT algorithm subargs
+ValkeyModuleCommandArg ftCreateFlatSubargs[] = {
+    {
+        .name = "dim",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "DIM",
+        .summary = "Vector dimensions (required)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "type",
+        .type = VALKEYMODULE_ARG_TYPE_DOUBLE,
+        .key_spec_index = -1,
+        .token = "TYPE",
+        .summary = "Vector data type (FLOAT32)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "distance_metric",
+        .type = VALKEYMODULE_ARG_TYPE_ONEOF,
+        .key_spec_index = -1,
+        .token = "DISTANCE_METRIC",
+        .summary = "Distance algorithm",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateDistanceMetricOptions,
+    },
+    {
+        .name = "initial_cap",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = "INITIAL_CAP",
+        .summary = "Initial index size (optional)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+// Vector algorithm options
+ValkeyModuleCommandArg ftCreateVectorAlgorithms[] = {
+    {
+        .name = "hnsw",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "HNSW",
+        .summary = "HNSW vector algorithm",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateHnswSubargs,
+    },
+    {
+        .name = "flat",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "FLAT",
+        .summary = "FLAT vector algorithm",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateFlatSubargs,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreateVectorSubargs[] = {
+    {
+        .name = "algorithm",
+        .type = VALKEYMODULE_ARG_TYPE_ONEOF,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Vector algorithm (HNSW or FLAT)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateVectorAlgorithms,
+    },
+    {
+        .name = "attribute_count",
+        .type = VALKEYMODULE_ARG_TYPE_INTEGER,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Number of vector attributes",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "attributes",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Vector attribute name-value pairs",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_MULTIPLE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreateSchemaFieldTypes[] = {
+    {
+        .name = "numeric",
+        .type = VALKEYMODULE_ARG_TYPE_PURE_TOKEN,
+        .key_spec_index = -1,
+        .token = "NUMERIC",
+        .summary = "Numeric field type",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "tag",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "TAG",
+        .summary = "Tag field type",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateTagSubargs,
+    },
+    {
+        .name = "vector",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "VECTOR",
+        .summary = "Vector field type",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateVectorSubargs,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreateSchemaSubargs[] = {
+    {
+        .name = "field_identifier",
+        .type = VALKEYMODULE_ARG_TYPE_STRING,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Field identifier",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "as",
+        .type = VALKEYMODULE_ARG_TYPE_STRING,
+        .key_spec_index = -1,
+        .token = "AS",
+        .summary = "Field alias",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "field_type",
+        .type = VALKEYMODULE_ARG_TYPE_ONEOF,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Field type (NUMERIC, TAG, VECTOR)",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateSchemaFieldTypes,
+    },
+    {
+        .name = "field_options",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Field type specific options",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL | VALKEYMODULE_CMD_ARG_MULTIPLE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {nullptr}  // Sentinel
+};
+
+ValkeyModuleCommandArg ftCreateArgs[] = {
+    {
+        .name = "index_name",
+        .type = VALKEYMODULE_ARG_TYPE_STRING,
+        .key_spec_index = -1,
+        .token = nullptr,
+        .summary = "Name of the index",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_NONE,
+        .deprecated_since = nullptr,
+        .subargs = nullptr,
+    },
+    {
+        .name = "on_data_type",
+        .type = VALKEYMODULE_ARG_TYPE_ONEOF,
+        .key_spec_index = -1,
+        .token = "ON",
+        .summary = "Data type to index",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateOnSubargs,
+    },
+    {
+        .name = "prefix",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "PREFIX",
+        .summary = "Key prefixes to index",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_OPTIONAL,
+        .deprecated_since = nullptr,
+        .subargs = ftCreatePrefixSubargs,
+    },
+    {
+        .name = "schema",
+        .type = VALKEYMODULE_ARG_TYPE_BLOCK,
+        .key_spec_index = -1,
+        .token = "SCHEMA",
+        .summary = "Schema definition",
+        .since = "1.0.0",
+        .flags = VALKEYMODULE_CMD_ARG_MULTIPLE,
+        .deprecated_since = nullptr,
+        .subargs = ftCreateSchemaSubargs,
+    },
+    {nullptr}  // Sentinel
+};
+
+const ValkeyModuleCommandInfo ftCreateInfo = {
+    .version = VALKEYMODULE_COMMAND_INFO_VERSION,
+    .summary = "Creates an empty search index and initiates the backfill process",
+    .complexity = "O(N log N), where N is the number of indexed items",
+    .since = "1.0.0",
+    .history = nullptr,
+    .tips = nullptr,
+    .arity = -2,
+    .key_specs = nullptr,
+    .args = ftCreateArgs,
+};
+
+}  // namespace valkey_search

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -50,6 +50,7 @@ vmsdk::module::Options options = {
                     valkey_search::kCreateCmdPermissions),
                 .flags = {vmsdk::module::kDenyOOMFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTCreateCmd>,
+                .command_info = &valkey_search::ftCreateInfo,
             },
             {
                 .cmd_name = valkey_search::kDropIndexCommand,

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -64,6 +64,14 @@ absl::Status RegisterCommands(ValkeyModuleCtx *ctx,
           absl::StrCat("Failed to set ACL categories `", permissions,
                        "` for the command: ", command.cmd_name.data()));
     }
+    if (command.command_info != nullptr) {
+      if (ValkeyModule_SetCommandInfo(cmd, command.command_info) ==
+          VALKEYMODULE_ERR) {
+        return absl::InternalError(
+            absl::StrCat("Failed to set command info for: ",
+                         command.cmd_name.data()));
+      }
+    }
   }
   return absl::OkStatus();
 }

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -58,6 +58,7 @@ struct CommandOptions {
   int first_key{0};
   int last_key{0};
   int key_step{0};
+  const ValkeyModuleCommandInfo *command_info{nullptr};
 };
 
 struct Options {


### PR DESCRIPTION
resolve: https://github.com/valkey-io/valkey-search/issues/266

Dividing 5 PRs. each one for commands.

If using json files as source of truth like [Valkey does](https://github.com/valkey-io/valkey/blob/unstable/src/commands/README.md), Different approach is needed. but I can't find that Valkey-search also follow valkey convention. 