### PR TITLE
Updated additional metrics of "info search" search_index_stats section to align with redisearch output.

### DIFF
--- a/integration/test_info.py
+++ b/integration/test_info.py
@@ -43,6 +43,11 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
             "search_number_of_attributes",
             "search_number_of_indexes",
             "search_total_indexed_documents",
+            "search_number_of_active_indexes",
+            "search_number_of_active_indexes_running_queries",
+            "search_number_of_active_indexes_indexing",
+            "search_total_active_write_threads",
+            "search_total_indexing_time",
             "search_used_memory_bytes",
             "search_index_reclaimable_memory"
         ]
@@ -79,4 +84,3 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
             assert field in info_data
             bytes_value = info_data[field]
             assert isinstance(bytes_value, str) and bytes_value.endswith("iB")
-

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -35,6 +35,7 @@
 #include "src/rdb_section.pb.h"
 #include "src/rdb_serialization.h"
 #include "src/vector_externalizer.h"
+#include "src/valkey_search.h"
 #include "vmsdk/src/info.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -668,6 +669,38 @@ static vmsdk::info_field::Integer total_indexed_documents(
     "index_stats", "total_indexed_documents",
     vmsdk::info_field::IntegerBuilder().App().Computed([] {
       return SchemaManager::Instance().GetTotalIndexedDocuments();
+    }));
+static vmsdk::info_field::Integer active_indexes(
+    "index_stats", "number_of_active_indexes",
+    vmsdk::info_field::IntegerBuilder().App().Computed([] {
+      return SchemaManager::Instance().GetNumberOfIndexSchemas();
+    }));
+static vmsdk::info_field::Integer active_indexes_running_queries(
+    "index_stats", "number_of_active_indexes_running_queries",
+    vmsdk::info_field::IntegerBuilder().App().Computed([] {
+      // TODO: need to implement active query tracking
+      return 0;
+    }));
+static vmsdk::info_field::Integer active_indexes_indexing(
+    "index_stats", "number_of_active_indexes_indexing",
+    vmsdk::info_field::IntegerBuilder().App().Computed([] {
+      return SchemaManager::Instance().IsIndexingInProgress() ? 1 : 0;
+    }));
+static vmsdk::info_field::Integer total_active_write_threads(
+    "index_stats", "total_active_write_threads",
+    vmsdk::info_field::IntegerBuilder().App().Computed([] {
+      auto& valkey_search = valkey_search::ValkeySearch::Instance();
+      auto writer_thread_pool = valkey_search.GetWriterThreadPool();
+      if (writer_thread_pool) {
+        return writer_thread_pool->IsSuspended() ? 0 : writer_thread_pool->Size();
+      }
+      return (unsigned long)0;
+    }));
+static vmsdk::info_field::Integer total_indexing_time(
+    "index_stats", "total_indexing_time",
+    vmsdk::info_field::IntegerBuilder().App().Computed([] {
+      // TODO: need to implement indexing time tracking
+      return 0;
     }));
 
 }  // namespace valkey_search

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -468,7 +468,9 @@ TEST_F(ValkeySearchTest, Info) {
     "global_ingestion\ningest_field_numeric: 400\ningest_field_tag: 500\ningest_field_vector: 300\n"
     "ingest_hash_blocked: 0\ningest_hash_keys: 100\ningest_json_blocked: 0\ningest_json_keys: 200\n"
     "ingest_last_batch_size: 600\ningest_total_batches: 700\ningest_total_failures: 800\n"
-    "index_stats\nnumber_of_attributes: 1\nnumber_of_indexes: 1\ntotal_indexed_documents: 4\n"
+    "index_stats\nnumber_of_indexes: 1\nnumber_of_attributes: 1\ntotal_indexed_documents: 4\nnumber_of_active_indexes: 1\n"
+    "number_of_active_indexes_running_queries: 0\nnumber_of_active_indexes_indexing: 1\n"
+    "total_active_write_threads: 5\ntotal_indexing_time: 0\n"
     "indexing\nbackground_indexing_status: 'IN_PROGRESS'\n"
     "memory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n"
 );


### PR DESCRIPTION
updated the corresponding lamda function for which we have data. for active index query and indexing time fields  are left with empty and returning 0(int) as default. once we have the mechanism we can update the metrics in real time.

after the changes the results looks below.

```
# search_index_stats
search_number_of_active_indexes:1
search_number_of_active_indexes_indexing:0
search_number_of_active_indexes_running_queries:0
search_number_of_attributes:2
search_number_of_indexes:1
search_total_active_write_threads:8
search_total_indexed_documents:0
search_total_indexing_time:0

```