### PR TITLE
Add .kiro folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ integration/valkeytestframework*
 dump.rdb
 test-data*
 integration/test-data/
+.kiro/


### PR DESCRIPTION
Add .kiro folder to .gitignore, enable developers to use kiro while prevent uploading kiro steering files