### PR TITLE
Address KeyIterator Gaps

### DIFF
--- a/integration/test_fulltext.py
+++ b/integration/test_fulltext.py
@@ -25,6 +25,41 @@ expected_hash_value = {
     b'category': b"books"
 }
 
+# Constants for per-field text search test
+text_index_on_hash_two_fields = "FT.CREATE products2 ON HASH PREFIX 1 product: SCHEMA desc TEXT desc2 TEXT"
+hash_docs_with_desc2 = [
+    ["HSET", "product:1", "category", "electronics", "name", "Laptop", "price", "999.99", "rating", "4.5", "desc", "Great", "desc2", "Wonderful experience here"],
+    ["HSET", "product:2", "category", "electronics", "name", "Tablet", "price", "499.00", "rating", "4.0", "desc", "Good", "desc2", "Hello, where are you here ?"],
+    ["HSET", "product:3", "category", "electronics", "name", "Phone", "price", "299.00", "rating", "3.8", "desc", "Ok", "desc2", "Hello, how are you doing?"],
+    ["HSET", "product:4", "category", "books", "name", "Book", "price", "19.99", "rating", "4.8", "desc", "Wonderful", "desc2", "Hello, what are you doing Great?"]
+]
+
+# Search queries for specific fields
+text_query_desc_field = ["FT.SEARCH", "products2", '@desc:"Wonderful"']
+text_query_desc2_field = ["FT.SEARCH", "products2", '@desc2:"Wonderful"']
+
+# Expected results for desc field search
+expected_desc_hash_key = b'product:4'
+expected_desc_hash_value = {
+    b'name': b"Book",
+    b'price': b'19.99', 
+    b'rating': b'4.8',
+    b'desc': b"Wonderful",
+    b'desc2': b"Hello, what are you doing Great?",
+    b'category': b"books"
+}
+
+# Expected results for desc2 field search  
+expected_desc2_hash_key = b'product:1'
+expected_desc2_hash_value = {
+    b'name': b"Laptop",
+    b'price': b'999.99',
+    b'rating': b'4.5', 
+    b'desc': b"Great",
+    b'desc2': b"Wonderful experience here",
+    b'category': b"electronics"
+}
+
 class TestFullText(ValkeySearchTestCaseBase):
 
     def test_text_search(self):
@@ -93,36 +128,43 @@ class TestFullText(ValkeySearchTestCaseBase):
         with pytest.raises(ResponseError):
             client.execute_command(*command_args)
 
-        # Command with different parameter combinations
+        # Test multiple text fields
         command_args = [
             "FT.CREATE", "idx4",
             "ON", "HASH",
-            "PUNCTUATION", "!@#$%",
-            "STOPWORDS", "5", "a", "an", "the", "is", "are", 
-            "SCHEMA", "title", "TEXT", "content", "TEXT"
+            "SCHEMA", "desc", "TEXT", "desc2", "TEXT"
         ]
         
         assert client.execute_command(*command_args) == b"OK"
         assert b"idx4" in client.execute_command("FT._LIST")
 
-        command_args = [
-            "FT.CREATE", "idx5",
-            "ON", "HASH",
-            "NOSTEM",
-            "WITHOFFSETS", 
-            "SCHEMA", "description", "TEXT"
-        ]
+    def test_text_search_per_field(self):
+        """
+        Test FT.SEARCH command with field-specific text searches.
+        Return only documents where the term appears in the specified field.
+        """
+        client: Valkey = self.server.get_new_client()
+        # Create the text index on Hash documents with two text fields
+        assert client.execute_command(text_index_on_hash_two_fields) == b"OK"
         
-        assert client.execute_command(*command_args) == b"OK"
-        assert b"idx5" in client.execute_command("FT._LIST")
-   
-        # Invalid command - TEXT without field name
-        command_args = [
-            "FT.CREATE", "idx6",
-            "ON", "HASH",
-            "SCHEMA", "TEXT"  # Missing field name before TEXT
-        ]
+        # Insert documents into the index - each doc has 6 fields now (including desc2)
+        for doc in hash_docs_with_desc2:
+            assert client.execute_command(*doc) == 6
         
-        # Should get parsing error
-        with pytest.raises(ResponseError):
-            client.execute_command(*command_args)
+        # Perform search on desc field for "Wonderful"
+        result_desc = client.execute_command(*text_query_desc_field)
+        assert len(result_desc) == 3
+        assert result_desc[0] == 1  # Number of documents found
+        assert result_desc[1] == expected_desc_hash_key
+        document_desc = result_desc[2]
+        doc_fields_desc = dict(zip(document_desc[::2], document_desc[1::2]))
+        assert doc_fields_desc == expected_desc_hash_value
+        
+        # Perform search on desc2 field for "Wonderful"
+        result_desc2 = client.execute_command(*text_query_desc2_field)
+        assert len(result_desc2) == 3
+        assert result_desc2[0] == 1  # Number of documents found
+        assert result_desc2[1] == expected_desc2_hash_key
+        document_desc2 = result_desc2[2]
+        doc_fields_desc2 = dict(zip(document_desc2[::2], document_desc2[1::2]))
+        assert doc_fields_desc2 == expected_desc2_hash_value

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -115,8 +115,7 @@ size_t Text::CalculateSize(const query::TextPredicate& predicate) const {
 std::unique_ptr<Text::EntriesFetcher> Text::Search(
     const query::TextPredicate& predicate,
     bool negate) const {
-  // TODO : Create FieldMask with multiple bits set when multiple fields queried in Text Predicate
-  // Create FieldMask with default all fields set, then clear and set specific field
+  // Create FieldMask with default all fields set,
   auto field_mask = text::FieldMask::Create(text_index_schema_->num_text_fields_);
   field_mask->SetAllFields();  // Initialize with default case all fields set (0xffffffffffff)
 

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -47,7 +47,7 @@ absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
               } else {
                 // Create new Postings object with schema configuration
                 // TODO: Get save_positions from IndexSchema, for now assume true
-                bool save_positions = true;
+                bool save_positions = text_index_schema_->with_offsets_;
                 uint8_t num_text_fields = text_index_schema_->num_text_fields_;
                 postings = std::make_shared<text::Postings>(save_positions, num_text_fields);
               }
@@ -118,7 +118,8 @@ std::unique_ptr<Text::EntriesFetcher> Text::Search(
   auto fetcher = std::make_unique<EntriesFetcher>(
     CalculateSize(predicate),
     text_index_schema_->text_index_,
-    negate ? &untracked_keys_ : nullptr);
+    negate ? &untracked_keys_ : nullptr,
+    text_field_number_);
   fetcher->operation_ = predicate.GetOperation();
   // Currently, we support a single word (exact term) match.
   fetcher->data_ = predicate.GetTextString();
@@ -135,7 +136,7 @@ std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
       std::vector<WordIterator> iterVec = {iter};
       bool slop = 0;
       bool in_order = true;
-      auto itr = std::make_unique<text::PhraseIterator>(iterVec, slop, in_order, untracked_keys_);
+      auto itr = std::make_unique<text::PhraseIterator>(iterVec, slop, in_order, untracked_keys_, text_field_number_);
       itr->Next();
       return itr;
     }

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -127,7 +127,7 @@ std::unique_ptr<Text::EntriesFetcher> Text::Search(
     CalculateSize(predicate),
     text_index_schema_->text_index_,
     negate ? &untracked_keys_ : nullptr,
-    std::move(field_mask));
+    field_mask->AsUint64());
   fetcher->operation_ = predicate.GetOperation();
   // Currently, we support a single word (exact term) match.
   fetcher->data_ = predicate.GetTextString();
@@ -144,7 +144,7 @@ std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
       std::vector<WordIterator> iterVec = {iter};
       bool slop = 0;
       bool in_order = true;
-      auto itr = std::make_unique<text::PhraseIterator>(iterVec, slop, in_order, std::move(field_mask_), untracked_keys_);
+      auto itr = std::make_unique<text::PhraseIterator>(iterVec, slop, in_order, field_mask_, untracked_keys_);
       itr->Next();
       return itr;
     }

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -76,10 +76,12 @@ class Text : public IndexBase {
    public:
     EntriesFetcher(size_t size,
                 const std::shared_ptr<text::TextIndex>& text_index,
-                const InternedStringSet* untracked_keys = nullptr)
+                const InternedStringSet* untracked_keys = nullptr,
+                size_t text_field_number = 0)
         : size_(size),
           text_index_(text_index),
-          untracked_keys_(untracked_keys) {}
+          untracked_keys_(untracked_keys),
+          text_field_number_(text_field_number) {}
 
     size_t Size() const override;
 
@@ -93,6 +95,7 @@ class Text : public IndexBase {
     query::TextPredicate::Operation operation_;
     absl::string_view data_;
     bool no_field_{false};
+    size_t text_field_number_;
   };
 
   // Calculate size based on the predicate.

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -77,11 +77,11 @@ class Text : public IndexBase {
     EntriesFetcher(size_t size,
                 const std::shared_ptr<text::TextIndex>& text_index,
                 const InternedStringSet* untracked_keys = nullptr,
-                size_t text_field_number = 0)
+                std::unique_ptr<text::FieldMask> field_mask = nullptr)
         : size_(size),
           text_index_(text_index),
           untracked_keys_(untracked_keys),
-          text_field_number_(text_field_number) {}
+          field_mask_(std::move(field_mask)) {}
 
     size_t Size() const override;
 
@@ -95,7 +95,7 @@ class Text : public IndexBase {
     query::TextPredicate::Operation operation_;
     absl::string_view data_;
     bool no_field_{false};
-    size_t text_field_number_;
+    std::unique_ptr<text::FieldMask> field_mask_;
   };
 
   // Calculate size based on the predicate.

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -77,11 +77,11 @@ class Text : public IndexBase {
     EntriesFetcher(size_t size,
                 const std::shared_ptr<text::TextIndex>& text_index,
                 const InternedStringSet* untracked_keys = nullptr,
-                std::unique_ptr<text::FieldMask> field_mask = nullptr)
+                uint64_t field_mask = ~0ULL)
         : size_(size),
           text_index_(text_index),
           untracked_keys_(untracked_keys),
-          field_mask_(std::move(field_mask)) {}
+          field_mask_(field_mask) {}
 
     size_t Size() const override;
 
@@ -95,7 +95,7 @@ class Text : public IndexBase {
     query::TextPredicate::Operation operation_;
     absl::string_view data_;
     bool no_field_{false};
-    std::unique_ptr<text::FieldMask> field_mask_;
+    uint64_t field_mask_;
   };
 
   // Calculate size based on the predicate.

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -77,7 +77,7 @@ class Text : public IndexBase {
     EntriesFetcher(size_t size,
                 const std::shared_ptr<text::TextIndex>& text_index,
                 const InternedStringSet* untracked_keys = nullptr,
-                uint64_t field_mask = ~0ULL)
+                text::FieldMaskPredicate field_mask = ~0ULL)
         : size_(size),
           text_index_(text_index),
           untracked_keys_(untracked_keys),
@@ -95,7 +95,7 @@ class Text : public IndexBase {
     query::TextPredicate::Operation operation_;
     absl::string_view data_;
     bool no_field_{false};
-    uint64_t field_mask_;
+    text::FieldMaskPredicate field_mask_;
   };
 
   // Calculate size based on the predicate.

--- a/src/indexes/text/phrase.cc
+++ b/src/indexes/text/phrase.cc
@@ -6,12 +6,12 @@ PhraseIterator::PhraseIterator(const std::vector<WordIterator>& words,
                               size_t slop,
                               bool in_order,
                               const InternedStringSet* untracked_keys,
-                              std::optional<size_t> text_field_number)
+                              std::unique_ptr<FieldMask> field_mask)
     : words_(words),
       slop_(slop),
       in_order_(in_order),
       untracked_keys_(untracked_keys),
-      text_field_number_(text_field_number) {
+      field_mask_(std::move(field_mask)) {
 }
 
 bool PhraseIterator::Done() const {
@@ -27,8 +27,8 @@ void PhraseIterator::Next() {
     begin_ = false;  // Set to false after the first call to Next.
     
     // Check first key for field requirement
-    if (text_field_number_.has_value() && !Done() && 
-        !key_iter_.ContainsField(text_field_number_.value())) {
+    if (field_mask_ != nullptr && !Done() && 
+        !key_iter_.ContainsFields(*field_mask_)) {
       Next();
     }
     return;
@@ -40,8 +40,8 @@ void PhraseIterator::Next() {
     if (Done()) {
       break;
     }
-  } while (text_field_number_.has_value() && 
-           !key_iter_.ContainsField(text_field_number_.value()));
+  } while (field_mask_ != nullptr && 
+           !key_iter_.ContainsFields(*field_mask_));
 }
 
 const InternedStringPtr& PhraseIterator::operator*() const {

--- a/src/indexes/text/phrase.cc
+++ b/src/indexes/text/phrase.cc
@@ -5,8 +5,8 @@ namespace valkey_search::indexes::text {
 PhraseIterator::PhraseIterator(const std::vector<WordIterator>& words,
                               size_t slop,
                               bool in_order,
-                              const InternedStringSet* untracked_keys,
-                              std::unique_ptr<FieldMask> field_mask)
+                              std::unique_ptr<FieldMask> field_mask,
+                              const InternedStringSet* untracked_keys)
     : words_(words),
       slop_(slop),
       in_order_(in_order),
@@ -27,8 +27,7 @@ void PhraseIterator::Next() {
     begin_ = false;  // Set to false after the first call to Next.
     
     // Check first key for field requirement
-    if (field_mask_ != nullptr && !Done() && 
-        !key_iter_.ContainsFields(*field_mask_)) {
+    if (!Done() && !key_iter_.ContainsFields(*field_mask_)) {
       Next();
     }
     return;
@@ -40,8 +39,7 @@ void PhraseIterator::Next() {
     if (Done()) {
       break;
     }
-  } while (field_mask_ != nullptr && 
-           !key_iter_.ContainsFields(*field_mask_));
+  } while (!key_iter_.ContainsFields(*field_mask_));
 }
 
 const InternedStringPtr& PhraseIterator::operator*() const {

--- a/src/indexes/text/phrase.cc
+++ b/src/indexes/text/phrase.cc
@@ -5,13 +5,13 @@ namespace valkey_search::indexes::text {
 PhraseIterator::PhraseIterator(const std::vector<WordIterator>& words,
                               size_t slop,
                               bool in_order,
-                              std::unique_ptr<FieldMask> field_mask,
+                              uint64_t field_mask,
                               const InternedStringSet* untracked_keys)
     : words_(words),
       slop_(slop),
       in_order_(in_order),
       untracked_keys_(untracked_keys),
-      field_mask_(std::move(field_mask)) {
+      field_mask_(field_mask) {
 }
 
 bool PhraseIterator::Done() const {
@@ -27,7 +27,7 @@ void PhraseIterator::Next() {
     begin_ = false;  // Set to false after the first call to Next.
     
     // Check first key for field requirement
-    if (!Done() && !key_iter_.ContainsFields(*field_mask_)) {
+    if (!Done() && !key_iter_.ContainsFields(field_mask_)) {
       Next();
     }
     return;
@@ -39,7 +39,7 @@ void PhraseIterator::Next() {
     if (Done()) {
       break;
     }
-  } while (!key_iter_.ContainsFields(*field_mask_));
+  } while (!key_iter_.ContainsFields(field_mask_));
 }
 
 const InternedStringPtr& PhraseIterator::operator*() const {

--- a/src/indexes/text/phrase.cc
+++ b/src/indexes/text/phrase.cc
@@ -5,7 +5,7 @@ namespace valkey_search::indexes::text {
 PhraseIterator::PhraseIterator(const std::vector<WordIterator>& words,
                               size_t slop,
                               bool in_order,
-                              uint64_t field_mask,
+                              FieldMaskPredicate field_mask,
                               const InternedStringSet* untracked_keys)
     : words_(words),
       slop_(slop),

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -10,6 +10,7 @@
 
 #include <vector>
 #include <cstddef>
+#include <optional>
 #include "src/indexes/index_base.h"
 #include "src/indexes/text/radix_tree.h"
 #include "src/utils/string_interning.h"
@@ -66,7 +67,8 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   PhraseIterator(const std::vector<WordIterator>& words,
                  size_t slop,
                  bool in_order,
-                 const InternedStringSet* untracked_keys = nullptr);
+                 const InternedStringSet* untracked_keys = nullptr,
+                 std::optional<size_t> text_field_number = std::nullopt);
 
   bool Done() const override;
   void Next() override;
@@ -76,12 +78,12 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   std::vector<WordIterator> words_;
   std::shared_ptr<Postings> target_posting_;
   Postings::KeyIterator key_iter_;
-  uint32_t current_idx_ = 0;
   bool begin_ = true;  // Used to track if we are at the beginning of the iterator.
   size_t slop_;
   bool in_order_;
   const InternedStringSet* untracked_keys_;
   InternedStringPtr current_key_;
+  std::optional<size_t> text_field_number_;
 };
 
 

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -66,7 +66,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   PhraseIterator(const std::vector<WordIterator>& words,
                  size_t slop,
                  bool in_order,
-                 std::unique_ptr<FieldMask> field_mask,
+                 uint64_t field_mask,
                  const InternedStringSet* untracked_keys = nullptr);
 
   bool Done() const override;
@@ -82,7 +82,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   bool in_order_;
   const InternedStringSet* untracked_keys_;
   InternedStringPtr current_key_;
-  std::unique_ptr<FieldMask> field_mask_;
+  uint64_t field_mask_;
 };
 
 

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -66,8 +66,8 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   PhraseIterator(const std::vector<WordIterator>& words,
                  size_t slop,
                  bool in_order,
-                 const InternedStringSet* untracked_keys = nullptr,
-                 std::unique_ptr<FieldMask> field_mask = nullptr);
+                 std::unique_ptr<FieldMask> field_mask,
+                 const InternedStringSet* untracked_keys = nullptr);
 
   bool Done() const override;
   void Next() override;

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -10,7 +10,6 @@
 
 #include <vector>
 #include <cstddef>
-#include <optional>
 #include "src/indexes/index_base.h"
 #include "src/indexes/text/radix_tree.h"
 #include "src/utils/string_interning.h"
@@ -68,7 +67,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
                  size_t slop,
                  bool in_order,
                  const InternedStringSet* untracked_keys = nullptr,
-                 std::optional<size_t> text_field_number = std::nullopt);
+                 std::unique_ptr<FieldMask> field_mask = nullptr);
 
   bool Done() const override;
   void Next() override;
@@ -83,7 +82,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   bool in_order_;
   const InternedStringSet* untracked_keys_;
   InternedStringPtr current_key_;
-  std::optional<size_t> text_field_number_;
+  std::unique_ptr<FieldMask> field_mask_;
 };
 
 

--- a/src/indexes/text/phrase.h
+++ b/src/indexes/text/phrase.h
@@ -18,6 +18,7 @@
 
 namespace valkey_search::indexes::text {
 
+using FieldMaskPredicate = uint64_t;
 using WordIterator = RadixTree<std::shared_ptr<Postings>, false>::WordIterator;
 
 /*
@@ -66,7 +67,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   PhraseIterator(const std::vector<WordIterator>& words,
                  size_t slop,
                  bool in_order,
-                 uint64_t field_mask,
+                 FieldMaskPredicate field_mask,
                  const InternedStringSet* untracked_keys = nullptr);
 
   bool Done() const override;
@@ -82,7 +83,7 @@ class PhraseIterator : public indexes::EntriesFetcherIteratorBase {
   bool in_order_;
   const InternedStringSet* untracked_keys_;
   InternedStringPtr current_key_;
-  uint64_t field_mask_;
+  FieldMaskPredicate field_mask_;
 };
 
 

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -288,7 +288,7 @@ bool Postings::KeyIterator::ContainsFields(uint64_t field_mask) const {
       return false;
     }
 
-    // Convert position field mask to uint64_t and compare
+    // Convert position field mask to uint64_t and compare if any of the fields from field_mask are present in position_field_mask
     uint64_t position_mask = position_field_mask->AsUint64();
     if ((position_mask & field_mask) != 0) {
       return true;

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -108,7 +108,6 @@ bool FieldMaskImpl<MaskType, MAX_FIELDS>::HasField(size_t field_index) const {
   }
 }
 
-
 // Set all field bits to true
 template<typename MaskType, size_t MAX_FIELDS>
 void FieldMaskImpl<MaskType, MAX_FIELDS>::SetAllFields() {
@@ -291,7 +290,7 @@ bool Postings::KeyIterator::ContainsFields(uint64_t field_mask) const {
 
     // Convert position field mask to uint64_t and compare
     uint64_t position_mask = position_field_mask->AsUint64();
-    if ((position_mask & field_mask) == field_mask) {
+    if ((position_mask & field_mask) != 0) {
       return true;
     }
   }

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -291,6 +291,26 @@ void Postings::KeyIterator::NextKey() {
   }
 }
 
+bool Postings::KeyIterator::ContainsField(size_t field_index) const {
+  CHECK(key_map_ != nullptr && current_ != end_) << "KeyIterator is invalid or exhausted";
+
+  // Check all positions for this key to see if field_index is set
+  for (const auto& [position, field_mask] : current_->second) {
+    // Safety check: Ensure field_mask is not null
+    if (field_mask == nullptr) {
+      CHECK(false) << "field_mask is null";
+      return false;
+    }
+
+    // Use HasField method to check if field is set
+    if (field_mask->HasField(field_index)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 bool Postings::KeyIterator::SkipForwardKey(const Key& key) {
   CHECK(key_map_ != nullptr) << "KeyIterator is invalid";
   
@@ -302,7 +322,7 @@ bool Postings::KeyIterator::SkipForwardKey(const Key& key) {
 }
 
 const Key& Postings::KeyIterator::GetKey() const {
-  // CHECK(key_map_ != nullptr && current_ != end_) << "KeyIterator is invalid or exhausted";
+  CHECK(key_map_ != nullptr && current_ != end_) << "KeyIterator is invalid or exhausted";
   return current_->first;
 }
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -106,6 +106,9 @@ struct Postings {
     // Get Current key
     const Key& GetKey() const;
 
+    // Check if word is present in the field specified for current key
+    bool ContainsField(size_t field_index) const;
+
     // Get Position Iterator
     PositionIterator GetPositionIterator() const;
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -51,7 +51,6 @@ public:
   virtual void SetField(size_t field_index) = 0;
   virtual void ClearField(size_t field_index) = 0;
   virtual bool HasField(size_t field_index) const = 0;
-  virtual bool HasFields(const FieldMask& field_mask) const = 0;
   virtual void SetAllFields() = 0;
   virtual void ClearAllFields() = 0;
   virtual size_t CountSetFields() const = 0;
@@ -123,7 +122,7 @@ struct Postings {
     const Key& GetKey() const;
 
     // Check if word is present in any of the fields specified by field_mask for current key
-    bool ContainsFields(const FieldMask& field_mask) const;
+    bool ContainsFields(uint64_t field_mask) const;
 
     // Get Position Iterator
     PositionIterator GetPositionIterator() const;

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -43,6 +43,22 @@ namespace valkey_search::indexes::text {
 using Key = InternedStringPtr;
 using Position = uint32_t;
 
+// Field mask interface optimized for different field counts
+class FieldMask {
+public:
+  static std::unique_ptr<FieldMask> Create(size_t num_fields);
+  virtual ~FieldMask() = default;
+  virtual void SetField(size_t field_index) = 0;
+  virtual void ClearField(size_t field_index) = 0;
+  virtual bool HasField(size_t field_index) const = 0;
+  virtual bool HasFields(const FieldMask& field_mask) const = 0;
+  virtual void SetAllFields() = 0;
+  virtual void ClearAllFields() = 0;
+  virtual size_t CountSetFields() const = 0;
+  virtual uint64_t AsUint64() const = 0;
+  virtual size_t MaxFields() const = 0;
+};
+
 
 //
 // this is the logical view of a posting. 
@@ -106,8 +122,8 @@ struct Postings {
     // Get Current key
     const Key& GetKey() const;
 
-    // Check if word is present in the field specified for current key
-    bool ContainsField(size_t field_index) const;
+    // Check if word is present in any of the fields specified by field_mask for current key
+    bool ContainsFields(const FieldMask& field_mask) const;
 
     // Get Position Iterator
     PositionIterator GetPositionIterator() const;

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -73,7 +73,7 @@ struct TextIndexSchema {
   // IndexSchema proto-derived configuration fields
   data_model::Language language_ = data_model::LANGUAGE_UNSPECIFIED;
   std::string punctuation_;
-  bool with_offsets_ = false;
+  bool with_offsets_ = true;
   std::vector<std::string> stop_words_;
 
   uint8_t AllocateTextFieldNumber() {

--- a/testing/posting_test.cc
+++ b/testing/posting_test.cc
@@ -337,4 +337,30 @@ TEST_F(PostingTest, EmptyPostingIterators) {
   EXPECT_FALSE(pos_iter.IsValid());
 }
 
+TEST_F(PostingTest, ContainsFieldsCheck) {
+  // Create a fresh posting to ensure no interference from other tests
+  Postings fresh_postings(true, 5);
+  
+  // Test basic field containment functionality 
+  fresh_postings.InsertPosting(InternKey("doc1"), 0, 10);
+  
+  auto field_mask = FieldMask::Create(5);
+  field_mask->SetField(0);
+  
+  auto key_iter = fresh_postings.GetKeyIterator();
+  
+  // Should have exactly one key
+  EXPECT_EQ(fresh_postings.GetKeyCount(), 1);
+  
+  // Iterator should be valid and contain the field we inserted
+  EXPECT_TRUE(key_iter.IsValid());
+  EXPECT_EQ(key_iter.GetKey()->Str(), "doc1");
+  EXPECT_TRUE(key_iter.ContainsFields(*field_mask));
+  
+  // Test that it doesn't contain fields that weren't set
+  auto field_mask_2 = FieldMask::Create(5);
+  field_mask_2->SetField(1);
+  EXPECT_FALSE(key_iter.ContainsFields(*field_mask_2));
+}
+
 }  // namespace valkey_search::indexes::text

--- a/testing/posting_test.cc
+++ b/testing/posting_test.cc
@@ -355,12 +355,12 @@ TEST_F(PostingTest, ContainsFieldsCheck) {
   // Iterator should be valid and contain the field we inserted
   EXPECT_TRUE(key_iter.IsValid());
   EXPECT_EQ(key_iter.GetKey()->Str(), "doc1");
-  EXPECT_TRUE(key_iter.ContainsFields(*field_mask));
+  EXPECT_TRUE(key_iter.ContainsFields(field_mask->AsUint64()));
   
   // Test that it doesn't contain fields that weren't set
   auto field_mask_2 = FieldMask::Create(5);
   field_mask_2->SetField(1);
-  EXPECT_FALSE(key_iter.ContainsFields(*field_mask_2));
+  EXPECT_FALSE(key_iter.ContainsFields(field_mask_2->AsUint64()));
 }
 
 }  // namespace valkey_search::indexes::text


### PR DESCRIPTION
* KeyIterator can now take field specifications to filter on certain fields
* Updated PhraseIterator to search on only field specified in the query
* Use WITHOFFSETS as input for save_positions.
* Add integration test for full text search per field when word is present in different fields