### PR TITLE
Lexical Ordering for Keys in Postings KeyIterator

### DIFF
--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -171,7 +171,7 @@ class Postings::Impl {
  public:
   bool save_positions_;
   size_t num_text_fields_;
-  std::map<Key, PositionMap> key_to_positions_;
+  std::map<Key, PositionMap, InternedStringPtrLess> key_to_positions_;
 
   Impl(bool save_positions, size_t num_text_fields)
       : save_positions_(save_positions), num_text_fields_(num_text_fields) {}

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -28,7 +28,7 @@ fields.
 
 A KeyIterator is provided to iterate over the keys within this object.
 A PositionIterator is provided to iterate over the positions of an individual
-Key.
+Key. 
 
 */
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -28,7 +28,7 @@ fields.
 
 A KeyIterator is provided to iterate over the keys within this object.
 A PositionIterator is provided to iterate over the positions of an individual
-Key. 
+Key.
 
 */
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -136,9 +136,9 @@ struct Postings {
 
     // Iterator state - pointer to key_to_positions map
     using PositionMap = std::map<Position, std::unique_ptr<class FieldMask>>;
-    const std::map<Key, PositionMap>* key_map_;
-    std::map<Key, PositionMap>::const_iterator current_;
-    std::map<Key, PositionMap>::const_iterator end_;
+    const std::map<Key, PositionMap, InternedStringPtrLess>* key_map_;
+    std::map<Key, PositionMap, InternedStringPtrLess>::const_iterator current_;
+    std::map<Key, PositionMap, InternedStringPtrLess>::const_iterator end_;
   };
 
   // The Position Iterator

--- a/src/utils/string_interning.h
+++ b/src/utils/string_interning.h
@@ -109,6 +109,13 @@ struct InternedStringPtrEqual {
   }
 };
 
+struct InternedStringPtrLess {
+  template <typename T, typename U>
+  bool operator()(const T &lhs, const U &rhs) const {
+    return lhs->Str() < rhs->Str();
+  }
+};
+
 template <typename T>
 using InternedStringMap =
     absl::flat_hash_map<InternedStringPtr, T, InternedStringPtrHash,


### PR DESCRIPTION
Implement custom comparator for Postings::KeyIterator, which compares the actual key strings itself and not the addresses to keep it sorted. Necessary for search results to be displayed in lexical order of key strings.