### PR TITLE
Increase M minimum limit to 2

### DIFF
--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -145,7 +145,7 @@ static auto max_dimensions =
 static auto max_m =
     vmsdk::config::NumberBuilder(kMaxMConfig,  // name
                                  kMaxM,        // default size
-                                 1,            // min size
+                                 2,            // min size
                                  kMaxM)        // max size
         .WithValidationCallback(CHECK_RANGE(1, kMaxM, kMaxMConfig))
         .Build();
@@ -533,9 +533,9 @@ std::unique_ptr<data_model::VectorIndex> HNSWParameters::ToProto() const {
 absl::Status HNSWParameters::Verify() const {
   VMSDK_RETURN_IF_ERROR(FTCreateVectorParameters::Verify());
   const auto max_m_value = options::GetMaxM().GetValue();
-  VMSDK_RETURN_IF_ERROR(vmsdk::VerifyRange(m, 1, max_m_value))
+  VMSDK_RETURN_IF_ERROR(vmsdk::VerifyRange(m, 2, max_m_value))
       << kMParam
-      << " must be a positive integer greater than 0 and cannot exceed "
+      << " must be a positive integer greater than 2 and cannot exceed "
       << max_m_value << ".";
 
   const auto max_ef_construction_value =

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -189,7 +189,7 @@ INSTANTIATE_TEST_SUITE_P(
              .command_str = " idx1 on HASH PREFIx 3 abc def ghi LANGUAGe "
                             "ENGLISh SCORE 1.0 SChema hash_field1 as "
                             "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                            "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                            "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                             " INITIAL_CAP 15000 EF_RUNTIME 25 ",
              .hnsw_parameters = {{
                  {
@@ -198,7 +198,7 @@ INSTANTIATE_TEST_SUITE_P(
                      .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
                      .initial_cap = 15000,
                  },
-                 /* .m =*/1,
+                 /* .m =*/2,
                  /* .ef_construction =*/5,
                  /* .ef_runtime =*/25,
              }},
@@ -244,7 +244,7 @@ INSTANTIATE_TEST_SUITE_P(
                             "ENGLISh SCORE 1.0 SChema hash_field10 as "
                             "hash_field10 numeric hash_field1 as "
                             "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                            "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                            "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                             " INITIAL_CAP 15000 EF_RUNTIME 25 ",
              .hnsw_parameters = {{
                  {
@@ -253,7 +253,7 @@ INSTANTIATE_TEST_SUITE_P(
                      .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
                      .initial_cap = 15000,
                  },
-                 /* .m =*/1,
+                 /* .m =*/2,
                  /* .ef_construction =*/5,
                  /* .ef_runtime =*/25,
              }},
@@ -283,7 +283,7 @@ INSTANTIATE_TEST_SUITE_P(
                  "ENGLISh SCORE 1.0 SChema hash_field10 as "
                  "hash_field10 tag SEPARATOR '|' CASESENSITIVE hash_field1 as "
                  "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                 "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                 "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                  " INITIAL_CAP 15000 EF_RUNTIME 25 ",
              .hnsw_parameters = {{
                  {
@@ -292,7 +292,7 @@ INSTANTIATE_TEST_SUITE_P(
                      .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
                      .initial_cap = 15000,
                  },
-                 /* .m =*/1,
+                 /* .m =*/2,
                  /* .ef_construction =*/5,
                  /* .ef_runtime =*/25,
              }},
@@ -328,7 +328,7 @@ INSTANTIATE_TEST_SUITE_P(
                  "hash_field21 tag SEPARATOR $ hash_field22 as "
                  "hash_field22 tag  hash_field1 as "
                  "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                 "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                 "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                  " INITIAL_CAP 15000 EF_RUNTIME 25 ",
              .hnsw_parameters = {{
                  {
@@ -337,7 +337,7 @@ INSTANTIATE_TEST_SUITE_P(
                      .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
                      .initial_cap = 15000,
                  },
-                 /* .m =*/1,
+                 /* .m =*/2,
                  /* .ef_construction =*/5,
                  /* .ef_runtime =*/25,
              }},
@@ -588,7 +588,7 @@ INSTANTIATE_TEST_SUITE_P(
                  "ENGLISh SCORE 1.0 SChema hash_field10 as "
                  "hash_field10 tag SEPARATOR @@ CASESENSITIVE hash_field1 as "
                  "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                 "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                 "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                  " INITIAL_CAP 15000 EF_RUNTIME 25 ",
              .tag_parameters = {{
                  .separator = "@@",
@@ -615,7 +615,7 @@ INSTANTIATE_TEST_SUITE_P(
                  " idx1 on HASH PREFIx 3 abc def ghi LANGUAGe "
                  "ENGLISh SCORE 1.0 SChema hash_field1 as "
                  "hash_field11 vector hnsw 14 TYPE  FLOAT32 DIM 3  "
-                 "DISTANCE_METRIC IP M 1 EF_CONSTRUCTION 5 "
+                 "DISTANCE_METRIC IP M 2 EF_CONSTRUCTION 5 "
                  " INITIAL_CAP 15000 EF_RUNTIME 25 random_token_at_the_end",
              .expected_error_message =
                  "Invalid field type for field `random_token_at_the_end`: "
@@ -653,7 +653,7 @@ INSTANTIATE_TEST_SUITE_P(
              .expected_error_message =
                  "Invalid field type for field `hash_field1`: Invalid range: "
                  "Value below minimum; M must be a positive integer greater "
-                 "than 0 and cannot exceed 2000000.",
+                 "than 2 and cannot exceed 2000000.",
          },
          {
              .test_name = "invalid_m_too_big",
@@ -664,7 +664,18 @@ INSTANTIATE_TEST_SUITE_P(
              .expected_error_message =
                  "Invalid field type for field `hash_field1`: Invalid range: "
                  "Value above maximum; M must be a positive integer greater "
-                 "than 0 and cannot exceed 2000000.",
+                 "than 2 and cannot exceed 2000000.",
+         },
+         {
+             .test_name = "invalid_m_too_small",
+             .success = false,
+             .command_str = "idx1 SChema hash_field1 as "
+                            "hash_field11 vector hnsw 8 TYPE  FLOAT32 DIM 3 "
+                            "DISTANCE_METRIC IP M 1",
+             .expected_error_message =
+                 "Invalid field type for field `hash_field1`: Invalid range: "
+                 "Value below minimum; M must be a positive integer greater "
+                 "than 2 and cannot exceed 2000000.",
          },
          {
              .test_name = "invalid_ef_construction_zero",

--- a/testing/ft_create_test.cc
+++ b/testing/ft_create_test.cc
@@ -390,7 +390,7 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_error_message =
                 "$140\r\nInvalid field type for field `vector`: Invalid range: "
                 "Value above maximum; M must be a positive integer greater "
-                "than 0 and cannot exceed 50.\r\n",
+                "than 2 and cannot exceed 50.\r\n",
         },
         {
             .test_name = "MaxEfConstructionLimit",


### PR DESCRIPTION
When using M=1, the server is crashing with an out of memory message.
Increased the minimum M value to be 2 instead of 1, and fixed the unit tests accordingly. 