### PR TITLE
Fix ASAN failure for unit tests commands_test and query_test

### DIFF
--- a/testing/filter_test.cc
+++ b/testing/filter_test.cc
@@ -120,7 +120,8 @@ TEST_P(FilterTest, ParseParams) {
   InitIndexSchema(index_schema.get());
   EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
       .Times(::testing::AnyNumber());
-  FilterParser parser(*index_schema, test_case.filter, {});
+  TextParsingOptions options{};
+  FilterParser parser(*index_schema, test_case.filter, options);
   auto parse_results = parser.Parse();
   EXPECT_EQ(test_case.create_success, parse_results.ok());
   if (!test_case.create_success) {

--- a/testing/ft_aggregate_exec_test.cc
+++ b/testing/ft_aggregate_exec_test.cc
@@ -91,6 +91,11 @@ struct AggregateExecTest : public vmsdk::ValkeyTest {
 
     auto result = parser.Parse(*params, itr);
     EXPECT_TRUE(result.ok()) << " Status is: " << result << "\n";
+
+    // Free the allocated ValkeyModuleStrings to avoid memory leaks
+    for (auto* str : argv) {
+      ValkeyModule_FreeString(nullptr, str);
+    }
     return params;
   }
 };

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -181,40 +181,32 @@ void InitIndexSchema(MockIndexSchema *index_schema) {
       "numeric_index_100_20", "numeric_index_100_20", numeric_index_100_20));
   VMSDK_EXPECT_OK(index_schema->AddIndex(
       "numeric_index_100_40", "numeric_index_100_40", numeric_index_100_40));
-  indexes::Numeric::EntriesRange entries_range;
+  static indexes::Numeric::EntriesRange entries_range;
 
-  EXPECT_CALL(*numeric_index_100_10, Search(_, false))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 10);
-      });
-  EXPECT_CALL(*numeric_index_100_10, Search(_, true))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 90);
-      });
-  EXPECT_CALL(*numeric_index_100_30, Search(_, false))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 30);
-      });
-  EXPECT_CALL(*numeric_index_100_30, Search(_, true))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 70);
-      });
-  EXPECT_CALL(*numeric_index_100_20, Search(_, false))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 20);
-      });
-  EXPECT_CALL(*numeric_index_100_20, Search(_, true))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 80);
-      });
-  EXPECT_CALL(*numeric_index_100_40, Search(_, false))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 40);
-      });
-  EXPECT_CALL(*numeric_index_100_40, Search(_, true))
-      .WillRepeatedly([&entries_range]() {
-        return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 60);
-      });
+  EXPECT_CALL(*numeric_index_100_10, Search(_, false)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 10);
+  });
+  EXPECT_CALL(*numeric_index_100_10, Search(_, true)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 90);
+  });
+  EXPECT_CALL(*numeric_index_100_30, Search(_, false)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 30);
+  });
+  EXPECT_CALL(*numeric_index_100_30, Search(_, true)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 70);
+  });
+  EXPECT_CALL(*numeric_index_100_20, Search(_, false)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 20);
+  });
+  EXPECT_CALL(*numeric_index_100_20, Search(_, true)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 80);
+  });
+  EXPECT_CALL(*numeric_index_100_40, Search(_, false)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 40);
+  });
+  EXPECT_CALL(*numeric_index_100_40, Search(_, true)).WillRepeatedly([]() {
+    return std::make_unique<TestedNumericEntriesFetcher>(entries_range, 60);
+  });
 
   data_model::TagIndex tag_index_proto;
   tag_index_proto.set_separator(",");
@@ -240,7 +232,8 @@ TEST_P(EvaluateFilterAsPrimaryTest, ParseParams) {
   const EvaluateFilterAsPrimaryTestCase &test_case = GetParam();
   auto index_schema = CreateIndexSchema(kIndexSchemaName).value();
   InitIndexSchema(index_schema.get());
-  FilterParser parser(*index_schema, test_case.filter, {});
+  TextParsingOptions options{};
+  FilterParser parser(*index_schema, test_case.filter, options);
   auto filter_parse_results = parser.Parse();
 
   // Generate the actual predicate tree structure
@@ -572,7 +565,8 @@ TEST_P(LocalSearchTest, LocalSearchTest) {
   params.ef = kEfRuntime;
   std::vector<float> query_vector(kVectorDimensions, 1.0);
   params.query = VectorToStr(query_vector);
-  FilterParser parser(*index_schema, test_case.filter, {});
+  TextParsingOptions options{};
+  FilterParser parser(*index_schema, test_case.filter, options);
   params.filter_parse_results = std::move(parser.Parse().value());
   params.index_schema = index_schema;
   auto time_slice_queries = Metrics::GetStats().time_slice_queries.load();
@@ -667,7 +661,8 @@ TEST_P(FetchFilteredKeysTest, ParseParams) {
       index_schema->GetIndex(kVectorAttributeAlias)->get());
   const FetchFilteredKeysTestCase &test_case = GetParam();
   query::SearchParameters params(100000, nullptr, 0);
-  FilterParser parser(*index_schema, test_case.filter, {});
+  TextParsingOptions options{};
+  FilterParser parser(*index_schema, test_case.filter, options);
   params.filter_parse_results = std::move(parser.Parse().value());
   params.k = 100;
   auto vectors = DeterministicallyGenerateVectors(1, kVectorDimensions, 10.0);
@@ -755,7 +750,8 @@ TEST_P(SearchTest, ParseParams) {
   std::vector<float> query_vector(kVectorDimensions, 0.0);
   params.query = VectorToStr(query_vector);
   if (!test_case.filter.empty()) {
-    FilterParser parser(*params.index_schema, test_case.filter, {});
+    TextParsingOptions options{};
+    FilterParser parser(*params.index_schema, test_case.filter, options);
     params.filter_parse_results = std::move(parser.Parse().value());
   }
   auto neighbors = Search(params, query::SearchMode::kLocal);


### PR DESCRIPTION
1. Fix `commands_test`
  a. Cleanup of `TextParsingOptions` dangling references in tests.
  b. Memory leak in `ft_aggregate_exec_test.cc`. Do cleanup during teardown.

2. Fix `query_test`
Make `entries_range` `static` to prevent dangling reference when mock lambdas execute after InitIndexSchema() returns.