### PR TITLE
Fix crash due to Valkey Timeout before Cancellation timeout

### DIFF
--- a/src/commands/ft_search.cc
+++ b/src/commands/ft_search.cc
@@ -215,11 +215,7 @@ namespace async {
 
 int Timeout(ValkeyModuleCtx *ctx, [[maybe_unused]] ValkeyModuleString **argv,
           [[maybe_unused]] int argc) {
-  auto *res =
-      static_cast<Result *>(ValkeyModule_GetBlockedClientPrivateData(ctx));
-  CHECK(res != nullptr);
-  res->parameters->cancellation_token->Cancel(); // Cancel to tell Free that it's been seen
-  return ValkeyModule_ReplyWithError(ctx, "Request timed out");
+  return ValkeyModule_ReplyWithError(ctx, "Search operation cancelled due to timeout");
 }
 
 int Reply(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc) {

--- a/src/commands/ft_search.h
+++ b/src/commands/ft_search.h
@@ -12,7 +12,6 @@
 #include <memory>
 
 #include "absl/status/statusor.h"
-#include "src/index_schema.h"
 #include "src/indexes/vector_base.h"
 #include "src/query/search.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
@@ -25,6 +24,7 @@ void SendReply(ValkeyModuleCtx *ctx, std::deque<indexes::Neighbor> &neighbors,
 namespace async {
 
 struct Result {
+  cancel::Token cancellation_token;
   absl::StatusOr<std::deque<indexes::Neighbor>> neighbors;
   std::unique_ptr<query::VectorSearchParameters> parameters;
 };

--- a/src/utils/cancel.cc
+++ b/src/utils/cancel.cc
@@ -18,12 +18,16 @@ static vmsdk::config::Number PollFrequency(
     "timeout-poll-frequency", 100, 1, std::numeric_limits<long long>::max());
 static vmsdk::config::Boolean TestForceTimeout("test-force-timeout", false);
 
+static vmsdk::config::Boolean TestForcePausePoint("test-force-pause", false);
+
 static vmsdk::info_field::Integer Timeouts(
     "timeouts", "cancel-timeouts", vmsdk::info_field::IntegerBuilder().Dev());
 static vmsdk::info_field::Integer gRPCCancels(
     "timeouts", "cancel-grpc", vmsdk::info_field::IntegerBuilder().Dev());
 static vmsdk::info_field::Integer ForceCancels(
     "timeouts", "cancel-forced", vmsdk::info_field::IntegerBuilder().Dev());
+static vmsdk::info_field::Integer PausedCancels(
+    "timeouts", "cancel-paused", vmsdk::info_field::IntegerBuilder().Dev());
 
 //
 // A Concrete implementation of Token that can be used to cancel
@@ -54,6 +58,18 @@ struct TokenImpl : public Base {
           is_cancelled_ = true;  // Operation should be cancelled
           ForceCancels.Increment(1);
           VMSDK_LOG(WARNING, nullptr) << "CANCEL: Timeout forced";
+        } else if (TestForcePausePoint.GetValue()) {
+          PausedCancels.Increment(1);
+          VMSDK_LOG(WARNING, nullptr) << "CANCEL: Paused";
+          absl::Time pause_start = absl::Now();
+          while (TestForcePausePoint.GetValue()) {
+            VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1) 
+              << "CANCEL: Paused for " 
+              << absl::ToInt64Seconds(absl::Now() - pause_start) 
+              << " Seconds.";
+            absl::SleepFor(absl::Milliseconds(30));
+          }
+          VMSDK_LOG(WARNING, nullptr) << "CANCEL: Unpaused";
         }
       }
     }


### PR DESCRIPTION
Timeout cancellation is a race between the Timeout operation of the main thread (initialied via the BlockClient call) and the self-cancellation of the background thread. Normally, the background thread wins but when the main thread wins, it would crash because the private data of the blocked client hadn't been set yet. This PR adds machinery to force the "main thread wins" path and eliminates the machinery to cancel the background thread.

Also, the mainthread timeout is setup to be slightly slower (10 mSec) than the background self-cancellation in order to allow the partial results machinery to operate.