### PR TITLE
Respect valkey and json module versions defined in build and integration tests

### DIFF
--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -166,11 +166,11 @@ function setup_valkey_server() {
   fi
 
   # Clone and build it
-  VALKEY_VERSION="8.1.1"
+  VALKEY_VERSION="${VALKEY_VERSION:=8.1.1}"
   export VALKEY_SERVER_HOME_DIR=$(get_third_party_build_dir)/valkey-server
   export VALKEY_SERVER_BUILD_DIR=${VALKEY_SERVER_HOME_DIR}/.build-release
   if [ ! -d ${VALKEY_SERVER_HOME_DIR} ]; then
-    LOG_INFO "Cloning valkey-server into ${VALKEY_SERVER_HOME_DIR}"
+    LOG_INFO "Cloning valkey-server@${VALKEY_VERSION} into ${VALKEY_SERVER_HOME_DIR}"
     git clone --branch ${VALKEY_VERSION} --single-branch https://github.com/valkey-io/valkey.git ${VALKEY_SERVER_HOME_DIR}
   fi
 
@@ -209,8 +209,7 @@ function setup_json_module() {
   fi
 
   # Clone and build it
-  export VALKEY_JSON_COMMIT_HASH="5b2f3db24c0135a8d8b8e5cf434c7a3d42bd91f0"
-  export VALKEY_JSON_VERSION="unstable"
+  VALKEY_JSON_VERSION="${VALKEY_JSON_VERSION:=unstable}"
   export VALKEY_JSON_HOME=$(get_third_party_build_dir)/valkey-json
   export VALKEY_JSON_BUILD_DIR=${VALKEY_JSON_HOME}/.build-release
 
@@ -222,8 +221,8 @@ function setup_json_module() {
   fi
 
   rm -fr "${VALKEY_JSON_HOME}"
-  LOG_INFO "Cloning valkey-json into ${VALKEY_JSON_HOME}"
-  git clone https://github.com/valkey-io/valkey-json.git ${VALKEY_JSON_HOME}
+  LOG_INFO "Cloning valkey-json@${VALKEY_JSON_VERSION} into ${VALKEY_JSON_HOME}"
+  git clone --branch ${VALKEY_JSON_VERSION} --single-branch https://github.com/valkey-io/valkey-json.git ${VALKEY_JSON_HOME}
 
   pushd ${VALKEY_JSON_HOME} >/dev/null
   LOG_INFO "Working directory: ${VALKEY_JSON_HOME}"


### PR DESCRIPTION
This change ensures that `VALKEY_VERSION` and `VALKEY_JSON_VERSION` defined in `run.sh` or `build.sh` are respected in both setup of build environment and integration tests. It also removes the unused `VALKEY_JSON_COMMIT_HASH` variable.

Related to previous changes to build.sh in commit https://github.com/valkey-io/valkey-search/commit/ca45eeb0a11c6731eed45f1a1dd8d70eb13c2403