### PR TITLE
Fixed: clients are blocked after MULTI operation

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -573,6 +573,7 @@ void IndexSchema::ProcessMutation(ValkeyModuleCtx *ctx,
   const bool inside_multi_exec = vmsdk::MultiOrLua(ctx);
   if (ABSL_PREDICT_FALSE(inside_multi_exec)) {
     EnqueueMultiMutation(interned_key);
+    return;
   }
   const bool block_client =
       ShouldBlockClient(ctx, inside_multi_exec, from_backfill);


### PR DESCRIPTION
When running the following commands:

```bash
FT.CREATE idx1 SCHEMA price NUMERIC
MULTI
HINCRBYFLOAT hash:1 field:7 34.555443
EXEC
HINCRBYFLOAT hash:1 field:13 33.937241
```

The last call to `HINCRBYFLOAT` is blocked. Further more, any client trying to access the key `hash:1` will get blocked.