### PR TITLE
Configuartion and version sections are added to info search 

### DIFF
--- a/integration/test_info.py
+++ b/integration/test_info.py
@@ -52,10 +52,28 @@ class TestVSSBasic(ValkeySearchTestCaseBase):
             "search_total_indexing_time",
             "search_used_memory_bytes",
             "search_index_reclaimable_memory"
+            "search_minimal_term_prefix",
+            "search_minimal_stem_length",
+            "search_maximal_prefix_expansions",
+            "search_query_timeout_ms",
+            "search_cursor_read_size",
+            "search_cursor_max_idle_time",
+            "search_max_doc_table_size",
+            "search_max_search_results",
+            "search_max_aggregate_results",
+            "search_gc_scan_size",
+            "search_min_phonetic_term_length",
+            "search_bm25std_tanh_factor"
         ]
 
         string_fields = [
             "search_background_indexing_status"
+            "search_extension_load",
+            "search_friso_ini",
+            "search_enableGC",
+            "search_timeout_policy",
+            "search_version",
+            "search_redis_version"
         ]
 
         bytes_fields = [

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -96,6 +96,21 @@ void AddLatencyStat(ValkeyModuleInfoCtx *ctx, absl::string_view stat_name,
  that's done this section will be empty and it can be removed.
  */
 
+// Version section fields
+static vmsdk::info_field::String version(
+    "version", "version",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          return "255.255.255";
+        }));
+
+static vmsdk::info_field::String redis_version(
+    "version", "redis_version",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          return "255.255.255";
+        }));
+
 static vmsdk::info_field::Integer human_used_memory(
     "memory", "used_memory_human",
     vmsdk::info_field::IntegerBuilder()
@@ -753,6 +768,123 @@ static vmsdk::info_field::String flat_vector_index_search_latency_usec(
           return Metrics::GetStats()
               .flat_vector_index_search_latency.HasSamples();
         }));
+
+// Configuration metrics
+static vmsdk::info_field::String extension_load(
+    "runtime_configurations", "extension_load",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          // Need to implement actual value retrieval
+          return " ";
+        }));
+
+static vmsdk::info_field::String friso_ini(
+    "runtime_configurations", "friso_ini",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          // Need to implement actual value retrieval
+          return " ";
+        }));
+
+static vmsdk::info_field::String enableGC(
+    "runtime_configurations", "enableGC",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          // Need to implement actual value retrieval
+          return "OFF";
+        }));
+
+static vmsdk::info_field::Integer minimal_term_prefix(
+    "runtime_configurations", "minimal_term_prefix",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer minimal_stem_length(
+    "runtime_configurations", "minimal_stem_length",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer maximal_prefix_expansions(
+    "runtime_configurations", "maximal_prefix_expansions",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer query_timeout_ms(
+    "runtime_configurations", "query_timeout_ms",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::String timeout_policy(
+    "runtime_configurations", "timeout_policy",
+    vmsdk::info_field::StringBuilder().App().ComputedCharPtr(
+        []() -> const char * {
+          // Need to implement actual value retrieval
+          return " ";
+        }));
+
+static vmsdk::info_field::Integer cursor_read_size(
+    "runtime_configurations", "cursor_read_size",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer cursor_max_idle_time(
+    "runtime_configurations", "cursor_max_idle_time",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer max_doc_table_size(
+    "runtime_configurations", "max_doc_table_size",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer max_search_results(
+    "runtime_configurations", "max_search_results",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer max_aggregate_results(
+    "runtime_configurations", "max_aggregate_results",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer gc_scan_size(
+    "runtime_configurations", "gc_scan_size",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer min_phonetic_term_length(
+    "runtime_configurations", "min_phonetic_term_length",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
+
+static vmsdk::info_field::Integer bm25std_tanh_factor(
+    "runtime_configurations", "bm25std_tanh_factor",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Need to implement actual value retrieval
+      return 0;
+    }));
 
 #ifdef DEBUG_INFO
 // Helper function to create subscription info fields with maximum deduplication

--- a/testing/valkey_search_test.cc
+++ b/testing/valkey_search_test.cc
@@ -476,6 +476,11 @@ TEST_F(ValkeySearchTest, Info) {
     "total_active_write_threads: 5\ntotal_indexing_time: 0\n"
     "indexing\nbackground_indexing_status: 'IN_PROGRESS'\n"
     "memory\nused_memory_bytes: 18408\nused_memory_human: '17.98KiB'\n"
+    "runtime_configurations\nbm25std_tanh_factor: 0\ncursor_max_idle_time: 0\ncursor_read_size: 0\nenableGC: OFF\n"
+    "extension_load: \nfriso_ini: \ngc_scan_size: 0\nmax_aggregate_results: 0\nmax_doc_table_size: 0\n"
+    "max_search_results: 0\nmaximal_prefix_expansions: 0\nmin_phonetic_term_length: 0\nminimal_stem_length: 0\n"
+    "minimal_term_prefix: 0\nquery_timeout_ms: 0\ntimeout_policy: \n"
+    "version\nversion: 255.255.255\nredis_version: 255.255.255\n"
 );
 #endif
   StringInternStore::SetMemoryUsage(0); // reset memory pool


### PR DESCRIPTION
Added the configuationa dn version section and updated with the hard coded values for the cases we dont metrics available.

current output provide below info:

```
# search_runtime_configurations
search_bm25std_tanh_factor:0
search_cursor_max_idle_time:0
search_cursor_read_size:0
search_enableGC:OFF
search_extension_load:
search_friso_ini:
search_gc_scan_size:0
search_max_aggregate_results:0
search_max_doc_table_size:0
search_max_search_results:0
search_maximal_prefix_expansions:0
search_min_phonetic_term_length:0
search_minimal_stem_length:0
search_minimal_term_prefix:0
search_query_timeout_ms:0
search_timeout_policy:
------
------
# search_version
search_redis_version:255.255.255
search_version:255.255.255
```