### PR TITLE
Better handling of nullptr in FromString String config

### DIFF
--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -324,10 +324,11 @@ absl::Status String::Register(ValkeyModuleCtx *ctx) {
 }
 
 absl::Status String::FromString(std::string_view value) {
-  if (value.data()) {
-    default_ = value.data();
-    SetValueOrLog(default_, WARNING);
+  if (value.data() == nullptr) {
+    return absl::InvalidArgumentError("Invalid string value: null");
   }
+  default_ = value.data();
+  SetValueOrLog(default_, WARNING);
   return absl::OkStatus();
 }
 


### PR DESCRIPTION
Better handle nullptr in FromString function in String config option. Return error in case the `value.data()` is nullptr.