### PR TITLE
Allow running single integration test

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,18 +24,18 @@ function print_usage() {
 cat<<EOF
 Usage: build.sh [options...]
 
-    --help | -h               Print this help message and exit.
-    --configure               Run cmake stage (aka configure stage).
-    --verbose | -v            Run verbose build.
-    --debug                   Build for debug version.
-    --clean                   Clean the current build configuration (debug or release).
-    --run-tests               Run all tests. Optionally, pass a test name to run: "--run-tests=<test-name>".
-    --no-build                By default, build.sh always triggers a build. This option disables this behavior.
-    --test-errors-stdout      When a test fails, dump the captured tests output to stdout.
-    --run-integration-tests   Run integration tests.
-    --use-system-modules      Use system's installed gRPC, Protobuf & Abseil dependencies.
-    --asan                    Build with address sanitizer enabled.
-    --tsan                    Build with thread sanitizer enabled.
+    --help | -h                       Print this help message and exit.
+    --configure                       Run cmake stage (aka configure stage).
+    --verbose | -v                    Run verbose build.
+    --debug                           Build for debug version.
+    --clean                           Clean the current build configuration (debug or release).
+    --run-tests                       Run all tests. Optionally, pass a test name to run: "--run-tests=<test-name>".
+    --no-build                        By default, build.sh always triggers a build. This option disables this behavior.
+    --test-errors-stdout              When a test fails, dump the captured tests output to stdout.
+    --run-integration-tests[=pattern] Run integration tests.
+    --use-system-modules              Use system's installed gRPC, Protobuf & Abseil dependencies.
+    --asan                            Build with address sanitizer enabled.
+    --tsan                            Build with thread sanitizer enabled.
 
 Example usage:
 
@@ -86,7 +86,13 @@ do
     --run-integration-tests)
         INTEGRATION_TEST="yes"
         shift || true
-        echo "Running integration tests"
+        echo "Running integration tests (all)"
+        ;;
+    --run-integration-tests=*)
+        INTEGRATION_TEST="yes"
+        TEST_PATTERN=${1#*=}
+        shift || true
+        echo "Running integration tests with pattern=${TEST_PATTERN}"
         ;;
     --test-errors-stdout)
         DUMP_TEST_ERRORS_STDOUT="yes"
@@ -310,28 +316,36 @@ elif [ ! -z "${RUN_TEST}" ]; then
     (${TESTS_DIR}/${RUN_TEST} && print_test_ok) || print_test_error_and_exit
     print_test_summary
 elif [[ "${INTEGRATION_TEST}" == "yes" ]]; then
-    pushd testing/integration >/dev/null
-        params=""
-        if [[ "${DUMP_TEST_ERRORS_STDOUT}" == "yes" ]]; then
-            params=" --test-errors-stdout"
-        fi
-        if [[ "${BUILD_CONFIG}" == "debug" ]]; then
-            params="${params} --debug"
-        fi
+    if [ ! -z "${TEST_PATTERN}" ]; then
+        echo ""
+        LOG_WARNING " ** TEST_PATTERN is found, skipping Abseil based integration tests **"
+        echo ""
+    else
+        # Abseil based tests do not support filtering tests based on "-k" flag
+        # so when the TEST_PATTERN env variable is found, skip Abseil based tests
+        pushd testing/integration >/dev/null
+            params=""
+            if [[ "${DUMP_TEST_ERRORS_STDOUT}" == "yes" ]]; then
+                params=" --test-errors-stdout"
+            fi
+            if [[ "${BUILD_CONFIG}" == "debug" ]]; then
+                params="${params} --debug"
+            fi
 
-        if [[ "${SAN_BUILD}" == "address" ]]; then
-            params="${params} --asan"
-        fi
-        if [[ "${SAN_BUILD}" == "thread" ]]; then
-            params="${params} --tsan"
-        fi
-        ./run.sh ${params}
-    popd >/dev/null
-    
+            if [[ "${SAN_BUILD}" == "address" ]]; then
+                params="${params} --asan"
+            fi
+            if [[ "${SAN_BUILD}" == "thread" ]]; then
+                params="${params} --tsan"
+            fi
+            ./run.sh ${params}
+        popd >/dev/null
+    fi
     # Run OSS integration tests
     pushd integration >/dev/null
         if [[ "${SAN_BUILD}" == "no" ]]; then
             # For now, run these this test suite without ASan.
+            export TEST_PATTERN=${TEST_PATTERN}
             ./run.sh
         fi
     popd >/dev/null

--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -41,7 +41,7 @@ _WORKSPACE_HOME=$(findup QUICK_START.md)
 _THIRD_PARTY_COMPONENTS_BUILD_DIR=${_WORKSPACE_HOME}/.build-release
 
 function get_third_party_build_dir() {
-  if [[ "${SAN_BUILD}" == "no" ]]; then
+  if [ -z "${SAN_BUILD}" ] || [[ "${SAN_BUILD}" == "no" ]]; then
     echo ${_THIRD_PARTY_COMPONENTS_BUILD_DIR}
   else
     echo ${_THIRD_PARTY_COMPONENTS_BUILD_DIR}-asan
@@ -170,7 +170,7 @@ function setup_json_module() {
   fi
 
   rm -fr "${VALKEY_JSON_HOME}"
-  LOG_INFO "Cloning valkey-server into ${VALKEY_JSON_HOME}"
+  LOG_INFO "Cloning valkey-json into ${VALKEY_JSON_HOME}"
   git clone https://github.com/valkey-io/valkey-json.git ${VALKEY_JSON_HOME}
 
   pushd ${VALKEY_JSON_HOME} >/dev/null


### PR DESCRIPTION
build.sh --run-integration-tests now accepts test pattern. Note that when passing test pattern, Abseil tests are disabled - this is due to limitation in the Abseil test framework.

Fixed wrong valkey-server & valkey-json checkout directory is used if integration/run.sh script is executed directly.