### PR TITLE
Implementation of operational limit check based on current indexes an…

### DIFF
--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -69,6 +69,11 @@ vmsdk::config::Number &GetMaxIndexes() {
   return dynamic_cast<vmsdk::config::Number &>(*max_indexes);
 }
 
+// register callback for max index creation
+void MaxIndexCreationCallback(uint32_t current_indexes) {
+  vmsdk::config::SetGetMaxIndexesCallback(
+      GetMaxIndexes, &current_indexes);  // register callback
+}
 /// Register the "--backfill-batch-size" flag. Controls the max number of
 /// indexes we can have.
 static auto backfill_batch_size =
@@ -82,6 +87,10 @@ static auto backfill_batch_size =
 
 vmsdk::config::Number &GetBackfillBatchSize() {
   return dynamic_cast<vmsdk::config::Number &>(*backfill_batch_size);
+}
+
+uint64_t GetMaxIndexesOptionUpdate() {
+  return vmsdk::config::g_updatedmax_index;
 }
 
 }  // namespace options
@@ -212,7 +221,8 @@ absl::StatusOr<coordinator::IndexFingerprintVersion>
 SchemaManager::CreateIndexSchema(
     ValkeyModuleCtx *ctx, const data_model::IndexSchema &index_schema_proto) {
   const auto max_indexes = options::GetMaxIndexes().GetValue();
-
+  uint32_t current_indexes = SchemaManager::Instance().GetNumberOfIndexSchemas() + 1;
+  options::MaxIndexCreationCallback(current_indexes); 
   VMSDK_RETURN_IF_ERROR(vmsdk::VerifyRange(
       SchemaManager::Instance().GetNumberOfIndexSchemas() + 1, std::nullopt,
       max_indexes))
@@ -610,7 +620,14 @@ absl::Status SchemaManager::LoadIndex(
                          _ << "Failed to load index schema from RDB!");
   uint32_t db_num = index_schema->GetDBNum();
   const std::string &name = index_schema->GetName();
-
+  uint32_t numIndex = this->GetNumberOfIndexSchemas();
+  uint32_t updatedindex = options::GetMaxIndexesOptionUpdate();
+  if (updatedindex != 0 && numIndex >= updatedindex) {
+         return absl::InternalError(
+                 absl::StrFormat("Unable to load indexes for max index %d as current "
+                        "indexes exceeds the limit %d",
+                        updatedindex, numIndex));
+  }
   // Select the DB number in the context for subsequent usage.
   if (ValkeyModule_SelectDb(ctx, db_num) != VALKEYMODULE_OK) {
     return absl::InternalError(

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -40,7 +40,8 @@ namespace options {
 
 /// Return the maximum number of indexes allowed to create.
 vmsdk::config::Number &GetMaxIndexes();
-
+//callback for config update
+void MaxIndexCreationCallback(uint32_t);
 }  // namespace options
 class SchemaManager {
  public:

--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -38,7 +38,8 @@ enum Flags {
 /// Return true if debug mode is enabled. "search.debug-mode == yes"
 constexpr absl::string_view kDebugMode{"debug-mode"};
 bool IsDebugModeEnabled();
-
+//config updated persist
+int64_t g_updatedmax_index;
 /// Support Valkey configuration entries in a one-liner.
 ///
 /// Example usage:
@@ -322,6 +323,9 @@ class String : public ConfigBase<std::string> {
   mutable UniqueValkeyString cached_string_;
   FRIEND_TEST(Builder, ConfigBuilder);
 };
+// callbacks for internal module changes for configs #376
+using GetMaxIndexesCallback = Number &(*)();
+void SetGetMaxIndexesCallback(GetMaxIndexesCallback cb, uint32_t *);
 
 template <typename ValkeyT>
 class ConfigBuilder {


### PR DESCRIPTION
…d max-indexes configurations ,RDB Load should not allow restore when server is started with configuration set command for max indexes lower  than current indexes Issue #375,#376

Key Points

Introduce functionality to dynamically track and update max_indexes relative to current_indexes.

Add validation to block configurations preventing max_indexes < current_indexes.

Ensure backward compatibility with existing configurations.

Provide meaningful error or warning messages when invalid configurations are detected.

Related Issues

Issue https://github.com/valkey-io/valkey-search/issues/375:

Issue https://github.com/valkey-io/valkey-search/issues/376: