### PR TITLE
Apply clang format to text_index.*

### DIFF
--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -62,8 +62,8 @@ class TextIndex {
 
  public:
   explicit TextIndex(bool suffix);
-  RadixTree<InvasivePtr<Postings>>& GetPrefix();
-  const RadixTree<InvasivePtr<Postings>>& GetPrefix() const;
+  RadixTree<InvasivePtr<Postings>> &GetPrefix();
+  const RadixTree<InvasivePtr<Postings>> &GetPrefix() const;
   std::optional<std::reference_wrapper<RadixTree<InvasivePtr<Postings>>>>
   GetSuffix();
   std::optional<std::reference_wrapper<const RadixTree<InvasivePtr<Postings>>>>
@@ -76,16 +76,16 @@ class TextIndex {
 
 class TextIndexSchema {
  public:
-  TextIndexSchema(data_model::Language language, const std::string& punctuation,
+  TextIndexSchema(data_model::Language language, const std::string &punctuation,
                   bool with_offsets,
-                  const std::vector<std::string>& stop_words);
+                  const std::vector<std::string> &stop_words);
 
-  absl::StatusOr<bool> StageAttributeData(const InternedStringPtr& key,
+  absl::StatusOr<bool> StageAttributeData(const InternedStringPtr &key,
                                           absl::string_view data,
                                           size_t text_field_number, bool stem,
                                           size_t min_stem_size, bool suffix);
-  void CommitKeyData(const InternedStringPtr& key);
-  void DeleteKeyData(const InternedStringPtr& key);
+  void CommitKeyData(const InternedStringPtr &key);
+  void DeleteKeyData(const InternedStringPtr &key);
 
   uint8_t AllocateTextFieldNumber() { return num_text_fields_++; }
   bool HasTextOffsets() const { return with_offsets_; }
@@ -94,7 +94,7 @@ class TextIndexSchema {
   Lexer GetLexer() const { return lexer_; }
 
   // Access to metadata for memory pool usage
-  TextIndexMetadata& GetMetadata() { return metadata_; }
+  TextIndexMetadata &GetMetadata() { return metadata_; }
 
   // Enable suffix trie.
   void EnableSuffix() {
@@ -159,7 +159,7 @@ class TextIndexSchema {
   // Thread-safe accessor for per-key text indexes. Executes the provided
   // function while holding the mutex lock, ensuring safe concurrent access.
   template <typename Func>
-  auto WithPerKeyTextIndexes(Func&& func)
+  auto WithPerKeyTextIndexes(Func &&func)
       -> decltype(func(per_key_text_indexes_)) {
     std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
     return func(per_key_text_indexes_);
@@ -167,14 +167,14 @@ class TextIndexSchema {
 
   // Direct accessor for per-key text indexes.
   // Assumes that lock is already acquired earlier.
-  const absl::node_hash_map<Key, TextIndex>& GetPerKeyTextIndexes() const {
+  const absl::node_hash_map<Key, TextIndex> &GetPerKeyTextIndexes() const {
     return per_key_text_indexes_;
   }
 
   // Helper function to lookup text index for a key
-  static const TextIndex* LookupTextIndex(
-      const absl::node_hash_map<Key, TextIndex>& per_key_indexes,
-      const Key& key) {
+  static const TextIndex *LookupTextIndex(
+      const absl::node_hash_map<Key, TextIndex> &per_key_indexes,
+      const Key &key) {
     if (!key) {
       CHECK(false) << "Invalid null key passed to LookupTextIndex";
       return nullptr;


### PR DESCRIPTION
I see @eifrah-aws added `PointerAlignment: Right` to `.clang-format` but from what I found that's overridden by `DerivePointerAlignment: true` from the Google style which aims to keep the pointer style consistent to what it currently is. I made some changes to `text_index.cc` that caused the derived pointer alignment to switch from left aligned to right aligned. I'm adding a separate formatting commit here first so the git history is clear.
