### PR TITLE
fix memory leak at config get

### DIFF
--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -59,8 +59,7 @@ static ValkeyModuleString *OnGetStringConfig(const char *config_name,
                                              void *priv_data) {
   auto entry = static_cast<String *>(priv_data);
   CHECK(entry) << "null private data";
-  return ValkeyModule_CreateString(nullptr, entry->GetString().c_str(),
-                                   entry->GetString().size());
+  return entry->GetCachedValkeyString();
 }
 
 static int OnSetStringConfig(const char *config_name, ValkeyModuleString *value,


### PR DESCRIPTION
Problem:
The `OnGetStringConfig` function was creating new `ValkeyModuleString` objects on every config get request without 
proper cleanup, causing memory leaks.
```
Indirect leak of 105 byte(s) in 2 object(s) allocated from:
    #0 0x7f6e93d4457d in malloc (/lib64 libasan.so.4+0xd857d)
    #1 0x69acb5 in ztrymalloc_usable_internal 
    #2 0x69b009 in zmalloc_usable 
    #3 0x69397d in _sdsnewlen
    #4 0x694209 in sdsnewlen 
    #5 0x6ec7df in createRawStringObject 
    #6 0x6ece8b in createStringObject
    #7 0x8b5feb in VM_CreateString
    #8 0x7f6e81d138e5 in  (libsearch.so+0x2988e5)
    #9 0x8e8c7e in getModuleStringConfig
    #10 0x7aff0a in sdsConfigGet 
    #11 0x7aa15c in configGetCommand
...

Solution:
Added caching mechanism with `GetCachedValkeyString` method and Added proper cleanup in destructor and when config values change

