### PR TITLE
Optimize NextKey / NextPosition in TermIterator with priority-queue for min key/position checks

### DIFF
--- a/src/indexes/text/term.h
+++ b/src/indexes/text/term.h
@@ -82,6 +82,7 @@ class TermIterator : public TextIterator {
 
   bool FindMinimumValidKey();
   void InsertValidKeyIterator(size_t idx);
+  void InsertValidPositionIterator(size_t idx);
 };
 
 }  // namespace valkey_search::indexes::text


### PR DESCRIPTION
Please do not review yet - I am working on this PR when I get time in between some other core changes, and waiting for the core changes to first get merged into the fulltext branch. After that, I will have this branch updated on latest changes and mark it as ready for review.

In this PR, I optimize NextKey / NextPosition in TermIterator by using a priority queue for efficiently finding the min key and min position when using the key iterator and position iterator