### PR TITLE
Fix use-after-free race in DefaultReplyScoreAs() fix #560

### DIFF
--- a/src/attribute.h
+++ b/src/attribute.h
@@ -46,20 +46,18 @@ class Attribute {
     return 1;
   }
 
+  // Creates a new score-as string for each call.
+  // We intentionally avoid caching because ValkeyModule_RetainString uses
+  // non-atomic refcount increment (o->refcount++), causing race conditions
+  // when multiple threads call it on the same ValkeyModuleString.
   inline vmsdk::UniqueValkeyString DefaultReplyScoreAs() const {
-    if (!cached_score_as_) {
-      cached_score_as_ =
-          vmsdk::MakeUniqueValkeyString(absl::StrCat("__", alias_, "_score"));
-    }
-    return vmsdk::RetainUniqueValkeyString(cached_score_as_.get());
+    return vmsdk::MakeUniqueValkeyString(absl::StrCat("__", alias_, "_score"));
   }
 
  private:
   std::string alias_;
   std::string identifier_;
   std::shared_ptr<indexes::IndexBase> index_;
-  // Maintaining a cached version
-  mutable vmsdk::UniqueValkeyString cached_score_as_;
 };
 
 }  // namespace valkey_search

--- a/vmsdk/src/managed_pointers.h
+++ b/vmsdk/src/managed_pointers.h
@@ -52,6 +52,7 @@ inline UniqueValkeyString MakeUniqueValkeyString(const char *str) {
 
 inline UniqueValkeyString RetainUniqueValkeyString(
     ValkeyModuleString *valkey_str) {
+  VerifyMainThread();
   ValkeyModule_RetainString(nullptr, valkey_str);
   return UniquePtrValkeyString(valkey_str);
 }


### PR DESCRIPTION
Remove cached ValkeyModuleString pattern that caused race condition between main thread (RetainString refcount++) and reader threads (FreeString refcount--). Both operations use non-atomic increments in Valkey, causing refcount corruption under high concurrency.

Also add VerifyMainThread() assertion to RetainUniqueValkeyString() to catch future misuse of the non-thread-safe retain operation.