### PR TITLE
Switch from deque of neighbors to vector

### DIFF
--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -25,7 +25,7 @@ namespace async {
 
 struct Result {
   cancel::Token cancellation_token;
-  absl::StatusOr<std::deque<indexes::Neighbor>> neighbors;
+  absl::StatusOr<std::vector<indexes::Neighbor>> neighbors;
   std::unique_ptr<QueryCommand> parameters;
 };
 

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -96,7 +96,7 @@ struct QueryCommand : public query::SearchParameters {
   // Executed on Main Thread after merge
   //
   virtual void SendReply(ValkeyModuleCtx *ctx,
-                         std::deque<indexes::Neighbor> &neighbors) = 0;
+                         std::vector<indexes::Neighbor> &neighbors) = 0;
 };
 
 namespace async {

--- a/src/commands/ft_aggregate.cc
+++ b/src/commands/ft_aggregate.cc
@@ -165,7 +165,7 @@ bool ReplyWithValue(ValkeyModuleCtx *ctx,
 }
 
 absl::Status SendReplyInner(ValkeyModuleCtx *ctx,
-                            std::deque<indexes::Neighbor> &neighbors,
+                            std::vector<indexes::Neighbor> &neighbors,
                             AggregateParameters &parameters) {
   auto identifier =
       parameters.index_schema->GetIdentifier(parameters.attribute_alias);
@@ -305,7 +305,7 @@ absl::Status SendReplyInner(ValkeyModuleCtx *ctx,
 }
 
 void AggregateParameters::SendReply(ValkeyModuleCtx *ctx,
-                                    std::deque<indexes::Neighbor> &neighbors) {
+                                    std::vector<indexes::Neighbor> &neighbors) {
   auto identifier = index_schema->GetIdentifier(attribute_alias);
   auto result = SendReplyInner(ctx, neighbors, *this);
   if (!result.ok()) {

--- a/src/commands/ft_aggregate_parser.h
+++ b/src/commands/ft_aggregate_parser.h
@@ -40,7 +40,7 @@ struct AggregateParameters : public expr::Expression::CompileContext,
   AggregateParameters(int db_num) : QueryCommand(db_num){};
   absl::Status ParseCommand(vmsdk::ArgsIterator& itr) override;
   void SendReply(ValkeyModuleCtx* ctx,
-                 std::deque<indexes::Neighbor>& neighbors) override;
+                 std::vector<indexes::Neighbor>& neighbors) override;
   bool loadall_{false};
   std::vector<std::string> loads_;
   bool load_key{false};

--- a/src/commands/ft_search_parser.h
+++ b/src/commands/ft_search_parser.h
@@ -35,7 +35,7 @@ struct SearchCommand : public QueryCommand {
   SearchCommand(int db_num) : QueryCommand(db_num) {}
   absl::Status ParseCommand(vmsdk::ArgsIterator &itr) override;
   void SendReply(ValkeyModuleCtx *ctx,
-                 std::deque<indexes::Neighbor> &neighbors) override;
+                 std::vector<indexes::Neighbor> &neighbors) override;
 };
 
 }  // namespace valkey_search

--- a/src/coordinator/server.cc
+++ b/src/coordinator/server.cc
@@ -96,7 +96,7 @@ void RecordSearchMetrics(bool failure,
 }
 
 void SerializeNeighbors(SearchIndexPartitionResponse* response,
-                        const std::deque<indexes::Neighbor>& neighbors) {
+                        const std::vector<indexes::Neighbor>& neighbors) {
   for (const auto& neighbor : neighbors) {
     auto* neighbor_proto = response->add_neighbors();
     neighbor_proto->set_key(std::move(*neighbor.external_id));
@@ -143,7 +143,7 @@ query::SearchResponseCallback Service::MakeSearchCallback(
     SearchIndexPartitionResponse* response, grpc::ServerUnaryReactor* reactor,
     std::unique_ptr<vmsdk::StopWatch> latency_sample) {
   return [response, reactor, latency_sample = std::move(latency_sample)](
-             absl::StatusOr<std::deque<indexes::Neighbor>>& neighbors,
+             absl::StatusOr<std::vector<indexes::Neighbor>>& neighbors,
              std::unique_ptr<query::SearchParameters> parameters) mutable {
     if (!neighbors.ok()) {
       reactor->Finish(ToGrpcStatus(neighbors.status()));

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -155,7 +155,7 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
   vmsdk::UniqueValkeyString NormalizeStringRecord(
       vmsdk::UniqueValkeyString record) const override;
   template <typename T>
-  absl::StatusOr<std::deque<Neighbor>> CreateReply(
+  absl::StatusOr<std::vector<Neighbor>> CreateReply(
       std::priority_queue<std::pair<T, hnswlib::labeltype>>& knn_res);
   absl::StatusOr<std::vector<char>> GetValue(const InternedStringPtr& key) const
       ABSL_NO_THREAD_SAFETY_ANALYSIS;

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -219,7 +219,7 @@ class CancelCondition : public hnswlib::BaseCancellationFunctor {
 };
 
 template <typename T>
-absl::StatusOr<std::deque<Neighbor>> VectorFlat<T>::Search(
+absl::StatusOr<std::vector<Neighbor>> VectorFlat<T>::Search(
     absl::string_view query, uint64_t count, cancel::Token &cancellation_token,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter) {
   if (!IsValidSizeVector(query)) {

--- a/src/indexes/vector_flat.h
+++ b/src/indexes/vector_flat.h
@@ -56,7 +56,7 @@ class VectorFlat : public VectorBase {
       ABSL_SHARED_LOCKS_REQUIRED(resize_mutex_) {
     return algo_->data_->getCapacity();
   }
-  absl::StatusOr<std::deque<Neighbor>> Search(
+  absl::StatusOr<std::vector<Neighbor>> Search(
       absl::string_view query, uint64_t count,
       cancel::Token& cancellation_token,
       std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr)

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -323,7 +323,7 @@ class CancelCondition : public hnswlib::BaseCancellationFunctor {
 };
 
 template <typename T>
-absl::StatusOr<std::deque<Neighbor>> VectorHNSW<T>::Search(
+absl::StatusOr<std::vector<Neighbor>> VectorHNSW<T>::Search(
     absl::string_view query, uint64_t count, cancel::Token &cancellation_token,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter,
     std::optional<size_t> ef_runtime, bool enable_partial_results) {

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -65,7 +65,7 @@ class VectorHNSW : public VectorBase {
     return algo_->ef_;
   }
 
-  absl::StatusOr<std::deque<Neighbor>> Search(
+  absl::StatusOr<std::vector<Neighbor>> Search(
       absl::string_view query, uint64_t count,
       cancel::Token& cancellation_token,
       std::unique_ptr<hnswlib::BaseFilterFunctor> filter = nullptr,

--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -125,7 +125,7 @@ struct SearchPartitionResultsTracker {
     }
   }
 
-  void AddResults(std::deque<indexes::Neighbor> &neighbors) {
+  void AddResults(std::vector<indexes::Neighbor> &neighbors) {
     absl::MutexLock lock(&mutex);
     for (auto &neighbor : neighbors) {
       AddResult(neighbor);
@@ -149,8 +149,8 @@ struct SearchPartitionResultsTracker {
 
   ~SearchPartitionResultsTracker() {
     absl::MutexLock lock(&mutex);
-    absl::StatusOr<std::deque<indexes::Neighbor>> result =
-        std::deque<indexes::Neighbor>();
+    absl::StatusOr<std::vector<indexes::Neighbor>> result =
+        std::vector<indexes::Neighbor>();
     if (consistency_failed) {
       result = absl::FailedPreconditionError(kFailedPreconditionMsg);
     } else if (reached_oom) {
@@ -253,7 +253,7 @@ absl::Status PerformSearchFanoutAsync(
         coordinator::GRPCSearchRequestToParameters(*request, nullptr));
     VMSDK_RETURN_IF_ERROR(query::SearchAsync(
         std::move(local_parameters), thread_pool,
-        [tracker](absl::StatusOr<std::deque<indexes::Neighbor>> &neighbors,
+        [tracker](absl::StatusOr<std::vector<indexes::Neighbor>> &neighbors,
                   std::unique_ptr<SearchParameters> parameters) {
           if (neighbors.ok()) {
             tracker->AddResults(*neighbors);

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -256,7 +256,7 @@ absl::StatusOr<RecordsMap> GetContent(
 // This function is meant to be used for non-vector queries.
 void ProcessNonVectorNeighborsForReply(
     ValkeyModuleCtx *ctx, const AttributeDataType &attribute_data_type,
-    std::deque<indexes::Neighbor> &neighbors,
+    std::vector<indexes::Neighbor> &neighbors,
     const query::SearchParameters &parameters) {
   ProcessNeighborsForReply(ctx, attribute_data_type, neighbors, parameters, "");
 }
@@ -267,7 +267,7 @@ void ProcessNonVectorNeighborsForReply(
 // Any data not found locally will be skipped.
 void ProcessNeighborsForReply(ValkeyModuleCtx *ctx,
                               const AttributeDataType &attribute_data_type,
-                              std::deque<indexes::Neighbor> &neighbors,
+                              std::vector<indexes::Neighbor> &neighbors,
                               const query::SearchParameters &parameters,
                               const std::string &identifier) {
   const auto max_content_size =

--- a/src/query/response_generator.h
+++ b/src/query/response_generator.h
@@ -38,13 +38,13 @@ namespace valkey_search::query {
 // Neighbor not comply to the pre-filter expression.
 void ProcessNeighborsForReply(ValkeyModuleCtx *ctx,
                               const AttributeDataType &attribute_data_type,
-                              std::deque<indexes::Neighbor> &neighbors,
+                              std::vector<indexes::Neighbor> &neighbors,
                               const query::SearchParameters &parameters,
                               const std::string &identifier);
 
 void ProcessNonVectorNeighborsForReply(
     ValkeyModuleCtx *ctx, const AttributeDataType &attribute_data_type,
-    std::deque<indexes::Neighbor> &neighbors,
+    std::vector<indexes::Neighbor> &neighbors,
     const query::SearchParameters &parameters);
 
 }  // namespace valkey_search::query

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -132,10 +132,10 @@ struct SearchParameters {
 
 // Callback to be called when the search is done.
 using SearchResponseCallback =
-    absl::AnyInvocable<void(absl::StatusOr<std::deque<indexes::Neighbor>>&,
+    absl::AnyInvocable<void(absl::StatusOr<std::vector<indexes::Neighbor>>&,
                             std::unique_ptr<SearchParameters>)>;
 
-absl::StatusOr<std::deque<indexes::Neighbor>> Search(
+absl::StatusOr<std::vector<indexes::Neighbor>> Search(
     const SearchParameters& parameters, SearchMode search_mode);
 
 absl::Status SearchAsync(std::unique_ptr<SearchParameters> parameters,
@@ -143,8 +143,8 @@ absl::Status SearchAsync(std::unique_ptr<SearchParameters> parameters,
                          SearchResponseCallback callback,
                          SearchMode search_mode);
 
-absl::StatusOr<std::deque<indexes::Neighbor>> MaybeAddIndexedContent(
-    absl::StatusOr<std::deque<indexes::Neighbor>> results,
+absl::StatusOr<std::vector<indexes::Neighbor>> MaybeAddIndexedContent(
+    absl::StatusOr<std::vector<indexes::Neighbor>> results,
     const SearchParameters& parameters);
 
 class Predicate;
@@ -155,7 +155,7 @@ size_t EvaluateFilterAsPrimary(
     bool negate);
 
 // Defined in the header to support testing
-absl::StatusOr<std::deque<indexes::Neighbor>> PerformVectorSearch(
+absl::StatusOr<std::vector<indexes::Neighbor>> PerformVectorSearch(
     indexes::VectorBase* vector_index, const SearchParameters& parameters);
 
 std::priority_queue<std::pair<float, hnswlib::labeltype>>

--- a/testing/ft_search_test.cc
+++ b/testing/ft_search_test.cc
@@ -172,7 +172,7 @@ void SendReplyTest::DoSendReplyTest(
                                .value();
   EXPECT_CALL(*test_index_schema, GetIdentifier(input.attribute_alias))
       .WillRepeatedly(testing::Return(attribute_id));
-  std::deque<indexes::Neighbor> neighbors;
+  std::vector<indexes::Neighbor> neighbors;
   for (const auto &neighbor : input.neighbors) {
     neighbors.push_back(ToIndexesNeighbor(neighbor));
   }

--- a/testing/query/response_generator_test.cc
+++ b/testing/query/response_generator_test.cc
@@ -77,7 +77,7 @@ TEST_P(ResponseGeneratorTest, ProcessNeighborsForReply) {
   auto &params = GetParam();
   ValkeyModuleCtx fake_ctx;
 
-  std::deque<indexes::Neighbor> expected_neighbors;
+  std::vector<indexes::Neighbor> expected_neighbors;
   for (const auto &external_id : params.external_id_neighbors) {
     auto string_interned_external_id = StringInternStore::Intern(external_id);
     expected_neighbors.push_back(
@@ -166,7 +166,7 @@ TEST_F(ResponseGeneratorTest, ProcessNeighborsForReplyContentLimits) {
       options::GetMaxSearchResultFieldsCount().SetValue(test_fields_limit));
 
   // Create neighbors with different content sizes and field counts
-  std::deque<indexes::Neighbor> neighbors;
+  std::vector<indexes::Neighbor> neighbors;
   auto small_external_id = StringInternStore::Intern("small_content_id");
   auto large_external_id = StringInternStore::Intern("large_content_id");
   auto many_fields_id = StringInternStore::Intern("many_fields_id");

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -945,8 +945,8 @@ struct IndexedContentTestCase {
   bool no_content;
   std::vector<TestReturnAttribute> return_attributes;
   std::vector<TestIndex> indexes;
-  absl::StatusOr<std::deque<TestNeighbor>> input;
-  absl::StatusOr<std::deque<TestNeighbor>> expected_output;
+  absl::StatusOr<std::vector<TestNeighbor>> input;
+  absl::StatusOr<std::vector<TestNeighbor>> expected_output;
 };
 
 class IndexedContentTest
@@ -1025,10 +1025,10 @@ TEST_P(IndexedContentTest, MaybeAddIndexedContentTest) {
   }
   parameters.no_content = test_case.no_content;
 
-  absl::StatusOr<std::deque<indexes::Neighbor>> got;
+  absl::StatusOr<std::vector<indexes::Neighbor>> got;
   if (test_case.input.ok()) {
-    absl::StatusOr<std::deque<indexes::Neighbor>> neighbors =
-        std::deque<indexes::Neighbor>();
+    absl::StatusOr<std::vector<indexes::Neighbor>> neighbors =
+        std::vector<indexes::Neighbor>();
     for (auto &neighbor : test_case.input.value()) {
       neighbors->push_back(neighbor.ToIndexesNeighbor());
     }

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -508,7 +508,7 @@ TEST_F(VectorIndexTest, SaveAndLoadFlat) {
     auto vectors = DeterministicallyGenerateVectors(1000, kDimensions, 2.2);
     auto search_vectors =
         DeterministicallyGenerateVectors(50, kDimensions, 1.5);
-    std::vector<std::deque<Neighbor>> expected_results;
+    std::vector<std::vector<Neighbor>> expected_results;
 
     data_model::VectorIndex flat_proto = CreateFlatVectorIndexProto(
         kDimensions, distance_metric, initial_cap, kBlockSize);


### PR DESCRIPTION
Switch from deque of neighbors to vector. We are now able to apply a vector reserve to handle searches in a more performant manner