### PR TITLE
Rough delete logic for the radix tree

### DIFF
--- a/src/indexes/text/radix_tree.h
+++ b/src/indexes/text/radix_tree.h
@@ -123,10 +123,8 @@ struct RadixTree {
   // Create a Path iterator at a specific starting prefix
   PathIterator GetPathIterator(absl::string_view prefix) const;
 
-  // Debug function to print tree structure
+  // Prints tree structure
   void DebugPrintTree(const std::string& label = "") const;
-
- private:
 
  private:
   /*
@@ -188,7 +186,6 @@ struct RadixTree {
 
   Node root_;
 
-  // Debug helper function
   void DebugPrintNode(const Node* node, const std::string& path, int depth) const {
     std::string indent(depth * 2, ' ');
     std::cout << indent << "Node[" << path << "]";
@@ -500,7 +497,7 @@ void RadixTree<Target, reverse>::Mutate(
             [&](std::pair<BytePath, std::unique_ptr<Node>>& child) {
               // The target node is a compressed node. If its parent is a
               // compressed node, we can modify the parent to have an edge
-              // directly to target node's child.
+              // directly to its child and remove the target node.
               const auto& parent = node_path.back();
               if (std::holds_alternative<
                       std::pair<BytePath, std::unique_ptr<Node>>>(

--- a/src/indexes/text/radix_tree.h
+++ b/src/indexes/text/radix_tree.h
@@ -310,8 +310,8 @@ void RadixTree<Target, reverse>::Mutate(
             [&](std::monostate&) {
               // Leaf case - we're at a leaf and still have more of the word
               // remaining. Create a compressed path to a new leaf node.
-              std::unique_ptr<Node> new_leaf = std::make_unique<Node>(
-                  Node{0, std::nullopt, std::monostate{}});
+              std::unique_ptr<Node> new_leaf =
+                  std::make_unique<Node>(0, std::nullopt, std::monostate{});
               next = new_leaf.get();
               n->children = std::pair{BytePath(remaining), std::move(new_leaf)};
               remaining.remove_prefix(remaining.length());
@@ -354,8 +354,8 @@ void RadixTree<Target, reverse>::Mutate(
                 } else {
                   // Create an intermediate compressed node to the leaf
                   new_branches[path[0]] = std::make_unique<Node>(
-                      Node{0, std::nullopt,
-                           std::pair{path.substr(1), std::move(child.second)}});
+                      0, std::nullopt,
+                      std::pair{path.substr(1), std::move(child.second)});
                 }
                 n->children = std::move(new_branches);
                 // Next iteration will hit the branching path for the same node
@@ -363,9 +363,9 @@ void RadixTree<Target, reverse>::Mutate(
               } else {
                 // Partial match - split the compressed node into two at the
                 // branching point
-                std::unique_ptr<Node> new_node = std::make_unique<Node>(Node{
+                std::unique_ptr<Node> new_node = std::make_unique<Node>(
                     0, std::nullopt,
-                    std::pair{path.substr(match), std::move(child.second)}});
+                    std::pair{path.substr(match), std::move(child.second)});
                 child.first = path.substr(0, match);
                 child.second = std::move(new_node);
 

--- a/testing/radix_test.cc
+++ b/testing/radix_test.cc
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: ************
  */
 
+#include <map>
 #include <string>
 #include <vector>
 
@@ -30,6 +31,59 @@ class RadixTreeTest : public vmsdk::ValkeyTest {
     prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
   }
 
+  // Helper: Add multiple words to tree
+  void AddWords(const std::vector<std::pair<std::string, int>>& words) {
+    for (const auto& [word, value] : words) {
+      prefix_tree_->Mutate(word, [value](auto) { return TestTarget(value); });
+    }
+  }
+
+  // Helper: Verify words exist with expected values
+  void VerifyWords(const std::vector<std::pair<std::string, int>>& expected) {
+    for (const auto& [word, value] : expected) {
+      prefix_tree_->Mutate(word, [value, word](auto existing) {
+        EXPECT_TRUE(existing.has_value())
+            << "Word '" << word << "' should exist";
+        EXPECT_EQ(existing->value, value)
+            << "Word '" << word << "' has wrong value";
+        return existing;
+      });
+    }
+  }
+
+  // Helper: Verify words don't exist
+  void VerifyWordsDeleted(const std::vector<std::string>& words) {
+    for (const auto& word : words) {
+      prefix_tree_->Mutate(word, [&word](auto existing) {
+        EXPECT_FALSE(existing.has_value())
+            << "Word '" << word << "' should be deleted";
+        return existing;
+      });
+    }
+  }
+
+  // Helper: Delete multiple words
+  void DeleteWords(const std::vector<std::string>& words) {
+    for (const auto& word : words) {
+      prefix_tree_->Mutate(
+          word, [](auto) -> std::optional<TestTarget> { return std::nullopt; });
+    }
+  }
+
+  // Helper: Verify iterator results
+  void VerifyIterator(
+      const std::string& prefix,
+      const std::vector<std::pair<std::string, int>>& expected) {
+    auto iter = prefix_tree_->GetWordIterator(prefix);
+    std::vector<std::pair<std::string, int>> actual;
+    while (!iter.Done()) {
+      actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
+      iter.Next();
+    }
+    EXPECT_EQ(actual, expected)
+        << "Iterator results don't match for prefix '" << prefix << "'";
+  }
+
   std::unique_ptr<RadixTree<TestTarget, false>> prefix_tree_;
 };
 
@@ -49,88 +103,45 @@ TEST_F(RadixTreeTest, CoreMutationOperations) {
   });
 
   // Verify final state
-  prefix_tree_->Mutate("hello", [](auto existing) {
-    EXPECT_TRUE(existing.has_value());
-    EXPECT_EQ(existing->value, 2);
-    return existing;
-  });
+  VerifyWords({{"hello", 2}});
 }
 
 // Test branch node operations: existing and new children
 TEST_F(RadixTreeTest, BranchNodeOperations) {
-  // Create initial branching structure
-  prefix_tree_->Mutate("cat", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("car", [](auto) { return TestTarget(2); });
-
-  // Add to existing branch (same prefix 'ca')
-  prefix_tree_->Mutate("can", [](auto) { return TestTarget(3); });
-
-  // Add completely new branch
-  prefix_tree_->Mutate("dog", [](auto) { return TestTarget(4); });
-
-  // Verify all branches work correctly
-  std::vector<std::pair<std::string, int>> expected = {
-      {"cat", 1}, {"car", 2}, {"can", 3}, {"dog", 4}};
-
-  for (const auto& [word, value] : expected) {
-    prefix_tree_->Mutate(word, [value](auto existing) {
-      EXPECT_TRUE(existing.has_value());
-      EXPECT_EQ(existing->value, value);
-      return existing;
-    });
-  }
+  // Create initial branching structure: ca->t/r, then add ca->n, then separate
+  // dog branch
+  AddWords({{"cat", 1}, {"car", 2}, {"can", 3}, {"dog", 4}});
+  VerifyWords({{"cat", 1}, {"car", 2}, {"can", 3}, {"dog", 4}});
 }
 
 // Test all compressed node scenarios: extension, branching, and splitting
 TEST_F(RadixTreeTest, CompressedNodeOperations) {
   // Test 1: Full match extension (hello -> helloworld)
-  prefix_tree_->Mutate("hello", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("helloworld", [](auto) { return TestTarget(2); });
-
   // Test 2: No match branching (add completely different word)
-  prefix_tree_->Mutate("xyz", [](auto) { return TestTarget(3); });
-
   // Test 3: Partial match splitting (testing -> test)
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(4); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(5); });
-
-  // Verify all words exist with correct values
-  std::vector<std::pair<std::string, int>> expected = {
-      {"hello", 1}, {"helloworld", 2}, {"xyz", 3}, {"testing", 4}, {"test", 5}};
-
-  for (const auto& [word, value] : expected) {
-    prefix_tree_->Mutate(word, [value](auto existing) {
-      EXPECT_TRUE(existing.has_value());
-      EXPECT_EQ(existing->value, value);
-      return existing;
-    });
-  }
+  AddWords({{"hello", 1},
+            {"helloworld", 2},
+            {"xyz", 3},
+            {"testing", 4},
+            {"test", 5}});
+  VerifyWords({{"hello", 1},
+               {"helloworld", 2},
+               {"xyz", 3},
+               {"testing", 4},
+               {"test", 5}});
 }
 
-// Test edge cases: single character words
+// Test edge cases: single character words creating specific branch patterns
 TEST_F(RadixTreeTest, EdgeCases) {
-  prefix_tree_->Mutate("a", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("b", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("ab", [](auto) { return TestTarget(3); });
-
-  std::vector<std::pair<std::string, int>> expected = {
-      {"a", 1}, {"b", 2}, {"ab", 3}};
-
-  for (const auto& [word, value] : expected) {
-    prefix_tree_->Mutate(word, [value](auto existing) {
-      EXPECT_TRUE(existing.has_value());
-      EXPECT_EQ(existing->value, value);
-      return existing;
-    });
-  }
+  AddWords({{"a", 1}, {"b", 2}, {"ab", 3}});
+  VerifyWords({{"a", 1}, {"b", 2}, {"ab", 3}});
 }
 
 TEST_F(RadixTreeTest, DeleteBasicCases) {
   // Case 1: Delete leaf node
   prefix_tree_->Mutate("hello", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("hello", [](auto) -> std::optional<TestTarget> {
-    return std::nullopt;
-  });
+  prefix_tree_->Mutate(
+      "hello", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
   prefix_tree_->Mutate("hello", [](auto existing) {
     EXPECT_FALSE(existing.has_value());
     return existing;
@@ -153,13 +164,12 @@ TEST_F(RadixTreeTest, DeleteStructuralCases) {
   prefix_tree_->Mutate("car", [](auto) { return TestTarget(2); });
   prefix_tree_->Mutate("can", [](auto) { return TestTarget(3); });
   prefix_tree_->DebugPrintTree("Initial: cat, car, can");
-  
-  prefix_tree_->Mutate("car", [](auto) -> std::optional<TestTarget> {
-    return std::nullopt;
-  });
-  
+
+  prefix_tree_->Mutate(
+      "car", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
+
   prefix_tree_->DebugPrintTree("After deleting 'car'");
-  
+
   // Verify remaining structure
   auto iter = prefix_tree_->GetWordIterator("ca");
   std::vector<std::pair<std::string, int>> actual;
@@ -174,11 +184,10 @@ TEST_F(RadixTreeTest, DeleteStructuralCases) {
   prefix_tree_->Mutate("testing", [](auto) { return TestTarget(4); });
   prefix_tree_->Mutate("test", [](auto) { return TestTarget(5); });
   prefix_tree_->DebugPrintTree("After adding testing/test");
-  prefix_tree_->Mutate("test", [](auto) -> std::optional<TestTarget> {
-    return std::nullopt;
-  });
+  prefix_tree_->Mutate(
+      "test", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
   prefix_tree_->DebugPrintTree("After deleting 'test'");
-  
+
   // Verify compressed node structure remains correct
   auto test_iter = prefix_tree_->GetWordIterator("test");
   EXPECT_FALSE(test_iter.Done());
@@ -187,105 +196,54 @@ TEST_F(RadixTreeTest, DeleteStructuralCases) {
 }
 
 TEST_F(RadixTreeTest, DeleteCausingMerge) {
-  prefix_tree_->Mutate("app", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("application", [](auto) { return TestTarget(2); });
-  
-  prefix_tree_->Mutate("app", [](auto) -> std::optional<TestTarget> {
-    return std::nullopt;
-  });
-  
-  prefix_tree_->Mutate("application", [](auto existing) {
-    EXPECT_TRUE(existing.has_value());
-    EXPECT_EQ(existing->value, 2);
-    return existing;
-  });
+  // Test app/application -> delete app leaves just application (merge scenario)
+  AddWords({{"app", 1}, {"application", 2}});
+  DeleteWords({"app"});
+  VerifyWords({{"application", 2}});
+  VerifyWordsDeleted({"app"});
 }
 
 TEST_F(RadixTreeTest, DeleteComplexScenarios) {
-  // Build a more complex tree structure
-  std::vector<std::pair<std::string, int>> initial = {
-    {"a", 1}, {"ab", 2}, {"abc", 3}, 
-    {"abcd", 4}, {"abce", 5}
-  };
-  
-  for (const auto& [word, value] : initial) {
-    prefix_tree_->Mutate(word, [value](auto) { return TestTarget(value); });
-  }
+  // Build complex tree: a->b->c->d/e, then delete in specific order to test
+  // restructuring
+  AddWords({{"a", 1}, {"ab", 2}, {"abc", 3}, {"abcd", 4}, {"abce", 5}});
 
   // Delete nodes in specific order to test various restructuring scenarios
-  std::vector<std::string> delete_order = {"abc", "a", "abce"};
-  for (const auto& word : delete_order) {
-    prefix_tree_->Mutate(word, [](auto) -> std::optional<TestTarget> {
-      return std::nullopt;
-    });
-  }
+  DeleteWords({"abc", "a", "abce"});
 
-  // Verify final structure
-  auto iter = prefix_tree_->GetWordIterator("");
-  std::vector<std::pair<std::string, int>> expected = {
-    {"ab", 2}, {"abcd", 4}
-  };
-  
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-  EXPECT_EQ(actual, expected);
+  // Verify final structure: should have ab, abcd remaining
+  VerifyIterator("", {{"ab", 2}, {"abcd", 4}});
+  VerifyWordsDeleted({"a", "abc", "abce"});
 }
 
 // Test complex scenarios: overlapping prefixes and special strings
 TEST_F(RadixTreeTest, ComplexScenarios) {
-  // Overlapping prefixes with multiple lengths
-  prefix_tree_->Mutate("te", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(3); });
-
-  // Complex tree with multiple splits
-  prefix_tree_->Mutate("app", [](auto) { return TestTarget(4); });
-  prefix_tree_->Mutate("application", [](auto) { return TestTarget(5); });
-
+  // Overlapping prefixes with multiple lengths: te->st->ing
+  // Complex tree with multiple splits: app->lication
   // Special strings: long string and Unicode
   std::string long_string(1000, 'x');
-  prefix_tree_->Mutate(long_string, [](auto) { return TestTarget(6); });
-  prefix_tree_->Mutate("こんにちは", [](auto) { return TestTarget(7); });
-
-  std::vector<std::pair<std::string, int>> expected = {
-      {"te", 1},          {"test", 2},      {"testing", 3},   {"app", 4},
-      {"application", 5}, {long_string, 6}, {"こんにちは", 7}};
-
-  for (const auto& [word, value] : expected) {
-    prefix_tree_->Mutate(word, [value](auto existing) {
-      EXPECT_TRUE(existing.has_value());
-      EXPECT_EQ(existing->value, value);
-      return existing;
-    });
-  }
+  AddWords({{"te", 1},
+            {"test", 2},
+            {"testing", 3},
+            {"app", 4},
+            {"application", 5},
+            {long_string, 6},
+            {"こんにちは", 7}});
+  VerifyWords({{"te", 1},
+               {"test", 2},
+               {"testing", 3},
+               {"app", 4},
+               {"application", 5},
+               {long_string, 6},
+               {"こんにちは", 7}});
 }
 
 // Test WordIterator functionality
 TEST_F(RadixTreeTest, WordIteratorBasic) {
-  // Add words to tree
-  prefix_tree_->Mutate("cat", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("car", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("card", [](auto) { return TestTarget(3); });
-  prefix_tree_->Mutate("dog", [](auto) { return TestTarget(4); });
-
-  // Test iterator with "ca" prefix
-  auto iter = prefix_tree_->GetWordIterator("ca");
-  EXPECT_FALSE(iter.Done());
-
-  // Should iterate in lexical order: car, card, cat
-  std::vector<std::pair<std::string, int>> expected = {
-      {"car", 2}, {"card", 3}, {"cat", 1}};
-
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-
-  EXPECT_EQ(actual, expected);
+  // Create tree: cat/car/card/dog, test "ca" prefix iteration (lexical order:
+  // car, card, cat)
+  AddWords({{"cat", 1}, {"car", 2}, {"card", 3}, {"dog", 4}});
+  VerifyIterator("ca", {{"car", 2}, {"card", 3}, {"cat", 1}});
 }
 
 TEST_F(RadixTreeTest, WordIteratorEmpty) {
@@ -315,67 +273,23 @@ TEST_F(RadixTreeTest, WordIteratorSingleWord) {
 }
 
 TEST_F(RadixTreeTest, WordIteratorCompressedPaths) {
-  // Test with compressed paths
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("tester", [](auto) { return TestTarget(3); });
-
-  auto iter = prefix_tree_->GetWordIterator("test");
-
-  std::vector<std::pair<std::string, int>> expected = {
-      {"test", 2}, {"tester", 3}, {"testing", 1}};
-
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-
-  EXPECT_EQ(actual, expected);
+  // Test with compressed paths: testing/test/tester with "test" prefix
+  AddWords({{"testing", 1}, {"test", 2}, {"tester", 3}});
+  VerifyIterator("test", {{"test", 2}, {"tester", 3}, {"testing", 1}});
 }
 
 TEST_F(RadixTreeTest, WordIteratorRootPrefix) {
-  // Test iterator with empty prefix (should get all words)
-  prefix_tree_->Mutate("a", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("b", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("c", [](auto) { return TestTarget(3); });
-
-  auto iter = prefix_tree_->GetWordIterator("");
-
-  std::vector<std::pair<std::string, int>> expected = {
-      {"a", 1}, {"b", 2}, {"c", 3}};
-
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-
-  EXPECT_EQ(actual, expected);
+  // Test iterator with empty prefix (should get all words in lexical order)
+  AddWords({{"a", 1}, {"b", 2}, {"c", 3}});
+  VerifyIterator("", {{"a", 1}, {"b", 2}, {"c", 3}});
 }
 
 TEST_F(RadixTreeTest, WordIteratorComplexTree) {
-  // Build complex tree from previous test
-  std::vector<std::pair<std::string, int>> words = {
-      {"app", 1}, {"application", 2}, {"apple", 3}, {"apply", 4}, {"a", 5}};
-
-  for (const auto& [word, value] : words) {
-    prefix_tree_->Mutate(word, [value](auto) { return TestTarget(value); });
-  }
-
-  // Test iterator with "app" prefix
-  auto iter = prefix_tree_->GetWordIterator("app");
-
-  std::vector<std::pair<std::string, int>> expected = {
-      {"app", 1}, {"apple", 3}, {"application", 2}, {"apply", 4}};
-
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-
-  EXPECT_EQ(actual, expected);
+  // Build complex tree: app/application/apple/apply/a, test "app" prefix
+  AddWords(
+      {{"app", 1}, {"application", 2}, {"apple", 3}, {"apply", 4}, {"a", 5}});
+  VerifyIterator("app",
+                 {{"app", 1}, {"apple", 3}, {"application", 2}, {"apply", 4}});
 }
 
 TEST_F(RadixTreeTest, WordIteratorLargeScale) {
@@ -386,14 +300,14 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
   In a lab full of gadgets all covered in glue.
 
   Young Sally McZee, with a hat far too wide,  
-  Said, “Let’s build a thing with a brain deep inside!  
+  Said, "Let's build a thing with a brain deep inside!  
   Not a blender or toaster or mop on a string,  
-  But a magical, logical, learnable thing!”
+  But a magical, logical, learnable thing!"
 
   With buttons and switches and circuits galore,  
-  They tinkered for weeks on the lab’s bouncy floor.  
+  They tinkered for weeks on the lab's bouncy floor.  
   It sizzled and sparked, then gave out a sneeze—  
-  And said, “Hello world!” with surprising ease.
+  And said, "Hello world!" with surprising ease.
 
   They called it The Friend, and it smiled with delight,  
   It blinked in the morning and purred through the night.  
@@ -408,7 +322,7 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
   It watered their gardens and walked all their cats,  
   It fluffed every pillow and dusted their hats.  
   It danced through the city, it spun like a top—  
-  And everyone loved it and begged it, “Don’t stop!”
+  And everyone loved it and begged it, "Don't stop!"
 
   It helped with their taxes and picked up their mail,  
   It built bigger backpacks and rockets with sails.  
@@ -421,9 +335,9 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
   And knew how to chill them and serve them still hot!
 
   Now Grumble McSnark, who once scoffed at the lot,  
-  Admitted, “By gum, this is smarter than I thought.”  
+  Admitted, "By gum, this is smarter than I thought."  
   He tipped his old hat and admitted with glee,  
-  “The Friend might be brighter than even McZee!”
+  "The Friend might be brighter than even McZee!"
 
   The mayor declared it a civic success,  
   And gave it a tie and a nameplate and desk.  
@@ -498,58 +412,111 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
 }
 
 TEST_F(RadixTreeTest, WordIteratorPrefixPartialMatch) {
-  // Reproduce the specific issue with WordIterator prefix matching
-  prefix_tree_->Mutate("cat", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("can", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(4); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(5); });
+  // Test specific prefix matching edge case: cat/can/testing/test
+  AddWords({{"cat", 1}, {"can", 2}, {"testing", 4}, {"test", 5}});
 
-  auto test_iter = prefix_tree_->GetWordIterator("te");
+  // Test "te" prefix - should only match test/testing
+  VerifyIterator("te", {{"test", 5}, {"testing", 4}});
 
-  std::vector<std::string> words;
-
-  while (!test_iter.Done()) {
-    std::string current_word = std::string(test_iter.GetWord());
-    words.push_back(current_word);
-    test_iter.Next();
-  }
-
-  // Expected: only "test" and "testing" should match prefix "te"
-  std::vector<std::string> expected = {"test", "testing"};
-  EXPECT_EQ(words, expected)
-      << "WordIterator should only return words that start with 'te'";
-
-  test_iter = prefix_tree_->GetWordIterator("ca");
-
-  words.clear();
-  while (!test_iter.Done()) {
-    std::string current_word = std::string(test_iter.GetWord());
-    words.push_back(current_word);
-    test_iter.Next();
-  }
-
-  // Expected: "can" and "cat" should match prefix "ca"
-  expected = {"can", "cat"};
-  EXPECT_EQ(words, expected)
-      << "WordIterator should return words that start with 'ca'";
+  // Test "ca" prefix - should only match can/cat
+  VerifyIterator("ca", {{"can", 2}, {"cat", 1}});
 }
 
-TEST_F(RadixTreeTest, TemporaryDebugTest) {
-  // Simple test to see DebugPrintNode output
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(2); });
-  prefix_tree_->DebugPrintTree("Before deletion");
-  
-  prefix_tree_->Mutate("test", [](auto) -> std::optional<TestTarget> {
-    return std::nullopt;
-  });
-  prefix_tree_->DebugPrintTree("After deleting test");
-  
-  auto iter = prefix_tree_->GetWordIterator("test");
-  std::cout << "Iterator Done: " << iter.Done() << std::endl;
-  if (!iter.Done()) {
-    std::cout << "Iterator Word: '" << iter.GetWord() << "'" << std::endl;
-  }
+TEST_F(RadixTreeTest, BranchToCompressedNodeConversion) {
+  // Test all three compression scenarios when branch nodes are converted.
+  // These test the complex logic in the deletion code that handles:
+  // 1. parent_compressed && child_compressed - connect parent to
+  // great-grandchild
+  // 2. parent_compressed only - connect parent to grandchild
+  // 3. child_compressed only - connect node to grandchild
+
+  // ========================================================================
+  // Scenario 1: parent_compressed && child_compressed
+  // ========================================================================
+  // Initial tree structure:
+  //                  [compressed]
+  //                   "x" |
+  //                   [branching]
+  //                "a" /     \ "t"
+  //          [compressed]   [compressed]
+  //          "bc" /           \ "est"
+  //   Target <- [leaf]           [leaf] -> Target
+  //
+  // Words: "xabc", "xtest"
+  AddWords({{"xabc", 1}, {"xtest", 2}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 1 - Initial: both parent and child compressed");
+
+  // Delete "xabc" - this triggers parent_compressed && child_compressed case
+  // It becomes the following after deleting "xabc":
+  //                  [compressed]
+  //              "xtest" |
+  //                   [leaf] -> Target
+  DeleteWords({"xabc"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 1 - After deletion: parent connected to great-grandchild");
+  VerifyIterator("x", {{"xtest", 2}});
+  VerifyWordsDeleted({"xabc"});
+
+  // Reset for scenario 2
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+
+  // ========================================================================
+  // Scenario 2: parent_compressed only
+  // ========================================================================
+  // Initial tree structure:
+  //                  [compressed]
+  //                 "cat" |
+  //                   [branching]
+  //                "s" /     \ "ch"
+  //      Target <- [Leaf]   [Leaf] -> Target
+  //          "" /           
+  //   Target <- [leaf]           
+  //
+  // Words: "cats", "catcher"
+  AddWords({{"cats", 3}, {"catcher", 4}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 2 - Initial: parent compressed, child branching");
+
+  // Delete "cats" - this triggers parent_compressed only case
+  // It becomes:
+  //                  [compressed]
+  //              "catcher" |
+  //                   [leaf] -> Target
+  DeleteWords({"cats"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 2 - After deletion: parent connected to grandchild");
+  VerifyIterator("cat", {{"catcher", 4}});
+  VerifyWordsDeleted({"cats"});
+
+  // Reset for scenario 3
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+
+  // ========================================================================
+  // Scenario 3: child_compressed only
+  // ========================================================================
+  // Initial tree structure:
+  //                   [branching]
+  //               "d" /     \ "r"
+  //          [compressed]   [compressed]
+  //          "og" /           \ "unner"
+  //   Target <- [leaf]           [leaf] -> Target
+  //
+  // Words: "dog", "runner"
+  AddWords({{"dog", 5}, {"runner", 6}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 3 - Initial: parent branching, child compressed");
+
+  // Delete "dog" - this triggers child_compressed only case
+  // It becomes:
+  //                  [compressed]
+  //              "runner" |
+  //                   [leaf] -> Target
+  DeleteWords({"dog"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 3 - After deletion: node connected to grandchild");
+  VerifyIterator("", {{"runner", 6}});
+  VerifyWordsDeleted({"dog"});
 }
 
 }  // namespace

--- a/testing/radix_test.cc
+++ b/testing/radix_test.cc
@@ -15,7 +15,6 @@
 namespace valkey_search::indexes::text {
 namespace {
 
-// Simple test target type
 struct TestTarget {
   int value;
   explicit TestTarget(int v) : value(v) {}
@@ -31,14 +30,19 @@ class RadixTreeTest : public vmsdk::ValkeyTest {
     prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
   }
 
-  // Helper: Add multiple words to tree
   void AddWords(const std::vector<std::pair<std::string, int>>& words) {
     for (const auto& [word, value] : words) {
       prefix_tree_->Mutate(word, [value](auto) { return TestTarget(value); });
     }
   }
 
-  // Helper: Verify words exist with expected values
+  void DeleteWords(const std::vector<std::string>& words) {
+    for (const auto& word : words) {
+      prefix_tree_->Mutate(
+          word, [](auto) -> std::optional<TestTarget> { return std::nullopt; });
+    }
+  }
+
   void VerifyWords(const std::vector<std::pair<std::string, int>>& expected) {
     for (const auto& [word, value] : expected) {
       prefix_tree_->Mutate(word, [value, word](auto existing) {
@@ -51,7 +55,6 @@ class RadixTreeTest : public vmsdk::ValkeyTest {
     }
   }
 
-  // Helper: Verify words don't exist
   void VerifyWordsDeleted(const std::vector<std::string>& words) {
     for (const auto& word : words) {
       prefix_tree_->Mutate(word, [&word](auto existing) {
@@ -62,15 +65,6 @@ class RadixTreeTest : public vmsdk::ValkeyTest {
     }
   }
 
-  // Helper: Delete multiple words
-  void DeleteWords(const std::vector<std::string>& words) {
-    for (const auto& word : words) {
-      prefix_tree_->Mutate(
-          word, [](auto) -> std::optional<TestTarget> { return std::nullopt; });
-    }
-  }
-
-  // Helper: Verify iterator results
   void VerifyIterator(
       const std::string& prefix,
       const std::vector<std::pair<std::string, int>>& expected) {
@@ -87,155 +81,177 @@ class RadixTreeTest : public vmsdk::ValkeyTest {
   std::unique_ptr<RadixTree<TestTarget, false>> prefix_tree_;
 };
 
-// Test core mutation operations: add, update, and basic tree structure
-TEST_F(RadixTreeTest, CoreMutationOperations) {
-  // Add first word (creates compressed path from root)
-  prefix_tree_->Mutate("hello", [](auto existing) {
-    EXPECT_FALSE(existing.has_value());
-    return TestTarget(1);
-  });
+TEST_F(RadixTreeTest, TreeConstruction) {
+  // Add a variety of words that lead to branching and compressed nodes
+  std::string long_string(1000, 'x');
+  AddWords({{"cat", 1},
+            {"car", 2},
+            {"can", 3},
+            {"c", 4},
+            {"b", 5},
+            {"dog", 6},
+            {"hello", 7},
+            {"helloworld", 8},
+            {"testing", 9},
+            {"test", 10},
+            {"xyz", 11},
+            {long_string, 12},
+            {"こんにちは", 13}});
 
-  // Update existing word
-  prefix_tree_->Mutate("hello", [](auto existing) {
-    EXPECT_TRUE(existing.has_value());
-    EXPECT_EQ(existing->value, 1);
-    return TestTarget(2);
-  });
+  // Update a word
+  AddWords({{"test", 123}});
 
-  // Verify final state
-  VerifyWords({{"hello", 2}});
+  VerifyWords({{"cat", 1},
+               {"car", 2},
+               {"can", 3},
+               {"c", 4},
+               {"b", 5},
+               {"dog", 6},
+               {"hello", 7},
+               {"helloworld", 8},
+               {"testing", 9},
+               {"test", 123},
+               {"xyz", 11},
+               {long_string, 12},
+               {"こんにちは", 13}});
 }
 
-// Test branch node operations: existing and new children
-TEST_F(RadixTreeTest, BranchNodeOperations) {
-  // Create initial branching structure: ca->t/r, then add ca->n, then separate
-  // dog branch
-  AddWords({{"cat", 1}, {"car", 2}, {"can", 3}, {"dog", 4}});
-  VerifyWords({{"cat", 1}, {"car", 2}, {"can", 3}, {"dog", 4}});
+TEST_F(RadixTreeTest, DeleteBranchNodeWord) {
+  AddWords({{"cat", 1}, {"car", 2}, {"can", 3}, {"ca", 4}});
+
+  // Delete word at branching node. Nothing structurally changes.
+  DeleteWords({"ca"});
+  VerifyWords({{"cat", 1}, {"car", 2}, {"can", 3}});
+  VerifyWordsDeleted({"ca"});
 }
 
-// Test all compressed node scenarios: extension, branching, and splitting
-TEST_F(RadixTreeTest, CompressedNodeOperations) {
-  // Test 1: Full match extension (hello -> helloworld)
-  // Test 2: No match branching (add completely different word)
-  // Test 3: Partial match splitting (testing -> test)
-  AddWords({{"hello", 1},
-            {"helloworld", 2},
-            {"xyz", 3},
-            {"testing", 4},
-            {"test", 5}});
-  VerifyWords({{"hello", 1},
-               {"helloworld", 2},
-               {"xyz", 3},
-               {"testing", 4},
-               {"test", 5}});
-}
-
-// Test edge cases: single character words creating specific branch patterns
-TEST_F(RadixTreeTest, EdgeCases) {
-  AddWords({{"a", 1}, {"b", 2}, {"ab", 3}});
-  VerifyWords({{"a", 1}, {"b", 2}, {"ab", 3}});
-}
-
-TEST_F(RadixTreeTest, DeleteBasicCases) {
-  // Case 1: Delete leaf node
-  prefix_tree_->Mutate("hello", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate(
-      "hello", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
-  prefix_tree_->Mutate("hello", [](auto existing) {
-    EXPECT_FALSE(existing.has_value());
-    return existing;
-  });
-
-  // Case 2: Delete non-existent node
-  prefix_tree_->Mutate("world", [](auto existing) -> std::optional<TestTarget> {
-    EXPECT_FALSE(existing.has_value());
-    return std::nullopt;
-  });
-
-  // TODO: Enable when assertion handling is clarified
-  EXPECT_DEATH(prefix_tree_->Mutate("", [](auto) { return TestTarget(1); }),
-               ".*");
-}
-
-TEST_F(RadixTreeTest, DeleteStructuralCases) {
-  // Case 1: Delete from branch node
-  prefix_tree_->Mutate("cat", [](auto) { return TestTarget(1); });
-  prefix_tree_->Mutate("car", [](auto) { return TestTarget(2); });
-  prefix_tree_->Mutate("can", [](auto) { return TestTarget(3); });
-  prefix_tree_->DebugPrintTree("Initial: cat, car, can");
-
-  prefix_tree_->Mutate(
-      "car", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
-
-  prefix_tree_->DebugPrintTree("After deleting 'car'");
-
-  // Verify remaining structure
-  auto iter = prefix_tree_->GetWordIterator("ca");
-  std::vector<std::pair<std::string, int>> actual;
-  while (!iter.Done()) {
-    actual.emplace_back(std::string(iter.GetWord()), iter.GetTarget().value);
-    iter.Next();
-  }
-  std::vector<std::pair<std::string, int>> expected = {{"can", 3}, {"cat", 1}};
-  EXPECT_EQ(actual, expected);
-
-  // Case 2: Delete from compressed node
-  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(4); });
-  prefix_tree_->Mutate("test", [](auto) { return TestTarget(5); });
-  prefix_tree_->DebugPrintTree("After adding testing/test");
-  prefix_tree_->Mutate(
-      "test", [](auto) -> std::optional<TestTarget> { return std::nullopt; });
-  prefix_tree_->DebugPrintTree("After deleting 'test'");
-
-  // Verify compressed node structure remains correct
-  auto test_iter = prefix_tree_->GetWordIterator("test");
-  EXPECT_FALSE(test_iter.Done());
-  EXPECT_EQ(test_iter.GetWord(), "testing");
-  EXPECT_EQ(test_iter.GetTarget().value, 4);
-}
-
-TEST_F(RadixTreeTest, DeleteCausingMerge) {
-  // Test app/application -> delete app leaves just application (merge scenario)
+TEST_F(RadixTreeTest, DeleteCompressedNodeWord) {
+  // Case 1: Compressed parent - The parent (root) is a compressed node that
+  // will point directly to "application" leaf node after "app" is deleted
   AddWords({{"app", 1}, {"application", 2}});
   DeleteWords({"app"});
   VerifyWords({{"application", 2}});
   VerifyWordsDeleted({"app"});
+
+  // Case 2: Branching parent - Tree structure doesn't change
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+  AddWords({{"cat", 1}, {"car", 2}, {"cards", 3}});
+  DeleteWords({"car"});
+  VerifyWords({{"cat", 1}, {"cards", 3}});
+  VerifyWordsDeleted({"car"});
 }
 
-TEST_F(RadixTreeTest, DeleteComplexScenarios) {
-  // Build complex tree: a->b->c->d/e, then delete in specific order to test
-  // restructuring
-  AddWords({{"a", 1}, {"ab", 2}, {"abc", 3}, {"abcd", 4}, {"abce", 5}});
+TEST_F(RadixTreeTest, DeleteLeafNodeWordSimpleScenarios) {
+  // Case 1: Simple leaf deletion
+  AddWords({{"hello", 1}});
+  DeleteWords({"hello"});
+  VerifyWordsDeleted({"hello"});
 
-  // Delete nodes in specific order to test various restructuring scenarios
-  DeleteWords({"abc", "a", "abce"});
+  // Case 2: Parent node with target gets turned into a leaf
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+  AddWords({{"test", 1}, {"testing", 2}});
+  DeleteWords({"testing"});
+  VerifyWords({{"test", 1}});
+  VerifyWordsDeleted({"testing"});
 
-  // Verify final structure: should have ab, abcd remaining
-  VerifyIterator("", {{"ab", 2}, {"abcd", 4}});
-  VerifyWordsDeleted({"a", "abc", "abce"});
+  // Case 3: Leaf deletion where parent is branching with children.size() > 1
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+  AddWords({{"cat", 1}, {"car", 2}, {"can", 3}});
+  DeleteWords({"car"});
+  VerifyWords({{"cat", 1}, {"can", 3}});
+  VerifyWordsDeleted({"car"});
 }
 
-// Test complex scenarios: overlapping prefixes and special strings
-TEST_F(RadixTreeTest, ComplexScenarios) {
-  // Overlapping prefixes with multiple lengths: te->st->ing
-  // Complex tree with multiple splits: app->lication
-  // Special strings: long string and Unicode
-  std::string long_string(1000, 'x');
-  AddWords({{"te", 1},
-            {"test", 2},
-            {"testing", 3},
-            {"app", 4},
-            {"application", 5},
-            {long_string, 6},
-            {"こんにちは", 7}});
-  VerifyWords({{"te", 1},
-               {"test", 2},
-               {"testing", 3},
-               {"app", 4},
-               {"application", 5},
-               {long_string, 6},
-               {"こんにちは", 7}});
+TEST_F(RadixTreeTest, DeleteLeafNodeWordComplexScenarios) {
+  // Test all three scenarios where a branch node gets converted to a compressed
+  // node. parent_compressed = the branch nodes parent is a compressed node
+  // child_compressed = the branch nodes child is a compressed node
+
+  // ========================================================================
+  // Scenario 1: parent_compressed && child_compressed (connect parent to its
+  // great grandchild)
+  // ========================================================================
+  // Initial tree structure:
+  //                  [compressed]
+  //                   "x" |
+  //                   [branching]
+  //                "a" /     \ "t"
+  //          [compressed]   [compressed]
+  //          "bc" /           \ "est"
+  //   Target <- [leaf]           [leaf] -> Target
+  //
+  // Words: "xabc", "xtest"
+  AddWords({{"xabc", 1}, {"xtest", 2}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 1 - Initial: both parent and child compressed");
+
+  // Tree structure after deleting "xabc":
+  //                  [compressed]
+  //              "xtest" |
+  //                   [leaf] -> Target
+  DeleteWords({"xabc"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 1 - After deletion: parent connected to great-grandchild");
+  VerifyWords({{"xtest", 2}});
+  VerifyWordsDeleted({"xabc"});
+
+  // Reset tree
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+
+  // ========================================================================
+  // Scenario 2: parent_compressed (connect parent to its grandchild)
+  // ========================================================================
+  // Initial tree structure:
+  //                  [compressed]
+  //                 "cat" |
+  //                   [branching]
+  //                "s" /     \ "c"
+  //      Target <- [Leaf]  [compressed]
+  //                            \ "her"
+  //                           [Leaf] => Target
+  //
+  // Words: "cats", "catcher"
+  AddWords({{"cats", 3}, {"catcher", 4}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 2 - Initial: parent compressed, child branching");
+
+  // The tree structure after deleting "catcher":
+  //                  [compressed]
+  //              "cats" |
+  //                   [leaf] -> Target
+  DeleteWords({"catcher"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 2 - After deletion: parent connected to grandchild");
+  VerifyWords({{"cats", 3}});
+  VerifyWordsDeleted({"catcher"});
+
+  // Reset tree
+  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
+
+  // ========================================================================
+  // Scenario 3: child_compressed (connect node to its grandchild)
+  // ========================================================================
+  // Initial tree structure:
+  //                   [branching]
+  //               "d" /     \ "r"
+  //          [compressed]   [compressed]
+  //          "og" /           \ "unner"
+  //   Target <- [leaf]           [leaf] -> Target
+  //
+  // Words: "dog", "runner"
+  AddWords({{"dog", 5}, {"runner", 6}});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 3 - Initial: parent branching, child compressed");
+
+  // The tree structure after deleting "dog":
+  //                  [compressed]
+  //              "runner" |
+  //                   [leaf] -> Target
+  DeleteWords({"dog"});
+  prefix_tree_->DebugPrintTree(
+      "Scenario 3 - After deletion: node connected to grandchild");
+  VerifyWords({{"runner", 6}});
+  VerifyWordsDeleted({"dog"});
 }
 
 // Test WordIterator functionality
@@ -373,14 +389,11 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
     words.push_back(word);
   }
 
-  // Count word frequencies and add to tree
+  // Count word frequencies and add words incrementally to tree
   std::map<std::string, int> word_counts;
   for (const auto& w : words) {
     word_counts[w]++;
-  }
-
-  // Add words to tree, incrementing count each time
-  for (const auto& w : words) {
+    // Add word to tree, incrementing count each time
     prefix_tree_->Mutate(w, [](auto existing) {
       if (existing.has_value()) {
         return TestTarget(existing->value + 1);
@@ -389,26 +402,14 @@ TEST_F(RadixTreeTest, WordIteratorLargeScale) {
       }
     });
   }
-
-  // Iterate over all words and verify counts
-  auto iter = prefix_tree_->GetWordIterator("");
-
-  std::map<std::string, int> iterated_counts;
-  while (!iter.Done()) {
-    std::string word = std::string(iter.GetWord());
-    int count = iter.GetTarget().value;
-
-    // Ensure we haven't seen this word before
-    EXPECT_EQ(iterated_counts.count(word), 0)
-        << "Word '" << word << "' encountered multiple times during iteration";
-
-    iterated_counts[word] = count;
-    iter.Next();
-  }
-
-  // Verify word counts match
-  EXPECT_EQ(iterated_counts, word_counts);
   EXPECT_GT(word_counts.size(), 100);  // Should have many unique words
+
+  // Convert expected counts to format for verification
+  std::vector<std::pair<std::string, int>> word_pairs(word_counts.begin(),
+                                                      word_counts.end());
+
+  // Use VerifyIterator helper to verify all words and counts match
+  VerifyIterator("", word_pairs);
 }
 
 TEST_F(RadixTreeTest, WordIteratorPrefixPartialMatch) {
@@ -420,103 +421,6 @@ TEST_F(RadixTreeTest, WordIteratorPrefixPartialMatch) {
 
   // Test "ca" prefix - should only match can/cat
   VerifyIterator("ca", {{"can", 2}, {"cat", 1}});
-}
-
-TEST_F(RadixTreeTest, BranchToCompressedNodeConversion) {
-  // Test all three compression scenarios when branch nodes are converted.
-  // These test the complex logic in the deletion code that handles:
-  // 1. parent_compressed && child_compressed - connect parent to
-  // great-grandchild
-  // 2. parent_compressed only - connect parent to grandchild
-  // 3. child_compressed only - connect node to grandchild
-
-  // ========================================================================
-  // Scenario 1: parent_compressed && child_compressed
-  // ========================================================================
-  // Initial tree structure:
-  //                  [compressed]
-  //                   "x" |
-  //                   [branching]
-  //                "a" /     \ "t"
-  //          [compressed]   [compressed]
-  //          "bc" /           \ "est"
-  //   Target <- [leaf]           [leaf] -> Target
-  //
-  // Words: "xabc", "xtest"
-  AddWords({{"xabc", 1}, {"xtest", 2}});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 1 - Initial: both parent and child compressed");
-
-  // Delete "xabc" - this triggers parent_compressed && child_compressed case
-  // It becomes the following after deleting "xabc":
-  //                  [compressed]
-  //              "xtest" |
-  //                   [leaf] -> Target
-  DeleteWords({"xabc"});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 1 - After deletion: parent connected to great-grandchild");
-  VerifyIterator("x", {{"xtest", 2}});
-  VerifyWordsDeleted({"xabc"});
-
-  // Reset for scenario 2
-  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
-
-  // ========================================================================
-  // Scenario 2: parent_compressed only
-  // ========================================================================
-  // Initial tree structure:
-  //                  [compressed]
-  //                 "cat" |
-  //                   [branching]
-  //                "s" /     \ "ch"
-  //      Target <- [Leaf]   [Leaf] -> Target
-  //          "" /           
-  //   Target <- [leaf]           
-  //
-  // Words: "cats", "catcher"
-  AddWords({{"cats", 3}, {"catcher", 4}});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 2 - Initial: parent compressed, child branching");
-
-  // Delete "cats" - this triggers parent_compressed only case
-  // It becomes:
-  //                  [compressed]
-  //              "catcher" |
-  //                   [leaf] -> Target
-  DeleteWords({"cats"});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 2 - After deletion: parent connected to grandchild");
-  VerifyIterator("cat", {{"catcher", 4}});
-  VerifyWordsDeleted({"cats"});
-
-  // Reset for scenario 3
-  prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
-
-  // ========================================================================
-  // Scenario 3: child_compressed only
-  // ========================================================================
-  // Initial tree structure:
-  //                   [branching]
-  //               "d" /     \ "r"
-  //          [compressed]   [compressed]
-  //          "og" /           \ "unner"
-  //   Target <- [leaf]           [leaf] -> Target
-  //
-  // Words: "dog", "runner"
-  AddWords({{"dog", 5}, {"runner", 6}});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 3 - Initial: parent branching, child compressed");
-
-  // Delete "dog" - this triggers child_compressed only case
-  // It becomes:
-  //                  [compressed]
-  //              "runner" |
-  //                   [leaf] -> Target
-  DeleteWords({"dog"});
-  prefix_tree_->DebugPrintTree(
-      "Scenario 3 - After deletion: node connected to grandchild");
-  VerifyIterator("", {{"runner", 6}});
-  VerifyWordsDeleted({"dog"});
 }
 
 }  // namespace

--- a/testing/radix_test.cc
+++ b/testing/radix_test.cc
@@ -250,14 +250,12 @@ TEST_F(RadixTreeTest, DeleteLeafNodeWordSimpleScenarios) {
 }
 
 TEST_F(RadixTreeTest, DeleteLeafNodeWordComplexScenarios) {
-  // Test all three scenarios where a branch node gets converted to a compressed
-  // node. parent_compressed = the branch nodes parent is a compressed node
-  // child_compressed = the branch nodes child is a compressed node
+  // Test scenarios where a branch node gets converted to a compressed
+  // node, causing compressed nodes to be merged
 
-  // ========================================================================
-  // Scenario 1: parent_compressed && child_compressed (connect parent to its
-  // great grandchild)
-  // ========================================================================
+  // ==========================================================================
+  // Scenario 1: Connect parent to its great grandchild
+  // ==========================================================================
   // Initial tree structure:
   //                  [compressed]
   //                   "x" |
@@ -297,9 +295,9 @@ TEST_F(RadixTreeTest, DeleteLeafNodeWordComplexScenarios) {
   // Reset tree
   prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
 
-  // ========================================================================
-  // Scenario 2: parent_compressed (connect parent to its grandchild)
-  // ========================================================================
+  // ==========================================================================
+  // Scenario 2: Connect parent to its grandchild
+  // ==========================================================================
   // Initial tree structure:
   //                  [compressed]
   //                 "cat" |
@@ -338,9 +336,10 @@ TEST_F(RadixTreeTest, DeleteLeafNodeWordComplexScenarios) {
   // Reset tree
   prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
 
-  // ========================================================================
-  // Scenario 3: child_compressed (connect node to its grandchild)
-  // ========================================================================
+  // =========================================================================
+  // Scenario 3: Connect node to its grandchild when parent isn't a compressed
+  // node (it doesn't exist in this case)
+  // =========================================================================
   // Initial tree structure:
   //                   [branching]
   //               "d" /     \ "r"
@@ -377,6 +376,10 @@ TEST_F(RadixTreeTest, DeleteLeafNodeWordComplexScenarios) {
   // Reset tree
   prefix_tree_ = std::make_unique<RadixTree<TestTarget, false>>();
 
+  // ==========================================================================
+  // Scenario 4: Connect node to its grandchild since node has a target and must
+  // still exist
+  // ==========================================================================
   // Initial tree structure:
   //                  [compressed]
   //                   "x" |

--- a/testing/radix_test.cc
+++ b/testing/radix_test.cc
@@ -534,5 +534,23 @@ TEST_F(RadixTreeTest, WordIteratorPrefixPartialMatch) {
       << "WordIterator should return words that start with 'ca'";
 }
 
+TEST_F(RadixTreeTest, TemporaryDebugTest) {
+  // Simple test to see DebugPrintNode output
+  prefix_tree_->Mutate("testing", [](auto) { return TestTarget(1); });
+  prefix_tree_->Mutate("test", [](auto) { return TestTarget(2); });
+  prefix_tree_->DebugPrintTree("Before deletion");
+  
+  prefix_tree_->Mutate("test", [](auto) -> std::optional<TestTarget> {
+    return std::nullopt;
+  });
+  prefix_tree_->DebugPrintTree("After deleting test");
+  
+  auto iter = prefix_tree_->GetWordIterator("test");
+  std::cout << "Iterator Done: " << iter.Done() << std::endl;
+  if (!iter.Done()) {
+    std::cout << "Iterator Word: '" << iter.GetWord() << "'" << std::endl;
+  }
+}
+
 }  // namespace
 }  // namespace valkey_search::indexes::text

--- a/testing/radix_test.cc
+++ b/testing/radix_test.cc
@@ -152,10 +152,13 @@ TEST_F(RadixTreeTest, DeleteStructuralCases) {
   prefix_tree_->Mutate("cat", [](auto) { return TestTarget(1); });
   prefix_tree_->Mutate("car", [](auto) { return TestTarget(2); });
   prefix_tree_->Mutate("can", [](auto) { return TestTarget(3); });
+  prefix_tree_->DebugPrintTree("Initial: cat, car, can");
   
   prefix_tree_->Mutate("car", [](auto) -> std::optional<TestTarget> {
     return std::nullopt;
   });
+  
+  prefix_tree_->DebugPrintTree("After deleting 'car'");
   
   // Verify remaining structure
   auto iter = prefix_tree_->GetWordIterator("ca");
@@ -170,9 +173,11 @@ TEST_F(RadixTreeTest, DeleteStructuralCases) {
   // Case 2: Delete from compressed node
   prefix_tree_->Mutate("testing", [](auto) { return TestTarget(4); });
   prefix_tree_->Mutate("test", [](auto) { return TestTarget(5); });
+  prefix_tree_->DebugPrintTree("After adding testing/test");
   prefix_tree_->Mutate("test", [](auto) -> std::optional<TestTarget> {
     return std::nullopt;
   });
+  prefix_tree_->DebugPrintTree("After deleting 'test'");
   
   // Verify compressed node structure remains correct
   auto test_iter = prefix_tree_->GetWordIterator("test");


### PR DESCRIPTION
Throwing out some very rough delete logic for the radix tree to unblock people if needed. I think the delete works but there is a bug in the word iterator causing `DeleteStructuralCases` to fail, but I ran out of time to look into it. I'll be back online by the weekend.