### PR TITLE
Change default Valkey to 9.0.1 release

### DIFF
--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -166,7 +166,7 @@ function setup_valkey_server() {
   fi
 
   # Clone and build it
-  VALKEY_VERSION="${VALKEY_VERSION:=9.0.0}"
+  VALKEY_VERSION="${VALKEY_VERSION:=9.0.1}"
   export VALKEY_SERVER_HOME_DIR=$(get_third_party_build_dir)/valkey-server
   export VALKEY_SERVER_BUILD_DIR=${VALKEY_SERVER_HOME_DIR}/.build-release
   if [ ! -d ${VALKEY_SERVER_HOME_DIR} ]; then

--- a/src/version.h
+++ b/src/version.h
@@ -24,7 +24,7 @@ constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 1, 0);
 //
 // Set the minimum acceptable server version
 //
-constexpr auto kMinimumServerVersion = vmsdk::ValkeyVersion(8, 1, 1);
+constexpr auto kMinimumServerVersion = vmsdk::ValkeyVersion(9, 0, 1);
 
 namespace valkey_search {
 

--- a/testing/integration/run.sh
+++ b/testing/integration/run.sh
@@ -7,7 +7,7 @@ BUILD_CONFIG=release
 # TEST=all
 TEST=vector_search_integration
 CLEAN="no"
-VALKEY_VERSION="9.0.0"
+VALKEY_VERSION="9.0.1"
 VALKEY_JSON_VERSION="unstable"
 DUMP_TEST_ERRORS_STDOUT="no"
 


### PR DESCRIPTION
Change default Valkey build logic to 9.0.1, this has the fix for CLUSTER SLOTS that is needed.