### PR TITLE
Fix check in Composed AND Predicate

### DIFF
--- a/integration/test_fulltext.py
+++ b/integration/test_fulltext.py
@@ -825,7 +825,7 @@ class TestFullText(ValkeySearchTestCaseBase):
         client.execute_command("HSET", "doc:4", "content", "alpha word word word beta")
         client.execute_command("HSET", "doc:5", "content", "alpha word word word beta word word word gamma")
         client.execute_command("HSET", "doc:7", "content", "gamma delta")
-        client.execute_command("HSET", "doc:8", "content", "gamma word beta word word word alpha")
+        client.execute_command("HSET", "doc:8", "content", "gamma word beta word word word alpha", "title", "some title")
 
         # Wait for index backfill to complete
         IndexingTestHelper.wait_for_backfill_complete_on_node(client, "idx")

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -372,7 +372,8 @@ EvaluationResult ComposedPredicate::Evaluate(Evaluator& evaluator) const {
               std::move(iterators), slop_, inorder_, field_mask, nullptr);
 
       // Check if any valid proximity matches exist
-      if (proximity_iterator->DonePositions()) {
+      if (proximity_iterator->DoneKeys() ||
+          proximity_iterator->DonePositions()) {
         return EvaluationResult(false);
       }
       // Validate against original target key from evaluator


### PR DESCRIPTION
Fix check in Composed AND Predicate to return false if no results were found.