### PR TITLE
Update ft info

### DIFF
--- a/integration/ft_info_parser.py
+++ b/integration/ft_info_parser.py
@@ -121,11 +121,6 @@ class FTInfoParser:
         return self.parsed_data.get("index_name", "")
 
     @property
-    def index_options(self) -> List[Any]:
-        """Get the index options."""
-        return self.parsed_data.get("index_options", [])
-
-    @property
     def index_definition(self) -> Dict[str, Any]:
         """Get the index definition."""
         return self.parsed_data.get("index_definition", {})
@@ -139,11 +134,6 @@ class FTInfoParser:
     def num_docs(self) -> int:
         """Get the number of documents in the index."""
         return self.parsed_data.get("num_docs", 0)
-
-    @property
-    def num_terms(self) -> int:
-        """Get the number of terms in the index."""
-        return self.parsed_data.get("num_terms", 0)
 
     @property
     def num_records(self) -> int:
@@ -234,6 +224,72 @@ class FTInfoParser:
     def is_backfill_complete(self) -> bool:
         """Check if backfill is complete."""
         return not self.backfill_in_progress and self.backfill_complete_percent >= 1.0
+
+    def get_text_min_stem_size(self, field_name: str) -> Optional[int]:
+        """
+        Get the min_stem_size of a text field.
+
+        Args:
+            field_name: The name of the text field
+
+        Returns:
+            The min_stem_size if found, None otherwise
+        """
+        attr = self.get_attribute_by_name(field_name)
+        if attr and attr.get("type") == "TEXT":
+            return attr.get("MIN_STEM_SIZE")
+        return None
+
+    def get_text_no_stem(self, field_name: str) -> Optional[bool]:
+        """
+        Get the no_stem setting of a text field.
+
+        Args:
+            field_name: The name of the text field
+
+        Returns:
+            True if no_stem is enabled, False if not, None if field not found
+        """
+        attr = self.get_attribute_by_name(field_name)
+        if attr and attr.get("type") == "TEXT":
+            return bool(attr.get("NO_STEM", 0))
+        return None
+
+    def get_text_with_suffix_trie(self, field_name: str) -> Optional[bool]:
+        """
+        Get the with_suffix_trie setting of a text field.
+
+        Args:
+            field_name: The name of the text field
+
+        Returns:
+            True if suffix trie is enabled, False if not, None if field not found
+        """
+        attr = self.get_attribute_by_name(field_name)
+        if attr and attr.get("type") == "TEXT":
+            return bool(attr.get("WITH_SUFFIX_TRIE", 0))
+        return None
+
+    @property
+    def language(self) -> Optional[str]:
+        """Get the language setting for text indexes."""
+        return self.parsed_data.get("language")
+
+    @property
+    def punctuation(self) -> Optional[str]:
+        """Get the punctuation characters for text indexes."""
+        return self.parsed_data.get("punctuation")
+
+    @property
+    def stop_words(self) -> Optional[List[str]]:
+        """Get the stop words list for text indexes."""
+        return self.parsed_data.get("stop_words")
+
+    @property
+    def with_offsets(self) -> Optional[bool]:
+        """Get the with_offsets setting for text indexes."""
+        offsets = self.parsed_data.get("with_offsets")
+        return bool(offsets) if offsets is not None else None
 
     def get_vector_dimensions(self, field_name: str) -> Optional[int]:
         """

--- a/integration/ft_info_parser.py
+++ b/integration/ft_info_parser.py
@@ -182,8 +182,15 @@ class FTInfoParser:
             The attribute dictionary if found, None otherwise
         """
         for attr in self.attributes:
-            if attr.get("identifier") == name:
-                return attr
+            # Handle case where attr might be a list instead of dict
+            if isinstance(attr, dict):
+                if attr.get("identifier") == name:
+                    return attr
+            elif isinstance(attr, list):
+                # Try to parse the list as key-value pairs
+                parsed_attr = self._parse_key_value_list(attr)
+                if isinstance(parsed_attr, dict) and parsed_attr.get("identifier") == name:
+                    return parsed_attr
         return None
 
     def get_attributes_by_type(self, field_type: str) -> List[Dict[str, Any]]:

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -733,22 +733,12 @@ uint64_t IndexSchema::CountRecords() const {
   return record_cnt;
 }
 
-bool IndexSchema::HasTextFields() const {
-  for (const auto &attribute : attributes_) {
-    if (attribute.second.GetIndex()->GetIndexerType() ==
-        indexes::IndexerType::kText) {
-      return true;
-    }
-  }
-  return false;
-}
-
 void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   int arrSize = 36;
 
   // Calculate additional array size for text-related fields only if text fields
   // exist
-  if (HasTextFields()) {
+  if (text_index_schema_) {
     arrSize += 6;
   }
 
@@ -864,7 +854,7 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   ValkeyModule_ReplyWithSimpleString(ctx, GetStateForInfo().data());
 
   // Add text-related schema fields
-  if (HasTextFields()) {
+  if (text_index_schema_) {
     ValkeyModule_ReplyWithSimpleString(ctx, "punctuation");
     ValkeyModule_ReplyWithSimpleString(ctx, punctuation_.c_str());
 
@@ -878,19 +868,14 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
     ValkeyModule_ReplyWithSimpleString(ctx, with_offsets_ ? "1" : "0");
   }
 
-  if (language_ != data_model::LANGUAGE_UNSPECIFIED) {
-    ValkeyModule_ReplyWithSimpleString(ctx, "language");
-    switch (language_) {
-      case data_model::LANGUAGE_ENGLISH:
-        ValkeyModule_ReplyWithSimpleString(ctx, "english");
-        break;
-      default:
-        ValkeyModule_ReplyWithSimpleString(ctx, "english");
-        break;
-    }
-  } else {
-    ValkeyModule_ReplyWithSimpleString(ctx, "language");
-    ValkeyModule_ReplyWithSimpleString(ctx, "english");
+  ValkeyModule_ReplyWithSimpleString(ctx, "language");
+  switch (language_) {
+    case data_model::LANGUAGE_ENGLISH:
+      ValkeyModule_ReplyWithSimpleString(ctx, "english");
+      break;
+    default:
+      ValkeyModule_ReplyWithSimpleString(ctx, "english");
+      break;
   }
 }
 

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -104,7 +104,6 @@ class IndexSchema : public KeyspaceEventSubscription,
                         std::shared_ptr<indexes::IndexBase> index);
 
   void RespondWithInfo(ValkeyModuleCtx *ctx) const;
-  bool HasTextFields() const;
 
   inline const AttributeDataType &GetAttributeDataType() const override {
     return *attribute_data_type_;

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -104,6 +104,7 @@ class IndexSchema : public KeyspaceEventSubscription,
                         std::shared_ptr<indexes::IndexBase> index);
 
   void RespondWithInfo(ValkeyModuleCtx *ctx) const;
+  bool HasTextFields() const;
 
   inline const AttributeDataType &GetAttributeDataType() const override {
     return *attribute_data_type_;

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -92,7 +92,8 @@ int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
     ValkeyModule_ReplyWithSimpleString(ctx, "MIN_STEM_SIZE");
     ValkeyModule_ReplyWithLongLong(ctx, min_stem_size_);
   }
-  // Text fields do not include a size field (unlike numeric/tag/vector fields)
+  // Text fields do not include a size field right now (unlike
+  // numeric/tag/vector fields)
   return 6;
 }
 

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -78,7 +78,22 @@ absl::StatusOr<bool> Text::ModifyRecord(const InternedStringPtr& key,
 }
 
 int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
-  throw std::runtime_error("Text::RespondWithInfo not implemented");
+  ValkeyModule_ReplyWithSimpleString(ctx, "type");
+  ValkeyModule_ReplyWithSimpleString(ctx, "TEXT");
+  ValkeyModule_ReplyWithSimpleString(ctx, "WITH_SUFFIX_TRIE");
+  ValkeyModule_ReplyWithSimpleString(ctx, with_suffix_trie_ ? "1" : "0");
+
+  // Show only one: if no_stem is specified, show no_stem, otherwise show
+  // min_stem_size
+  if (no_stem_) {
+    ValkeyModule_ReplyWithSimpleString(ctx, "NO_STEM");
+    ValkeyModule_ReplyWithSimpleString(ctx, "1");
+  } else {
+    ValkeyModule_ReplyWithSimpleString(ctx, "MIN_STEM_SIZE");
+    ValkeyModule_ReplyWithLongLong(ctx, min_stem_size_);
+  }
+  // Text fields do not include a size field (unlike numeric/tag/vector fields)
+  return 6;
 }
 
 bool Text::IsTracked(const InternedStringPtr& key) const { return false; }

--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -134,7 +134,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                         .expect_return_failure = false,
                         .expected_output =
-                            "*34\r\n+index_name\r\n+test_name\r\n+index_"
+                            "*36\r\n+index_name\r\n+test_name\r\n+index_"
                             "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
@@ -178,7 +178,8 @@ INSTANTIATE_TEST_SUITE_P(
                             "progress\r\n$1\r\n0\r\n+backfill_complete_"
                             "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"
                             "size\r\n$1\r\n0\r\n+recent_mutations_queue_"
-                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n",
+                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n+"
+                            "language\r\n+english\r\n",
                     },
                 },
         },
@@ -212,7 +213,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                         .expect_return_failure = false,
                         .expected_output =
-                            "*34\r\n+index_name\r\n+test_name\r\n+index_"
+                            "*36\r\n+index_name\r\n+test_name\r\n+index_"
                             "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
@@ -253,7 +254,8 @@ INSTANTIATE_TEST_SUITE_P(
                             "backfill_in_progress\r\n$1\r\n0\r\n+backfill_"
                             "complete_percent\r\n$8\r\n1.000000\r\n+mutation_"
                             "queue_size\r\n$1\r\n0\r\n+recent_mutations_queue_"
-                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n",
+                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n+"
+                            "language\r\n+english\r\n",
                     },
                 },
         },
@@ -280,7 +282,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                         .expect_return_failure = false,
                         .expected_output =
-                            "*34\r\n+index_name\r\n+test_name\r\n+index_"
+                            "*36\r\n+index_name\r\n+test_name\r\n+index_"
                             "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
@@ -313,7 +315,8 @@ INSTANTIATE_TEST_SUITE_P(
                             "1\r\n0\r\n+backfill_complete_percent\r\n$8\r\n1."
                             "000000\r\n+mutation_queue_size\r\n$1\r\n0\r\n+"
                             "recent_mutations_queue_delay\r\n$5\r\n0 sec\r\n"
-                            "+state\r\n+ready\r\n",
+                            "+state\r\n+ready\r\n"
+                            "+language\r\n+english\r\n",
                     },
                 },
         },
@@ -341,7 +344,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                         .expect_return_failure = false,
                         .expected_output =
-                            "*34\r\n+index_name\r\n+test_name\r\n+index_"
+                            "*36\r\n+index_name\r\n+test_name\r\n+index_"
                             "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
@@ -375,7 +378,8 @@ INSTANTIATE_TEST_SUITE_P(
                             "progress\r\n$1\r\n0\r\n+backfill_complete_"
                             "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"
                             "size\r\n$1\r\n0\r\n+recent_mutations_queue_"
-                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n",
+                            "delay\r\n$5\r\n0 sec\r\n+state\r\n+ready\r\n+"
+                            "language\r\n+english\r\n",
                     },
                 },
         },
@@ -400,7 +404,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                         .expect_return_failure = false,
                         .expected_output =
-                            "*34\r\n+index_name\r\n+test_name\r\n+index_"
+                            "*36\r\n+index_name\r\n+test_name\r\n+index_"
                             "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
                             "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
                             "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
@@ -433,7 +437,8 @@ INSTANTIATE_TEST_SUITE_P(
                             "backfill_complete_percent\r\n$8\r\n1.000000\r\n+"
                             "mutation_queue_size\r\n$1\r\n0\r\n+recent_"
                             "mutations_queue_delay\r\n$5\r\n0 sec\r\n+state\r\n"
-                            "+ready\r\n",
+                            "+ready\r\n"
+                            "+language\r\n+english\r\n",
                     },
                 },
         },
@@ -461,6 +466,141 @@ INSTANTIATE_TEST_SUITE_P(
                         .expected_output =
                             "$47\r\nIndex with name 'non_exist_test_name' not "
                             "found\r\n",
+                    },
+                },
+        },
+        {
+            .test_name = "happy_path_text_defaults",
+            .test_cases =
+                {
+                    {
+                        .argv = {"FT.Info", "test_name"},
+                        .index_schema_pbtxt = R"(
+                          name: "test_name"
+                          db_num: 0
+                          subscribed_key_prefixes: "prefix_1"
+                          attribute_data_type: ATTRIBUTE_DATA_TYPE_HASH
+                          attributes: {
+                            alias: "test_attribute_1"
+                            identifier: "test_identifier_1"
+                            index: {
+                              text_index: {}
+                            }
+                          }
+                        )",
+                        .expect_return_failure = false,
+                        .expected_output =
+                            "*42\r\n+index_name\r\n+test_name\r\n+index_"
+                            "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
+                            "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
+                            "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
+                            "10\r\n+identifier\r\n+test_identifier_1\r\n+"
+                            "attribute\r\n+test_attribute_1\r\n+type\r\n+"
+                            "TEXT\r\n+WITH_SUFFIX_TRIE\r\n+0\r\n+MIN_STEM_"
+                            "SIZE\r\n:0\r\n+"
+                            "num_docs\r\n:0\r\n+num_"
+                            "terms\r\n:0\r\n+num_records\r\n:0\r\n+"
+                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_"
+                            "stats\r\n*14\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
+                            "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
+                            "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
+                            "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
+                            "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
+                            "backfill_in_progress\r\n$1\r\n0\r\n+"
+                            "backfill_complete_percent\r\n$8\r\n1.000000\r\n+"
+                            "mutation_queue_size\r\n$1\r\n0\r\n+recent_"
+                            "mutations_queue_delay\r\n$5\r\n0 sec\r\n+state\r\n"
+                            "+ready\r\n+punctuation\r\n+\r\n+stop_words\r\n*"
+                            "0\r\n+"
+                            "with_offsets\r\n+0\r\n+language\r\n+english\r\n",
+                    },
+                },
+        },
+        {
+            .test_name = "happy_path_text_all_options",
+            .test_cases =
+                {
+                    {
+                        .argv = {"FT.Info", "test_name"},
+                        .index_schema_pbtxt = R"(
+                          name: "test_name"
+                          db_num: 0
+                          subscribed_key_prefixes: "prefix_1"
+                          attribute_data_type: ATTRIBUTE_DATA_TYPE_HASH
+                          language: LANGUAGE_ENGLISH
+                          punctuation: ".,!?"
+                          with_offsets: true
+                          stop_words: "the"
+                          stop_words: "and"
+                          stop_words: "or"
+                          attributes: {
+                            alias: "test_attribute_1"
+                            identifier: "test_identifier_1"
+                            index: {
+                              text_index: {
+                                with_suffix_trie: true
+                                no_stem: true
+                                min_stem_size: 3
+                              }
+                            }
+                          }
+                        )",
+                        .expect_return_failure = false,
+                        .expected_output =
+                            "*42\r\n+index_name\r\n+test_name\r\n+index_"
+                            "options\r\n*0\r\n+index_definition\r\n*6\r\n+key_"
+                            "type\r\n+HASH\r\n+prefixes\r\n*1\r\n+prefix_1\r\n+"
+                            "default_score\r\n$1\r\n1\r\n+attributes\r\n*1\r\n*"
+                            "10\r\n+identifier\r\n+test_identifier_1\r\n+"
+                            "attribute\r\n+test_attribute_1\r\n+type\r\n+"
+                            "TEXT\r\n+WITH_SUFFIX_TRIE\r\n+1\r\n+NO_STEM\r\n+"
+                            "1\r\n+"
+                            "num_docs\r\n:0\r\n+num_"
+                            "terms\r\n:0\r\n+num_records\r\n:0\r\n+"
+                            "hash_indexing_failures\r\n$1\r\n0\r\n+gc_"
+                            "stats\r\n*14\r\n+"
+                            "bytes_collected\r\n$1\r\n0\r\n+total_ms_run\r\n$"
+                            "1\r\n0\r\n+"
+                            "total_cycles\r\n$1\r\n0\r\n+average_cycle_time_"
+                            "ms\r\n$3\r\nnan\r\n+"
+                            "last_run_time_ms\r\n$1\r\n0\r\n+gc_numeric_trees_"
+                            "missed\r\n$1\r\n0\r\n+"
+                            "gc_blocks_denied\r\n$1\r\n0\r\n+cursor_stats\r\n*"
+                            "8\r\n+"
+                            "global_idle\r\n:0\r\n+global_total\r\n:0\r\n+"
+                            "index_capacity\r\n:0\r\n+index_total\r\n:0\r\n+"
+                            "dialect_stats\r\n*8\r\n+"
+                            "dialect_1\r\n:0\r\n+dialect_2\r\n:0\r\n+"
+                            "dialect_3\r\n:0\r\n+dialect_4\r\n:0\r\n+"
+                            "Index Errors\r\n*8\r\n+"
+                            "indexing failures\r\n:0\r\n+last indexing "
+                            "error\r\n+N/A\r\n+"
+                            "last indexing error "
+                            "key\r\n$3\r\nN/A\r\n+background indexing "
+                            "status\r\n+OK\r\n+"
+                            "backfill_in_progress\r\n$1\r\n0\r\n+"
+                            "backfill_complete_percent\r\n$8\r\n1.000000\r\n+"
+                            "mutation_queue_size\r\n$1\r\n0\r\n+recent_"
+                            "mutations_queue_delay\r\n$5\r\n0 sec\r\n+state\r\n"
+                            "+ready\r\n+punctuation\r\n+.,!?\r\n+stop_"
+                            "words\r\n*3\r\n+"
+                            "the\r\n+and\r\n+or\r\n+with_offsets\r\n+1\r\n+"
+                            "language\r\n+english\r\n",
                     },
                 },
         },


### PR DESCRIPTION
This changes makes the FT.INFO more faithful with attributes and statistics in valkey-search module. We are doing this by removing any statics that were place holders made just to be compatible with redis search. We have also added additional statistics, added attributes and chaged the design of FT.INFO which we are going to show to the users. This is in continuation to the PR in the main branch where only attributes and statistics not related to fulltext are added.