### PR TITLE
Add text negation querying with per-field tracked/untracked keys

### DIFF
--- a/integration/test_fulltext.py
+++ b/integration/test_fulltext.py
@@ -190,6 +190,11 @@ def validate_fulltext_search(client: Valkey):
     result = client.execute_command("FT.SEARCH", "products", 'artificial intelligence research')
     assert result[0] == 1
     assert result[1] == b"product:6"
+    
+    # Basic term negation
+    result = client.execute_command("FT.SEARCH", "products", '-@desc:"wonder"')
+    assert result[0] == 5  # All except product:4
+    assert b"product:4" not in result
 
 class TestFullText(ValkeySearchTestCaseDebugMode):
 
@@ -767,6 +772,44 @@ class TestFullText(ValkeySearchTestCaseDebugMode):
         result = self.client.execute_command("FT.SEARCH", "idx", "*unning")
         assert result[0] == 1  # Only doc:1 is matched for "running"
         assert result[1] == b'doc:1'
+        
+        # Test suffix negation
+        result = self.client.execute_command("FT.SEARCH", "idx", '-@content:*ning')
+        assert result[0] == 3  # Excludes doc:1 (has "running")
+        assert b'doc:1' not in result
+
+    def test_text_negation(self):
+        """Test edge cases for text negation"""
+        client = self.server.get_new_client()
+        
+        # Setup: Two-field index
+        client.execute_command("FT.CREATE", "idx", "ON", "HASH", "SCHEMA", "title", "TEXT", "NOSTEM", "body", "TEXT", "NOSTEM")
+        
+        # Doc with both fields
+        client.execute_command("HSET", "doc:1", "title", "error report", "body", "system failure")
+        # Doc with only body (no title) - tests untracked_keys
+        client.execute_command("HSET", "doc:2", "body", "all working")
+        # Doc with only title (no body)
+        client.execute_command("HSET", "doc:3", "title", "success story")
+        
+        IndexingTestHelper.wait_for_backfill_complete_on_node(client, "idx")
+        
+        # Test: Keys without field included in negation (untracked testing)
+        result = client.execute_command("FT.SEARCH", "idx", '-@title:error')
+        assert result[0] == 2  # doc:2 (no title), doc:3 (no "error")
+        assert b'doc:2' in result and b'doc:3' in result
+        
+        # Test: Multiple field negations
+        result = client.execute_command("FT.SEARCH", "idx", '-@title:error -@body:all')
+        assert result[0] == 1  # doc:3
+
+         # Test: Prefix wildcard negation with multi-field
+        result = client.execute_command("FT.SEARCH", "idx", '-@title:err*')
+        assert result[0] == 2  # doc:2 (no title), doc:3 (no "err*")
+        
+        # Test: Schema-wide negation
+        result = client.execute_command("FT.SEARCH", "idx", '-error')
+        assert result[0] == 2  # doc:2, doc:3 (no "error" in either field)
 
     @pytest.mark.parametrize("prefilter_eval_enabled", [pytest.param(False, id="Prefilter_eval=False"), pytest.param(True, id="Prefilter_eval=True")])
     def test_mixed_predicates(self, prefilter_eval_enabled):
@@ -824,8 +867,8 @@ class TestFullText(ValkeySearchTestCaseDebugMode):
         assert (result[0], result[1]) == (1, b"doc:1")
 
         # Test 8: Negation with mixed types
-        # result = client.execute_command("FT.SEARCH", "idx", '-@content:"manager" @skills:{python}')
-        # assert (result[0], result[1]) == (1, b"doc:1")
+        result = client.execute_command("FT.SEARCH", "idx", '-@content:"manager" @skills:{python}')
+        assert (result[0], result[1]) == (1, b"doc:1")
 
     def test_nooffsets_option(self):
         """
@@ -1037,6 +1080,34 @@ class TestFullText(ValkeySearchTestCaseDebugMode):
         # content / default field.
         result = client.execute_command("FT.SEARCH", "idx", 'word10 @content:word11 word12', "INORDER")
         assert (result[0], result[1]) == (1, b"doc:7")
+        
+        # Test phrase negation
+        # NOTE: Phrase negation with SLOP/INORDER requires prefilter evaluation for
+        # correctness validation. Skipping prefilter_eval=False mode as the current
+        # architecture relies on PrefilterEvaluator for proximity constraint validation
+        # in positive queries.
+        if not prefilter_eval_enabled:
+            return
+        
+        # Exact phrase negation
+        result = client.execute_command("FT.SEARCH", "idx", '-@content:"alpha beta"', "NOCONTENT")
+        assert result[0] == 10 and b"doc:1" not in result
+        
+        # Phrase negation with INORDER
+        result = client.execute_command("FT.SEARCH", "idx", '-alpha -beta', "INORDER")
+        assert b"doc:1" not in result and b"doc:2" not in result and b"doc:5" not in result
+        
+        # Phrase negation without INORDER
+        result = client.execute_command("FT.SEARCH", "idx", '-alpha -beta')
+        expected_excluded = {b"doc:1", b"doc:2", b"doc:3", b"doc:5", b"doc:8"}
+        assert len(expected_excluded & set(result[1::2])) == 0
+        
+        # Phrase negation with SLOP
+        result = client.execute_command("FT.SEARCH", "idx", '-alpha -beta', "SLOP", "0")
+        assert b"doc:1" not in result and b"doc:3" not in result  # Adjacent pairs excluded
+        
+        result = client.execute_command("FT.SEARCH", "idx", '-alpha -beta', "SLOP", "1")
+        assert b"doc:1" not in result and b"doc:2" not in result and b"doc:3" not in result
 
     def test_proximity_slop_violation_advancement(self):
         """

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -88,6 +88,9 @@ class IndexSchema : public KeyspaceEventSubscription,
     // Single interface to get all stats data
     InfoIndexPartitionData GetStats() const;
   };
+
+  enum class KeySetType { kTracked, kUntracked };
+
   std::shared_ptr<IndexSchema> GetSharedPtr() { return shared_from_this(); }
   std::weak_ptr<IndexSchema> GetWeakPtr() { return weak_from_this(); }
 
@@ -107,6 +110,12 @@ class IndexSchema : public KeyspaceEventSubscription,
                                     indexes::IndexBase *index);
   absl::flat_hash_set<std::string> GetTextIdentifiersByFieldMask(
       FieldMaskPredicate field_mask) const;
+
+  // Aggregate keys (tracked or untracked) across text fields matching
+  // field_mask
+  InternedStringSet GetKeysByFieldMask(FieldMaskPredicate field_mask,
+                                       KeySetType type) const;
+
   virtual absl::StatusOr<std::string> GetIdentifier(
       absl::string_view attribute_alias) const;
   absl::StatusOr<std::string> GetAlias(absl::string_view identifier) const;

--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -101,6 +101,8 @@ set(SRCS_TEXT ${CMAKE_CURRENT_LIST_DIR}/text/text_index.h
               ${CMAKE_CURRENT_LIST_DIR}/text/orproximity.cc
               ${CMAKE_CURRENT_LIST_DIR}/text/term.cc
               ${CMAKE_CURRENT_LIST_DIR}/text/term.h
+              ${CMAKE_CURRENT_LIST_DIR}/text/negation_iterator.cc
+              ${CMAKE_CURRENT_LIST_DIR}/text/negation_iterator.h
               ${CMAKE_CURRENT_LIST_DIR}/text/lexer.cc
               ${CMAKE_CURRENT_LIST_DIR}/text/lexer.h
               ${CMAKE_CURRENT_LIST_DIR}/text/unicode_normalizer.cc
@@ -115,4 +117,4 @@ target_link_libraries(text PUBLIC string_interning)
 target_link_libraries(text PUBLIC valkey_module)
 target_link_libraries(text PUBLIC snowball)
 target_link_libraries(text PUBLIC scanner)
-target_link_libraries(text PUBLIC icu) 
+target_link_libraries(text PUBLIC icu)

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -12,8 +12,10 @@
 #include "absl/container/inlined_vector.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
+#include "src/index_schema.h"
 #include "src/index_schema.pb.h"
 #include "src/indexes/text/lexer.h"
+#include "src/indexes/text/negation_iterator.h"
 
 namespace valkey_search::indexes {
 
@@ -34,11 +36,25 @@ Text::Text(const data_model::TextIndex& text_index_proto,
 
 absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
                                      absl::string_view data) {
-  // TODO: Key Tracking
+  auto result = text_index_schema_->StageAttributeData(
+      key, data, text_field_number_, !no_stem_, min_stem_size_,
+      with_suffix_trie_);
 
-  return text_index_schema_->StageAttributeData(key, data, text_field_number_,
-                                                !no_stem_, min_stem_size_,
-                                                with_suffix_trie_);
+  if (!result.ok()) {
+    return result;
+  }
+
+  absl::MutexLock lock(&index_mutex_);
+  if (result.value()) {
+    // Has indexable content
+    tracked_keys_.insert(key);
+    untracked_keys_.erase(key);
+  } else {
+    // No indexable content
+    untracked_keys_.insert(key);
+  }
+
+  return result;
 }
 
 absl::StatusOr<bool> Text::RemoveRecord(const InternedStringPtr& key,
@@ -47,21 +63,47 @@ absl::StatusOr<bool> Text::RemoveRecord(const InternedStringPtr& key,
   // TextIndexSchema::DeleteKey(), so there is no need to touch the index
   // structures here
 
-  // TODO: key tracking
+  absl::MutexLock lock(&index_mutex_);
+  if (deletion_type == DeletionType::kRecord) {
+    // If key is DELETED, remove it from untracked_keys_.
+    untracked_keys_.erase(key);
+  } else {
+    // If key doesn't have text but exists, insert it to untracked_keys_.
+    untracked_keys_.insert(key);
+  }
 
-  return true;
+  // Check if key was tracked before erasing
+  bool was_tracked = tracked_keys_.contains(key);
+  tracked_keys_.erase(key);
+
+  return was_tracked;
 }
 
 absl::StatusOr<bool> Text::ModifyRecord(const InternedStringPtr& key,
                                         absl::string_view data) {
-  // TODO: key tracking
-
   // The old key value has already been removed from the index by a call to
   // TextIndexSchema::DeleteKey() at this point, so we simply add the new key
   // data
-  return text_index_schema_->StageAttributeData(key, data, text_field_number_,
-                                                !no_stem_, min_stem_size_,
-                                                with_suffix_trie_);
+  auto result = text_index_schema_->StageAttributeData(
+      key, data, text_field_number_, !no_stem_, min_stem_size_,
+      with_suffix_trie_);
+
+  if (!result.ok()) {
+    return result;
+  }
+
+  absl::MutexLock lock(&index_mutex_);
+  if (result.value()) {
+    // Has indexable content
+    tracked_keys_.insert(key);
+    untracked_keys_.erase(key);
+  } else {
+    // No indexable content
+    untracked_keys_.insert(key);
+    tracked_keys_.erase(key);
+  }
+
+  return result;
 }
 
 int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
@@ -85,13 +127,13 @@ int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
 }
 
 bool Text::IsTracked(const InternedStringPtr& key) const {
-  // TODO
-  return false;
+  absl::MutexLock lock(&index_mutex_);
+  return tracked_keys_.contains(key);
 }
 
 size_t Text::GetTrackedKeyCount() const {
-  // TODO: keep track of number of keys indexed for this attribute
-  return 0;
+  absl::MutexLock lock(&index_mutex_);
+  return tracked_keys_.size();
 }
 
 std::unique_ptr<data_model::Index> Text::ToProto() const {
@@ -113,7 +155,36 @@ size_t Text::CalculateSize(const query::TextPredicate& predicate) const {
 size_t Text::EntriesFetcher::Size() const { return size_; }
 
 std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
-  auto iter = predicate_->BuildTextIterator(this);
+  if (is_negated_phrase_) {
+    absl::InlinedVector<std::unique_ptr<text::TextIterator>,
+                        text::kProximityTermsInlineCapacity>
+        child_iterators;
+    child_iterators.reserve(phrase_children_.size());
+
+    for (auto& child_fetcher : phrase_children_) {
+      auto* text_fetcher = dynamic_cast<EntriesFetcher*>(child_fetcher.get());
+      CHECK(text_fetcher);
+      child_iterators.push_back(
+          text_fetcher->predicate_->BuildTextIterator(text_fetcher, true));
+    }
+
+    auto proximity_iter = std::make_unique<text::ProximityIterator>(
+        std::move(child_iterators), phrase_slop_, phrase_inorder_, field_mask_,
+        untracked_keys_);
+
+    auto negated_iter = std::make_unique<text::NegationTextIterator>(
+        std::move(proximity_iter), tracked_keys_, untracked_keys_, field_mask_);
+
+    return std::make_unique<text::TextFetcher>(std::move(negated_iter));
+  }
+
+  auto iter = predicate_->BuildTextIterator(this, false);
+
+  if (negate_ && tracked_keys_) {
+    iter = std::make_unique<text::NegationTextIterator>(
+        std::move(iter), tracked_keys_, untracked_keys_, field_mask_);
+  }
+
   return std::make_unique<text::TextFetcher>(std::move(iter));
 }
 
@@ -122,17 +193,49 @@ std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
 // Implement the TextPredicate BuildTextIterator virtual method
 namespace valkey_search::query {
 
-void* TextPredicate::Search(bool negate) const {
+void* TextPredicate::Search(bool negate,
+                            const IndexSchema* index_schema) const {
   size_t estimated_size = EstimateSize();
+
+  // Get aggregated tracked/untracked keys for negation support
+  const InternedStringSet* tracked_keys_ptr = nullptr;
+  const InternedStringSet* untracked_keys_ptr = nullptr;
+  std::unique_ptr<InternedStringSet> aggregated_tracked;
+  std::unique_ptr<InternedStringSet> aggregated_untracked;
+
+  if (negate && index_schema) {
+    aggregated_tracked =
+        std::make_unique<InternedStringSet>(index_schema->GetKeysByFieldMask(
+            GetFieldMask(), IndexSchema::KeySetType::kTracked));
+    tracked_keys_ptr = aggregated_tracked.get();
+
+    aggregated_untracked =
+        std::make_unique<InternedStringSet>(index_schema->GetKeysByFieldMask(
+            GetFieldMask(), IndexSchema::KeySetType::kUntracked));
+    untracked_keys_ptr = aggregated_untracked.get();
+
+    // For negation, size = (tracked_keys - matched_keys) + untracked_keys
+    estimated_size = aggregated_tracked->size() + aggregated_untracked->size();
+  }
+
   auto fetcher = std::make_unique<indexes::Text::EntriesFetcher>(
-      estimated_size, GetTextIndexSchema()->GetTextIndex(), nullptr,
-      GetFieldMask());
+      estimated_size, GetTextIndexSchema()->GetTextIndex(), tracked_keys_ptr,
+      untracked_keys_ptr, GetFieldMask(), negate);
   fetcher->predicate_ = this;
+
+  // Transfer ownership of aggregated keys to keep them alive
+  if (aggregated_tracked) {
+    fetcher->owned_tracked_keys_ = std::move(aggregated_tracked);
+  }
+  if (aggregated_untracked) {
+    fetcher->owned_untracked_keys_ = std::move(aggregated_untracked);
+  }
+
   return fetcher.release();
 }
 
 std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void* fetcher_ptr, bool require_positions) const {
   const auto* fetcher =
       static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
   auto word_iter =
@@ -146,15 +249,13 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
     }
     word_iter.Next();
   }
-  // We do not perform positional checks on the initial background search.
-  bool require_positions = false;
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), fetcher->field_mask_, fetcher->untracked_keys_,
       require_positions);
 }
 
 std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void* fetcher_ptr, bool require_positions) const {
   const auto* fetcher =
       static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
   auto word_iter =
@@ -166,15 +267,13 @@ std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
     key_iterators.emplace_back(word_iter.GetTarget()->GetKeyIterator());
     word_iter.Next();
   }
-  // We do not perform positional checks on the initial background search.
-  bool require_positions = false;
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), fetcher->field_mask_, fetcher->untracked_keys_,
       require_positions);
 }
 
 std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void* fetcher_ptr, bool require_positions) const {
   const auto* fetcher =
       static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
   CHECK(fetcher->text_index_->GetSuffix().has_value())
@@ -190,20 +289,18 @@ std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
     key_iterators.emplace_back(word_iter.GetTarget()->GetKeyIterator());
     word_iter.Next();
   }
-  // We do not perform positional checks on the initial background search.
-  bool require_positions = false;
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), fetcher->field_mask_, fetcher->untracked_keys_,
       require_positions);
 }
 
 std::unique_ptr<indexes::text::TextIterator> InfixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void* fetcher_ptr, bool require_positions) const {
   CHECK(false) << "Unsupported TextPredicate type";
 }
 
 std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void* fetcher_ptr, bool require_positions) const {
   CHECK(false) << "Unsupported TextPredicate type";
 }
 

--- a/src/indexes/text/negation_iterator.cc
+++ b/src/indexes/text/negation_iterator.cc
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/text/negation_iterator.h"
+
+#include "absl/log/check.h"
+#include "vmsdk/src/log.h"
+
+namespace valkey_search::indexes::text {
+
+NegationTextIterator::NegationTextIterator(
+    std::unique_ptr<TextIterator> positive_iterator,
+    const InternedStringSet* tracked_keys,
+    const InternedStringSet* untracked_keys,
+    FieldMaskPredicate query_field_mask)
+    : positive_iterator_(std::move(positive_iterator)),
+      tracked_keys_(tracked_keys),
+      untracked_keys_(untracked_keys),
+      query_field_mask_(query_field_mask) {
+  // Collect all keys that matched the positive query
+  if (positive_iterator_) {
+    while (!positive_iterator_->DoneKeys()) {
+      matched_keys_.insert(positive_iterator_->CurrentKey());
+      positive_iterator_->NextKey();
+    }
+  }
+  // Prime to first negated key
+  NextKey();
+}
+
+FieldMaskPredicate NegationTextIterator::QueryFieldMask() const {
+  return query_field_mask_;
+}
+
+bool NegationTextIterator::DoneKeys() const { return !current_key_; }
+
+const Key& NegationTextIterator::CurrentKey() const {
+  CHECK(current_key_) << "CurrentKey called when iterator is done";
+  return current_key_;
+}
+
+bool NegationTextIterator::NextKey() {
+  // Phase 1: Iterate tracked_keys
+  if (tracked_keys_ && !tracked_iter_.has_value()) {
+    tracked_iter_ = tracked_keys_->begin();
+  }
+
+  if (tracked_keys_ && tracked_iter_.has_value()) {
+    while (tracked_iter_.value() != tracked_keys_->end()) {
+      const auto& key = *tracked_iter_.value();
+      ++tracked_iter_.value();  // Increment BEFORE checking
+      // Skip if this key matched the positive query
+      if (!matched_keys_.contains(key)) {
+        current_key_ = key;
+        return true;
+      }
+    }
+  }
+
+  // Phase 2: Iterate untracked_keys
+  if (untracked_keys_ && !untracked_iter_.has_value()) {
+    untracked_iter_ = untracked_keys_->begin();
+  }
+
+  if (untracked_keys_ && untracked_iter_.has_value()) {
+    if (untracked_iter_.value() != untracked_keys_->end()) {
+      current_key_ = *untracked_iter_.value();
+      ++untracked_iter_.value();
+      return true;
+    }
+  }
+
+  current_key_ = InternedStringPtr();
+  return false;
+}
+
+bool NegationTextIterator::SeekForwardKey(const Key& target_key) {
+  CHECK(false) << "SeekForwardKey not supported for negation queries";
+  return false;
+}
+
+// Position-related methods - not supported for negation queries
+bool NegationTextIterator::DonePositions() const {
+  return true;  // Negation doesn't track positions
+}
+
+const PositionRange& NegationTextIterator::CurrentPosition() const {
+  CHECK(false) << "Positions not supported for negation queries";
+  static PositionRange dummy{0, 0};
+  return dummy;
+}
+
+bool NegationTextIterator::NextPosition() {
+  return false;  // No positions for negation
+}
+
+FieldMaskPredicate NegationTextIterator::CurrentFieldMask() const {
+  return query_field_mask_;  // All matched fields
+}
+
+bool NegationTextIterator::IsIteratorValid() const {
+  return static_cast<bool>(current_key_);
+}
+
+}  // namespace valkey_search::indexes::text

--- a/src/indexes/text/negation_iterator.h
+++ b/src/indexes/text/negation_iterator.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef _VALKEY_SEARCH_INDEXES_TEXT_NEGATION_ITERATOR_H_
+#define _VALKEY_SEARCH_INDEXES_TEXT_NEGATION_ITERATOR_H_
+
+#include <memory>
+#include <optional>
+
+#include "src/indexes/text/text_iterator.h"
+#include "src/utils/string_interning.h"
+
+namespace valkey_search::indexes::text {
+
+// NegationTextIterator returns all keys from tracked_keys that are NOT in the
+// positive query results, plus all untracked_keys.
+// Formula: (tracked_keys - matched_keys) ∪ untracked_keys
+class NegationTextIterator : public TextIterator {
+ public:
+  NegationTextIterator(std::unique_ptr<TextIterator> positive_iterator,
+                       const InternedStringSet* tracked_keys,
+                       const InternedStringSet* untracked_keys,
+                       FieldMaskPredicate query_field_mask);
+
+  // TextIterator implementation
+  FieldMaskPredicate QueryFieldMask() const override;
+  bool DoneKeys() const override;
+  const Key& CurrentKey() const override;
+  bool NextKey() override;
+  bool SeekForwardKey(const Key& target_key) override;
+  bool DonePositions() const override;
+  const PositionRange& CurrentPosition() const override;
+  bool NextPosition() override;
+  FieldMaskPredicate CurrentFieldMask() const override;
+  bool IsIteratorValid() const override;
+
+ private:
+  std::unique_ptr<TextIterator> positive_iterator_;
+  const InternedStringSet* tracked_keys_;
+  const InternedStringSet* untracked_keys_;
+  FieldMaskPredicate query_field_mask_;
+
+  // Build set of matched keys for fast lookup
+  InternedStringSet matched_keys_;
+
+  // Current iteration state
+  std::optional<InternedStringSet::const_iterator> tracked_iter_;
+  std::optional<InternedStringSet::const_iterator> untracked_iter_;
+  Key current_key_;
+};
+
+}  // namespace valkey_search::indexes::text
+
+#endif

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -152,7 +152,7 @@ class Predicate;
 size_t EvaluateFilterAsPrimary(
     const Predicate* predicate,
     std::queue<std::unique_ptr<indexes::EntriesFetcherBase>>& entries_fetchers,
-    bool negate);
+    bool negate, const valkey_search::IndexSchema* index_schema);
 
 // Defined in the header to support testing
 absl::StatusOr<std::deque<indexes::Neighbor>> PerformVectorSearch(

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -254,7 +254,7 @@ TEST_P(EvaluateFilterAsPrimaryTest, ParseParams) {
   std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> entries_fetchers;
   EXPECT_EQ(
       EvaluateFilterAsPrimary(filter_parse_results.value().root_predicate.get(),
-                              entries_fetchers, false),
+                              entries_fetchers, false, index_schema.get()),
       test_case.evaluate_size);
 
   EXPECT_EQ(entries_fetchers.size(), test_case.fetcher_ids.size());


### PR DESCRIPTION
Add text negation querying with per-field tracked/untracked keys. Aggregate tracked/untracked keys across relevant fields and remove matched term of negation ((tracked_keys - matched_keys) + untracked_keys = negation result)