### PR TITLE
Unit test fix failing on node limit

### DIFF
--- a/integration/test_query_parser.py
+++ b/integration/test_query_parser.py
@@ -100,8 +100,9 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             Test the query string terms count limit in Valkey Search using Vector based queries.
         """
         client: Valkey = self.server.get_new_client()
-        # Test that the default query string terms count limit is 16
-        assert client.execute_command("CONFIG GET search.query-string-terms-count") == [b"search.query-string-terms-count", b"16"]
+        default_limit = b"1000"
+        # Test that the default query string terms count limit is expected default_limit
+        assert client.execute_command("CONFIG GET search.query-string-terms-count") == [b"search.query-string-terms-count", default_limit]
         # Create an index for testing
         assert client.execute_command("FT.CREATE my_index ON HASH PREFIX 1 doc: SCHEMA price NUMERIC category TAG SEPARATOR | doc_embedding VECTOR FLAT 6 TYPE FLOAT32 DIM 128 DISTANCE_METRIC COSINE") == b"OK"
         
@@ -145,14 +146,14 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             "RETURN", 1, "doc_embedding"
         ) == [0]
         
-        # Test that the config ranges from 1 to 32
+        # Test that the config ranges from 1 to default_limit
         try:
             client.execute_command("CONFIG SET search.query-string-terms-count 0")
             assert False
         except ResponseError as e:
-            assert "argument must be between 1 and 32 inclusive" in str(e)
+            assert f"argument must be between 1 and {default_limit.decode()} inclusive" in str(e)
         try:
-            client.execute_command("CONFIG SET search.query-string-terms-count 33")
+            client.execute_command(f"CONFIG SET search.query-string-terms-count {int(default_limit)+1}")
             assert False
         except ResponseError as e:
-            assert "argument must be between 1 and 32 inclusive" in str(e)
+            assert f"argument must be between 1 and {default_limit.decode()} inclusive" in str(e)

--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -53,8 +53,8 @@ static auto query_string_depth =
 /// predicate tree.
 constexpr absl::string_view kQueryStringTermsCountConfig{
     "query-string-terms-count"};
-constexpr uint32_t kDefaultQueryTermsCount{16};
-constexpr uint32_t kMaxQueryTermsCount{32};
+constexpr uint32_t kDefaultQueryTermsCount{1000};
+constexpr uint32_t kMaxQueryTermsCount{1000};
 static auto query_terms_count =
     config::NumberBuilder(kQueryStringTermsCountConfig,  // name
                           kDefaultQueryTermsCount,       // default size

--- a/testing/filter_test.cc
+++ b/testing/filter_test.cc
@@ -621,9 +621,7 @@ INSTANTIATE_TEST_SUITE_P(
                 "@tag_field_1:{books} @text_field2:Neural | "
                 "@text_field1:%%%word%%% @text_field2:network",
             .create_success = false,
-            .create_expected_error_message =
-                "Invalid range: Value above maximum; Query string is too "
-                "complex: max number of terms can't exceed 16",
+            .create_expected_error_message = "Unsupported query operation",
         },
         {
             .test_name = "invalid_fuzzy1",


### PR DESCRIPTION
Proximity predicate is now a speacial case of composed AND , which operates on binary predicate which leads to increase in overall term count (including the intermediate terms). This will change soon after N-ary flattening change id done.
Increasing the limit of this to 1000 for now. We will revisit the limits again towards end of full text development. 