### PR TITLE
Expose global symbols so that crash dump backtraces are useful

### DIFF
--- a/vmsdk/versionscript.lds
+++ b/vmsdk/versionscript.lds
@@ -1,7 +1,3 @@
 {
-  global:
-    # Only expose the ValkeyModule APIs
-    ValkeyModule_OnLoad;
-    ValkeyModule_OnUnload;
-  local: *;  # hide everything else
+  global: *; # Expose all symbols so that crash dumps have them.
 };


### PR DESCRIPTION
Current suppression of global symbols makes crash dumps almost useless.