### PR TITLE
Add more integration tests for FT.DROPINDEX consistency check

### DIFF
--- a/integration/test_ft_dropindex_consistency.py
+++ b/integration/test_ft_dropindex_consistency.py
@@ -3,8 +3,55 @@ from valkey.cluster import ValkeyCluster
 from valkey.client import Valkey
 from valkeytestframework.conftest import resource_port_tracker
 from valkey.exceptions import ResponseError
+from valkeytestframework.util import waiters
 import threading
 import pytest
+
+RETRY_MIN_THRESHOLD=50
+
+def do_dropindex(node0, index_name, dropindex_result):
+    try:
+        dropindex_result[0] = node0.execute_command("FT.DROPINDEX", index_name)
+    except Exception as e:
+        dropindex_result[0] = e
+
+# type0: reset handle cluster message pausepoint on node1 first
+# type1: reset consistency check pausepoint on node0 first
+def run_pausepoint_reset(type, node0, node1, reset_pausepoint_result, reset_pause_handle_message_result, exceptions):
+    try:
+        def wait_for_pausepoint():
+            res = str(node0.execute_command("FT._DEBUG PAUSEPOINT TEST fanout_remote_pausepoint"))
+            return int(res) > 0
+
+        def counter_is_increasing():
+            count = int(node1.info("SEARCH")["search_pause_handle_cluster_message_round_count"])
+            return count > 0
+
+        # wait for reaching consistency check pausepoint
+        waiters.wait_for_true(wait_for_pausepoint, timeout=5)
+        # wait for reaching handle cluster message pausepoint
+        waiters.wait_for_true(counter_is_increasing, timeout=5)
+
+        if type == 0:
+            metadata_reconciliation_completed_count_before = node1.info("SEARCH")["search_coordinator_metadata_reconciliation_completed_count"]
+            # reset handle cluster message pausepoint first
+            reset_pause_handle_message_result[0] = node1.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET PauseHandleClusterMessage no")
+            # wait for metadata to reconcile
+            waiters.wait_for_true(
+                lambda: int(node1.info("SEARCH")["search_coordinator_metadata_reconciliation_completed_count"]) 
+                    > metadata_reconciliation_completed_count_before, 
+                timeout=5
+            )
+            # reset consistency check pausepoint second
+            reset_pausepoint_result[0] = node0.execute_command("FT._DEBUG PAUSEPOINT RESET fanout_remote_pausepoint")
+
+        elif type == 1:
+            # reset consistency check pausepoint first
+            reset_pausepoint_result[0] = node0.execute_command("FT._DEBUG PAUSEPOINT RESET fanout_remote_pausepoint")
+            # reset handle cluster message pausepoint second
+            reset_pause_handle_message_result[0] = node1.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET PauseHandleClusterMessage no")
+    except Exception as e:
+        exceptions[0] = e
 
 class TestFTDropindexConsistency(ValkeySearchClusterTestCaseDebugMode):
 
@@ -45,16 +92,10 @@ class TestFTDropindexConsistency(ValkeySearchClusterTestCaseDebugMode):
         err_msg = "Index with name '" + index_name + "' not found"
         assert err_msg in str(e)
 
-    def test_concurrent_dropindex(self):
-
-        def dropindex_on_node(node, node_id):
-            barrier.wait()
-            try:
-                result = node.execute_command("FT.DROPINDEX", index_name)
-                results[node_id] = result
-            except Exception as e:
-                exceptions[node_id] = e
-
+    # synchronize the handle metadata on node1 and consistency check on node0
+    # release pausepoint on node1 first to finish metadata reconciliation first
+    # expect very small number of retries in consistency check
+    def test_dropindex_synchronize_handle_message_first(self):
         cluster: ValkeyCluster = self.new_cluster_client()
         node0: Valkey = self.new_client_for_primary(0)
         node1: Valkey = self.new_client_for_primary(1)
@@ -66,27 +107,79 @@ class TestFTDropindexConsistency(ValkeySearchClusterTestCaseDebugMode):
             "PREFIX", "1", "doc:",
             "SCHEMA", "price", "NUMERIC"
         ) == b"OK"
+
+        retry_count_before = node0.info("SEARCH")["search_info_fanout_retry_count"]
+
+        assert node0.execute_command("FT._DEBUG PAUSEPOINT SET fanout_remote_pausepoint") == b"OK"
+        assert node1.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET PauseHandleClusterMessage yes") == b"OK"
+
+        dropindex_result = [None]
+        reset_pausepoint_result = [None]
+        reset_pause_handle_message_result = [None]
+        exceptions = [None]
         
-        results = {}
-        exceptions = {}
+        # thread on node0 to start dropindex
+        thread1 = threading.Thread(target=do_dropindex, args=(node0, index_name, dropindex_result))
+        # thread to synchronize and release pausepoint
+        thread2 = threading.Thread(
+            target=run_pausepoint_reset, 
+            args=(0, node0, node1, reset_pausepoint_result, reset_pause_handle_message_result, exceptions)
+        )
 
-        # Barrier to synchronize thread execution
-        barrier = threading.Barrier(2)
-        # Create and start threads
-        thread0 = threading.Thread(
-            target=dropindex_on_node, 
-            args=(node0, 0)
-        )
-        thread1 = threading.Thread(
-            target=dropindex_on_node, 
-            args=(node1, 1)
-        )
-        thread0.start()
         thread1.start()
-        # Wait for both threads to complete
-        thread0.join()
-        thread1.join()
+        thread2.start()
+        thread1.join(timeout=10)
+        thread2.join(timeout=10)
 
-        res1, res2 = results.values()
-        assert "OK" in str(res1)
-        assert "OK" in str(res2)
+        assert dropindex_result[0] == b"OK"
+        # assert no retry when handle message on node1 released first
+        # taking the threshold to account for retries caused by grpc launch latency
+        retry_count_after = node0.info("SEARCH")["search_info_fanout_retry_count"]
+        assert retry_count_after - retry_count_before <= RETRY_MIN_THRESHOLD
+        pause_handle_cluster_message_round_count = int(node1.info("SEARCH")["search_pause_handle_cluster_message_round_count"])
+        assert pause_handle_cluster_message_round_count > 0
+    
+    # synchronize the handle metadata on node1 and consistency check on node0
+    # release pausepoint on node0 first to start consistency check first
+    # expect large number of retries in consistency check
+    def test_dropindex_synchronize_consistency_check_first(self):
+        cluster: ValkeyCluster = self.new_cluster_client()
+        node0: Valkey = self.new_client_for_primary(0)
+        node1: Valkey = self.new_client_for_primary(1)
+        index_name = "index1"
+
+        assert node0.execute_command(
+            "FT.CREATE", index_name,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA", "price", "NUMERIC"
+        ) == b"OK"
+
+        retry_count_before = node0.info("SEARCH")["search_info_fanout_retry_count"]
+
+        assert node0.execute_command("FT._DEBUG PAUSEPOINT SET fanout_remote_pausepoint") == b"OK"
+        assert node1.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET PauseHandleClusterMessage yes") == b"OK"
+
+        dropindex_result = [None]
+        reset_pausepoint_result = [None]
+        reset_pause_handle_message_result = [None]
+        exceptions = [None]
+        
+        # thread on node0 to start dropindex
+        thread1 = threading.Thread(target=do_dropindex, args=(node0, index_name, dropindex_result))
+        # thread to synchronize and release pausepoint
+        thread2 = threading.Thread(
+            target=run_pausepoint_reset, 
+            args=(1, node0, node1, reset_pausepoint_result, reset_pause_handle_message_result, exceptions)
+        )
+
+        thread1.start()
+        thread2.start()
+        thread1.join(timeout=10)
+        thread2.join(timeout=10)
+
+        assert dropindex_result[0] == b"OK"
+        retry_count_after = node0.info("SEARCH")["search_info_fanout_retry_count"]
+        assert retry_count_after - retry_count_before > RETRY_MIN_THRESHOLD
+        pause_handle_cluster_message_round_count = int(node1.info("SEARCH")["search_pause_handle_cluster_message_round_count"])
+        assert pause_handle_cluster_message_round_count > 0

--- a/integration/test_info_cluster.py
+++ b/integration/test_info_cluster.py
@@ -47,6 +47,44 @@ class TestFTInfoCluster(ValkeySearchClusterTestCaseDebugMode):
         assert float(info["backfill_complete_percent_max"]) == 1.000000
         assert float(info["backfill_complete_percent_min"]) == 1.000000
         assert str(info["state"]) == "ready"
+
+    def test_ft_info_cluster_force_index_name_error_retry(self):
+        cluster: ValkeyCluster = self.new_cluster_client()
+        node0: Valkey = self.new_client_for_primary(0)
+        node1: Valkey = self.new_client_for_primary(1)
+        index_name = "index1"
+
+        N = 5
+        for i in range(N):
+            cluster.execute_command("HSET", f"doc:{i}", "price", str(10 + i))
+
+        assert node0.execute_command(
+            "FT.CREATE", index_name,
+            "ON", "HASH",
+            "PREFIX", "1", "doc:",
+            "SCHEMA", "price", "NUMERIC"
+        ) == b"OK"
+
+        waiters.wait_for_true(lambda: self.is_backfill_complete(node0, index_name))
+        retry_count_before = node0.info("SEARCH")["search_info_fanout_retry_count"]
+        assert node1.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET ForceIndexNotFoundError 3") == b"OK"
+
+        raw = node0.execute_command("FT.INFO", index_name, "CLUSTER")
+        parser = FTInfoParser([])
+        info = parser._parse_key_value_list(raw)
+
+        # check cluster info results
+        assert info is not None
+        assert str(info.get("index_name")) == index_name
+        assert str(info.get("mode")) == "cluster"
+        assert int(info["backfill_in_progress"]) == 0
+        assert float(info["backfill_complete_percent_max"]) == 1.000000
+        assert float(info["backfill_complete_percent_min"]) == 1.000000
+        assert str(info["state"]) == "ready"
+
+        retry_count_after = node0.info("SEARCH")["search_info_fanout_retry_count"]
+
+        assert retry_count_before + 3 == retry_count_after, f"Expected retry_count increment by 3, got {retry_count_after - retry_count_before}"
     
     def test_ft_info_cluster_retry(self):
         cluster: ValkeyCluster = self.new_cluster_client()

--- a/src/coordinator/metadata_manager.h
+++ b/src/coordinator/metadata_manager.h
@@ -109,6 +109,10 @@ class MetadataManager {
   void BroadcastMetadata(ValkeyModuleCtx *ctx,
                          const GlobalMetadataVersionHeader &version_header);
 
+  void DelayHandleClusterMessage(
+      ValkeyModuleCtx *ctx, const char *sender_id,
+      std::unique_ptr<GlobalMetadataVersionHeader> header);
+
   void HandleClusterMessage(ValkeyModuleCtx *ctx, const char *sender_id,
                             uint8_t type, const unsigned char *payload,
                             uint32_t len);
@@ -136,6 +140,7 @@ class MetadataManager {
   void RegisterForClusterMessages(ValkeyModuleCtx *ctx);
 
   int64_t GetMilliSecondsSinceLastHealthyMetadata() const;
+  int64_t GetMetadataReconciliationCompletedCount() const;
 
   static bool IsInitialized();
   static void InitInstance(std::unique_ptr<MetadataManager> instance);
@@ -160,6 +165,7 @@ class MetadataManager {
   coordinator::ClientPool &client_pool_;
   vmsdk::UniqueValkeyDetachedThreadSafeContext detached_ctx_;
   std::atomic_int64_t last_healthy_metadata_millis_{0};
+  std::atomic_int64_t metadata_reconciliation_completed_count_{0};
 };
 }  // namespace valkey_search::coordinator
 

--- a/src/coordinator/server.cc
+++ b/src/coordinator/server.cc
@@ -49,6 +49,7 @@
 namespace valkey_search::coordinator {
 
 CONTROLLED_SIZE_T(ForceRemoteFailCount, 0);
+CONTROLLED_SIZE_T(ForceIndexNotFoundError, 0);
 
 grpc::ServerUnaryReactor* Service::GetGlobalMetadata(
     grpc::CallbackServerContext* context,
@@ -191,6 +192,18 @@ Service::GenerateInfoResponse(
   uint32_t db_num = request.db_num();
   std::string index_name = request.index_name();
   coordinator::InfoIndexPartitionResponse response;
+  // test path: simulate index not found error
+  if (ForceIndexNotFoundError.GetValue() > 0) {
+    ForceIndexNotFoundError.Decrement();
+    std::string test_error_str =
+        "Test Error: Index " + index_name + " not found";
+    response.set_exists(false);
+    response.set_index_name(index_name);
+    response.set_error(test_error_str);
+    response.set_error_type(coordinator::FanoutErrorType::INDEX_NAME_ERROR);
+    grpc::Status error_status(grpc::StatusCode::NOT_FOUND, test_error_str);
+    return std::make_pair(error_status, response);
+  }
   auto status_or_schema =
       SchemaManager::Instance().GetIndexSchema(db_num, index_name);
   if (!status_or_schema.ok()) {

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -127,6 +127,7 @@ class Metrics {
 
     std::atomic<uint64_t> info_fanout_retry_cnt{0};
     std::atomic<uint64_t> info_fanout_fail_cnt{0};
+    std::atomic<uint64_t> pause_handle_cluster_message_round_cnt{0};
   };
   static Stats& GetStats() { return GetInstance().stats_; }
 

--- a/src/query/primary_info_fanout_operation.cc
+++ b/src/query/primary_info_fanout_operation.cc
@@ -145,7 +145,7 @@ void PrimaryInfoFanoutOperation::ResetForRetry() {
 // retry condition: (1) inconsistent state (2) network error
 bool PrimaryInfoFanoutOperation::ShouldRetry() {
   return !inconsistent_state_error_nodes.empty() ||
-         !communication_error_nodes.empty();
+         !communication_error_nodes.empty() || !index_name_error_nodes.empty();
 }
 
 }  // namespace valkey_search::query::primary_info_fanout

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -570,6 +570,19 @@ static vmsdk::info_field::Integer coordinator_last_time_since_healthy_metadata(
           return ValkeySearch::Instance().UsingCoordinator();
         }));
 
+static vmsdk::info_field::Integer
+    coordinator_metadata_reconciliation_completed_count(
+        "coordinator", "coordinator_metadata_reconciliation_completed_count",
+        vmsdk::info_field::IntegerBuilder()
+            .App()
+            .Computed([]() -> int64_t {
+              return coordinator::MetadataManager::Instance()
+                  .GetMetadataReconciliationCompletedCount();
+            })
+            .VisibleIf([]() -> bool {
+              return ValkeySearch::Instance().UsingCoordinator();
+            }));
+
 static vmsdk::info_field::String
     coordinator_client_get_global_metadata_success_latency_usec(
         "coordinator",
@@ -758,6 +771,12 @@ static vmsdk::info_field::Integer info_fanout_fail_count(
     "fanout", "info_fanout_fail_count",
     vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
       return Metrics::GetStats().info_fanout_fail_cnt;
+    }));
+
+static vmsdk::info_field::Integer pause_handle_cluster_message_round_cnt(
+    "fanout", "pause_handle_cluster_message_round_count",
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      return Metrics::GetStats().pause_handle_cluster_message_round_cnt;
     }));
 
 #ifdef DEBUG_INFO


### PR DESCRIPTION
1. Added two synchronized integration tests for FT.DROPINDEX, testing the execution order of handle cluster message and consistency check
2. Added integration tests to check index name errors would trigger retry in fanout