### PR TITLE
Fix 2 ASAN failures

### DIFF
--- a/src/utils/string_interning.cc
+++ b/src/utils/string_interning.cc
@@ -94,8 +94,10 @@ void InternedString::Destructor() {
     if (!is_inline_) {
       auto ptr = reinterpret_cast<const OutOfLineInternedString*>(this);
       Allocator::Free(const_cast<char*>(ptr->out_of_line_data_));
+      delete ptr;
+    } else {
+      delete[] reinterpret_cast<char*>(this);
     }
-    delete[] reinterpret_cast<char*>(this);
   }
 }
 

--- a/testing/coordinator/metadata_manager_test.cc
+++ b/testing/coordinator/metadata_manager_test.cc
@@ -2047,7 +2047,7 @@ TEST_F(MetadataManagerTimestampTest, TestTimestampPersistsAcrossLoadMetadata) {
             0);
 }
 
-TEST(IndexNameTest, IndexName) {
+TEST_F(MetadataManagerTest, IndexName) {
   for (std::string prefix : {"", "a", "abc", "{", "}"}) {
     for (std::string hash_tag : {"", "{a}", "{b}", "{}"}) {
       for (std::string suffix : {"", "x", "xy", "{", "}", "{}"}) {


### PR DESCRIPTION
1. new/delete mismatch in string intern.
2. didn't initialize test infrastructure in new metadata object format.