### PR TITLE
Update text query/search paths to use inline vector to avoid heap allocations

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
@@ -149,18 +150,7 @@ std::string PrintPredicateTree(const query::Predicate* predicate, int indent) {
       std::string field_mask_str = std::to_string(text->GetFieldMask());
 
       // Determine specific text predicate type
-      if (auto proximity =
-              dynamic_cast<const query::ProximityPredicate*>(predicate)) {
-        result += indent_str + "TEXT-PROXIMITY(field_mask=" + field_mask_str +
-                  ", slop=" + std::to_string(proximity->Slop()) +
-                  ", inorder=" + (proximity->InOrder() ? "true" : "false") +
-                  "){\n";
-        for (const auto& term : proximity->Terms()) {
-          result += PrintPredicateTree(term.get(), indent + 1);
-        }
-        result += indent_str + "}\n";
-      } else if (auto term =
-                     dynamic_cast<const query::TermPredicate*>(predicate)) {
+      if (auto term = dynamic_cast<const query::TermPredicate*>(predicate)) {
         result += indent_str + "TEXT-TERM(\"" +
                   std::string(term->GetTextString()) +
                   "\", field_mask=" + field_mask_str + ")\n";
@@ -759,19 +749,20 @@ absl::Status FilterParser::SetupTextFieldConfiguration(
 // This function is called when the characters detected are potentially those of
 // a text predicate.
 // Text Parsing Syntax:
-//   Quoted: "word1 word2" -> ProximityPredicate(exact, slop=0, inorder=true)
+//   Quoted: "word1 word2" -> ComposedAND(exact, slop=0, inorder=true)
 //   Unquoted: word1 word2 -> TermPredicate(word1) - stops at first token
 // Token boundaries for unquoted text: <punctuation> ( ) | @ " - { } [ ] : ; $
 // Quoted phrases (Exact Phrase) parse all tokens within quotes, unquoted
 // parsing stops after first token.
-// TODO: Update ProximityPredicate to ComposedAND.
 absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::ParseTextTokens(
     const std::optional<std::string>& field_or_default) {
   auto text_index_schema = index_schema_.GetTextIndexSchema();
   if (!text_index_schema) {
     return absl::InvalidArgumentError("Index does not have any text field");
   }
-  std::vector<std::unique_ptr<query::TextPredicate>> terms;
+  absl::InlinedVector<std::unique_ptr<query::TextPredicate>,
+                      indexes::text::kProximityTermsInlineCapacity>
+      terms;
   bool in_quotes = false;
   bool exact_phrase = false;
   while (!IsEnd()) {

--- a/src/coordinator/coordinator.proto
+++ b/src/coordinator/coordinator.proto
@@ -75,12 +75,6 @@ message FuzzyPredicate {
   uint32 distance = 3;
 }
 
-message ProximityPredicate {
-  repeated Predicate nodes = 1;
-  uint32 slop = 2;
-  bool inorder = 3;
-}
-
 message AndPredicate {
   repeated Predicate children = 1;
   optional uint32 slop = 2;
@@ -107,7 +101,6 @@ message Predicate {
     SuffixPredicate suffix = 8;
     InfixPredicate infix = 9;
     FuzzyPredicate fuzzy = 10;
-    ProximityPredicate proximity = 11;
   }
 }
 

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -10,6 +10,13 @@
 
 #include <memory>
 
+namespace valkey_search::indexes::text {
+// Inline capacity for word expansion key iterators
+constexpr size_t kWordExpansionInlineCapacity = 200;
+// Inline capacity for proximity terms
+constexpr size_t kProximityTermsInlineCapacity = 64;
+}  // namespace valkey_search::indexes::text
+
 #include "absl/base/thread_annotations.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
@@ -63,6 +70,7 @@ class Text : public IndexBase {
       const override {
     absl::MutexLock lock(&index_mutex_);
     // TODO: Implement proper key tracking
+    return absl::OkStatus();
   }
 
   size_t GetUnTrackedKeyCount() const override {
@@ -80,6 +88,7 @@ class Text : public IndexBase {
       const override {
     absl::MutexLock lock(&index_mutex_);
     // TODO
+    return absl::OkStatus();
   }
 
   size_t GetTrackedKeyCount() const override;

--- a/src/indexes/text/orproximity.cc
+++ b/src/indexes/text/orproximity.cc
@@ -3,7 +3,8 @@
 namespace valkey_search::indexes::text {
 
 OrProximityIterator::OrProximityIterator(
-    std::vector<std::unique_ptr<TextIterator>>&& iters,
+    absl::InlinedVector<std::unique_ptr<TextIterator>,
+                        kProximityTermsInlineCapacity>&& iters,
     const InternedStringSet* untracked_keys)
     : iters_(std::move(iters)),
       current_key_(),

--- a/src/indexes/text/proximity.cc
+++ b/src/indexes/text/proximity.cc
@@ -24,7 +24,8 @@ bool GetProximityInorderCompatMode() {
 namespace valkey_search::indexes::text {
 
 ProximityIterator::ProximityIterator(
-    std::vector<std::unique_ptr<TextIterator>>&& iters,
+    absl::InlinedVector<std::unique_ptr<TextIterator>,
+                        kProximityTermsInlineCapacity>&& iters,
     std::optional<uint32_t> slop, bool in_order,
     FieldMaskPredicate query_field_mask,
     const InternedStringSet* untracked_keys)

--- a/src/indexes/text/term.cc
+++ b/src/indexes/text/term.cc
@@ -9,10 +9,11 @@
 
 namespace valkey_search::indexes::text {
 
-TermIterator::TermIterator(std::vector<Postings::KeyIterator>&& key_iterators,
-                           const FieldMaskPredicate query_field_mask,
-                           const InternedStringSet* untracked_keys,
-                           const bool require_positions)
+TermIterator::TermIterator(
+    absl::InlinedVector<Postings::KeyIterator, kWordExpansionInlineCapacity>&&
+        key_iterators,
+    const FieldMaskPredicate query_field_mask,
+    const InternedStringSet* untracked_keys, const bool require_positions)
     : query_field_mask_(query_field_mask),
       key_iterators_(std::move(key_iterators)),
       current_position_(std::nullopt),

--- a/src/indexes/text/term.h
+++ b/src/indexes/text/term.h
@@ -10,6 +10,8 @@
 
 #include <vector>
 
+#include "absl/container/inlined_vector.h"
+#include "src/indexes/text.h"
 #include "src/indexes/text/text_iterator.h"
 
 namespace valkey_search::indexes::text {
@@ -38,10 +40,11 @@ from all the posting iterators that are on the current key and field mask.
 */
 class TermIterator : public TextIterator {
  public:
-  TermIterator(std::vector<Postings::KeyIterator>&& key_iterators,
-               const FieldMaskPredicate field_mask,
-               const InternedStringSet* untracked_keys,
-               const bool require_positions);
+  TermIterator(
+      absl::InlinedVector<Postings::KeyIterator, kWordExpansionInlineCapacity>&&
+          key_iterators,
+      const FieldMaskPredicate field_mask,
+      const InternedStringSet* untracked_keys, const bool require_positions);
   /* Implementation of TextIterator APIs */
   FieldMaskPredicate QueryFieldMask() const override;
   // Key-level iteration
@@ -70,8 +73,10 @@ class TermIterator : public TextIterator {
 
  private:
   const FieldMaskPredicate query_field_mask_;
-  std::vector<Postings::KeyIterator> key_iterators_;
-  std::vector<Postings::PositionIterator> pos_iterators_;
+  absl::InlinedVector<Postings::KeyIterator, kWordExpansionInlineCapacity>
+      key_iterators_;
+  absl::InlinedVector<Postings::PositionIterator, kWordExpansionInlineCapacity>
+      pos_iterators_;
   Key current_key_;
   std::optional<PositionRange> current_position_;
   FieldMaskPredicate current_field_mask_;

--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -14,6 +14,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_set.h"
+#include "absl/container/inlined_vector.h"
 #include "absl/strings/string_view.h"
 #include "src/indexes/text/text_iterator.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -317,37 +318,6 @@ class FuzzyPredicate : public TextPredicate {
   FieldMaskPredicate field_mask_;
   std::string term_;
   uint32_t distance_;
-};
-
-class ProximityPredicate : public TextPredicate {
- public:
-  ProximityPredicate(std::vector<std::unique_ptr<TextPredicate>> terms,
-                     uint32_t slop = 0, bool inorder = true);
-  uint32_t Slop() const { return slop_; }
-  bool InOrder() const { return inorder_; }
-  EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
-  EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
-      const InternedStringPtr& target_key,
-      bool require_positions) const override;
-  std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const void* fetcher) const override;
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
-    return terms_[0]->GetTextIndexSchema();
-  }
-  const FieldMaskPredicate GetFieldMask() const override {
-    return terms_[0]->GetFieldMask();
-  }
-  const std::vector<std::unique_ptr<TextPredicate>>& Terms() const {
-    return terms_;
-  }
-  size_t EstimateSize() const override;
-
- private:
-  std::vector<std::unique_ptr<TextPredicate>> terms_;
-  bool inorder_;
-  uint32_t slop_;
 };
 
 enum class LogicalOperator { kAnd, kOr };


### PR DESCRIPTION
1. Update text query/search paths to use inline vector to avoid heap allocations.
2. Deleted the ProximityPredicate because we moved to ComposedAND/ComposedOR usage
