### PR TITLE
fix: tracks only stored interned string

### DIFF
--- a/testing/utils/string_interning_test.cc
+++ b/testing/utils/string_interning_test.cc
@@ -126,6 +126,20 @@ TEST_F(StringInterningTest, StringInternStoreTracksMemoryInternally) {
   EXPECT_EQ(StringInternStore::GetMemoryUsage(), 12);
 
   interned_str.reset();
+
+  EXPECT_EQ(StringInternStore::GetMemoryUsage(), 0);
+}
+
+TEST_F(StringInterningTest, NonInternedStringDoesNotAffectStoreMemory) {
+  int64_t initial_memory = StringInternStore::GetMemoryUsage();
+  
+  auto non_interned = std::make_shared<InternedString>("non_interned_string");
+  
+  EXPECT_EQ(StringInternStore::GetMemoryUsage(), initial_memory);
+  
+  non_interned.reset();
+  
+  EXPECT_EQ(StringInternStore::GetMemoryUsage(), initial_memory);
 }
 
 INSTANTIATE_TEST_SUITE_P(StringInterningTests, StringInterningTest,


### PR DESCRIPTION
@allenss-amazon 

I found missed part. there are interned string, but not stored in the store. but deallocation track all interned strings. so we should track only shared interned strings which are stored in the store.