### PR TITLE
Minor fix in WordIterator to allow partial prefix match

### DIFF
--- a/src/indexes/text/radix_tree.h
+++ b/src/indexes/text/radix_tree.h
@@ -371,6 +371,7 @@ RadixTree<Target, reverse>::GetWordIterator(absl::string_view prefix) const {
   const Node* n = &root_;
   absl::string_view remaining = prefix;
   bool no_match = false;
+  std::string actual_prefix = std::string(prefix);
 
   // Find the highest node in the sub-branch that matches the prefix
   while (!remaining.empty()) {
@@ -392,6 +393,8 @@ RadixTree<Target, reverse>::GetWordIterator(absl::string_view prefix) const {
               if (remaining.starts_with(path)) {
                 remaining.remove_prefix(path.length());
               } else if (path.starts_with(remaining)) {
+                // The prefix is a sub-path of the current path, we need to reconstruct prefix to be passed to the iterator and return word found so far
+                actual_prefix = actual_prefix.substr(0, actual_prefix.length() - remaining.length()) + path;
                 remaining.remove_prefix(remaining.length());
               } else {
                 no_match = true;
@@ -405,7 +408,7 @@ RadixTree<Target, reverse>::GetWordIterator(absl::string_view prefix) const {
       break;
     }
   }
-  return WordIterator(n, prefix);
+  return WordIterator(n, actual_prefix);
 }
 
 template <typename Target, bool reverse>


### PR DESCRIPTION
Currently, if we pass an input to the WordIterator that partially matches the Compressed Node value when recursing through on the WordIterator and generating results, we do not amend the rest of the path; this results in distorted results. Example below. 

Let's say there is a tree structure like this
```
=== Tree Structure - Initial tree with cat, can, testing, test ===
Node[] BRANCH(2)
  Node[c] COMPRESSED[a]
    Node[ca] BRANCH(2)
      Node[can] TARGET LEAF
      Node[cat] TARGET LEAF
  Node[t] COMPRESSED[est]
    Node[test] TARGET COMPRESSED[ing]
      Node[testing] TARGET LEAF
=== End Structure ===
```
When i create WordIterator like  GetWordIterator("ca") . It gave me "can" and "cat" correctly, because prefix "ca" is an exact match in radix tree. But when i created GetWordIterator("te") , it gave me "te" and "teing" :bangbang:. 