### PR TITLE
Stemming - Ingestion and Search handling

### DIFF
--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -101,6 +101,11 @@ class Text : public IndexBase {
     absl::string_view data_;
     bool no_field_{false};
     text::FieldMaskPredicate field_mask_;
+    
+    // Stemming configuration
+    std::shared_ptr<text::TextIndexSchema> text_index_schema_;
+    bool no_stem_;
+    int32_t min_stem_size_;
   };
 
   // Calculate size based on the predicate.

--- a/src/indexes/text/lexer.cc
+++ b/src/indexes/text/lexer.cc
@@ -6,6 +6,7 @@
 
 #include "src/indexes/text/lexer.h"
 
+#include <memory>
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/strings/ascii.h"
@@ -17,7 +18,9 @@ namespace valkey_search::indexes::text {
 absl::StatusOr<std::vector<std::string>> Lexer::Tokenize(
     absl::string_view text, const std::bitset<256>& punct_bitmap,
     sb_stemmer* stemmer, bool stemming_enabled, uint32_t min_stem_size,
-    const absl::flat_hash_set<std::string>& stop_words_set) const {
+    const absl::flat_hash_set<std::string>& stop_words_set,
+    std::vector<std::string>* stemmed_words,
+    std::mutex* stemmer_mutex) const {
   if (!IsValidUtf8(text)) {
     return absl::InvalidArgumentError("Invalid UTF-8");
   }
@@ -39,15 +42,18 @@ absl::StatusOr<std::vector<std::string>> Lexer::Tokenize(
     if (pos > word_start) {
       absl::string_view word_view(text.data() + word_start, pos - word_start);
 
-      std::string word = absl::AsciiStrToLower(word_view);
+      std::string original_word = absl::AsciiStrToLower(word_view);
 
-      if (Lexer::IsStopWord(word, stop_words_set)) {
+      if (Lexer::IsStopWord(original_word, stop_words_set)) {
         continue;  // Skip stop words
       }
 
-      word = StemWord(word, stemmer, stemming_enabled, min_stem_size);
+      std::string stemmed_word = StemWord(original_word, stemmer, stemming_enabled, min_stem_size, stemmer_mutex);
 
-      tokens.push_back(std::move(word));
+      if (stemmed_words && original_word != stemmed_word) {
+        stemmed_words->push_back(stemmed_word);
+      }
+      tokens.push_back(std::move(original_word));
     }
   }
 
@@ -56,19 +62,36 @@ absl::StatusOr<std::vector<std::string>> Lexer::Tokenize(
 
 std::string Lexer::StemWord(const std::string& word, sb_stemmer* stemmer,
                             bool stemming_enabled,
-                            uint32_t min_stem_size) const {
+                            uint32_t min_stem_size,
+                            std::mutex* stemmer_mutex) const {
   if (word.empty() || !stemming_enabled || word.length() < min_stem_size) {
     return word;
   }
 
-  CHECK(stemmer) << "Stemmer not initialized";
+  // If stemmer is not initialized, return the original word
+  if (!stemmer) {
+    return word;
+  }
+
+  // Lock the stemmer mutex to ensure thread-safe access (if provided)
+  std::unique_ptr<std::lock_guard<std::mutex>> lock;
+  if (stemmer_mutex) {
+    lock = std::make_unique<std::lock_guard<std::mutex>>(*stemmer_mutex);
+  }
 
   const sb_symbol* stemmed = sb_stemmer_stem(
       stemmer, reinterpret_cast<const sb_symbol*>(word.c_str()), word.length());
 
-  DCHECK(stemmed) << "Stemming failed for word: " + word;
+  // If stemming fails (e.g., for non-English words), return the original word
+  if (!stemmed) {
+    return word;
+  }
 
   int stemmed_length = sb_stemmer_length(stemmer);
+  if (stemmed_length <= 0) {
+    return word;
+  }
+
   return std::string(reinterpret_cast<const char*>(stemmed), stemmed_length);
 }
 

--- a/src/indexes/text/lexer.h
+++ b/src/indexes/text/lexer.h
@@ -25,6 +25,7 @@ Tokenization Pipeline:
 */
 
 #include <bitset>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -40,7 +41,9 @@ struct Lexer {
   absl::StatusOr<std::vector<std::string>> Tokenize(
       absl::string_view text, const std::bitset<256>& punct_bitmap,
       sb_stemmer* stemmer, bool stemming_enabled, uint32_t min_stem_size,
-      const absl::flat_hash_set<std::string>& stop_words_set) const;
+      const absl::flat_hash_set<std::string>& stop_words_set,
+      std::vector<std::string>* stemmed_words = nullptr,
+      std::mutex* stemmer_mutex = nullptr) const;
 
   // Punctuation checking API
   static bool IsPunctuation(char c, const std::bitset<256>& punct_bitmap) {
@@ -54,9 +57,12 @@ struct Lexer {
     return stop_words_set.contains(lowercase_word);
   }
 
- private:
+  // Stemming API
   std::string StemWord(const std::string& word, sb_stemmer* stemmer,
-                       bool stemming_enabled, uint32_t min_stem_size) const;
+                       bool stemming_enabled, uint32_t min_stem_size,
+                       std::mutex* stemmer_mutex) const;
+
+ private:
 
   // UTF-8 processing helpers
   bool IsValidUtf8(absl::string_view text) const;

--- a/src/indexes/text/term.cc
+++ b/src/indexes/text/term.cc
@@ -6,47 +6,127 @@
  */
 
 #include "src/indexes/text/term.h"
+#include "src/indexes/text/lexer.h"
+#include "src/indexes/text/text_index.h"
 
 namespace valkey_search::indexes::text {
 
 TermIterator::TermIterator(const WordIterator& word,
                            const absl::string_view data,
                            const FieldMaskPredicate field_mask,
-                           const InternedStringSet* untracked_keys)
+                           const InternedStringSet* untracked_keys,
+                           bool stemming_enabled,
+                           std::shared_ptr<TextIndexSchema> text_index_schema,
+                           uint32_t min_stem_size,
+                           std::shared_ptr<TextIndex> text_index)
     : word_(word),
       data_(data),
       field_mask_(field_mask),
-      untracked_keys_(untracked_keys) {}
+      untracked_keys_(untracked_keys),
+      stemming_enabled_(stemming_enabled),
+      text_index_schema_(text_index_schema),
+      min_stem_size_(min_stem_size),
+      text_index_(text_index) {}
 
 bool TermIterator::Done() const {
-  if (nomatch_ || word_.GetWord() != data_) {
+  if (nomatch_) {
     return true;
   }
-  // Check if key iterator is valid
+  
+  if (stemming_enabled_) {
+    if (key_iter_.IsValid()) {
+      return false;
+    }
+    if (stem_target_ && stem_word_iter_ != stem_target_->end()) {
+      return false;
+    }
+    if (word_.GetWord() != data_) {
+      return false;
+    }
+    return true;
+  }
+  
+  if (word_.GetWord() != data_) {
+    return true;
+  }
   return !key_iter_.IsValid();
 }
 
 void TermIterator::Next() {
-  // On a Begin() call, we initialize the target_posting_ and key_iter_.
   if (begin_) {
+    if (stemming_enabled_ && text_index_schema_ && text_index_) {
+      Lexer lexer;
+      std::string search_term = std::string(data_);
+      std::string stemmed_term = lexer.StemWord(
+          search_term, text_index_schema_->GetStemmer(), true, min_stem_size_,
+          text_index_schema_->GetStemmerMutex());
+      
+      auto stem_iter = text_index_->stem_.GetWordIterator(stemmed_term);
+      if (!stem_iter.Done() && stem_iter.GetWord() == stemmed_term) {
+        stem_target_ = stem_iter.GetTarget();
+        if (stem_target_ && !stem_target_->empty()) {
+          stem_word_iter_ = stem_target_->begin();
+          word_ = text_index_->prefix_.GetWordIterator(*stem_word_iter_);
+        }
+      }
+    }
+    
     if (word_.Done()) {
       nomatch_ = true;
       return;
     }
     target_posting_ = word_.GetTarget();
     key_iter_ = target_posting_->GetKeyIterator();
-    begin_ = false;  // Set to false after the first call to Next.
-  } else {
+    begin_ = false;
+  } else if (key_iter_.IsValid()) {
     key_iter_.NextKey();
   }
-  // Advance until we find a valid key or reach the end
-  while (!Done() && !key_iter_.ContainsFields(field_mask_)) {
+  
+  if (stemming_enabled_) {
+    while (stem_target_ && stem_word_iter_ != stem_target_->end()) {
+      while (key_iter_.IsValid() && !key_iter_.ContainsFields(field_mask_)) {
+        key_iter_.NextKey();
+      }
+      if (key_iter_.IsValid()) {
+        return;
+      }
+      
+      ++stem_word_iter_;
+      if (stem_word_iter_ != stem_target_->end()) {
+        word_ = text_index_->prefix_.GetWordIterator(*stem_word_iter_);
+        if (!word_.Done()) {
+          target_posting_ = word_.GetTarget();
+          if (target_posting_) {
+            key_iter_ = target_posting_->GetKeyIterator();
+          }
+        }
+      }
+    }
+    
+    if ((!stem_target_ || stem_word_iter_ == stem_target_->end()) && 
+        (word_.GetWord() != data_ || word_.Done())) {
+      word_ = text_index_->prefix_.GetWordIterator(data_);
+      if (!word_.Done() && word_.GetWord() == data_) {
+        target_posting_ = word_.GetTarget();
+        if (target_posting_) {
+          key_iter_ = target_posting_->GetKeyIterator();
+          while (key_iter_.IsValid() && !key_iter_.ContainsFields(field_mask_)) {
+            key_iter_.NextKey();
+          }
+          if (key_iter_.IsValid()) {
+            return;
+          }
+        }
+      }
+    }
+  }
+  
+  while (!Done() && key_iter_.IsValid() && !key_iter_.ContainsFields(field_mask_)) {
     key_iter_.NextKey();
   }
 }
 
 const InternedStringPtr& TermIterator::operator*() const {
-  // Return the current key from the key iterator of the posting object.
   return key_iter_.GetKey();
 }
 

--- a/src/indexes/text/term.h
+++ b/src/indexes/text/term.h
@@ -14,6 +14,7 @@
 #include "src/indexes/index_base.h"
 #include "src/indexes/text/posting.h"
 #include "src/indexes/text/radix_tree.h"
+#include "src/indexes/text/text_index.h"
 #include "src/utils/string_interning.h"
 
 namespace valkey_search::indexes::text {
@@ -31,7 +32,11 @@ class TermIterator : public indexes::EntriesFetcherIteratorBase {
  public:
   TermIterator(const WordIterator& word, const absl::string_view data,
                const FieldMaskPredicate field_mask,
-               const InternedStringSet* untracked_keys = nullptr);
+               const InternedStringSet* untracked_keys = nullptr,
+               bool stemming_enabled = false,
+               std::shared_ptr<TextIndexSchema> text_index_schema = nullptr,
+               uint32_t min_stem_size = 0,
+               std::shared_ptr<TextIndex> text_index = nullptr);
 
   bool Done() const override;
   void Next() override;
@@ -49,6 +54,14 @@ class TermIterator : public indexes::EntriesFetcherIteratorBase {
   const InternedStringSet* untracked_keys_;
   InternedStringPtr current_key_;
   FieldMaskPredicate field_mask_;
+  
+  // Stemming support
+  bool stemming_enabled_ = false;
+  std::shared_ptr<TextIndexSchema> text_index_schema_;
+  uint32_t min_stem_size_ = 0;
+  std::shared_ptr<TextIndex> text_index_;
+  std::shared_ptr<StemTarget> stem_target_;
+  StemTarget::iterator stem_word_iter_;
 };
 
 }  // namespace valkey_search::indexes::text

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -9,6 +9,7 @@
 
 #include "absl/strings/ascii.h"
 #include "libstemmer.h"
+#include "third_party/snowball/language_mapping.h"
 
 namespace valkey_search::indexes::text {
 
@@ -63,12 +64,11 @@ TextIndexSchema::~TextIndexSchema() {
 }
 
 const char* TextIndexSchema::GetLanguageString() const {
-  switch (language_) {
-    case data_model::LANGUAGE_ENGLISH:
-      return "english";
-    default:
-      return "english";
+  auto it = snowball::language_map.find(language_);
+  if (it != snowball::language_map.end()) {
+    return it->second;
   }
+  return "english";  // fallback
 }
 
 }  // namespace valkey_search::indexes::text

--- a/testing/lexer_test.cc
+++ b/testing/lexer_test.cc
@@ -81,7 +81,8 @@ TEST_P(LexerParameterizedTest, TokenizeTest) {
   auto result =
       lexer_->Tokenize(test_case.input, schema->GetPunctuationBitmap(),
                        schema->GetStemmer(), test_case.stemming_enabled,
-                       test_case.min_stem_size, schema->GetStopWordsSet());
+                       test_case.min_stem_size, schema->GetStopWordsSet(),
+                       nullptr, schema->GetStemmerMutex());
 
   ASSERT_TRUE(result.ok()) << "Test case: " << test_case.description;
   EXPECT_EQ(*result, test_case.expected)
@@ -172,7 +173,8 @@ TEST_F(LexerTest, InvalidUTF8) {
   auto result =
       lexer_->Tokenize(invalid_utf8, text_schema_->GetPunctuationBitmap(),
                        text_schema_->GetStemmer(), stemming_enabled_,
-                       min_stem_size_, text_schema_->GetStopWordsSet());
+                       min_stem_size_, text_schema_->GetStopWordsSet(),
+                       nullptr, text_schema_->GetStemmerMutex());
   EXPECT_FALSE(result.ok());
   EXPECT_EQ(result.status().code(), absl::StatusCode::kInvalidArgument);
   EXPECT_EQ(result.status().message(), "Invalid UTF-8");
@@ -183,7 +185,8 @@ TEST_F(LexerTest, LongWord) {
   auto result =
       lexer_->Tokenize(long_word, text_schema_->GetPunctuationBitmap(),
                        text_schema_->GetStemmer(), stemming_enabled_,
-                       min_stem_size_, text_schema_->GetStopWordsSet());
+                       min_stem_size_, text_schema_->GetStopWordsSet(),
+                       nullptr, text_schema_->GetStemmerMutex());
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(*result, std::vector<std::string>({long_word}));
 }
@@ -202,7 +205,8 @@ TEST_F(LexerTest, EmptyStopWordsHandling) {
   auto result =
       lexer_->Tokenize("Hello, world! TESTING 123 with-dashes and/or symbols",
                        no_stop_schema->GetPunctuationBitmap(),
-                       no_stop_schema->GetStemmer(), true, 3, empty_set);
+                       no_stop_schema->GetStemmer(), true, 3, empty_set,
+                       nullptr, no_stop_schema->GetStemmerMutex());
 
   ASSERT_TRUE(result.ok());
   EXPECT_EQ(*result,

--- a/third_party/snowball/language_mapping.h
+++ b/third_party/snowball/language_mapping.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef THIRD_PARTY_SNOWBALL_LANGUAGE_MAPPING_H_
+#define THIRD_PARTY_SNOWBALL_LANGUAGE_MAPPING_H_
+
+#include <unordered_map>
+#include "src/index_schema.pb.h"
+
+namespace snowball {
+
+// Map from Language enum to snowball language strings
+static const std::unordered_map<valkey_search::data_model::Language, const char*> language_map = {
+  {valkey_search::data_model::LANGUAGE_UNSPECIFIED, "english"},
+  {valkey_search::data_model::LANGUAGE_ENGLISH, "english"},
+};
+
+}  // namespace snowball
+
+#endif  // THIRD_PARTY_SNOWBALL_LANGUAGE_MAPPING_H_


### PR DESCRIPTION
## Ingestion 

```
happy and happiness stem to -> happi
personal and person stem to -> person 

→ payload: {doc:1 happy, 
            doc:2 happiness, 
            doc:3 happi,
            doc:4 personal,
            doc:5 person
            }
            
Prefix Trie path:                  ()
                                /       \
                           happ      person   
                          /     \          \
                      iness      y          al  
                  
Posting objects to be stored :

 happy : Posting {doc:1},
 happi : Posting {doc:3} ,
 happiness : Posting {doc:2}, 
 personal: Posting {doc:4}, 
 person: Posting {doc:5}, 

Stem Trie path:                    ()
                                /       \
                           happi      person   

Stem Targets to be stored :

happi -> {happy, happiness} 
person -> {personal}

(even 'happi' stems to 'happi' but mapping a word to itslef doesnt make sense)
```


## Search

```
A non exact term search should return both original word and all stem parents of the stemmed root of original word

For instance for query FT.SEARCH testindex '@desc:happi'

Results should include the original word + All stem targets of word happi + Exact Stem root if exists



```

Other things added with this PR

- Addressed comments onGetLanguageString() function