### PR TITLE
Update clang tidy/format github job and apply formatting

### DIFF
--- a/.github/workflows/clang_tidy_format.yml
+++ b/.github/workflows/clang_tidy_format.yml
@@ -25,7 +25,32 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Relevant for push case
+
+      - name: Determine base branch
+        id: determine-base
+        run: |
+          set -euo pipefail
+          # If it's a pull request, compare against the base branch.
+          # If it's a direct push, compare against the previous commit.
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            git fetch origin ${{ github.event.pull_request.base.ref }}
+            BASE_BRANCH="origin/${{ github.event.pull_request.base.ref }}"
+            echo "PR detected. Comparing with base branch: $BASE_BRANCH"
+          else
+            BASE_BRANCH=$(git rev-parse HEAD~1)
+            echo "Push detected. Comparing with previous commit: $BASE_BRANCH"
+          fi
+          
+          # Verify the base branch/commit exists
+          if ! git rev-parse --verify "$BASE_BRANCH" >/dev/null 2>&1; then
+            echo "Error: Base branch/commit '$BASE_BRANCH' not found"
+            exit 1
+          fi
+          
+          echo "BASE_BRANCH=$BASE_BRANCH" >> $GITHUB_ENV
 
       # Build the Docker image from the Dockerfile in your repo
       - name: Build Docker Image
@@ -37,19 +62,9 @@ jobs:
           echo "Building CompDB"
           docker run --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image bash -c "sudo su ubuntu && export USERNAME='ubuntu' && sudo chown -R ubuntu:ubuntu /workspace && export HOME='/home/ubuntu'  && export USERNAME='ubuntu' && ci/refresh_comp_db.sh "
 
-      - name: Determine base branch
-        id: determine-base
-        run: |
-          # If it's a pull request, compare against the base branch.
-          # If it's a push to main, compare against the previous commit.
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "BASE_BRANCH=${{ github.base_ref }}" >> $GITHUB_ENV
-          else
-            echo "BASE_BRANCH=$(git rev-parse HEAD~1)" >> $GITHUB_ENV
-          fi
-
       - name: Find and process modified files
         run: |
+          set -euo pipefail
           echo "Finding modified or added .cc and .h files..."
           MODIFIED_FILES=$(git diff --name-only --diff-filter=AM $BASE_BRANCH | grep -E '\.(cc|h)$' || echo "")
 
@@ -62,9 +77,14 @@ jobs:
           echo "$MODIFIED_FILES"
 
           for FILE in $MODIFIED_FILES; do
-            echo "Running script on $FILE"
-            docker run --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" clang-tidy-format-image \
-            bash -c ' clang-tidy --quiet -p compile_commands.json "$FILE" 2>&1 | tail -n +3 && ci/check_clang_format.sh "$FILE"'
+            echo "Running clang-format check on $FILE"
+            docker run --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image \
+            bash -c "ci/check_clang_format.sh \"$FILE\""
+            
+            # TODO: Enable clang tidy after the existing code is tidied
+            # echo "Running clang-tidy on $FILE"
+            # docker run --rm  -v "$(pwd):/workspace" --user "ubuntu:ubuntu" presubmit-image \
+            # bash -c "clang-tidy --quiet -p compile_commands.json \"$FILE\" 2>&1 | tail -n +3"
           done
 
       - name: Ensure script execution success

--- a/src/acl.cc
+++ b/src/acl.cc
@@ -343,7 +343,7 @@ absl::Status AclPrefixCheck(
   // to access ALL keys.
   if (module_prefixes.empty() && !IsPrefixAllowed("", acl_keys)) {
     return absl::PermissionDeniedError(
-          "The user doesn't have a permission to execute a command");
+        "The user doesn't have a permission to execute a command");
   }
 
   // We allow the user to execute command only if the user has permissions for

--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -83,7 +83,8 @@ absl::StatusOr<RecordsMap> HashAttributeDataType::FetchAllRecords(
         absl::StrCat("No such record with key: `", vector_identifier, "`"));
   }
   // Only check for vector_identifier if it's not empty (vector queries)
-  if (!vector_identifier.empty() && !HashHasRecord(key_obj.get(), vector_identifier)) {
+  if (!vector_identifier.empty() &&
+      !HashHasRecord(key_obj.get(), vector_identifier)) {
     return absl::NotFoundError(absl::StrCat("No such record with identifier: `",
                                             vector_identifier, "`"));
   }

--- a/src/attribute_data_type.h
+++ b/src/attribute_data_type.h
@@ -99,7 +99,8 @@ class JsonAttributeDataType : public AttributeDataType {
       ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
       absl::string_view identifier) const override;
   inline int GetValkeyEventTypes() const override {
-    return VALKEYMODULE_NOTIFY_MODULE | AttributeDataType::GetValkeyEventTypes();
+    return VALKEYMODULE_NOTIFY_MODULE |
+           AttributeDataType::GetValkeyEventTypes();
   }
   inline data_model::AttributeDataType ToProto() const override {
     return data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_JSON;

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -51,7 +51,6 @@ const absl::flat_hash_set<absl::string_view> kListCmdPermissions{
 const absl::flat_hash_set<absl::string_view> kDebugCmdPermissions{
     kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
 
-
 inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions,
     absl::string_view command) {
@@ -71,7 +70,7 @@ absl::Status FTListCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
 absl::Status FTSearchCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                          int argc);
 absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
-                         int argc);
+                        int argc);
 }  // namespace valkey_search
 
 #endif  // VALKEYSEARCH_SRC_COMMANDS_COMMANDS_H_

--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -21,7 +21,6 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_cat.h"
 #include "absl/strings/string_view.h"
-#include "src/valkey_search_options.h"
 #include "src/index_schema.h"
 #include "src/indexes/index_base.h"
 #include "src/indexes/numeric.h"

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -176,9 +176,9 @@ static auto max_ef_runtime =
 /// in milliseconds for FT.SEARCH.
 static auto default_timeout_ms =
     vmsdk::config::NumberBuilder(kDefaultTimeoutMs,  // name
-                                 kTimeoutMs,            // default timeout
-                                 kMinTimeoutMs,         // min timeout
-                                 kMaxTimeoutMs)         // max timeout
+                                 kTimeoutMs,         // default timeout
+                                 kMinTimeoutMs,      // min timeout
+                                 kMaxTimeoutMs)      // max timeout
         .Build();
 
 const absl::NoDestructor<

--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -10,8 +10,8 @@
 
 #include "module_config.h"
 #include "src/commands/commands.h"
-#include "vmsdk/src/debug.h"
 #include "vmsdk/src/command_parser.h"
+#include "vmsdk/src/debug.h"
 #include "vmsdk/src/info.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/status/status_macros.h"
@@ -23,26 +23,33 @@ namespace valkey_search {
 // FT.DEBUG PAUSEPOINT [ SET | RESET | TEST | LIST] <pausepoint>
 //
 // Connects to the vmsdk::debug mechanism
-// A pausepoint is a mechanism to pause a thread at a specific location for testing purposes.
+// A pausepoint is a mechanism to pause a thread at a specific location for
+// testing purposes.
 //
-// Individual pausepoints are labelled by a unique string. No checking for the uniqueness is done.
-// A pause point in the code is enabled by calling vmsdk::debug::PausePoint("<string>");
-// If that pausepoint is not set, then this call does nothing. But if the pausepoint is set then
-// the calling thread "hangs" at that point.
+// Individual pausepoints are labelled by a unique string. No checking for the
+// uniqueness is done. A pause point in the code is enabled by calling
+// vmsdk::debug::PausePoint("<string>"); If that pausepoint is not set, then
+// this call does nothing. But if the pausepoint is set then the calling thread
+// "hangs" at that point.
 //
-// The TEST option can be used to determine if one or more threads are paused at a particular pausepoint,
-// the number of paused threads is returned by that command, with 0 indicating that no threads are paused.
-// If threads are paused, then by RESETing the pausepoint they are released.
+// The TEST option can be used to determine if one or more threads are paused at
+// a particular pausepoint, the number of paused threads is returned by that
+// command, with 0 indicating that no threads are paused. If threads are paused,
+// then by RESETing the pausepoint they are released.
 //
-// A typical test scenario is to enable a pause point and then trigger some background activity, i.e.,
-//  a query, ingestion or other background activity. The test program then waits until the background
-// thread reaches the pause point, which the test detects by polling the pause point with the TEST subcommand.
-// Once the background thread is paused, the test can proceed by clearing the pausepoint with the RESET subcommand.
+// A typical test scenario is to enable a pause point and then trigger some
+// background activity, i.e.,
+//  a query, ingestion or other background activity. The test program then waits
+//  until the background
+// thread reaches the pause point, which the test detects by polling the pause
+// point with the TEST subcommand. Once the background thread is paused, the
+// test can proceed by clearing the pausepoint with the RESET subcommand.
 //
-// Note, a pausepoint cannot be attempted by the main thread. It's also recommended that it not be done while
-// holding a mutex/lock.
+// Note, a pausepoint cannot be attempted by the main thread. It's also
+// recommended that it not be done while holding a mutex/lock.
 //
-absl::Status PausePointControlCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator& itr) {
+absl::Status PausePointControlCmd(ValkeyModuleCtx *ctx,
+                                  vmsdk::ArgsIterator &itr) {
   std::string keyword;
   VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, keyword));
   keyword = absl::AsciiStrToUpper(keyword);
@@ -63,7 +70,8 @@ absl::Status PausePointControlCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator& itr
     vmsdk::debug::PausePointControl(point, keyword == "SET");
     ValkeyModule_ReplyWithSimpleString(ctx, "OK");
   } else {
-    ValkeyModule_ReplyWithError(ctx, absl::StrCat("Unknown keyword", keyword).data());
+    ValkeyModule_ReplyWithError(
+        ctx, absl::StrCat("Unknown keyword", keyword).data());
   }
   return absl::OkStatus();
 }
@@ -73,7 +81,8 @@ absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
   if (!vmsdk::config::IsDebugModeEnabled()) {
     // Pretend like we don't exist
     std::ostringstream msg;
-    msg << "ERR unknown command '" << vmsdk::ToStringView(argv[0]) << "', with args beginning with:";
+    msg << "ERR unknown command '" << vmsdk::ToStringView(argv[0])
+        << "', with args beginning with:";
     for (int i = 1; i < argc; ++i) {
       msg << " '" << vmsdk::ToStringView(argv[i]) << "'";
     }
@@ -92,11 +101,12 @@ absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
   VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, keyword));
   keyword = absl::AsciiStrToUpper(keyword);
   if (keyword == "SHOW_INFO") {
-      return vmsdk::info_field::ShowInfo(ctx, itr, options);
+    return vmsdk::info_field::ShowInfo(ctx, itr, options);
   } else if (keyword == "PAUSEPOINT") {
-      return PausePointControlCmd(ctx, itr);
+    return PausePointControlCmd(ctx, itr);
   } else {
-    return absl::InvalidArgumentError(absl::StrCat("Unknown subcommand: ", *itr.GetStringView()));
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unknown subcommand: ", *itr.GetStringView()));
   }
 }
 

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -369,7 +369,8 @@ absl::Status ParseQueryString(query::VectorSearchParameters &parameters) {
       parameters.filter_parse_results,
       ParsePreFilter(*parameters.index_schema, pre_filter),
       _.SetPrepend() << "Invalid filter expression: `" << pre_filter << "`. ");
-  if (!parameters.filter_parse_results.root_predicate && vector_filter.empty()) {
+  if (!parameters.filter_parse_results.root_predicate &&
+      vector_filter.empty()) {
     // Return an error if no valid pre-filter and no vector filter is provided.
     return absl::InvalidArgumentError("Vector query clause is missing");
   }

--- a/src/coordinator/client.cc
+++ b/src/coordinator/client.cc
@@ -54,16 +54,17 @@ constexpr absl::string_view kRetryPolicy =
     "}]}";
 // clang-format on
 
-static constexpr absl::string_view kCoordinatorQueryTimeout{"coordinator-query-timeout-secs"};
+static constexpr absl::string_view kCoordinatorQueryTimeout{
+    "coordinator-query-timeout-secs"};
 static constexpr int kCoordinatorQueryDefaultTimeout{120};
 static constexpr int kCoordinatorQueryMinTimeout{1};
 static constexpr int kCoordinatorQueryMaxTimeout{3600};
 
-static auto query_connection_timeout = vmsdk::config::NumberBuilder(kCoordinatorQueryTimeout,
-  kCoordinatorQueryDefaultTimeout,
-  kCoordinatorQueryMinTimeout,
-  kCoordinatorQueryMaxTimeout
-).Build();
+static auto query_connection_timeout =
+    vmsdk::config::NumberBuilder(
+        kCoordinatorQueryTimeout, kCoordinatorQueryDefaultTimeout,
+        kCoordinatorQueryMinTimeout, kCoordinatorQueryMaxTimeout)
+        .Build();
 
 grpc::ChannelArguments& GetChannelArgs() {
   static absl::once_flag once;
@@ -88,9 +89,9 @@ std::shared_ptr<Client> ClientImpl::MakeInsecureClient(
                                       Coordinator::NewStub(channel));
 }
 
-ClientImpl::ClientImpl(vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
-                       absl::string_view address,
-                       std::unique_ptr<Coordinator::Stub> stub)
+ClientImpl::ClientImpl(
+    vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx,
+    absl::string_view address, std::unique_ptr<Coordinator::Stub> stub)
     : detached_ctx_(std::move(detached_ctx)),
       address_(address),
       stub_(std::move(stub)) {}
@@ -143,8 +144,8 @@ void ClientImpl::SearchIndexPartition(
     std::unique_ptr<vmsdk::StopWatch> latency_sample;
   };
   auto args = std::make_unique<SearchIndexPartitionArgs>();
-  args->context.set_deadline(
-      absl::ToChronoTime(absl::Now() + absl::Seconds(query_connection_timeout->GetValue())));
+  args->context.set_deadline(absl::ToChronoTime(
+      absl::Now() + absl::Seconds(query_connection_timeout->GetValue())));
   args->callback = std::move(done);
   args->request = std::move(request);
   args->latency_sample = SAMPLE_EVERY_N(100);
@@ -179,8 +180,7 @@ void ClientImpl::SearchIndexPartition(
 
 void ClientImpl::InfoIndexPartition(
     std::unique_ptr<InfoIndexPartitionRequest> request,
-    InfoIndexPartitionCallback done,
-    int timeout_ms) {
+    InfoIndexPartitionCallback done, int timeout_ms) {
   struct InfoIndexPartitionArgs {
     ::grpc::ClientContext context;
     std::unique_ptr<InfoIndexPartitionRequest> request;
@@ -198,9 +198,7 @@ void ClientImpl::InfoIndexPartition(
   Metrics::GetStats().coordinator_bytes_out.fetch_add(
       args_raw->request->ByteSizeLong(), std::memory_order_relaxed);
   stub_->async()->InfoIndexPartition(
-      &args_raw->context,
-      args_raw->request.get(),
-      &args_raw->response,
+      &args_raw->context, args_raw->request.get(), &args_raw->response,
       // std::function is not move-only
       [args_raw](grpc::Status s) mutable {
         GRPCSuspensionGuard guard(GRPCSuspender::Instance());
@@ -209,7 +207,7 @@ void ClientImpl::InfoIndexPartition(
         // (Optional) record metrics here
         if (s.ok()) {
           Metrics::GetStats().coordinator_bytes_in.fetch_add(
-            args->response.ByteSizeLong(), std::memory_order_relaxed);
+              args->response.ByteSizeLong(), std::memory_order_relaxed);
         }
       });
 }

--- a/src/coordinator/client.h
+++ b/src/coordinator/client.h
@@ -24,7 +24,7 @@ using GetGlobalMetadataCallback =
     absl::AnyInvocable<void(grpc::Status, GetGlobalMetadataResponse&)>;
 using SearchIndexPartitionCallback =
     absl::AnyInvocable<void(grpc::Status, SearchIndexPartitionResponse&)>;
-using InfoIndexPartitionCallback = 
+using InfoIndexPartitionCallback =
     absl::AnyInvocable<void(grpc::Status, InfoIndexPartitionResponse&)>;
 
 class Client {
@@ -36,8 +36,7 @@ class Client {
       SearchIndexPartitionCallback done) = 0;
   virtual void InfoIndexPartition(
       std::unique_ptr<InfoIndexPartitionRequest> request,
-      InfoIndexPartitionCallback done,
-      int timeout_ms = 5000) = 0;
+      InfoIndexPartitionCallback done, int timeout_ms = 5000) = 0;
 };
 
 class ClientImpl : public Client {
@@ -56,10 +55,9 @@ class ClientImpl : public Client {
   void SearchIndexPartition(
       std::unique_ptr<SearchIndexPartitionRequest> request,
       SearchIndexPartitionCallback done) override;
-  void InfoIndexPartition(
-      std::unique_ptr<InfoIndexPartitionRequest> request,
-      InfoIndexPartitionCallback done,
-      int timeout_ms = 5000) override;
+  void InfoIndexPartition(std::unique_ptr<InfoIndexPartitionRequest> request,
+                          InfoIndexPartitionCallback done,
+                          int timeout_ms = 5000) override;
 
  private:
   vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;

--- a/src/coordinator/search_converter.cc
+++ b/src/coordinator/search_converter.cc
@@ -117,8 +117,10 @@ absl::StatusOr<std::unique_ptr<query::Predicate>> GRPCPredicateToPredicate(
 }
 
 absl::StatusOr<std::unique_ptr<query::VectorSearchParameters>>
-GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request, grpc::CallbackServerContext *context) {
-  auto parameters = std::make_unique<query::VectorSearchParameters>(request.timeout_ms(), context);
+GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request,
+                              grpc::CallbackServerContext* context) {
+  auto parameters = std::make_unique<query::VectorSearchParameters>(
+      request.timeout_ms(), context);
   parameters->index_schema_name = request.index_schema_name();
   parameters->attribute_alias = request.attribute_alias();
   VMSDK_ASSIGN_OR_RETURN(

--- a/src/coordinator/search_converter.h
+++ b/src/coordinator/search_converter.h
@@ -11,14 +11,15 @@
 #include <memory>
 
 #include "absl/status/statusor.h"
+#include "grpcpp/server_context.h"
 #include "src/coordinator/coordinator.pb.h"
 #include "src/query/search.h"
-#include "grpcpp/server_context.h"
 
 namespace valkey_search::coordinator {
 
 absl::StatusOr<std::unique_ptr<query::VectorSearchParameters>>
-GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request, grpc::CallbackServerContext *context);
+GRPCSearchRequestToParameters(const SearchIndexPartitionRequest& request,
+                              grpc::CallbackServerContext* context);
 
 std::unique_ptr<SearchIndexPartitionRequest> ParametersToGRPCSearchRequest(
     const query::VectorSearchParameters& parameters);

--- a/src/coordinator/server.h
+++ b/src/coordinator/server.h
@@ -44,7 +44,7 @@ class Service final : public Coordinator::CallbackService {
       grpc::CallbackServerContext* context,
       const SearchIndexPartitionRequest* request,
       SearchIndexPartitionResponse* response) override;
-  
+
   grpc::ServerUnaryReactor* InfoIndexPartition(
       grpc::CallbackServerContext* context,
       const InfoIndexPartitionRequest* request,

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -89,7 +89,8 @@ class IndexSchema : public KeyspaceEventSubscription,
 
   static absl::StatusOr<std::shared_ptr<IndexSchema>> Create(
       ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto,
-      vmsdk::ThreadPool *mutations_thread_pool, bool skip_attributes, bool reload);
+      vmsdk::ThreadPool *mutations_thread_pool, bool skip_attributes,
+      bool reload);
   ~IndexSchema() override;
   absl::StatusOr<std::shared_ptr<indexes::IndexBase>> GetIndex(
       absl::string_view attribute_alias) const;

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -101,7 +101,7 @@ class Tag : public IndexBase {
           size_(size),
           entries_(entries),
           negate_(negate),
-          untracked_keys_(untracked_keys) {};
+          untracked_keys_(untracked_keys){};
     size_t Size() const override;
     std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
 

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -12,8 +12,8 @@ Top level iterator for a phrase.
 A Phrase is defined as a sequence of words that can be separated by up to 'slop'
 words. Optionally, the order of the words can be required or not.
 
-This is implemented as a merge operation on the various Word Iterators passed in.
-The code below is conceptual and is written like a Python generator
+This is implemented as a merge operation on the various Word Iterators passed
+in. The code below is conceptual and is written like a Python generator
 
 for (word0 : all words in word[0]) {
   for (word1 : all words in word[1]) {
@@ -40,21 +40,20 @@ void process_one_key(KeyIterators[*]) {
     if (PositionIterators[*] satisfy the Slop and In-order requirements) {
       Yield word;
     }
-    Find smallest PositionIterator and advance it to the next Smallest Position Iterator.
+    Find smallest PositionIterator and advance it to the next Smallest Position
+Iterator.
 
   }
 }
 */
 }
 struct PhraseIterator : public indexes::EntriesFetcherIteratorBase {
-  PhraseIterator(std::vector<WordIterator *> words, size_t slop, bool in_order);
+  PhraseIterator(std::vector<WordIterator*> words, size_t slop, bool in_order);
 
   virtual bool Done() const override;
   virtual void Next() = override;
   virtual const Key& operator*() const override;
-
 };
-
 
 }
 }

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -4,22 +4,24 @@
 /*
 
 For each entry in the inverted term index, there is an instance of
-this structure which is used to contain the key/field/position information for each
-word. It is expected that there will be a very large number of these objects
-most of which will have only a small number of key/field/position entries. However,
-there will be a small number of instances where the number of key/field/position
-entries is quite large. Thus it's likely that the fully optimized version of
-this object will have two or more encodings for its contents. This optimization
-is hidden from external view. 
+this structure which is used to contain the key/field/position information for
+each word. It is expected that there will be a very large number of these
+objects most of which will have only a small number of key/field/position
+entries. However, there will be a small number of instances where the number of
+key/field/position entries is quite large. Thus it's likely that the fully
+optimized version of this object will have two or more encodings for its
+contents. This optimization is hidden from external view.
 
 This object is NOT multi-thread safe, it's expected that the caller performs
 locking for mutation operations.
 
-Conceptually, this object holds an ordered list of Keys and for each Key there is
-an ordered list of Positions. Each position is tagged with a bitmask of fields.
+Conceptually, this object holds an ordered list of Keys and for each Key there
+is an ordered list of Positions. Each position is tagged with a bitmask of
+fields.
 
 A KeyIterator is provided to iterate over the keys within this object.
-A PositionIterator is provided to iterate over the positions of an individual Key.
+A PositionIterator is provided to iterate over the positions of an individual
+Key.
 
 */
 
@@ -29,7 +31,7 @@ A PositionIterator is provided to iterate over the positions of an individual Ke
 namespace valkey_search::text {
 
 //
-// this is the logical view of a posting. 
+// this is the logical view of a posting.
 //
 struct Posting {
   const Key& GetKey() const;
@@ -42,8 +44,8 @@ struct Postings {
   struct PositionIterator;
   // Construct a posting. If save_positions is off, then any keys that
   // are inserted have an assumed single position of 0.
-  // The "num_text_fields" entry identifies how many bits of the field-mask are required
-  // and is used to select the representation.
+  // The "num_text_fields" entry identifies how many bits of the field-mask are
+  // required and is used to select the representation.
   Postings(bool save_positions, size_t num_text_fields);
 
   // Are there any postings in this object?
@@ -62,9 +64,9 @@ struct Postings {
   size_t GetPostingCount() const;
 
   // Defrag this contents of this object. Returns the updated "this" pointer.
-  Postings *Defrag();
+  Postings* Defrag();
 
-  // Get a Key iterator. 
+  // Get a Key iterator.
   KeyIterator GetKeyIterator() const;
 
   // The Key Iterator
@@ -101,7 +103,6 @@ struct Postings {
     // Get Current Position
     const Position& GetPosition() const;
   };
-
 };
 
 }  // namespace valkey_search::text

--- a/src/indexes/text/text.h
+++ b/src/indexes/text/text.h
@@ -27,8 +27,8 @@ struct TextFieldIndex : public indexes::IndexBase {
 
   virtual absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
                                          absl::string_view data) override;
-  virtual absl::StatusOr<bool> RemoveRecord(const InternedStringPtr& key,
-                                            DeletionType deletion_type) override;
+  virtual absl::StatusOr<bool> RemoveRecord(
+      const InternedStringPtr& key, DeletionType deletion_type) override;
   virtual absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                             absl::string_view data) override;
   virtual int RespondWithInfo(RedisModuleCtx* ctx) const override;
@@ -42,8 +42,8 @@ struct TextFieldIndex : public indexes::IndexBase {
   virtual uint64_t GetRecordCount() const override;
 
  private:
-  // Each text field is assigned a unique number within the containing index, this is used
-  // by the Postings object to identify fields.
+  // Each text field is assigned a unique number within the containing index,
+  // this is used by the Postings object to identify fields.
   size_t text_field_number;
   // The per-index text index.
   std::shared_ptr<TextIndex> text_
@@ -52,33 +52,36 @@ struct TextFieldIndex : public indexes::IndexBase {
 struct TextIndex {
   //
   // The main query data structure maps Words into Postings objects. This
-  // is always done with a prefix tree. Optionally, a suffix tree can also be maintained.
-  // But in any case for the same word the two trees must point to the same Postings object,
-  // which is owned by this pair of trees. Plus, updates to these two trees need
-  // to be atomic when viewed externally. The locking provided by the RadixTree object
-  // is NOT quite sufficient to guarantee that the two trees are always in lock step.
-  // thus this object becomes responsible for cross-tree locking issues.
-  // Multiple locking strategies are possible. TBD (a shared-ed word lock table should work well)
+  // is always done with a prefix tree. Optionally, a suffix tree can also be
+  // maintained. But in any case for the same word the two trees must point to
+  // the same Postings object, which is owned by this pair of trees. Plus,
+  // updates to these two trees need to be atomic when viewed externally. The
+  // locking provided by the RadixTree object is NOT quite sufficient to
+  // guarantee that the two trees are always in lock step. thus this object
+  // becomes responsible for cross-tree locking issues. Multiple locking
+  // strategies are possible. TBD (a shared-ed word lock table should work well)
   //
-  std::shared_ptr<RadixTree<std::unique_ptr<Postings *>, false>>> prefix_;
-  std::optional<RadixTree<Postings *, true>> suffix_;
+  std::shared_ptr < RadixTree < std::unique_ptr<Postings*>, false >>> prefix_;
+  std::optional<RadixTree<Postings*, true>> suffix_;
 };
 
 //
-// this is a logical extension of the index-schema. could easily be merged into that object.
+// this is a logical extension of the index-schema. could easily be merged into
+// that object.
 //
 struct IndexSchemaText
-  //
-  // This is the main index of all Text fields in this index schema
-  //
-  TextIndex corpus_;
-  //
-  // To support the Delete record and the post-filtering case, there is a separate
-  // table of postings that are indexed by Key.
-  //
-  // This object must also ensure that updates of this object are multi-thread safe.
-  //
-  absl::flat_hash_map<Key, TextIndex>> by_key_;
+    //
+    // This is the main index of all Text fields in this index schema
+    //
+    TextIndex corpus_;
+//
+// To support the Delete record and the post-filtering case, there is a separate
+// table of postings that are indexed by Key.
+//
+// This object must also ensure that updates of this object are multi-thread
+// safe.
+//
+absl::flat_hash_map < Key, TextIndex >> by_key_;
 };
 
 }  // namespace text

--- a/src/indexes/text/wildcard_iterator.h
+++ b/src/indexes/text/wildcard_iterator.h
@@ -13,23 +13,23 @@ two algorithms based on the constructor form used and/or runtime sizing
 information.
 
 Algorithm 1: Is used when there is no suffix tree OR the number of
-prefix-matching words is small (exact algo here is TBD, probably some ratio w.r.t. 
-the size of the suffix tree).
+prefix-matching words is small (exact algo here is TBD, probably some ratio
+w.r.t. the size of the suffix tree).
 
 This algorithm iterates over a candidate list defined only by the prefix. As
-each candidate is visited, the suffix is compared and if not present, the iterator
-advances until the next valid suffix is found. This algorithm operates in time
-O(#PrefixMatches)
+each candidate is visited, the suffix is compared and if not present, the
+iterator advances until the next valid suffix is found. This algorithm operates
+in time O(#PrefixMatches)
 
 Algorithm 2: Is used when a suffix tree is present and the number of
 suffix-matching words is a less than the number of prefix-matching
 words.
 
-This algorithm operates by constructing a temporary RadixTree. The suffix RadixTree is used
-to generate suffix-matching candidates. These candidates are filtered by their
-prefix with the survivors being inserted into the temporary RadixTree which
-essentially serves to sort them since the suffix-matching candidates won't be
-iterated in lexical order.
+This algorithm operates by constructing a temporary RadixTree. The suffix
+RadixTree is used to generate suffix-matching candidates. These candidates are
+filtered by their prefix with the survivors being inserted into the temporary
+RadixTree which essentially serves to sort them since the suffix-matching
+candidates won't be iterated in lexical order.
 
 This algorithm operates in time O(#SuffixMatches)
 
@@ -73,7 +73,7 @@ struct WildCardIterator : public WordIterator {
   absl::string_view prefix_;
   absl::string_view suffix_;
   // the one to iterator over, could be temporary or not....
-  std::shared_ptr<RadixTree<Postings *>> radix_tree_;
+  std::shared_ptr<RadixTree<Postings*>> radix_tree_;
 };
 
 }  // namespace text

--- a/src/indexes/text/word_iterator.h
+++ b/src/indexes/text/word_iterator.h
@@ -2,6 +2,7 @@
 #define VALKEY_SEARCH_INDEXES_TEXT_WORD_ITERATOR_H_
 
 #include <memory>
+
 #include "absl/strings/string_view.h"
 
 namespace valkey_search {
@@ -9,7 +10,8 @@ namespace text {
 
 /*
 
-Base Class for all Word Iterators. currently this includes WildCard and Fuzzy, more may come in the future.
+Base Class for all Word Iterators. currently this includes WildCard and Fuzzy,
+more may come in the future.
 
 */
 struct WordIterator {
@@ -18,9 +20,10 @@ struct WordIterator {
   virtual absl::string_view GetWord() const = 0;
   virtual std::unique_ptr<WordIterator> Clone() const = 0;
 
-  absl::string_view operator*() const = { return GetWord(); }
-};
-
+  absl::string_view operator*() const = {return GetWord();
 }
+};  // namespace text
+
+}  // namespace valkey_search
 }
 #endif

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -208,22 +208,19 @@ absl::Status VectorFlat<T>::RemoveRecordImpl(uint64_t internal_id) {
 // Paper over the impedance mismatch between the
 // cancel::Token and hnswlib::BaseCancellationFunctor.
 class CancelCondition : public hnswlib::BaseCancellationFunctor {
-  public:
-  explicit CancelCondition(cancel::Token &token)
-      : token_(token) { CHECK(&token); }
-  bool isCancelled() override { 
-    return token_->IsCancelled();
+ public:
+  explicit CancelCondition(cancel::Token &token) : token_(token) {
+    CHECK(&token);
   }
+  bool isCancelled() override { return token_->IsCancelled(); }
 
-  private:
+ private:
   cancel::Token &token_;
 };
 
-
 template <typename T>
 absl::StatusOr<std::deque<Neighbor>> VectorFlat<T>::Search(
-    absl::string_view query, uint64_t count,
-    cancel::Token &cancellation_token,
+    absl::string_view query, uint64_t count, cancel::Token &cancellation_token,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter) {
   if (!IsValidSizeVector(query)) {
     return absl::InvalidArgumentError(absl::StrCat(
@@ -231,7 +228,8 @@ absl::StatusOr<std::deque<Neighbor>> VectorFlat<T>::Search(
         query.size(), ") does not match index's expected size (",
         dimensions_ * GetDataTypeSize(), ")."));
   }
-  auto perform_search = [this, count, &filter, &cancellation_token](absl::string_view query)
+  auto perform_search = [this, count, &filter,
+                         &cancellation_token](absl::string_view query)
       -> absl::StatusOr<std::priority_queue<std::pair<T, hnswlib::labeltype>>> {
     absl::ReaderMutexLock lock(&resize_mutex_);
     try {
@@ -239,8 +237,7 @@ absl::StatusOr<std::deque<Neighbor>> VectorFlat<T>::Search(
       return algo_->searchKnn(
           (T *)query.data(),
           std::min(count, static_cast<uint64_t>(algo_->cur_element_count_)),
-          filter.get(),
-          &canceler);
+          filter.get(), &canceler);
     } catch (const std::exception &e) {
       Metrics::GetStats().flat_search_exceptions_cnt.fetch_add(
           1, std::memory_order_relaxed);
@@ -315,11 +312,11 @@ int VectorFlat<T>::RespondWithInfoImpl(ValkeyModuleCtx *ctx) const {
   ValkeyModule_ReplyWithSimpleString(ctx, "dim");
   ValkeyModule_ReplyWithLongLong(ctx, dimensions_);
   ValkeyModule_ReplyWithSimpleString(ctx, "distance_metric");
-  ValkeyModule_ReplyWithSimpleString(ctx, LookupKeyByValue(*kDistanceMetricByStr, distance_metric_).data());
-  
+  ValkeyModule_ReplyWithSimpleString(
+      ctx, LookupKeyByValue(*kDistanceMetricByStr, distance_metric_).data());
+
   ValkeyModule_ReplyWithSimpleString(ctx, "block_size");
   ValkeyModule_ReplyWithLongLong(ctx, block_size_);
-  
 
   return 10;
 }

--- a/src/indexes/vector_flat.h
+++ b/src/indexes/vector_flat.h
@@ -59,8 +59,7 @@ class VectorFlat : public VectorBase {
   absl::StatusOr<std::deque<Neighbor>> Search(
       absl::string_view query, uint64_t count,
       cancel::Token& cancellation_token,
-      std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr
-    )
+      std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr)
       ABSL_LOCKS_EXCLUDED(resize_mutex_);
 
  protected:

--- a/src/keyspace_event_manager.h
+++ b/src/keyspace_event_manager.h
@@ -67,8 +67,8 @@ class KeyspaceEventManager {
   absl::Status StartValkeySubscriptionIfNeeded(ValkeyModuleCtx *ctx, int types);
 
   static inline int OnValkeyKeyspaceNotification(ValkeyModuleCtx *ctx, int type,
-                                                const char *event,
-                                                ValkeyModuleString *key) {
+                                                 const char *event,
+                                                 ValkeyModuleString *key) {
     Instance().NotifySubscribers(ctx, type, event, key);
     return VALKEYMODULE_OK;
   }

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -72,7 +72,7 @@ class Metrics {
         0};
     std::atomic<uint64_t> coordinator_bytes_out{0};
     std::atomic<uint64_t> coordinator_bytes_in{0};
-    
+
     // Global ingestion stats (counts across all indexes)
     std::atomic<uint64_t> ingest_hash_keys{0};
     std::atomic<uint64_t> ingest_hash_blocked{0};
@@ -118,10 +118,10 @@ class Metrics {
             absl::ToInt64Nanoseconds(absl::Seconds(1)), LATENCY_PRECISION};
     // Time Slice Mutex metrics
     std::atomic<uint64_t> time_slice_read_periods{0};
-    std::atomic<uint64_t> time_slice_read_time{0};      // microseconds, cumulative
+    std::atomic<uint64_t> time_slice_read_time{0};  // microseconds, cumulative
     std::atomic<uint64_t> time_slice_queries{0};
     std::atomic<uint64_t> time_slice_write_periods{0};
-    std::atomic<uint64_t> time_slice_write_time{0};     // microseconds, cumulative
+    std::atomic<uint64_t> time_slice_write_time{0};  // microseconds, cumulative
     std::atomic<uint64_t> time_slice_upserts{0};
     std::atomic<uint64_t> time_slice_deletes{0};
   };

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -33,7 +33,7 @@ inline std::list<absl::string_view> ACLPermissionFormatter(
   }
   return permissions;
 }
-}
+}  // namespace
 
 vmsdk::module::Options options = {
     .name = "search",
@@ -48,21 +48,15 @@ vmsdk::module::Options options = {
                 .cmd_name = valkey_search::kCreateCommand,
                 .permissions = ACLPermissionFormatter(
                     valkey_search::kCreateCmdPermissions),
-                .flags = {
-                    vmsdk::module::kWriteFlag,
-                    vmsdk::module::kFastFlag,
-                    vmsdk::module::kDenyOOMFlag
-                },
+                .flags = {vmsdk::module::kWriteFlag, vmsdk::module::kFastFlag,
+                          vmsdk::module::kDenyOOMFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTCreateCmd>,
             },
             {
                 .cmd_name = valkey_search::kDropIndexCommand,
                 .permissions = ACLPermissionFormatter(
                     valkey_search::kDropIndexCmdPermissions),
-                .flags = {
-                    vmsdk::module::kWriteFlag,
-                    vmsdk::module::kFastFlag
-                },
+                .flags = {vmsdk::module::kWriteFlag, vmsdk::module::kFastFlag},
                 .cmd_func =
                     &vmsdk::CreateCommand<valkey_search::FTDropIndexCmd>,
             },
@@ -70,40 +64,32 @@ vmsdk::module::Options options = {
                 .cmd_name = valkey_search::kInfoCommand,
                 .permissions =
                     ACLPermissionFormatter(valkey_search::kInfoCmdPermissions),
-                .flags = {
-                    vmsdk::module::kReadOnlyFlag,
-                    vmsdk::module::kFastFlag
-                },
+                .flags = {vmsdk::module::kReadOnlyFlag,
+                          vmsdk::module::kFastFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTInfoCmd>,
             },
             {
                 .cmd_name = valkey_search::kListCommand,
                 .permissions =
                     ACLPermissionFormatter(valkey_search::kListCmdPermissions),
-                .flags = {
-                    vmsdk::module::kReadOnlyFlag,
-                    vmsdk::module::kAdminFlag
-                },
+                .flags = {vmsdk::module::kReadOnlyFlag,
+                          vmsdk::module::kAdminFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTListCmd>,
             },
             {
                 .cmd_name = valkey_search::kSearchCommand,
                 .permissions = ACLPermissionFormatter(
                     valkey_search::kSearchCmdPermissions),
-                .flags = {
-                    vmsdk::module::kReadOnlyFlag,
-                    vmsdk::module::kDenyOOMFlag
-                },
+                .flags = {vmsdk::module::kReadOnlyFlag,
+                          vmsdk::module::kDenyOOMFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTSearchCmd>,
             },
             {
                 .cmd_name = valkey_search::kDebugCommand,
                 .permissions =
                     ACLPermissionFormatter(valkey_search::kDebugCmdPermissions),
-                .flags = {
-                    vmsdk::module::kReadOnlyFlag,
-                    vmsdk::module::kAdminFlag
-                },
+                .flags = {vmsdk::module::kReadOnlyFlag,
+                          vmsdk::module::kAdminFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTDebugCmd>,
             },
         }  // namespace

--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -33,8 +33,8 @@
 #include "src/coordinator/search_converter.h"
 #include "src/coordinator/util.h"
 #include "src/indexes/vector_base.h"
-#include "src/query/search.h"
 #include "src/query/fanout_template.h"
+#include "src/query/search.h"
 #include "src/utils/string_interning.h"
 #include "valkey_search_options.h"
 #include "vmsdk/src/log.h"
@@ -250,8 +250,8 @@ absl::Status PerformSearchFanoutAsync(
 // TODO See if caching this improves performance.
 std::vector<fanout::FanoutSearchTarget> GetSearchTargetsForFanout(
     ValkeyModuleCtx *ctx) {
-  return fanout::FanoutTemplate::GetTargets(ctx, fanout::FanoutTargetMode::kRandom);
+  return fanout::FanoutTemplate::GetTargets(ctx,
+                                            fanout::FanoutTargetMode::kRandom);
 }
-
 
 }  // namespace valkey_search::query::fanout

--- a/src/query/fanout.h
+++ b/src/query/fanout.h
@@ -17,10 +17,10 @@
 #include "src/coordinator/client_pool.h"
 #include "src/coordinator/coordinator.pb.h"
 #include "src/index_schema.h"
+#include "src/query/fanout_template.h"
 #include "src/query/search.h"
 #include "vmsdk/src/thread_pool.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
-#include "src/query/fanout_template.h"
 
 namespace valkey_search::query::fanout {
 

--- a/src/query/fanout_template.h
+++ b/src/query/fanout_template.h
@@ -11,8 +11,8 @@
 #include "absl/random/random.h"
 #include "absl/status/status.h"
 #include "absl/strings/str_cat.h"
-#include "src/coordinator/util.h"
 #include "src/coordinator/client_pool.h"
+#include "src/coordinator/util.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
@@ -220,7 +220,8 @@ class FanoutTemplate {
 
     grpc_invoker(
         client, std::move(request),
-        [tracker, address, callback_logic](grpc::Status status, ResponseT& response) mutable {
+        [tracker, address, callback_logic](grpc::Status status,
+                                           ResponseT& response) mutable {
           callback_logic(status, response, tracker, address);
         },
         timeout_ms);

--- a/src/query/primary_info_fanout_operation.cc
+++ b/src/query/primary_info_fanout_operation.cc
@@ -77,7 +77,8 @@ void PrimaryInfoFanoutOperation::OnResponse(
     grpc::Status status =
         grpc::Status(grpc::StatusCode::INTERNAL,
                      "Cluster not in a consistent state, please retry.");
-    OnError(status, coordinator::FanoutErrorType::INCONSISTENT_STATE_ERROR, target);
+    OnError(status, coordinator::FanoutErrorType::INCONSISTENT_STATE_ERROR,
+            target);
     return;
   }
   exists_ = true;

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -204,11 +204,11 @@ absl::StatusOr<RecordsMap> GetContent(
 
 // Adds all local content for neighbors to the list of neighbors.
 // This function is meant to be used for non-vector queries.
-void ProcessNonVectorNeighborsForReply(ValkeyModuleCtx *ctx,
-                                      const AttributeDataType &attribute_data_type,
-                                      std::deque<indexes::Neighbor> &neighbors,
-                                      const query::VectorSearchParameters &parameters) {
-    ProcessNeighborsForReply(ctx, attribute_data_type, neighbors, parameters, "");
+void ProcessNonVectorNeighborsForReply(
+    ValkeyModuleCtx *ctx, const AttributeDataType &attribute_data_type,
+    std::deque<indexes::Neighbor> &neighbors,
+    const query::VectorSearchParameters &parameters) {
+  ProcessNeighborsForReply(ctx, attribute_data_type, neighbors, parameters, "");
 }
 
 // Adds all local content for neighbors to the list of neighbors.

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -78,7 +78,7 @@ absl::StatusOr<std::deque<indexes::Neighbor>> PerformVectorSearch(
 
     auto latency_sample = SAMPLE_EVERY_N(100);
     auto res = vector_hnsw->Search(parameters.query, parameters.k,
-                                  parameters.cancellation_token,
+                                   parameters.cancellation_token,
                                    std::move(inline_filter), parameters.ef);
     Metrics::GetStats().hnsw_vector_index_search_latency.SubmitSample(
         std::move(latency_sample));
@@ -88,7 +88,7 @@ absl::StatusOr<std::deque<indexes::Neighbor>> PerformVectorSearch(
     auto vector_flat = dynamic_cast<indexes::VectorFlat<float> *>(vector_index);
     auto latency_sample = SAMPLE_EVERY_N(100);
     auto res = vector_flat->Search(parameters.query, parameters.k,
-                                    parameters.cancellation_token,
+                                   parameters.cancellation_token,
                                    std::move(inline_filter));
     Metrics::GetStats().flat_vector_index_search_latency.SubmitSample(
         std::move(latency_sample));
@@ -203,7 +203,7 @@ CalcBestMatchingPrefilteredKeys(
       }
       iterator->Next();
       if (parameters.cancellation_token->IsCancelled()) {
-        return results; 
+        return results;
       }
     }
   }
@@ -371,7 +371,7 @@ absl::StatusOr<std::deque<indexes::Neighbor>> Search(
   auto &time_sliced_mutex = parameters.index_schema->GetTimeSlicedMutex();
   vmsdk::ReaderMutexLock lock(&time_sliced_mutex);
   ++Metrics::GetStats().time_slice_queries;
-  
+
   if (!parameters.filter_parse_results.root_predicate) {
     return MaybeAddIndexedContent(PerformVectorSearch(vector_index, parameters),
                                   parameters);
@@ -388,8 +388,8 @@ absl::StatusOr<std::deque<indexes::Neighbor>> Search(
         << qualified_entries;
     // Do an exact nearest neighbour search on the reduced search space.
     ++Metrics::GetStats().query_prefiltering_requests_cnt;
-    auto results = CalcBestMatchingPrefilteredKeys(
-        parameters, entries_fetchers, vector_index);
+    auto results = CalcBestMatchingPrefilteredKeys(parameters, entries_fetchers,
+                                                   vector_index);
 
     return vector_index->CreateReply(results);
   }

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -80,11 +80,10 @@ struct VectorSearchParameters {
       assert(params.empty());
     }
   } parse_vars;
-  bool IsNonVectorQuery() const {
-    return attribute_alias.empty();
-  }
-  VectorSearchParameters(uint64_t timeout, grpc::CallbackServerContext *context)
-      : timeout_ms(timeout), cancellation_token(cancel::Make(timeout, context)) {}
+  bool IsNonVectorQuery() const { return attribute_alias.empty(); }
+  VectorSearchParameters(uint64_t timeout, grpc::CallbackServerContext* context)
+      : timeout_ms(timeout),
+        cancellation_token(cancel::Make(timeout, context)) {}
 };
 
 // Callback to be called when the search is done.

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -34,8 +34,8 @@
 #include "src/index_schema.pb.h"
 #include "src/rdb_section.pb.h"
 #include "src/rdb_serialization.h"
-#include "src/vector_externalizer.h"
 #include "src/valkey_search.h"
+#include "src/vector_externalizer.h"
 #include "vmsdk/src/info.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -196,7 +196,8 @@ absl::Status SchemaManager::CreateIndexSchemaInternal(
 
   VMSDK_ASSIGN_OR_RETURN(
       auto index_schema,
-      IndexSchema::Create(ctx, index_schema_proto, mutations_thread_pool_, false, false));
+      IndexSchema::Create(ctx, index_schema_proto, mutations_thread_pool_,
+                          false, false));
 
   db_to_index_schemas_[db_num][name] = std::move(index_schema);
 
@@ -669,7 +670,8 @@ void SchemaManager::OnServerCronCallback(ValkeyModuleCtx *ctx,
                                          [[maybe_unused]] ValkeyModuleEvent eid,
                                          [[maybe_unused]] uint64_t subevent,
                                          [[maybe_unused]] void *data) {
-  SchemaManager::Instance().PerformBackfill(ctx, options::GetBackfillBatchSize().GetValue());
+  SchemaManager::Instance().PerformBackfill(
+      ctx, options::GetBackfillBatchSize().GetValue());
 }
 
 static vmsdk::info_field::Integer number_of_indexes(
@@ -706,10 +708,11 @@ static vmsdk::info_field::Integer active_indexes_indexing(
 static vmsdk::info_field::Integer total_active_write_threads(
     "index_stats", "total_active_write_threads",
     vmsdk::info_field::IntegerBuilder().App().Computed([] {
-      auto& valkey_search = valkey_search::ValkeySearch::Instance();
+      auto &valkey_search = valkey_search::ValkeySearch::Instance();
       auto writer_thread_pool = valkey_search.GetWriterThreadPool();
       if (writer_thread_pool) {
-        return writer_thread_pool->IsSuspended() ? 0 : writer_thread_pool->Size();
+        return writer_thread_pool->IsSuspended() ? 0
+                                                 : writer_thread_pool->Size();
       }
       return (unsigned long)0;
     }));

--- a/src/utils/cancel.h
+++ b/src/utils/cancel.h
@@ -9,8 +9,9 @@
 #define VALKEYSEARCH_SRC_UTILS_CANCEL_H_
 
 #include <memory>
-#include "vmsdk/src/valkey_module_api/valkey_module.h"
+
 #include "grpcpp/server_context.h"
+#include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search {
 namespace cancel {
@@ -34,13 +35,12 @@ struct Base {
 using Token = std::shared_ptr<Base>;
 
 //
-// Make a Cancellation Token based on a timeout and optionally a rGPC server context
+// Make a Cancellation Token based on a timeout and optionally a rGPC server
+// context
 //
 Token Make(long long timeout_ms, grpc::CallbackServerContext *context);
 
-} // namespace cancel
-} // namespace valkey_search
-
-
+}  // namespace cancel
+}  // namespace valkey_search
 
 #endif

--- a/src/utils/lru.h
+++ b/src/utils/lru.h
@@ -16,7 +16,7 @@ namespace valkey_search {
 template <typename T>
 class LRU {
  public:
-  explicit LRU(size_t capacity) : capacity_(capacity) {};
+  explicit LRU(size_t capacity) : capacity_(capacity){};
   T *InsertAtTop(T *node);
   void Promote(T *node);
   void Remove(T *node);

--- a/src/utils/string_interning.cc
+++ b/src/utils/string_interning.cc
@@ -13,8 +13,8 @@
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
 #include "src/utils/allocator.h"
-#include "vmsdk/src/memory_tracker.h"
 #include "vmsdk/src/memory_allocation_overrides.h"
+#include "vmsdk/src/memory_tracker.h"
 
 namespace valkey_search {
 
@@ -32,12 +32,12 @@ InternedString::InternedString(char* data, size_t length)
 
 InternedString::~InternedString() {
   // NOTE: isolate memory tracking for deallocation.
-  IsolatedMemoryScope scope {StringInternStore::memory_pool_};
+  IsolatedMemoryScope scope{StringInternStore::memory_pool_};
 
   if (is_shared_) {
     StringInternStore::Instance().Release(this);
   }
-  
+
   if (is_data_owner_) {
     delete[] data_;
   } else {
@@ -67,7 +67,7 @@ std::shared_ptr<InternedString> StringInternStore::Intern(
 
 std::shared_ptr<InternedString> StringInternStore::InternImpl(
     absl::string_view str, Allocator* allocator) {
-  IsolatedMemoryScope scope {memory_pool_};
+  IsolatedMemoryScope scope{memory_pool_};
 
   absl::MutexLock lock(&mutex_);
   auto it = str_to_interned_.find(str);
@@ -92,8 +92,6 @@ std::shared_ptr<InternedString> StringInternStore::InternImpl(
   return interned_string;
 }
 
-int64_t StringInternStore::GetMemoryUsage() {
-  return memory_pool_.GetUsage();
-}
+int64_t StringInternStore::GetMemoryUsage() { return memory_pool_.GetUsage(); }
 
 }  // namespace valkey_search

--- a/src/utils/string_interning.h
+++ b/src/utils/string_interning.h
@@ -75,7 +75,7 @@ class InternedString {
   // It is intended for cases where an API requires a `StringIntern` object
   // but interning is unnecessary or inefficient. For example, this applies
   // when fetching data from remote nodes.
-  InternedString(absl::string_view str) : InternedString(str, false) {};
+  InternedString(absl::string_view str) : InternedString(str, false){};
 
   ~InternedString();
 

--- a/src/utils/string_interning.h
+++ b/src/utils/string_interning.h
@@ -17,9 +17,9 @@
 #include "absl/hash/hash.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
+#include "gtest/gtest_prod.h"
 #include "src/utils/allocator.h"
 #include "vmsdk/src/memory_tracker.h"
-#include "gtest/gtest_prod.h"
 
 namespace valkey_search {
 

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -818,18 +818,20 @@ static vmsdk::info_field::Integer &remove_subscription_skipped_count =
 
 #endif
 
-static vmsdk::info_field::Integer string_interning_memory_bytes("string_interning", "string_interning_memory_bytes",
-  vmsdk::info_field::IntegerBuilder()
-      .App()
-      .Computed(StringInternStore::GetMemoryUsage)
-      .CrashSafe());
+static vmsdk::info_field::Integer string_interning_memory_bytes(
+    "string_interning", "string_interning_memory_bytes",
+    vmsdk::info_field::IntegerBuilder()
+        .App()
+        .Computed(StringInternStore::GetMemoryUsage)
+        .CrashSafe());
 
-static vmsdk::info_field::Integer string_interning_memory_human("string_interning", "string_interning_memory_human",
-  vmsdk::info_field::IntegerBuilder()
-      .SIBytes()
-      .App()
-      .Computed(StringInternStore::GetMemoryUsage)
-      .CrashSafe());
+static vmsdk::info_field::Integer string_interning_memory_human(
+    "string_interning", "string_interning_memory_human",
+    vmsdk::info_field::IntegerBuilder()
+        .SIBytes()
+        .App()
+        .Computed(StringInternStore::GetMemoryUsage)
+        .CrashSafe());
 
 void ValkeySearch::Info(ValkeyModuleInfoCtx *ctx, bool for_crash_report) const {
   vmsdk::info_field::DoSections(ctx, for_crash_report);
@@ -909,17 +911,18 @@ void ValkeySearch::OnForkChildCallback(ValkeyModuleCtx *ctx,
                                        [[maybe_unused]] ValkeyModuleEvent eid,
                                        uint64_t subevent,
                                        [[maybe_unused]] void *data) {
-  // if max-worker-suspension-secs config > 0, we resume the workers either when fork dies
-  // or when time expires (the second condition is checked on cron callback).
+  // if max-worker-suspension-secs config > 0, we resume the workers either when
+  // fork dies or when time expires (the second condition is checked on cron
+  // callback).
   if (options::GetMaxWorkerSuspensionSecs().GetValue() > 0) {
     if (subevent & VALKEYMODULE_SUBEVENT_FORK_CHILD_DIED) {
       ResumeWriterThreadPool(ctx, /*is_expired=*/false);
     }
   } else {
-    // max-worker-suspension-secs <= 0 - we resume the workers on a 'fork born' event.
-    // We don't check if it's a 'fork born' event - in case the config was modified
-    // in the middle of the fork, we want to resume the workers also after 'fork died'
-    // event in case it wasn't already.
+    // max-worker-suspension-secs <= 0 - we resume the workers on a 'fork born'
+    // event. We don't check if it's a 'fork born' event - in case the config
+    // was modified in the middle of the fork, we want to resume the workers
+    // also after 'fork died' event in case it wasn't already.
     ResumeWriterThreadPool(ctx, /*is_expired=*/false);
   }
 }

--- a/src/vector_externalizer.cc
+++ b/src/vector_externalizer.cc
@@ -151,8 +151,8 @@ void VectorExternalizer::ProcessEngineUpdateQueue() {
       entry.vector = std::move(vector_externalizer_entry.vector);
       if (!key_obj) {
         auto key_str = vmsdk::MakeUniqueValkeyString(key->Str());
-        key_obj = vmsdk::MakeUniqueValkeyOpenKey(ctx_.Get().get(), key_str.get(),
-                                                VALKEYMODULE_WRITE);
+        key_obj = vmsdk::MakeUniqueValkeyOpenKey(
+            ctx_.Get().get(), key_str.get(), VALKEYMODULE_WRITE);
         if (!key_obj) {
           break;
         }

--- a/testing/coordinator/client_test.cc
+++ b/testing/coordinator/client_test.cc
@@ -29,17 +29,19 @@ class ClientByteCountingTest : public ::testing::Test {
     // Reset metrics before each test
     Metrics::GetStats().coordinator_bytes_out.store(0);
     Metrics::GetStats().coordinator_bytes_in.store(0);
-    
+
     // Create a mock client for testing
     mock_client_ = std::make_shared<MockClient>();
   }
-  
+
   std::shared_ptr<MockClient> mock_client_;
 };
 
-// Test that we correctly count bytes for successful requests using real protobuf objects
+// Test that we correctly count bytes for successful requests using real
+// protobuf objects
 TEST_F(ClientByteCountingTest, CountsCorrectBytesOnSuccess) {
-  // Create a real SearchIndexPartitionRequest with data based on the proto definition
+  // Create a real SearchIndexPartitionRequest with data based on the proto
+  // definition
   auto request = std::make_unique<SearchIndexPartitionRequest>();
   request->set_timeout_ms(1000);
   request->set_index_schema_name("test_index_schema");
@@ -49,19 +51,21 @@ TEST_F(ClientByteCountingTest, CountsCorrectBytesOnSuccess) {
   request->set_k(100);
   request->set_ef(1000);
   request->set_no_content(true);
-  
+
   // Add bytes for the query field
-  std::string query_data = "test query data with some extra bytes to make it larger";
+  std::string query_data =
+      "test query data with some extra bytes to make it larger";
   request->set_query(query_data);
-  
+
   // Get the actual size of the request
   const size_t actual_request_size = request->ByteSizeLong();
   ASSERT_GT(actual_request_size, 0);
-  
+
   // Create a SearchIndexPartitionResponse with some data
-  // According to the proto definition: message SearchIndexPartitionResponse { repeated NeighborEntry neighbors = 1; }
+  // According to the proto definition: message SearchIndexPartitionResponse {
+  // repeated NeighborEntry neighbors = 1; }
   SearchIndexPartitionResponse response;
-  
+
   // Add some neighbor entries to make it non-empty
   auto* neighbor1 = response.add_neighbors();
   if (neighbor1) {
@@ -69,58 +73,62 @@ TEST_F(ClientByteCountingTest, CountsCorrectBytesOnSuccess) {
     neighbor1->set_key("neighbor1");
     neighbor1->set_score(0.95);
   }
-  
+
   auto* neighbor2 = response.add_neighbors();
   if (neighbor2) {
     // Set fields based on the NeighborEntry proto definition
     neighbor2->set_key("neighbor2");
     neighbor2->set_score(0.85);
   }
-  
+
   // Get the actual size of the response
   const size_t actual_response_size = response.ByteSizeLong();
   ASSERT_GT(actual_response_size, 0);
-  
+
   // Mock the SearchIndexPartition method to simulate the real implementation
   EXPECT_CALL(*mock_client_, SearchIndexPartition(testing::_, testing::_))
       .WillOnce([&](std::unique_ptr<SearchIndexPartitionRequest> req,
-                   SearchIndexPartitionCallback done) {
+                    SearchIndexPartitionCallback done) {
         // Verify we're working with the same request
         EXPECT_EQ(req->timeout_ms(), 1000);
-        
+
         // Simulate what happens in ClientImpl::SearchIndexPartition
         // Count the exact request size before sending
         Metrics::GetStats().coordinator_bytes_out.fetch_add(
             req->ByteSizeLong(), std::memory_order_relaxed);
-            
+
         // In the real implementation, we count bytes inside this callback
         // for successful responses, right before calling the user's callback
         Metrics::GetStats().coordinator_bytes_in.fetch_add(
             response.ByteSizeLong(), std::memory_order_relaxed);
-            
+
         // Call the callback with success status
         done(grpc::Status::OK, response);
       });
-      
+
   // Call the method
   bool callback_called = false;
   mock_client_->SearchIndexPartition(
       std::move(request),
-      [&callback_called](grpc::Status status, SearchIndexPartitionResponse& resp) {
+      [&callback_called](grpc::Status status,
+                         SearchIndexPartitionResponse& resp) {
         EXPECT_TRUE(status.ok());
         callback_called = true;
       });
-      
+
   EXPECT_TRUE(callback_called);
-  
+
   // Verify byte counters match the actual sizes of the protobuf objects
-  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_out.load(), actual_request_size);
-  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_in.load(), actual_response_size);
+  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_out.load(),
+            actual_request_size);
+  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_in.load(),
+            actual_response_size);
 }
 
 // Test that we don't count incoming bytes for error responses
 TEST_F(ClientByteCountingTest, DoesNotCountResponseBytesOnError) {
-  // Create a real SearchIndexPartitionRequest with data based on the proto definition
+  // Create a real SearchIndexPartitionRequest with data based on the proto
+  // definition
   auto request = std::make_unique<SearchIndexPartitionRequest>();
   request->set_timeout_ms(1000);
   request->set_index_schema_name("test_index_schema");
@@ -128,52 +136,55 @@ TEST_F(ClientByteCountingTest, DoesNotCountResponseBytesOnError) {
   request->set_dialect(1);
   request->set_k(100);
   request->set_no_content(true);
-  
+
   // Get the actual size of the request
   const size_t actual_request_size = request->ByteSizeLong();
   ASSERT_GT(actual_request_size, 0);
-  
-  // Create a SearchIndexPartitionResponse with data (to verify we don't count it on errors)
+
+  // Create a SearchIndexPartitionResponse with data (to verify we don't count
+  // it on errors)
   SearchIndexPartitionResponse response;
-  
+
   // Add neighbor entries to make it non-empty, just like in the success case
   auto* neighbor = response.add_neighbors();
   if (neighbor) {
     neighbor->set_key("error_neighbor");
     neighbor->set_score(0.75);
   }
-  
+
   // Mock the SearchIndexPartition method to simulate the real implementation
   EXPECT_CALL(*mock_client_, SearchIndexPartition(testing::_, testing::_))
       .WillOnce([&](std::unique_ptr<SearchIndexPartitionRequest> req,
-                   SearchIndexPartitionCallback done) {
+                    SearchIndexPartitionCallback done) {
         // Verify we're working with the same request
         EXPECT_EQ(req->timeout_ms(), 1000);
-        
+
         // Simulate what happens in ClientImpl::SearchIndexPartition
         // Count the exact request size before sending
         Metrics::GetStats().coordinator_bytes_out.fetch_add(
             req->ByteSizeLong(), std::memory_order_relaxed);
-            
+
         // Call the callback with error status
         // Do NOT count response bytes on error
-        done(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Service unavailable"), 
+        done(grpc::Status(grpc::StatusCode::UNAVAILABLE, "Service unavailable"),
              response);
       });
-      
+
   // Call the method
   bool callback_called = false;
   mock_client_->SearchIndexPartition(
       std::move(request),
-      [&callback_called](grpc::Status status, SearchIndexPartitionResponse& resp) {
+      [&callback_called](grpc::Status status,
+                         SearchIndexPartitionResponse& resp) {
         EXPECT_FALSE(status.ok());
         callback_called = true;
       });
-      
+
   EXPECT_TRUE(callback_called);
-  
+
   // Verify only request bytes were counted, not response bytes
-  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_out.load(), actual_request_size);
+  EXPECT_EQ(Metrics::GetStats().coordinator_bytes_out.load(),
+            actual_request_size);
   EXPECT_EQ(Metrics::GetStats().coordinator_bytes_in.load(), 0);
 }
 

--- a/testing/filter_test.cc
+++ b/testing/filter_test.cc
@@ -93,7 +93,8 @@ TEST_P(FilterTest, ParseParams) {
   const FilterTestCase &test_case = GetParam();
   auto index_schema = CreateIndexSchema("index_schema_name").value();
   InitIndexSchema(index_schema.get());
-  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_)).Times(::testing::AnyNumber());
+  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
+      .Times(::testing::AnyNumber());
   FilterParser parser(*index_schema, test_case.filter);
   auto parse_results = parser.Parse();
   EXPECT_EQ(test_case.create_success, parse_results.ok());

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -556,29 +556,29 @@ INSTANTIATE_TEST_SUITE_P(
              .command_str = "idx1 on HASH SChema hash_field1 as "
                             "hash_field11 numeric ",
              .expected = {.index_schema_name = "idx1",
-                        .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
-                        .attributes = {{
-                            .identifier = "hash_field1",
-                            .attribute_alias = "hash_field11",
-                            .indexer_type = indexes::IndexerType::kNumeric,
-                        }}},
+                          .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                          .attributes = {{
+                              .identifier = "hash_field1",
+                              .attribute_alias = "hash_field11",
+                              .indexer_type = indexes::IndexerType::kNumeric,
+                          }}},
          },
-        {
+         {
              .test_name = "happy_path_tag_index_on_hash",
              .success = true,
              .command_str = "idx1 on HASH SCHEMA hash_field1 as "
                             "hash_field11 tag ",
-            .tag_parameters = {{
+             .tag_parameters = {{
                  .separator = ",",
                  .case_sensitive = false,
              }},
              .expected = {.index_schema_name = "idx1",
-                        .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
-                        .attributes = {{
-                            .identifier = "hash_field1",
-                            .attribute_alias = "hash_field11",
-                            .indexer_type = indexes::IndexerType::kTag,
-                        }}},
+                          .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                          .attributes = {{
+                              .identifier = "hash_field1",
+                              .attribute_alias = "hash_field11",
+                              .indexer_type = indexes::IndexerType::kTag,
+                          }}},
          },
          {
              .test_name = "invalid_separator",

--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -105,7 +105,7 @@ INSTANTIATE_TEST_SUITE_P(
         {
             .test_name = "happy_path_hnsw",
             .test_cases =
-	          {
+                {
                     {
                         .argv = {"FT.Info", "test_name"},
                         .index_schema_pbtxt = R"(
@@ -139,34 +139,42 @@ INSTANTIATE_TEST_SUITE_P(
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
                             "24\r\n+"
-			    "identifier\r\n+test_identifier_1\r\n+"
+                            "identifier\r\n+test_identifier_1\r\n+"
                             "attribute\r\n+test_attribute_1\r\n+"
-			    "type\r\n+VECTOR\r\n+"
-			    "algorithm\r\n+HNSW\r\n+"
-			    "data_type\r\n+FLOAT32\r\n+"
-			    "dim\r\n:10\r\n+"
-			    "distance_metric\r\n+COSINE\r\n+"
-			    "M\r\n:240\r\n+"
-			    "ef_construction\r\n:400\r\n+"
-			    "ef_runtime\r\n:30\r\n+"
-			    "capacity\r\n:100\r\n+"
-			    "size\r\n$1\r\n0\r\n+"
-			    "num_docs\r\n:0\r\n+num_"
+                            "type\r\n+VECTOR\r\n+"
+                            "algorithm\r\n+HNSW\r\n+"
+                            "data_type\r\n+FLOAT32\r\n+"
+                            "dim\r\n:10\r\n+"
+                            "distance_metric\r\n+COSINE\r\n+"
+                            "M\r\n:240\r\n+"
+                            "ef_construction\r\n:400\r\n+"
+                            "ef_runtime\r\n:30\r\n+"
+                            "capacity\r\n:100\r\n+"
+                            "size\r\n$1\r\n0\r\n+"
+                            "num_docs\r\n:0\r\n+num_"
                             "terms\r\n:0\r\n+num_records\r\n:0\r\n+"
-                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_stats\r\n*14\r\n+"
-			    "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$1\r\n0\r\n+"
-			    "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_ms\r\n$3\r\nnan\r\n+"
-			    "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_missed\r\n$1\r\n0\r\n+"
-			    "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*8\r\n+"
+                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_"
+                            "stats\r\n*14\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
                             "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
                             "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
-			    "dialect_stats\r\n*8\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
                             "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
                             "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
-			    "Index Errors\r\n*8\r\n+"
-                            "indexing failures\r\n:0\r\n+last indexing error\r\n+N/A\r\n+"
-                            "last indexing error key\r\n$3\r\nN/A\r\n+background indexing status\r\n+OK\r\n+"
-			    "backfill_in_"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
+                            "backfill_in_"
                             "progress\r\n$1\r\n0\r\n+backfill_complete_"
                             "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"
                             "size\r\n$1\r\n0\r\n+recent_mutations_queue_"
@@ -177,7 +185,7 @@ INSTANTIATE_TEST_SUITE_P(
         {
             .test_name = "happy_path_flat",
             .test_cases =
-	         {
+                {
                     {
                         .argv = {"FT.Info", "test_name"},
                         .index_schema_pbtxt = R"(
@@ -209,31 +217,39 @@ INSTANTIATE_TEST_SUITE_P(
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
                             "20\r\n+"
-			    "identifier\r\n+test_identifier_1\r\n+"
+                            "identifier\r\n+test_identifier_1\r\n+"
                             "attribute\r\n+test_attribute_1\r\n+"
-			    "type\r\n+VECTOR\r\n+"
-			    "algorithm\r\n+FLAT\r\n+"
-			    "data_type\r\n+FLOAT32\r\n+"
-			    "dim\r\n:10\r\n+"
-			    "distance_metric\r\n+COSINE\r\n+"
-			    "block_size\r\n:1024\r\n+"
+                            "type\r\n+VECTOR\r\n+"
+                            "algorithm\r\n+FLAT\r\n+"
+                            "data_type\r\n+FLOAT32\r\n+"
+                            "dim\r\n:10\r\n+"
+                            "distance_metric\r\n+COSINE\r\n+"
+                            "block_size\r\n:1024\r\n+"
                             "capacity\r\n:100\r\n+"
-			    "size\r\n$1\r\n0\r\n+"
-			    "num_docs\r\n:0\r\n+"
-                            "num_terms\r\n:0\r\n+num_records\r\n:0\r\n+hash_indexing_failures\r\n$1\r\n0\r\n+"
+                            "size\r\n$1\r\n0\r\n+"
+                            "num_docs\r\n:0\r\n+"
+                            "num_terms\r\n:0\r\n+num_records\r\n:0\r\n+hash_"
+                            "indexing_failures\r\n$1\r\n0\r\n+"
                             "gc_stats\r\n*14\r\n+"
-                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$1\r\n0\r\n+"
-			    "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_ms\r\n$3\r\nnan\r\n+"
-			    "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_missed\r\n$1\r\n0\r\n+"
-			    "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*8\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
                             "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
                             "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
-			    "dialect_stats\r\n*8\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
                             "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
                             "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
-			    "Index Errors\r\n*8\r\n+"
-                            "indexing failures\r\n:0\r\n+last indexing error\r\n+N/A\r\n+"
-                            "last indexing error key\r\n$3\r\nN/A\r\n+background indexing status\r\n+OK\r\n+"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
                             "backfill_in_progress\r\n$1\r\n0\r\n+backfill_"
                             "complete_percent\r\n$8\r\n1.000000\r\n+mutation_"
                             "queue_size\r\n$1\r\n0\r\n+recent_mutations_queue_"
@@ -244,7 +260,7 @@ INSTANTIATE_TEST_SUITE_P(
         {
             .test_name = "happy_path_tag_no_flags",
             .test_cases =
-		 {
+                {
                     {
                         .argv = {"FT.Info", "test_name"},
                         .index_schema_pbtxt = R"(
@@ -272,20 +288,28 @@ INSTANTIATE_TEST_SUITE_P(
                             "attribute\r\n+test_attribute_1\r\n+type\r\n+"
                             "TAG\r\n+SEPARATOR\r\n+@\r\n+size\r\n$1\r\n0\r\n+"
                             "num_docs\r\n:0\r\n+num_terms\r\n:0\r\n+"
-                            "num_records\r\n:0\r\n+hash_indexing_failures\r\n$1\r\n0\r\n+gc_stats\r\n*14\r\n+"
-                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$1\r\n0\r\n+"
-			    "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_ms\r\n$3\r\nnan\r\n+"
-			    "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_missed\r\n$1\r\n0\r\n+"
-			    "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*8\r\n+"
+                            "num_records\r\n:0\r\n+hash_indexing_failures\r\n$"
+                            "1\r\n0\r\n+gc_stats\r\n*14\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
                             "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
                             "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
-			    "dialect_stats\r\n*8\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
                             "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
                             "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
-			    "Index Errors\r\n*8\r\n+"
-                            "indexing failures\r\n:0\r\n+last indexing error\r\n+N/A\r\n+"
-                            "last indexing error key\r\n$3\r\nN/A\r\n+background indexing status\r\n+OK\r\n+"
-			    "backfill_in_progress\r\n$"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
+                            "backfill_in_progress\r\n$"
                             "1\r\n0\r\n+backfill_complete_percent\r\n$8\r\n1."
                             "000000\r\n+mutation_queue_size\r\n$1\r\n0\r\n+"
                             "recent_mutations_queue_delay\r\n$5\r\n0 sec\r\n"
@@ -296,7 +320,7 @@ INSTANTIATE_TEST_SUITE_P(
         {
             .test_name = "happy_path_tag_case_sensitive_true",
             .test_cases =
-		 {
+                {
                     {
                         .argv = {"FT.Info", "test_name"},
                         .index_schema_pbtxt = R"(
@@ -326,19 +350,27 @@ INSTANTIATE_TEST_SUITE_P(
                             "TAG\r\n+SEPARATOR\r\n+@\r\n+CASESENSITIVE\r\n+"
                             "size\r\n$1\r\n0\r\n+num_docs\r\n:0\r\n+num_"
                             "terms\r\n:0\r\n+num_records\r\n:0\r\n+"
-                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_stats\r\n*14\r\n+"
-                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$1\r\n0\r\n+"
-			    "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_ms\r\n$3\r\nnan\r\n+"
-			    "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_missed\r\n$1\r\n0\r\n+"
-			    "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*8\r\n+"
+                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_"
+                            "stats\r\n*14\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
                             "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
                             "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
-			    "dialect_stats\r\n*8\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
                             "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
                             "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
-			    "Index Errors\r\n*8\r\n+"
-                            "indexing failures\r\n:0\r\n+last indexing error\r\n+N/A\r\n+"
-                            "last indexing error key\r\n$3\r\nN/A\r\n+background indexing status\r\n+OK\r\n+"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
                             "backfill_in_"
                             "progress\r\n$1\r\n0\r\n+backfill_complete_"
                             "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"
@@ -350,7 +382,7 @@ INSTANTIATE_TEST_SUITE_P(
         {
             .test_name = "happy_path_numeric",
             .test_cases =
-		{
+                {
                     {
                         .argv = {"FT.Info", "test_name"},
                         .index_schema_pbtxt = R"(
@@ -374,21 +406,29 @@ INSTANTIATE_TEST_SUITE_P(
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
                             "8\r\n+identifier\r\n+test_identifier_1\r\n+"
                             "attribute\r\n+test_attribute_1\r\n+type\r\n+"
-                            "NUMERIC\r\n+size\r\n$1\r\n0\r\n+num_docs\r\n:0\r\n+num_terms\r\n:0\r\n+num_"
+                            "NUMERIC\r\n+size\r\n$1\r\n0\r\n+num_docs\r\n:"
+                            "0\r\n+num_terms\r\n:0\r\n+num_"
                             "records\r\n:0\r\n+hash_indexing_failures\r\n$"
                             "1\r\n0\r\n+gc_stats\r\n*14\r\n+"
-                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$1\r\n0\r\n+"
-			    "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_ms\r\n$3\r\nnan\r\n+"
-			    "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_missed\r\n$1\r\n0\r\n+"
-			    "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*8\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
                             "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
                             "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
-			    "dialect_stats\r\n*8\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
                             "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
                             "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
-			    "Index Errors\r\n*8\r\n+"
-                            "indexing failures\r\n:0\r\n+last indexing error\r\n+N/A\r\n+"
-                            "last indexing error key\r\n$3\r\nN/A\r\n+background indexing status\r\n+OK\r\n+"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
                             "backfill_in_progress\r\n$1\r\n0\r\n+"
                             "backfill_complete_percent\r\n$8\r\n1.000000\r\n+"
                             "mutation_queue_size\r\n$1\r\n0\r\n+recent_"
@@ -404,8 +444,9 @@ INSTANTIATE_TEST_SUITE_P(
                     {
                         .argv = {"FT.Info"},
                         .expect_return_failure = true,
-                        .expected_output = "$51\r\nERR wrong number of "
-                                           "arguments for 'FT.INFO' command\r\n",
+                        .expected_output =
+                            "$51\r\nERR wrong number of "
+                            "arguments for 'FT.INFO' command\r\n",
                     },
                 },
         },

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -21,8 +21,8 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "src/index_schema.pb.h"
-#include "src/indexes/vector_flat.h"
 #include "src/indexes/numeric.h"
+#include "src/indexes/vector_flat.h"
 #include "src/query/search.h"
 #include "src/schema_manager.h"
 #include "testing/common.h"
@@ -111,7 +111,8 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
       *kMockValkeyModule,
       OpenKey(testing::_, testing::An<ValkeyModuleString *>(), testing::_))
       .WillRepeatedly(TestValkeyModule_OpenKeyDefaultImpl);
-  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_)).Times(::testing::AnyNumber());
+  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
+      .Times(::testing::AnyNumber());
   if (test_case.vector_query) {
     // Vector index setup
     data_model::VectorIndex vector_index_proto;
@@ -124,15 +125,16 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
     vector_index_proto.set_allocated_flat_algorithm(
         flat_algorithm_proto.release());
     auto index = indexes::VectorFlat<float>::Create(
-                    vector_index_proto, "attribute_identifier_1",
-                    data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH)
-                    .value();
+                     vector_index_proto, "attribute_identifier_1",
+                     data_model::AttributeDataType::ATTRIBUTE_DATA_TYPE_HASH)
+                     .value();
     VMSDK_EXPECT_OK(
         index_schema->AddIndex(test_case.attribute_alias, "id1", index));
   } else {
     // Non Vector index setup
     data_model::NumericIndex numeric_index_proto;
-    auto numeric_index = std::make_shared<indexes::Numeric>(numeric_index_proto);
+    auto numeric_index =
+        std::make_shared<indexes::Numeric>(numeric_index_proto);
     VMSDK_EXPECT_OK(
         index_schema->AddIndex("attribute_identifier_1", "id1", numeric_index));
     data_model::TagIndex tag_index_proto;
@@ -181,10 +183,10 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
     args.insert(args.end(), search_parameters_vec.begin(),
                 search_parameters_vec.end());
     if (!kDialectOptions[dialect_itr].second.empty()) {
-        auto dialect_vec =
-            vmsdk::ToValkeyStringVector(kDialectOptions[dialect_itr].second);
-        args.insert(args.end(), dialect_vec.begin(), dialect_vec.end());
-        dialect_expected_success = kDialectOptions[dialect_itr].first;
+      auto dialect_vec =
+          vmsdk::ToValkeyStringVector(kDialectOptions[dialect_itr].second);
+      args.insert(args.end(), dialect_vec.begin(), dialect_vec.end());
+      dialect_expected_success = kDialectOptions[dialect_itr].first;
     }
   }
   if (add_end_unexpected_param) {
@@ -209,25 +211,27 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   if (search_params.ok()) {
     EXPECT_EQ(search_params.value()->index_schema_name, key_str);
     if (test_case.vector_query) {
-        // Vector query specific checks
-        std::string vector_str((char *)(&floats[0]), floats.size() * sizeof(float));
-        EXPECT_EQ(search_params.value()->query, vector_str.c_str());
-        EXPECT_EQ(search_params.value()->k, test_case.k);
-        EXPECT_EQ(search_params.value()->ef, test_case.ef);
-        EXPECT_EQ(search_params.value()->attribute_alias, test_case.attribute_alias);
-        auto score_as = vmsdk::MakeUniqueValkeyString(test_case.score_as);
-        if (test_case.score_as.empty()) {
-        score_as =
-            index_schema->DefaultReplyScoreAs(test_case.attribute_alias).value();
-        }
-        EXPECT_EQ(vmsdk::ToStringView(search_params.value()->score_as.get()),
+      // Vector query specific checks
+      std::string vector_str((char *)(&floats[0]),
+                             floats.size() * sizeof(float));
+      EXPECT_EQ(search_params.value()->query, vector_str.c_str());
+      EXPECT_EQ(search_params.value()->k, test_case.k);
+      EXPECT_EQ(search_params.value()->ef, test_case.ef);
+      EXPECT_EQ(search_params.value()->attribute_alias,
+                test_case.attribute_alias);
+      auto score_as = vmsdk::MakeUniqueValkeyString(test_case.score_as);
+      if (test_case.score_as.empty()) {
+        score_as = index_schema->DefaultReplyScoreAs(test_case.attribute_alias)
+                       .value();
+      }
+      EXPECT_EQ(vmsdk::ToStringView(search_params.value()->score_as.get()),
                 vmsdk::ToStringView(score_as.get()));
     } else {
-        // Non vector query specific checks
-        EXPECT_TRUE(search_params.value()->query.empty());
-        EXPECT_EQ(search_params.value()->k, 0);
-        EXPECT_FALSE(search_params.value()->ef.has_value());
-        EXPECT_TRUE(search_params.value()->attribute_alias.empty());
+      // Non vector query specific checks
+      EXPECT_TRUE(search_params.value()->query.empty());
+      EXPECT_EQ(search_params.value()->k, 0);
+      EXPECT_FALSE(search_params.value()->ef.has_value());
+      EXPECT_TRUE(search_params.value()->attribute_alias.empty());
     }
     EXPECT_EQ(search_params.value()->no_content,
               no_content || test_case.no_content);
@@ -392,7 +396,8 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "happy_path_numeric_and_tag",
             .success = true,
             .params_str = "",
-            .filter_str = "@attribute_identifier_2:{electronics} @attribute_identifier_1:[300 1000]",
+            .filter_str = "@attribute_identifier_2:{electronics} "
+                          "@attribute_identifier_1:[300 1000]",
             .attribute_alias = "",
             .k = 0,
             .ef = 0,

--- a/testing/ft_search_test.cc
+++ b/testing/ft_search_test.cc
@@ -176,7 +176,8 @@ void SendReplyTest::DoSendReplyTest(
   for (const auto &neighbor : input.neighbors) {
     neighbors.push_back(ToIndexesNeighbor(neighbor));
   }
-  auto parameters = std::make_unique<query::VectorSearchParameters>(10000, nullptr);
+  auto parameters =
+      std::make_unique<query::VectorSearchParameters>(10000, nullptr);
   parameters->index_schema = test_index_schema;
   parameters->attribute_alias = attribute_alias;
   parameters->score_as = vmsdk::MakeUniqueValkeyString(score_as);
@@ -505,7 +506,7 @@ TEST_P(FTSearchTest, FTSearchTests) {
           delete[] ids;
         });
     for (size_t i = 0; i < node_ids.size(); ++i) {
-      const auto& node_id = node_ids[i];
+      const auto &node_id = node_ids[i];
       EXPECT_CALL(
           *kMockValkeyModule,
           GetClusterNodeInfo(testing::_, testing::StrEq(node_id), testing::_,
@@ -565,14 +566,14 @@ TEST_P(FTSearchTest, FTSearchTests) {
       .Times(::testing::AnyNumber());
   auto vectors = DeterministicallyGenerateVectors(100, dimensions, 10.0);
   AddVectors(vectors);
-  
+
   // Capture initial metrics before starting searches
-  auto& stats = Metrics::GetStats();
-  auto& mrmw_stats = vmsdk::GetGlobalTimeSlicedMRMWStats();
+  auto &stats = Metrics::GetStats();
+  auto &mrmw_stats = vmsdk::GetGlobalTimeSlicedMRMWStats();
   uint64_t initial_queries = stats.time_slice_queries;
   uint64_t initial_read_periods = mrmw_stats.read_periods;
   uint64_t initial_read_time = mrmw_stats.read_time_microseconds;
-  
+
   RE2 reply_regex(R"(\*3\r\n:1\r\n\+\d+\r\n\*2\r\n\+score\r\n\+.*\r\n)");
   uint64_t i = 0;
   for (auto &vector : vectors) {
@@ -626,7 +627,7 @@ TEST_P(FTSearchTest, FTSearchTests) {
       TestValkeyModule_FreeString(&fake_ctx_, cmd_arg);
     }
   }
-  
+
   // Verify that metrics were incremented correctly
   EXPECT_EQ(stats.time_slice_queries, initial_queries + vectors.size());
   EXPECT_GT(mrmw_stats.read_periods, initial_read_periods);
@@ -673,7 +674,8 @@ struct MaxLimitTestCase {
   std::string expected_error_message;
 };
 
-class FTSearchMaxLimitTest : public ValkeySearchTestWithParam<MaxLimitTestCase> {
+class FTSearchMaxLimitTest
+    : public ValkeySearchTestWithParam<MaxLimitTestCase> {
  public:
   void AddVectors(const std::vector<std::vector<float>> &vectors) {
     auto index_schema =

--- a/testing/multi_exec_test.cc
+++ b/testing/multi_exec_test.cc
@@ -176,9 +176,9 @@ TEST_F(MultiExecTest, Basic) {
 
 TEST_F(MultiExecTest, TrackMutationOverride) {
   // Get initial metrics values to compare after operations
-  auto& metrics = Metrics::GetStats();
+  auto &metrics = Metrics::GetStats();
   uint64_t initial_batches = metrics.ingest_total_batches;
-  
+
   VMSDK_EXPECT_OK(mutations_thread_pool->SuspendWorkers());
   EXPECT_CALL(*kMockValkeyModule, EventLoopAddOneShot(testing::_, testing::_))
       .WillOnce([this](ValkeyModuleEventLoopOneShotFunc func, void *data) {
@@ -242,14 +242,20 @@ TEST_F(MultiExecTest, TrackMutationOverride) {
         std::string(record_value_) + "1", std::string(record_value_) + "4",
         std::string(record_value_) + "3"};
     EXPECT_THAT(expected_keys, testing::UnorderedElementsAreArray(added_keys));
-    
+
     // Check that the batch metrics were updated
     EXPECT_GT(metrics.ingest_total_batches, initial_batches);
     EXPECT_EQ(metrics.ingest_last_batch_size, expected_keys.size());
   }
-  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(vmsdk::BlockedClientCategory::kHash), 0);
-  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(vmsdk::BlockedClientCategory::kJson), 0);
-  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(vmsdk::BlockedClientCategory::kOther), 0);
+  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(
+                vmsdk::BlockedClientCategory::kHash),
+            0);
+  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(
+                vmsdk::BlockedClientCategory::kJson),
+            0);
+  EXPECT_EQ(vmsdk::BlockedClientTracker::GetInstance().GetClientCount(
+                vmsdk::BlockedClientCategory::kOther),
+            0);
   index_schema = nullptr;
 }
 

--- a/testing/query/response_generator_test.cc
+++ b/testing/query/response_generator_test.cc
@@ -271,7 +271,7 @@ TEST_F(ResponseGeneratorTest, ProcessNeighborsForReplyContentLimits) {
 
   // Verify that the metric was incremented correctly
   // Should be incremented by 2: once for large content, once for many fields
-  EXPECT_EQ( Metrics::GetStats().query_result_record_dropped_cnt, 2);
+  EXPECT_EQ(Metrics::GetStats().query_result_record_dropped_cnt, 2);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -164,7 +164,8 @@ class EvaluateFilterAsPrimaryTest
 void InitIndexSchema(MockIndexSchema *index_schema) {
   data_model::NumericIndex numeric_index_proto;
 
-  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_)).Times(::testing::AnyNumber());
+  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
+      .Times(::testing::AnyNumber());
 
   auto numeric_index_100_10 =
       std::make_shared<MockNumeric>(numeric_index_proto);
@@ -319,7 +320,8 @@ struct PerformVectorSearchTestCase {
 std::shared_ptr<MockIndexSchema> CreateIndexSchemaWithMultipleAttributes(
     const IndexerType vector_indexer_type = indexes::IndexerType::kHNSW) {
   auto index_schema = CreateIndexSchema(kIndexSchemaName).value();
-  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_)).Times(::testing::AnyNumber());
+  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
+      .Times(::testing::AnyNumber());
 
   // Add vector index
   std::shared_ptr<indexes::IndexBase> vector_index;
@@ -357,9 +359,9 @@ std::shared_ptr<MockIndexSchema> CreateIndexSchemaWithMultipleAttributes(
 
   // Add records
   size_t num_records = 10000;
-  #ifdef SAN_BUILD
+#ifdef SAN_BUILD
   num_records = 100;
-  #endif
+#endif
   auto vectors =
       DeterministicallyGenerateVectors(num_records, kVectorDimensions, 10.0);
   for (size_t i = 0; i < num_records; ++i) {

--- a/testing/utils/string_interning_test.cc
+++ b/testing/utils/string_interning_test.cc
@@ -11,15 +11,15 @@
 #include <memory>
 #include <string>
 
-#include "gtest/gtest.h"
 #include "gmock/gmock.h"
-#include "vmsdk/src/memory_allocation.h"
-#include "vmsdk/src/memory_tracker.h"
+#include "gtest/gtest.h"
 #include "src/utils/allocator.h"
 #include "src/utils/intrusive_ref_count.h"
-#include "vmsdk/src/testing_infra/utils.h"
-#include "vmsdk/src/testing_infra/module.h"
+#include "vmsdk/src/memory_allocation.h"
 #include "vmsdk/src/memory_allocation_overrides.h"
+#include "vmsdk/src/memory_tracker.h"
+#include "vmsdk/src/testing_infra/module.h"
+#include "vmsdk/src/testing_infra/utils.h"
 
 namespace valkey_search {
 
@@ -36,7 +36,7 @@ class MockAllocator : public Allocator {
   char* Allocate(size_t size) override {
     // simulate the memory allocation in the current tracking scope
     vmsdk::ReportAllocMemorySize(size);
-    
+
     if (!chunk_.free_list.empty()) {
       auto ptr = chunk_.free_list.top();
       chunk_.free_list.pop();
@@ -46,15 +46,13 @@ class MockAllocator : public Allocator {
     return nullptr;  // Out of memory
   }
 
-  size_t ChunkSize() const override {
-    return 1024;
-  }
-  
-protected:
+  size_t ChunkSize() const override { return 1024; }
+
+ protected:
   void Free(AllocatorChunk* chunk, char* ptr) override {
     // Report memory deallocation to balance the allocation
     vmsdk::ReportFreeMemorySize(allocated_size_);
-    
+
     chunk->free_list.push(ptr);
   }
 
@@ -130,7 +128,7 @@ TEST_F(StringInterningTest, StringInternStoreTracksMemoryInternally) {
 
 INSTANTIATE_TEST_SUITE_P(StringInterningTests, StringInterningTest,
                          ::testing::Values(true, false),
-                         [](const TestParamInfo<bool> &info) {
+                         [](const TestParamInfo<bool>& info) {
                            return std::to_string(info.param);
                          });
 }  // namespace

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -402,7 +402,7 @@ TEST_F(ValkeySearchTest, Info) {
   stats.hnsw_modify_exceptions_cnt = 5;
   stats.hnsw_search_exceptions_cnt = 6;
   stats.hnsw_create_exceptions_cnt = 7;
-  
+
   // Set global ingestion stats
   stats.ingest_hash_keys = 100;
   // Let's set the blocked clients values in the test
@@ -444,42 +444,61 @@ TEST_F(ValkeySearchTest, Info) {
   stats.coordinator_bytes_in = 2000;
   auto interned_key_1 = StringInternStore::Intern("key1");
   EXPECT_EQ(std::string(*interned_key_1), "key1");
-  
+
   StringInternStore::SetMemoryUsage(2097152);  // 2MB in bytes
-  
+
   ValkeyModuleInfoCtx fake_info_ctx;
   ValkeySearch::Instance().Info(&fake_info_ctx, false);
 #ifndef TESTING_TMP_DISABLED
   EXPECT_EQ(
       fake_info_ctx.info_capture.GetInfo(),
-    "thread-pool\nused_read_cpu: 0\nused_write_cpu: 0\nquery_queue_size: 10\nwriter_queue_size: 5\n"
-    "worker_pool_suspend_cnt: 13\nwriter_resumed_cnt: 14\nreader_resumed_cnt: 15\nwriter_suspension_expired_cnt: 16\n"
-    "rdb\nrdb_load_success_cnt: 17\nrdb_load_failure_cnt: 18\nrdb_save_success_cnt: 19\nrdb_save_failure_cnt: 20\n"
-    "query\nsuccessful_requests_count: 2\nfailure_requests_count: 1\nhybrid_requests_count: 1\ninline_filtering_requests_count: 2\n"
-    "hnswlib\nhnsw_add_exceptions_count: 3\nhnsw_remove_exceptions_count: 4\nhnsw_modify_exceptions_count: 5\n"
-    "hnsw_search_exceptions_count: 6\nhnsw_create_exceptions_count: 7\n"
-    "latency\nhnsw_vector_index_search_latency_usec: 'p50=100139.007,p99=200278.015,p99.9=200278.015'\n"
-    "coordinator\ncoordinator_server_listening_port: 0\n"
-    "coordinator_server_get_global_metadata_success_count: 26\ncoordinator_server_get_global_metadata_failure_count: 25\n"
-    "coordinator_server_search_index_partition_success_count: 28\ncoordinator_server_search_index_partition_failure_count: 27\n"
-    "coordinator_client_get_global_metadata_success_count: 22\ncoordinator_client_get_global_metadata_failure_count: 21\n"
-    "coordinator_client_search_index_partition_success_count: 24\ncoordinator_client_search_index_partition_failure_count: 23\n"
-    "coordinator_bytes_out: 1000\ncoordinator_bytes_in: 2000\n"
-    "string_interning\nstring_interning_store_size: 1\nstring_interning_memory_bytes: 2097152\nstring_interning_memory_human: '2.00MiB'\n"
-    "vector_externing\nvector_externing_entry_count: 0\nvector_externing_hash_extern_errors: 0\n"
-    "vector_externing_generated_value_cnt: 0\nvector_externing_num_lru_entries: 0\n"
-    "vector_externing_lru_promote_cnt: 0\nvector_externing_deferred_entry_cnt: 0\n"
-    "global_ingestion\ningest_field_numeric: 400\ningest_field_tag: 500\ningest_field_vector: 300\n"
-    "ingest_hash_blocked: 0\ningest_hash_keys: 100\ningest_json_blocked: 0\ningest_json_keys: 200\n"
-    "ingest_last_batch_size: 600\ningest_total_batches: 700\ningest_total_failures: 800\n"
-    "index_stats\nnumber_of_indexes: 1\nnumber_of_attributes: 1\ntotal_indexed_documents: 4\nnumber_of_active_indexes: 1\n"
-    "number_of_active_indexes_running_queries: 0\nnumber_of_active_indexes_indexing: 1\n"
-    "total_active_write_threads: 5\ntotal_indexing_time: 0\n"
-    "indexing\nbackground_indexing_status: 'IN_PROGRESS'\n"
-    "memory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n"
-);
+      "thread-pool\nused_read_cpu: 0\nused_write_cpu: 0\nquery_queue_size: "
+      "10\nwriter_queue_size: 5\n"
+      "worker_pool_suspend_cnt: 13\nwriter_resumed_cnt: "
+      "14\nreader_resumed_cnt: 15\nwriter_suspension_expired_cnt: 16\n"
+      "rdb\nrdb_load_success_cnt: 17\nrdb_load_failure_cnt: "
+      "18\nrdb_save_success_cnt: 19\nrdb_save_failure_cnt: 20\n"
+      "query\nsuccessful_requests_count: 2\nfailure_requests_count: "
+      "1\nhybrid_requests_count: 1\ninline_filtering_requests_count: 2\n"
+      "hnswlib\nhnsw_add_exceptions_count: 3\nhnsw_remove_exceptions_count: "
+      "4\nhnsw_modify_exceptions_count: 5\n"
+      "hnsw_search_exceptions_count: 6\nhnsw_create_exceptions_count: 7\n"
+      "latency\nhnsw_vector_index_search_latency_usec: "
+      "'p50=100139.007,p99=200278.015,p99.9=200278.015'\n"
+      "coordinator\ncoordinator_server_listening_port: 0\n"
+      "coordinator_server_get_global_metadata_success_count: "
+      "26\ncoordinator_server_get_global_metadata_failure_count: 25\n"
+      "coordinator_server_search_index_partition_success_count: "
+      "28\ncoordinator_server_search_index_partition_failure_count: 27\n"
+      "coordinator_client_get_global_metadata_success_count: "
+      "22\ncoordinator_client_get_global_metadata_failure_count: 21\n"
+      "coordinator_client_search_index_partition_success_count: "
+      "24\ncoordinator_client_search_index_partition_failure_count: 23\n"
+      "coordinator_bytes_out: 1000\ncoordinator_bytes_in: 2000\n"
+      "string_interning\nstring_interning_store_size: "
+      "1\nstring_interning_memory_bytes: "
+      "2097152\nstring_interning_memory_human: '2.00MiB'\n"
+      "vector_externing\nvector_externing_entry_count: "
+      "0\nvector_externing_hash_extern_errors: 0\n"
+      "vector_externing_generated_value_cnt: "
+      "0\nvector_externing_num_lru_entries: 0\n"
+      "vector_externing_lru_promote_cnt: "
+      "0\nvector_externing_deferred_entry_cnt: 0\n"
+      "global_ingestion\ningest_field_numeric: 400\ningest_field_tag: "
+      "500\ningest_field_vector: 300\n"
+      "ingest_hash_blocked: 0\ningest_hash_keys: 100\ningest_json_blocked: "
+      "0\ningest_json_keys: 200\n"
+      "ingest_last_batch_size: 600\ningest_total_batches: "
+      "700\ningest_total_failures: 800\n"
+      "index_stats\nnumber_of_indexes: 1\nnumber_of_attributes: "
+      "1\ntotal_indexed_documents: 4\nnumber_of_active_indexes: 1\n"
+      "number_of_active_indexes_running_queries: "
+      "0\nnumber_of_active_indexes_indexing: 1\n"
+      "total_active_write_threads: 5\ntotal_indexing_time: 0\n"
+      "indexing\nbackground_indexing_status: 'IN_PROGRESS'\n"
+      "memory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n");
 #endif
-  StringInternStore::SetMemoryUsage(0); // reset memory pool
+  StringInternStore::SetMemoryUsage(0);  // reset memory pool
 }
 
 TEST_F(ValkeySearchTest, OnForkChildDiedCallback) {

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -368,7 +368,8 @@ float CalcRecall(VectorFlat<float>* flat_index, VectorHNSW<float>* hnsw_index,
   int cnt = 0;
   for (const auto& search_vector : search_vectors) {
     absl::string_view vector = VectorToStr(search_vector);
-    auto res_hnsw = hnsw_index->Search(vector, k, CancelNever(), nullptr, ef_runtime);
+    auto res_hnsw =
+        hnsw_index->Search(vector, k, CancelNever(), nullptr, ef_runtime);
     auto res_flat = flat_index->Search(vector, k, CancelNever());
     for (auto& label : *res_hnsw) {
       for (auto& real_label : *res_flat) {

--- a/vmsdk/src/blocked_client.h
+++ b/vmsdk/src/blocked_client.h
@@ -33,23 +33,27 @@ struct BlockedClientEntry;
 
 class BlockedClientTracker {
  public:
-  static BlockedClientTracker& GetInstance();
-  
-  size_t GetClientCount(BlockedClientCategory category) const ABSL_LOCKS_EXCLUDED(blocked_clients_mutex);
-  
+  static BlockedClientTracker &GetInstance();
+
+  size_t GetClientCount(BlockedClientCategory category) const
+      ABSL_LOCKS_EXCLUDED(blocked_clients_mutex);
+
   // Access to the map for a specific category
-  absl::flat_hash_map<unsigned long long, BlockedClientEntry>& 
-  operator[](BlockedClientCategory category) ABSL_EXCLUSIVE_LOCKS_REQUIRED(blocked_clients_mutex);
-  
-  const absl::flat_hash_map<unsigned long long, BlockedClientEntry>& 
-  operator[](BlockedClientCategory category) const ABSL_EXCLUSIVE_LOCKS_REQUIRED(blocked_clients_mutex);
-  
+  absl::flat_hash_map<unsigned long long, BlockedClientEntry> &operator[](
+      BlockedClientCategory category)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(blocked_clients_mutex);
+
+  const absl::flat_hash_map<unsigned long long, BlockedClientEntry> &operator[](
+      BlockedClientCategory category) const
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(blocked_clients_mutex);
+
  private:
   BlockedClientTracker() = default;
-  
+
   std::array<absl::NoDestructor<
-      absl::flat_hash_map<unsigned long long, BlockedClientEntry>>, 
-      static_cast<size_t>(BlockedClientCategory::kCategoryCount)> tracked_blocked_clients_;
+                 absl::flat_hash_map<unsigned long long, BlockedClientEntry>>,
+             static_cast<size_t>(BlockedClientCategory::kCategoryCount)>
+      tracked_blocked_clients_;
 };
 
 class BlockedClient {
@@ -67,7 +71,8 @@ class BlockedClient {
         tracked_client_id_(std::exchange(other.tracked_client_id_, 0)),
         time_measurement_ongoing_(
             std::exchange(other.time_measurement_ongoing_, false)),
-            category_(std::exchange(other.category_, BlockedClientCategory::kOther)) {}
+        category_(
+            std::exchange(other.category_, BlockedClientCategory::kOther)) {}
 
   BlockedClient &operator=(BlockedClient &&other) noexcept;
 

--- a/vmsdk/src/debug.h
+++ b/vmsdk/src/debug.h
@@ -10,7 +10,9 @@
 
 #include <absl/status/statusor.h>
 #include <absl/strings/string_view.h>
+
 #include <source_location>
+
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace vmsdk {
@@ -21,19 +23,23 @@ namespace debug {
 //
 
 //
-// This function is put into your code at points that you want to pause the current thread.
-// A unique label is provided to distinguish this pause point with others.
+// This function is put into your code at points that you want to pause the
+// current thread. A unique label is provided to distinguish this pause point
+// with others.
 //
-#define PAUSEPOINT(name) vmsdk::debug::PausePoint(name, std::source_location::current())
+#define PAUSEPOINT(name) \
+  vmsdk::debug::PausePoint(name, std::source_location::current())
 void PausePoint(absl::string_view point, std::source_location location);
 
 //
-// This function is used by the control machinery (FT.DEBUG) to enable/disable and test PausePoints.
+// This function is used by the control machinery (FT.DEBUG) to enable/disable
+// and test PausePoints.
 //
 void PausePointControl(absl::string_view point, bool enable);
 
 //
-// This function is used to determine how many threads are waiting at the PausePoint
+// This function is used to determine how many threads are waiting at the
+// PausePoint
 //
 absl::StatusOr<size_t> PausePointWaiters(absl::string_view point);
 
@@ -42,8 +48,7 @@ absl::StatusOr<size_t> PausePointWaiters(absl::string_view point);
 //
 void PausePointList(ValkeyModuleCtx *ctx);
 
-}    
-}
-
+}  // namespace debug
+}  // namespace vmsdk
 
 #endif

--- a/vmsdk/src/managed_pointers.h
+++ b/vmsdk/src/managed_pointers.h
@@ -26,7 +26,8 @@ struct ValkeyStringDeleter {
 using UniqueValkeyString =
     std::unique_ptr<ValkeyModuleString, ValkeyStringDeleter>;
 
-inline UniqueValkeyString UniquePtrValkeyString(ValkeyModuleString *valkey_str) {
+inline UniqueValkeyString UniquePtrValkeyString(
+    ValkeyModuleString *valkey_str) {
   return std::unique_ptr<ValkeyModuleString, ValkeyStringDeleter>(valkey_str);
 }
 
@@ -64,8 +65,8 @@ inline UniqueValkeyOpenKey UniquePtrValkeyOpenKey(ValkeyModuleKey *valkey_key) {
 }
 
 inline UniqueValkeyOpenKey MakeUniqueValkeyOpenKey(ValkeyModuleCtx *ctx,
-                                                 ValkeyModuleString *str,
-                                                 int flags) {
+                                                   ValkeyModuleString *str,
+                                                   int flags) {
   VerifyMainThread();
   auto module_key = ValkeyModule_OpenKey(ctx, str, flags);
   return std::unique_ptr<ValkeyModuleKey, ValkeyOpenKeyDeleter>(module_key);

--- a/vmsdk/src/memory_allocation.cc
+++ b/vmsdk/src/memory_allocation.cc
@@ -69,12 +69,8 @@ void ReportFreeMemorySize(uint64_t size) {
   memory_delta -= static_cast<int64_t>(size);
 }
 
-int64_t GetMemoryDelta() {
-  return memory_delta;
-}
+int64_t GetMemoryDelta() { return memory_delta; }
 
-void SetMemoryDelta(int64_t delta) {
-  memory_delta = delta;
-}
+void SetMemoryDelta(int64_t delta) { memory_delta = delta; }
 
 }  // namespace vmsdk

--- a/vmsdk/src/memory_tracker.cc
+++ b/vmsdk/src/memory_tracker.cc
@@ -28,29 +28,27 @@
  */
 
 #include "memory_tracker.h"
+
 #include "vmsdk/src/memory_allocation.h"
 
 MemoryScope::MemoryScope(MemoryPool& pool)
     : target_pool_(pool), baseline_memory_(vmsdk::GetMemoryDelta()) {}
 
 IsolatedMemoryScope::IsolatedMemoryScope(MemoryPool& pool)
-    : MemoryScope(pool) {
-}
+    : MemoryScope(pool) {}
 
 IsolatedMemoryScope::~IsolatedMemoryScope() {
-    int64_t current_delta = vmsdk::GetMemoryDelta();
-    int64_t net_change = current_delta - baseline_memory_;
-    target_pool_.Add(net_change);
+  int64_t current_delta = vmsdk::GetMemoryDelta();
+  int64_t net_change = current_delta - baseline_memory_;
+  target_pool_.Add(net_change);
 
-    vmsdk::SetMemoryDelta(baseline_memory_);
+  vmsdk::SetMemoryDelta(baseline_memory_);
 }
 
-NestedMemoryScope::NestedMemoryScope(MemoryPool& pool)
-    : MemoryScope(pool) {
-}
+NestedMemoryScope::NestedMemoryScope(MemoryPool& pool) : MemoryScope(pool) {}
 
 NestedMemoryScope::~NestedMemoryScope() {
-    int64_t current_delta = vmsdk::GetMemoryDelta();
-    int64_t net_change = current_delta - baseline_memory_;
-    target_pool_.Add(net_change);
+  int64_t current_delta = vmsdk::GetMemoryDelta();
+  int64_t net_change = current_delta - baseline_memory_;
+  target_pool_.Add(net_change);
 }

--- a/vmsdk/src/status/status_builder.h
+++ b/vmsdk/src/status/status_builder.h
@@ -328,7 +328,7 @@ class ABSL_MUST_USE_RESULT StatusBuilder {
   template <typename Adaptor>
   ABSL_MUST_USE_RESULT auto
   With(Adaptor&& adaptor) && -> decltype(std::forward<Adaptor>(adaptor)(
-      std::move(*this))) {
+                                 std::move(*this))) {
     return std::forward<Adaptor>(adaptor)(std::move(*this));
   }
 

--- a/vmsdk/src/testing_infra/module.h
+++ b/vmsdk/src/testing_infra/module.h
@@ -479,8 +479,7 @@ class InfoCapture {
       info_ << str << ": '" << field << "'" << std::endl;
     }
   }
-  void InfoAddFieldDouble(const char *str, double field,
-                            int in_dict_field) {
+  void InfoAddFieldDouble(const char *str, double field, int in_dict_field) {
     if (in_dict_field) {
       info_ << str << "=" << field << ",";
     } else {
@@ -974,8 +973,7 @@ inline int TestValkeyModule_InfoAddFieldCString(ValkeyModuleInfoCtx *ctx,
 }
 
 inline int TestValkeyModule_InfoAddFieldDouble(ValkeyModuleInfoCtx *ctx,
-                                          const char *str,
-                                          double field) {
+                                               const char *str, double field) {
   if (ctx) {
     ctx->info_capture.InfoAddFieldDouble(str, field, ctx->in_dict_field);
   }
@@ -1496,8 +1494,7 @@ inline void TestValkeyModule_Init() {
   ValkeyModule_ModuleTypeGetType = &TestValkeyModule_ModuleTypeGetType;
   ValkeyModule_GetDetachedThreadSafeContext =
       &TestValkeyModule_GetDetachedThreadSafeContext;
-  ValkeyModule_GetThreadSafeContext =
-      &TestValkeyModule_GetThreadSafeContext;
+  ValkeyModule_GetThreadSafeContext = &TestValkeyModule_GetThreadSafeContext;
   ValkeyModule_FreeThreadSafeContext = &TestValkeyModule_FreeThreadSafeContext;
   ValkeyModule_SelectDb = &TestValkeyModule_SelectDb;
   ValkeyModule_GetSelectedDb = &TestValkeyModule_GetSelectedDb;
@@ -1617,7 +1614,7 @@ inline void TestValkeyModule_Init() {
   ON_CALL(*kMockValkeyModule, Milliseconds()).WillByDefault([]() -> long long {
     static long long fake_time = 0;
     return ++fake_time;
-   });
+  });
   static absl::once_flag flag;
   absl::call_once(flag, []() { vmsdk::TrackCurrentAsMainThread(); });
   CHECK(vmsdk::InitLogging(nullptr, "debug").ok());

--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -66,7 +66,7 @@ absl::StatusOr<double> ThreadPool::GetAvgCPUPercentage() {
   std::vector<double> cpu_results;
   absl::Status err = absl::OkStatus();
   threads_.ForEach([&cpu_results, &err, this](auto thread) {
-    if(!err.ok()) {
+    if (!err.ok()) {
       return;
     }
     auto status = thread->thread_monitor_->GetThreadCPUPercentage();
@@ -77,7 +77,8 @@ absl::StatusOr<double> ThreadPool::GetAvgCPUPercentage() {
     cpu_results.push_back(status.value());
   });
   VMSDK_RETURN_IF_ERROR(err);
-  double sum_all_cpus = std::accumulate(cpu_results.begin(), cpu_results.end(), 0.0);
+  double sum_all_cpus =
+      std::accumulate(cpu_results.begin(), cpu_results.end(), 0.0);
   if (cpu_results.empty()) {
     return sum_all_cpus;
   }

--- a/vmsdk/src/thread_pool.h
+++ b/vmsdk/src/thread_pool.h
@@ -23,8 +23,8 @@
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/synchronization/mutex.h"
 #include "gtest/gtest_prod.h"
-#include "vmsdk/src/thread_safe_vector.h"
 #include "vmsdk/src/thread_monitoring.h"
+#include "vmsdk/src/thread_safe_vector.h"
 
 namespace vmsdk {
 // Note google3/thread can't be used as it's not open source

--- a/vmsdk/src/thread_safe_vector.h
+++ b/vmsdk/src/thread_safe_vector.h
@@ -84,7 +84,8 @@ class ThreadSafeVector {
   void Clear() { ClearWithCallback(nullptr); }
 
  private:
-  void ForEachInternal(std::function<void(T)> callback) ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
+  void ForEachInternal(std::function<void(T)> callback)
+      ABSL_EXCLUSIVE_LOCKS_REQUIRED(mutex_) {
     if (callback != nullptr) {
       for (auto& item : vec_) {
         callback(item);

--- a/vmsdk/src/time_sliced_mrmw_mutex.h
+++ b/vmsdk/src/time_sliced_mrmw_mutex.h
@@ -22,7 +22,7 @@ struct TimeSlicedMRMWStats {
   std::atomic<uint64_t> read_periods{0};
   std::atomic<uint64_t> read_time_microseconds{0};  // cumulative
   std::atomic<uint64_t> write_periods{0};
-  std::atomic<uint64_t> write_time_microseconds{0}; // cumulative
+  std::atomic<uint64_t> write_time_microseconds{0};  // cumulative
 };
 
 // Forward declaration for global statistics
@@ -149,9 +149,9 @@ class ABSL_SCOPED_LOCKABLE ReaderMutexLock {
   ReaderMutexLock& operator=(const ReaderMutexLock&) = delete;
   ReaderMutexLock& operator=(ReaderMutexLock&&) = delete;
   void SetMayProlong();
-  ~ReaderMutexLock() ABSL_UNLOCK_FUNCTION() { 
+  ~ReaderMutexLock() ABSL_UNLOCK_FUNCTION() {
     mutex_->Unlock(may_prolong_);
-    global_stats.read_time_microseconds += 
+    global_stats.read_time_microseconds +=
         absl::ToInt64Microseconds(timer_.Duration());
   }
 
@@ -176,9 +176,9 @@ class ABSL_SCOPED_LOCKABLE WriterMutexLock {
   WriterMutexLock& operator=(const WriterMutexLock&) = delete;
   WriterMutexLock& operator=(WriterMutexLock&&) = delete;
   void SetMayProlong();
-  ~WriterMutexLock() ABSL_UNLOCK_FUNCTION() { 
+  ~WriterMutexLock() ABSL_UNLOCK_FUNCTION() {
     mutex_->Unlock(may_prolong_);
-    global_stats.write_time_microseconds += 
+    global_stats.write_time_microseconds +=
         absl::ToInt64Microseconds(timer_.Duration());
   }
 

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -103,16 +103,16 @@ size_t DisplayAsSIBytes(size_t value, char *buffer, size_t buffer_size);
 absl::Status VerifyRange(long long num_value, std::optional<long long> min,
                          std::optional<long long> max);
 
-#define VMSDK_NON_COPYABLE(ClassName)              \
-  ClassName(const ClassName&) = delete;            \
-  ClassName& operator=(const ClassName&) = delete
+#define VMSDK_NON_COPYABLE(ClassName)    \
+  ClassName(const ClassName &) = delete; \
+  ClassName &operator=(const ClassName &) = delete
 
-#define VMSDK_NON_MOVABLE(ClassName)               \
-  ClassName(ClassName&&) = delete;                 \
-  ClassName& operator=(ClassName&&) = delete
+#define VMSDK_NON_MOVABLE(ClassName) \
+  ClassName(ClassName &&) = delete;  \
+  ClassName &operator=(ClassName &&) = delete
 
-#define VMSDK_NON_COPYABLE_NON_MOVABLE(ClassName)  \
-  VMSDK_NON_COPYABLE(ClassName);                   \
+#define VMSDK_NON_COPYABLE_NON_MOVABLE(ClassName) \
+  VMSDK_NON_COPYABLE(ClassName);                  \
   VMSDK_NON_MOVABLE(ClassName)
 
 }  // namespace vmsdk

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -689,7 +689,8 @@ typedef struct ValkeyModuleClientInfo {
 
 #define ValkeyModuleClientInfo ValkeyModuleClientInfoV1
 
-#define VALKEYMODULE_CLIENTINFO_INITIALIZER_V1 {.version = 1}
+#define VALKEYMODULE_CLIENTINFO_INITIALIZER_V1 \
+  { .version = 1 }
 
 #define VALKEYMODULE_REPLICATIONINFO_VERSION 1
 typedef struct ValkeyModuleReplicationInfo {
@@ -785,7 +786,8 @@ typedef struct ValkeyModuleClusterInfo {
 
 #define ValkeyModuleClusterInfo ValkeyModuleClusterInfoV1
 
-#define VALKEYMODULE_CLUSTERINFO_INITIALIZER_V1 {.version = 1}
+#define VALKEYMODULE_CLUSTERINFO_INITIALIZER_V1 \
+  { .version = 1 }
 
 /* If PSC connection cannot be extracted from a client,
  * Consider it to be 0. */

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -307,8 +307,8 @@ typedef uint64_t ValkeyModuleTimerID;
  */
 #define VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS (1 << 0)
 
-/* When set, Valkey will not call ValkeyModule_SignalModifiedKey(), implicitly in
- * ValkeyModule_CloseKey, and the module needs to do that when manually when
+/* When set, Valkey will not call ValkeyModule_SignalModifiedKey(), implicitly
+ * in ValkeyModule_CloseKey, and the module needs to do that when manually when
  * keys are modified from the user's perspective, to invalidate WATCH. */
 #define VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED (1 << 1)
 
@@ -625,7 +625,8 @@ static const ValkeyModuleEvent
 #define VALKEYMODULE_SUBEVENT_LOADING_PROGRESS_AOF 1
 #define _VALKEYMODULE_SUBEVENT_LOADING_PROGRESS_NEXT 2
 
-/* Replication Backup events are deprecated since Valkey 7.0 and are never fired.
+/* Replication Backup events are deprecated since Valkey 7.0 and are never
+ * fired.
  */
 #define VALKEYMODULE_SUBEVENT_REPL_BACKUP_CREATE 0
 #define VALKEYMODULE_SUBEVENT_REPL_BACKUP_RESTORE 1

--- a/vmsdk/testing/blocked_client_test.cc
+++ b/vmsdk/testing/blocked_client_test.cc
@@ -26,9 +26,10 @@ class BlockedClientTest
  protected:
 };
 
-std::vector<size_t> FetchTrackedBlockedClients(BlockedClientCategory category = BlockedClientCategory::kOther) {
+std::vector<size_t> FetchTrackedBlockedClients(
+    BlockedClientCategory category = BlockedClientCategory::kOther) {
   std::vector<size_t> tracked_bc_cnt;
-  const auto& category_map = BlockedClientTracker::GetInstance()[category];
+  const auto &category_map = BlockedClientTracker::GetInstance()[category];
   for (auto &entry : category_map) {
     tracked_bc_cnt.push_back(entry.second.cnt);
   }
@@ -36,9 +37,12 @@ std::vector<size_t> FetchTrackedBlockedClients(BlockedClientCategory category = 
 }
 
 bool AreAllCategoriesEmpty() {
-  return BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash) == 0 &&
-         BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson) == 0 &&
-         BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther) == 0;
+  return BlockedClientTracker::GetInstance().GetClientCount(
+             BlockedClientCategory::kHash) == 0 &&
+         BlockedClientTracker::GetInstance().GetClientCount(
+             BlockedClientCategory::kJson) == 0 &&
+         BlockedClientTracker::GetInstance().GetClientCount(
+             BlockedClientCategory::kOther) == 0;
 }
 
 TEST_P(BlockedClientTest, EngineVersion) {
@@ -98,83 +102,126 @@ TEST_P(BlockedClientTest, EngineVersion) {
 // Test for category tracking
 TEST_F(BlockedClientTest, CategoryTracking) {
   ValkeyModuleCtx fake_ctx;
-  
+
   // Verify initial counts are zero
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 0);
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 0);
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
-  
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kHash),
+            0);
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kJson),
+            0);
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kOther),
+            0);
+
   // Set up mock expectations
   EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
       .WillOnce(testing::Return(1))
       .WillOnce(testing::Return(2))
       .WillOnce(testing::Return(3));
-      
-  EXPECT_CALL(*kMockValkeyModule, BlockClient(&fake_ctx, nullptr, nullptr, nullptr, 0))
-      .WillOnce(testing::Return((ValkeyModuleBlockedClient*)0x1))
-      .WillOnce(testing::Return((ValkeyModuleBlockedClient*)0x2))
-      .WillOnce(testing::Return((ValkeyModuleBlockedClient*)0x3));
-  
-  EXPECT_CALL(*kMockValkeyModule, UnblockClient(testing::_, nullptr))
-      .Times(3);
-  
+
+  EXPECT_CALL(*kMockValkeyModule,
+              BlockClient(&fake_ctx, nullptr, nullptr, nullptr, 0))
+      .WillOnce(testing::Return((ValkeyModuleBlockedClient *)0x1))
+      .WillOnce(testing::Return((ValkeyModuleBlockedClient *)0x2))
+      .WillOnce(testing::Return((ValkeyModuleBlockedClient *)0x3));
+
+  EXPECT_CALL(*kMockValkeyModule, UnblockClient(testing::_, nullptr)).Times(3);
+
   {
     // Create clients with different categories
     BlockedClient hash_client(&fake_ctx, true, BlockedClientCategory::kHash);
-    
+
     // Check hash client count increased
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 1);
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 0);
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
-    
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kHash),
+              1);
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kJson),
+              0);
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kOther),
+              0);
+
     {
       BlockedClient json_client(&fake_ctx, true, BlockedClientCategory::kJson);
-      
+
       // Check json client count increased
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 1);
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 1);
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
-      
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kHash),
+                1);
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kJson),
+                1);
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kOther),
+                0);
+
       {
-        BlockedClient other_client(&fake_ctx, true, BlockedClientCategory::kOther);
-        
+        BlockedClient other_client(&fake_ctx, true,
+                                   BlockedClientCategory::kOther);
+
         // Check other client count increased
-        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 1);
-        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 1);
-        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 1);
+        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                      BlockedClientCategory::kHash),
+                  1);
+        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                      BlockedClientCategory::kJson),
+                  1);
+        EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                      BlockedClientCategory::kOther),
+                  1);
       }
-      
+
       // Check other client count decreased
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 1);
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 1);
-      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kHash),
+                1);
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kJson),
+                1);
+      EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                    BlockedClientCategory::kOther),
+                0);
     }
-    
+
     // Check json client count decreased
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 1);
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 0);
-    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kHash),
+              1);
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kJson),
+              0);
+    EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                  BlockedClientCategory::kOther),
+              0);
   }
-  
+
   // Check all counts are zero
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kHash), 0);
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kJson), 0);
-  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(BlockedClientCategory::kOther), 0);
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kHash),
+            0);
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kJson),
+            0);
+  EXPECT_EQ(BlockedClientTracker::GetInstance().GetClientCount(
+                BlockedClientCategory::kOther),
+            0);
 }
 
 // Test for GetCategory
 TEST_F(BlockedClientTest, GetCategory) {
   ValkeyModuleCtx fake_ctx;
-  
+
   BlockedClient hash_client(&fake_ctx, false, BlockedClientCategory::kHash);
   EXPECT_EQ(hash_client.GetCategory(), BlockedClientCategory::kHash);
-  
+
   BlockedClient json_client(&fake_ctx, false, BlockedClientCategory::kJson);
   EXPECT_EQ(json_client.GetCategory(), BlockedClientCategory::kJson);
-  
+
   BlockedClient other_client(&fake_ctx, false, BlockedClientCategory::kOther);
   EXPECT_EQ(other_client.GetCategory(), BlockedClientCategory::kOther);
-  
+
   // Test default category
   BlockedClient default_client(&fake_ctx, false);
   EXPECT_EQ(default_client.GetCategory(), BlockedClientCategory::kOther);

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -126,14 +126,13 @@ TEST_F(UtilsTest, IsRealUserClient) {
 
 TEST_F(UtilsTest, DisplayAsSIBytes) {
   std::vector<std::pair<size_t, std::string>> testcases{
-    {0.0, "0"},
-    {1023, "1023"},
-    {1ull << 10, "1.00KiB"},
-    {1ull << 20, "1.00MiB"},
-    {1ull << 30, "1.00GiB"},
-    {1ull << 40, "1.00TiB"},
-    {1ull << 50, "1.00PiB"}
-  };
+      {0.0, "0"},
+      {1023, "1023"},
+      {1ull << 10, "1.00KiB"},
+      {1ull << 20, "1.00MiB"},
+      {1ull << 30, "1.00GiB"},
+      {1ull << 40, "1.00TiB"},
+      {1ull << 50, "1.00PiB"}};
   for (auto& [value, expected] : testcases) {
     char buffer[100];
     size_t bytes = DisplayAsSIBytes(value, buffer, sizeof(buffer));
@@ -141,31 +140,30 @@ TEST_F(UtilsTest, DisplayAsSIBytes) {
     std::memset(buffer, -1, sizeof(buffer));
     bytes = DisplayAsSIBytes(value, buffer, 1);
     EXPECT_EQ(buffer[0], 0);
-    EXPECT_EQ(buffer[1], '\xFF'); // untouched.
+    EXPECT_EQ(buffer[1], '\xFF');  // untouched.
   }
 }
 
 TEST_F(UtilsTest, WrongArity) {
   // Test standard FT commands
-  EXPECT_EQ(WrongArity("FT.INFO"), 
+  EXPECT_EQ(WrongArity("FT.INFO"),
             "ERR wrong number of arguments for 'FT.INFO' command");
-  EXPECT_EQ(WrongArity("FT.SEARCH"), 
+  EXPECT_EQ(WrongArity("FT.SEARCH"),
             "ERR wrong number of arguments for 'FT.SEARCH' command");
-  EXPECT_EQ(WrongArity("FT.DROPINDEX"), 
+  EXPECT_EQ(WrongArity("FT.DROPINDEX"),
             "ERR wrong number of arguments for 'FT.DROPINDEX' command");
-  EXPECT_EQ(WrongArity("FT._LIST"), 
+  EXPECT_EQ(WrongArity("FT._LIST"),
             "ERR wrong number of arguments for 'FT._LIST' command");
-  
+
   // Test edge cases
-  EXPECT_EQ(WrongArity(""), 
-            "ERR wrong number of arguments for '' command");
-  EXPECT_EQ(WrongArity("SINGLE"), 
+  EXPECT_EQ(WrongArity(""), "ERR wrong number of arguments for '' command");
+  EXPECT_EQ(WrongArity("SINGLE"),
             "ERR wrong number of arguments for 'SINGLE' command");
-  
+
   // Test with special characters
-  EXPECT_EQ(WrongArity("CMD.WITH-DASH"), 
+  EXPECT_EQ(WrongArity("CMD.WITH-DASH"),
             "ERR wrong number of arguments for 'CMD.WITH-DASH' command");
-  EXPECT_EQ(WrongArity("CMD_WITH_UNDERSCORE"), 
+  EXPECT_EQ(WrongArity("CMD_WITH_UNDERSCORE"),
             "ERR wrong number of arguments for 'CMD_WITH_UNDERSCORE' command");
 }
 


### PR DESCRIPTION
I updated `clang_tidy_format.yml` so that hopefully now it will always generate the diff and find the files to check the formatting of. In past PRs the main branch wasn't fetched, so the diff failed and the job concluded that no .cc or .h files were modified.

e.g.
```
Run echo "Finding modified or added .cc and .h files..."
Finding modified or added .cc and .h files...
fatal: ambiguous argument 'main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
No .cc or .h files modified.
```

I also applied clang-format to all .h/.cc files under:
- src/**
- testing/**
- vmsdk/src/**
- vmsdk/testing/**

I ran the `ci/check_changes.sh` script locally against all the files afterwards and it seemed happy, but I think it's just giving false positives. Looks like clang-tidy actually spits out tons of errors. I'm disabling the clang-tidy check in the github job until we get the existing code to a tidied state.