### PR TITLE
Introduced new "debug-mode" configuration entry.

### DIFF
--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -5,6 +5,7 @@ GREEN='\e[32;1m'
 RED='\e[31;1m'
 BLUE='\e[34;1m'
 YELLOW='\e[33;1m'
+UNAME_S=$(uname -s)
 
 function LOG_INFO() {
   printf "${GREEN}$1${RESET}\n"
@@ -28,11 +29,19 @@ function print_environment_var() {
   printf "${BLUE}${varname}${RESET} => ${GREEN}${value}${RESET}\n"
 }
 
-if [[ "$(uname -s)" == "Darwin" ]]; then
+if [[ "${UNAME_S}" == "Darwin" ]]; then
   export MODULE_EXT="dylib"
 else
   export MODULE_EXT="so"
 fi
+
+function num_proc() {
+  if [[ "${UNAME_S}" == "Darwin" ]]; then
+    echo $(sysctl -n hw.ncpu)
+  else
+    echo $(nproc)
+  fi
+}
 
 function findup() {
   # Check if a filename was provided
@@ -184,7 +193,7 @@ function setup_valkey_server() {
   LOG_INFO "Working directory: ${VALKEY_SERVER_BUILD_DIR}"
   LOG_INFO "Building valkey-server: cmake -DCMAKE_BUILD_TYPE=Release .. ${VALKEY_CMAKE_EXTRA_ARGS}"
   cmake -DCMAKE_BUILD_TYPE=Release .. ${VALKEY_CMAKE_EXTRA_ARGS}
-  make -j$(nproc)
+  make -j$(num_proc)
   popd >/dev/null
   export VALKEY_SERVER_PATH=${VALKEY_SERVER_BUILD_DIR}/bin/valkey-server
   export VALKEY_CLI_PATH=${VALKEY_SERVER_BUILD_DIR}/bin/valkey-cli

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -110,7 +110,8 @@ static auto writer_threads_count =
 ///     fork is died or after max-worker-suspension-secs seconds passed.
 ///   - If max-worker-suspension-secs <= 0, resume the workers when the fork
 ///     is born.
-constexpr absl::string_view kMaxWorkerSuspensionSecs{"max-worker-suspension-secs"};
+constexpr absl::string_view kMaxWorkerSuspensionSecs{
+    "max-worker-suspension-secs"};
 static auto max_worker_suspension_secs =
     config::Number(kMaxWorkerSuspensionSecs,  // name
                    60,                        // default value
@@ -119,11 +120,9 @@ static auto max_worker_suspension_secs =
 
 /// Should this instance use coordinator?
 constexpr absl::string_view kUseCoordinator{"use-coordinator"};
-static auto use_coordinator =
-    config::BooleanBuilder(kUseCoordinator, false)
-        .WithFlags(VALKEYMODULE_CONFIG_IMMUTABLE)  // can only be set during
-                                                   // start-up
-        .Build();
+static auto use_coordinator = config::BooleanBuilder(kUseCoordinator, false)
+                                  .Hidden()  // can only be set during start-up
+                                  .Build();
 
 // Register an enumerator for the log level
 static const std::vector<std::string_view> kLogLevelNames = {
@@ -187,7 +186,7 @@ vmsdk::config::Number& GetWriterThreadCount() {
 }
 
 vmsdk::config::Number& GetMaxWorkerSuspensionSecs() {
-      return max_worker_suspension_secs;
+  return max_worker_suspension_secs;
 }
 
 const vmsdk::config::Boolean& GetUseCoordinator() {

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -18,6 +18,14 @@
 namespace vmsdk {
 namespace config {
 
+/// Controls the modules debug mode flag. We set it here to "true" to allow
+/// Valkey to load the configurations first time when the module loaded. Once
+/// this is done, we set it back to false. If the user passes "--debug-mode yes"
+/// we will change it back to "true".
+static auto debug_mode = BooleanBuilder(kDebugMode, true).Hidden().Build();
+
+bool IsDebugModeEnabled() { return debug_mode->GetValue(); }
+
 namespace {
 
 constexpr absl::string_view kUseCoordinator = "--use-coordinator";
@@ -111,6 +119,8 @@ absl::Status ModuleConfigManager::Init(ValkeyModuleCtx *ctx) {
 absl::Status ModuleConfigManager::ParseAndLoadArgv(ValkeyModuleCtx *ctx,
                                                    ValkeyModuleString **argv,
                                                    int argc) {
+  // reset the debug mode to "false".
+  debug_mode->SetValueOrLog(false, LogLevel::kWarning);
   vmsdk::ArgsIterator iter{argv, argc};
   while (iter.HasNext()) {
     VMSDK_ASSIGN_OR_RETURN(auto key, iter.Get());


### PR DESCRIPTION
With this PR, a new module configuration entry "search.debug-mode" is added. When this setting is set to "no" (which is the default), all configuration entries, marked as "Dev()" become both immutable & hidden. The global configuration "search.debug-mode" can only be set via the command line, i.e. by passing "--debug-mode yes". This allows developers to add "Dev" only configuration entries that can only be used when the server starts with "--debug-mode yes".

In addition, this PR also adds a new build option: --jobs=N to reduce the number of cores used by the build system.

For example:

```bash
# Dev configurations can not be changed during runtime.
127.0.0.1:6379> config set search.debug-only-configuration debug
(error) ERR CONFIG SET failed (possibly related to argument 'search.debug-only-configuration') - Modification of 'debug-only-configuration' requires 'debug-mode' to be enabled.

# We can query their value
127.0.0.1:6379> config get search.debug-only-configuration
1) "search.debug-only-configuration"
2) "notice"

# search.debug-mode can not be modified from the CLI
127.0.0.1:6379> config get search.debug-mode
(empty array)
127.0.0.1:6379> config set search.debug-mode yes
(error) ERR Unknown option or number of arguments for CONFIG SET - 'search.debug-mode'
```