### PR TITLE
FT.SEARCH basic params added

### DIFF
--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -74,13 +74,7 @@ constexpr absl::string_view kLocalOnly{"LOCALONLY"};
 constexpr absl::string_view kVectorFilterDelimiter = "=>";
 constexpr absl::string_view kSlop{"SLOP"};
 constexpr absl::string_view kInorder{"INORDER"};
-constexpr absl::string_view kLanguage{"LANGUAGE"};
 constexpr absl::string_view kVerbatim{"VERBATIM"};
-
-// Language lookup map for enum parsing (English only, case-insensitive)
-const absl::NoDestructor<
-    absl::flat_hash_map<absl::string_view, data_model::Language>>
-    kLanguageByStr({{"ENGLISH", data_model::LANGUAGE_ENGLISH}});
 
 absl::StatusOr<absl::string_view> SubstituteParam(
     query::SearchParameters &parameters, absl::string_view source) {
@@ -353,9 +347,6 @@ vmsdk::KeyValueParser<query::SearchParameters> CreateSearchParser() {
       kVerbatim, GENERATE_FLAG_PARSER(query::SearchParameters, verbatim));
   parser.AddParamParser(kSlop,
                         GENERATE_VALUE_PARSER(query::SearchParameters, slop));
-  parser.AddParamParser(
-      kLanguage,
-      GENERATE_ENUM_PARSER(query::SearchParameters, language, *kLanguageByStr));
   return parser;
 }
 

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -84,9 +84,8 @@ struct SearchParameters {
   FilterParseResults filter_parse_results;
   std::vector<ReturnAttribute> return_attributes;
   bool inorder{false};
-  unsigned int slop{0};
+  std::optional<uint32_t> slop;
   bool verbatim{false};
-  data_model::Language language{data_model::LANGUAGE_ENGLISH};
   struct ParseTimeVariables {
     // Members of this struct are only valid during the parsing of
     // VectorSearchParameters on the mainthread. They get cleared


### PR DESCRIPTION
Added the basic search params and their parsing for FT.SEARCH- 
  inorder{false};
  slop{0}; (Optional)
  verbatim{false};  