### PR TITLE
Remove double locking in prefilter locking

### DIFF
--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -167,6 +167,12 @@ class TextIndexSchema {
     std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
     return func(per_key_text_indexes_);
   }
+
+  // Direct accessor for per-key text indexes.
+  // Assumes that lock is already acquired earlier.
+  const absl::node_hash_map<Key, TextIndex>& GetPerKeyTextIndexes() const {
+    return per_key_text_indexes_;
+  }
 };
 
 }  // namespace valkey_search::indexes::text


### PR DESCRIPTION
Remove redundant lock in PrefilterEvaluator::EvaluateText()

PrefilterEvaluator::EvaluateText() was acquiring per_key_text_indexes_mutex_, but DoSearch() (3 levels higher in the call stack) already holds a time-sliced reader lock protecting this data. This double-locking caused performance degradation.

Added GetPerKeyTextIndexes() direct accessor and updated prefilter evaluation to use it instead of WithPerKeyTextIndexes().