### PR TITLE
Build script fixes

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,4 +31,4 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Integration Tests
-      run: docker run --privileged --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image sudo ci/build_ubuntu.sh --run-integration-tests
+      run: docker run --privileged --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image sudo ci/build_ubuntu.sh --run-integration-tests --retries=3

--- a/build.sh
+++ b/build.sh
@@ -14,6 +14,7 @@ INTEGRATION_TEST="no"
 SAN_BUILD="no"
 ARGV=$@
 EXIT_CODE=0
+INTEG_RETRIES=1
 
 echo "Root directory: ${ROOT_DIR}"
 
@@ -36,7 +37,8 @@ Usage: build.sh [options...]
     --use-system-modules              Use system's installed gRPC, Protobuf & Abseil dependencies.
     --asan                            Build with address sanitizer enabled.
     --tsan                            Build with thread sanitizer enabled.
-
+    --retries=N                       Attempt to run integration tests N times. Default is 1.
+    
 Example usage:
 
     # Build the release configuration, run cmake if needed
@@ -93,6 +95,10 @@ do
         TEST_PATTERN=${1#*=}
         shift || true
         echo "Running integration tests with pattern=${TEST_PATTERN}"
+        ;;
+    --retries=*)
+        INTEG_RETRIES=${1#*=}
+        shift || true
         ;;
     --test-errors-stdout)
         DUMP_TEST_ERRORS_STDOUT="yes"
@@ -346,6 +352,7 @@ elif [[ "${INTEGRATION_TEST}" == "yes" ]]; then
         if [[ "${SAN_BUILD}" == "no" ]]; then
             # For now, run these this test suite without ASan.
             export TEST_PATTERN=${TEST_PATTERN}
+            export INTEG_RETRIES=${INTEG_RETRIES}
             ./run.sh
         fi
     popd >/dev/null


### PR DESCRIPTION
- OSS integration tests retry is now default to 1. User can use --retries=N to control this.
- Use --retries=3 in CI builds.