### PR TITLE
Added the cursor, garbage collector metrics along with additional memory metrics in "info search" to align redisearch

### DIFF
--- a/integration/test_info.py
+++ b/integration/test_info.py
@@ -44,7 +44,20 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
             "search_number_of_indexes",
             "search_total_indexed_documents",
             "search_used_memory_bytes",
-            "search_index_reclaimable_memory"
+            "search_index_reclaimable_memory",
+            "search_used_memory_indexes",
+            "search_smallest_memory_index",
+            "search_largest_memory_index",
+            "search_used_memory_vector_index",
+            "search_global_idle_user",
+            "search_global_idle_internal",
+            "search_global_total_user",
+            "search_global_total_internal",
+            "search_gc_bytes_collected",
+            "search_gc_total_cycles",
+            "search_gc_total_ms_run",
+            "search_gc_total_docs_not_collected",
+            "search_gc_marked_deleted_vectors"
         ]
 
         string_fields = [
@@ -52,7 +65,10 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
         ]
 
         bytes_fields = [
-            "search_used_memory_human"
+            "search_used_memory_human",
+            "search_used_memory_indexes_human",
+            "search_smallest_memory_index_human",
+            "search_largest_memory_index_human"
         ]
         
         double_fields = [

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -120,6 +120,79 @@ static vmsdk::info_field::Integer reclaimable_memory(
         })
         .CrashSafe());
 
+static vmsdk::info_field::Integer used_memory_indexes(
+    "memory", "used_memory_indexes",
+    vmsdk::info_field::IntegerBuilder()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for indexes
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer used_memory_indexes_human(
+    "memory", "used_memory_indexes_human",
+    vmsdk::info_field::IntegerBuilder()
+        .SIBytes()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for indexes
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer smallest_memory_index(
+    "memory", "smallest_memory_index",
+    vmsdk::info_field::IntegerBuilder()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for smallest index
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer smallest_memory_index_human(
+    "memory", "smallest_memory_index_human",
+    vmsdk::info_field::IntegerBuilder()
+        .SIBytes()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for smallest index
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer largest_memory_index(
+    "memory", "largest_memory_index",
+    vmsdk::info_field::IntegerBuilder()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for largest index
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer largest_memory_index_human(
+    "memory", "largest_memory_index_human",
+    vmsdk::info_field::IntegerBuilder()
+        .SIBytes()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for largest index
+          return 0;
+        })
+        .CrashSafe());
+
+static vmsdk::info_field::Integer used_memory_vector_index(
+    "memory", "used_memory_vector_index",
+    vmsdk::info_field::IntegerBuilder()
+        .App()
+        .Computed([]() -> uint64_t {
+          // TODO: need to implement actual memory calculation for vector index
+          return 0;
+        })
+        .CrashSafe());
+
 static vmsdk::info_field::String background_indexing_status(
     "indexing", "background_indexing_status",
     vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
@@ -821,8 +894,73 @@ static vmsdk::info_field::Integer &remove_subscription_failure_count =
     remove_subscription_fields[1];
 static vmsdk::info_field::Integer &remove_subscription_skipped_count =
     remove_subscription_fields[2];
-
 #endif
+
+// Search cursors info fields
+static vmsdk::info_field::Integer global_idle_user(
+    "cursors", "global_idle_user",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual cursor idle user count
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer global_idle_internal(
+    "cursors", "global_idle_internal",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual cursor idle internal count
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer global_total_user(
+    "cursors", "global_total_user",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual cursor total user count
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer global_total_internal(
+    "cursors", "global_total_internal",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual cursor total internal count
+      return 0;
+    }));
+
+// Search garbage collector info fields
+static vmsdk::info_field::Integer gc_bytes_collected(
+    "garbage_collector", "gc_bytes_collected",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual GC bytes collected
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer gc_total_cycles(
+    "garbage_collector", "gc_total_cycles",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual GC total cycles
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer gc_total_ms_run(
+    "garbage_collector", "gc_total_ms_run",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual GC total milliseconds run
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer gc_total_docs_not_collected(
+    "garbage_collector", "gc_total_docs_not_collected",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual GC total docs not collected
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer gc_marked_deleted_vectors(
+    "garbage_collector", "gc_marked_deleted_vectors",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // TODO: need to implement actual GC marked deleted vectors
+      return 0;
+    }));
+
 void ValkeySearch::Info(ValkeyModuleInfoCtx *ctx, bool for_crash_report) const {
   vmsdk::info_field::DoSections(ctx, for_crash_report);
 }

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -13,6 +13,8 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <sstream>
+#include <map>
 
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
@@ -469,8 +471,11 @@ TEST_F(ValkeySearchTest, Info) {
     "ingest_hash_blocked: 0\ningest_hash_keys: 100\ningest_json_blocked: 0\ningest_json_keys: 200\n"
     "ingest_last_batch_size: 600\ningest_total_batches: 700\ningest_total_failures: 800\n"
     "index_stats\nnumber_of_attributes: 1\nnumber_of_indexes: 1\ntotal_indexed_documents: 4\n"
-    "indexing\nbackground_indexing_status: 'IN_PROGRESS'\n"
-    "memory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n"
+    "indexing\nbackground_indexing_status: 'IN_PROGRESS'\nmemory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n"
+    "used_memory_indexes: 0\nused_memory_indexes_human: 0\nsmallest_memory_index: 0\nsmallest_memory_index_human: 0\n"
+    "largest_memory_index: 0\nlargest_memory_index_human: 0\nused_memory_vector_index: 0\ncursors\nglobal_idle_user: 0\n"
+    "global_idle_internal: 0\nglobal_total_user: 0\nglobal_total_internal: 0\ngarbage_collector\ngc_bytes_collected: 0\n"
+    "gc_total_cycles: 0\ngc_total_ms_run: 0\ngc_total_docs_not_collected: 0\ngc_marked_deleted_vectors: 0\n"
 );
 #endif
 }


### PR DESCRIPTION
Added empty values to align with redisearch "info serch" output to make sure applications or client which retrive those value would not break. Once mechanism implemented the real time values can be updated.

here are the output after the changes.

```
127.0.0.1:6379> info search
# search_cursors
search_global_idle_internal:0
search_global_idle_user:0
search_global_total_internal:0
search_global_total_user:0

# search_garbage_collector
search_gc_bytes_collected:0
search_gc_marked_deleted_vectors:0
search_gc_total_cycles:0
search_gc_total_docs_not_collected:0
search_gc_total_ms_run:0

# search_hnswlib
search_hnsw_add_exceptions_count:0
search_hnsw_create_exceptions_count:0
search_hnsw_modify_exceptions_count:0
search_hnsw_remove_exceptions_count:0
search_hnsw_search_exceptions_count:0

# search_index_stats
search_number_of_attributes:0
search_number_of_indexes:0
search_total_indexed_documents:0

# search_indexing
search_background_indexing_status:NO_ACTIVITY

# search_memory
search_index_reclaimable_memory:0
search_largest_memory_index:0
search_largest_memory_index_human:0
search_smallest_memory_index:0
search_smallest_memory_index_human:0
search_used_memory_bytes:18480
search_used_memory_human:18.05KiB
search_used_memory_indexes:0
search_used_memory_indexes_human:0
search_used_memory_vector_index:0

# search_query
search_failure_requests_count:0
search_hybrid_requests_count:0
search_inline_filtering_requests_count:0
search_query_prefiltering_requests_cnt:0
search_result_record_dropped_count:0
search_successful_requests_count:0

# search_rdb
search_rdb_load_failure_cnt:0
search_rdb_load_success_cnt:0
search_rdb_save_failure_cnt:0
search_rdb_save_success_cnt:0

# search_string_interning
search_string_interning_store_size:0

# search_thread-pool
search_query_queue_size:0
search_reader_resumed_cnt:0
search_used_read_cpu:0
search_used_write_cpu:0
search_worker_pool_suspend_cnt:0
search_writer_queue_size:0
search_writer_resumed_cnt:0
search_writer_suspension_expired_cnt:0

# search_vector_externing
search_vector_externing_deferred_entry_cnt:0
search_vector_externing_entry_count:0
search_vector_externing_generated_value_cnt:0
search_vector_externing_hash_extern_errors:0
search_vector_externing_lru_promote_cnt:0
search_vector_externing_num_lru_entries:0
127.0.0.1:6379>

```