### PR TITLE
Fix Workflow files

### DIFF
--- a/.github/workflows/integration_tests-asan.yml
+++ b/.github/workflows/integration_tests-asan.yml
@@ -31,17 +31,30 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Integration Tests
-      run: mkdir test-results && docker run --privileged --rm
-        --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results
-        -v "$(pwd):/workspace"
-        --user "ubuntu:ubuntu"
-        presubmit-image
-        sudo ci/build_ubuntu.sh --run-integration-tests --asan --integration-output=/workspace/test-results
+      id: test-run
       continue-on-error: true
+      run: |
+        mkdir test-results
+        docker run --privileged --rm \
+          --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results \
+          -v "$(pwd):/workspace" \
+          --user "ubuntu:ubuntu" \
+          presubmit-image \
+          sudo ci/build_ubuntu.sh --run-integration-tests --asan --integration-output=/workspace/test-results
+
+    - name: Update Test Results Permissions
+      if: always()
+      run: sudo chmod -R 755 test-results
 
     # Upload test results as artifacts
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: integration-test-results
         path: test-results
+
+    # Fail the job if tests failed
+    - name: Check Test Results
+      if: steps.test-run.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,17 +31,30 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Integration Tests
-      run: mkdir test-results && docker run --privileged --rm
-        --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results
-        -v "$(pwd):/workspace"
-        --user "ubuntu:ubuntu"
-        presubmit-image
-        sudo ci/build_ubuntu.sh --run-integration-tests --integration-output=/workspace/test-results
+      id: test-run
       continue-on-error: true
+      run: |
+        mkdir test-results
+        docker run --privileged --rm \
+          --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results \
+          -v "$(pwd):/workspace" \
+          --user "ubuntu:ubuntu" \
+          presubmit-image \
+          sudo ci/build_ubuntu.sh --run-integration-tests --integration-output=/workspace/test-results
+
+    - name: Update Test Results Permissions
+      if: always()
+      run: sudo chmod -R 755 test-results
 
     # Upload test results as artifacts
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: integration-test-results
         path: test-results
+
+    # Fail the job if tests failed
+    - name: Check Test Results
+      if: steps.test-run.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/unittests-asan.yml
+++ b/.github/workflows/unittests-asan.yml
@@ -31,17 +31,30 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Tests ASAN
-      run: mkdir test-results && docker run --privileged --rm
-        --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results
-        -v "$(pwd):/workspace"
-        --user "ubuntu:ubuntu"
-        presubmit-image
-        sudo ci/build_ubuntu.sh --run-tests --asan --unittest-output=/workspace/test-results
+      id: test-run
       continue-on-error: true
+      run: |
+        mkdir test-results
+        docker run --privileged --rm \
+          --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results \
+          -v "$(pwd):/workspace" \
+          --user "ubuntu:ubuntu" \
+          presubmit-image \
+          sudo ci/build_ubuntu.sh --run-tests --asan --unittest-output=/workspace/test-results
+
+    - name: Update Test Results Permissions
+      if: always()
+      run: sudo chmod -R 755 test-results
 
      # Upload test results as artifacts
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: unittest-results
         path: test-results
+
+    # Fail the job if tests failed
+    - name: Check Test Results
+      if: steps.test-run.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/unittests-tsan.yml
+++ b/.github/workflows/unittests-tsan.yml
@@ -31,17 +31,30 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Tests TSAN
-      run: mkdir test-results && docker run --privileged --rm
-        --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results
-        -v "$(pwd):/workspace"
-        --user "ubuntu:ubuntu"
-        presubmit-image
-        sudo ci/build_ubuntu.sh --run-tests --tsan --unittest-output=/workspace/test-results
+      id: test-run
       continue-on-error: true
+      run: |
+        mkdir test-results
+        docker run --privileged --rm \
+          --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results \
+          -v "$(pwd):/workspace" \
+          --user "ubuntu:ubuntu" \
+          presubmit-image \
+          sudo ci/build_ubuntu.sh --run-tests --tsan --unittest-output=/workspace/test-results
+
+    - name: Update Test Results Permissions
+      if: always()
+      run: sudo chmod -R 755 test-results
 
      # Upload test results as artifacts
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: unittest-results
         path: test-results
+
+    # Fail the job if tests failed
+    - name: Check Test Results
+      if: steps.test-run.outcome == 'failure'
+      run: exit 1

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -31,17 +31,30 @@ jobs:
       run: docker build -t presubmit-image -f .devcontainer/Dockerfile .
 
     - name: Run Tests
-      run: mkdir test-results && docker run --privileged --rm
-        --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results
-        -v "$(pwd):/workspace"
-        --user "ubuntu:ubuntu"
-        presubmit-image
-        sudo ci/build_ubuntu.sh --run-tests --unittest-output=/workspace/test-results
+      id: test-run
       continue-on-error: true
+      run: |
+        mkdir test-results
+        docker run --privileged --rm \
+          --mount type=bind,source="$(pwd)/test-results",target=/workspace/test-results \
+          -v "$(pwd):/workspace" \
+          --user "ubuntu:ubuntu" \
+          presubmit-image \
+          sudo ci/build_ubuntu.sh --run-tests --unittest-output=/workspace/test-results
+
+    - name: Update Test Results Permissions
+      if: always()
+      run: sudo chmod -R 755 test-results
 
      # Upload test results as artifacts
     - name: Upload Test Results
       uses: actions/upload-artifact@v4
+      if: always()
       with:
         name: unittest-results
         path: test-results
+
+    # Fail the job if tests failed
+    - name: Check Test Results
+      if: steps.test-run.outcome == 'failure'
+      run: exit 1


### PR DESCRIPTION
After this change: https://github.com/valkey-io/valkey-search/pull/426 . the workflows were returning success even though tests failed. Now the test output gets uploaded first and if the tests had failed, workflow shows failure.