### PR TITLE
Fix build warnings

### DIFF
--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -192,7 +192,8 @@ class TermPredicate : public TextPredicate {
   TermPredicate(
       std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
       FieldMaskPredicate field_mask, std::string term, bool exact);
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
+      const override {
     return text_index_schema_;
   }
   absl::string_view GetTextString() const { return term_; }
@@ -220,7 +221,8 @@ class PrefixPredicate : public TextPredicate {
   PrefixPredicate(
       std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
       FieldMaskPredicate field_mask, std::string term);
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
+      const override {
     return text_index_schema_;
   }
   absl::string_view GetTextString() const { return term_; }
@@ -246,7 +248,8 @@ class SuffixPredicate : public TextPredicate {
   SuffixPredicate(
       std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
       FieldMaskPredicate field_mask, std::string term);
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
+      const override {
     return text_index_schema_;
   }
   absl::string_view GetTextString() const { return term_; }
@@ -272,7 +275,8 @@ class InfixPredicate : public TextPredicate {
   InfixPredicate(
       std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
       FieldMaskPredicate field_mask, std::string term);
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
+      const override {
     return text_index_schema_;
   }
   absl::string_view GetTextString() const { return term_; }
@@ -298,7 +302,8 @@ class FuzzyPredicate : public TextPredicate {
   FuzzyPredicate(
       std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
       FieldMaskPredicate field_mask, std::string term, uint32_t distance);
-  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
+  std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
+      const override {
     return text_index_schema_;
   }
   absl::string_view GetTextString() const { return term_; }

--- a/third_party/snowball/CMakeLists.txt
+++ b/third_party/snowball/CMakeLists.txt
@@ -22,6 +22,9 @@ add_library(snowball STATIC ${LIBSTEMMER_SOURCES} ${STEMMER_SOURCES})
 # Set include directories
 target_include_directories(snowball PUBLIC
   ${SNOWBALL_SOURCE_DIR}/include
+)
+
+target_include_directories(snowball PRIVATE
   ${SNOWBALL_SOURCE_DIR}
 )
 


### PR DESCRIPTION
Fix warnings seen in a macos build / test execution

See: https://github.com/valkey-io/valkey-search/actions/runs/20882279394/job/60059739369?pr=597


Snowball:
```
In file included from /Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/cstddef:37:
/Users/runner/work/valkey-search/valkey-search/third_party/snowball/version:1:1: error: unknown type name 'v3'
    1 | v3.0.1
      | ^
/Users/runner/work/valkey-search/valkey-search/third_party/snowball/version:1:3: error: expected unqualified-id
    1 | v3.0.1
      |   ^
```


predicate.cc
```
/Users/runner/work/valkey-search/valkey-search/src/query/predicate.h:195:51: warning: 'GetTextIndexSchema' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  195 |   std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
      |                                                   ^
/Users/runner/work/valkey-search/valkey-search/src/query/predicate.h:181:59: note: overridden virtual function is here
  181 |   virtual std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
      |                                                           ^
/Users/runner/work/valkey-search/valkey-search/src/query/predicate.h:223:51: warning: 'GetTextIndexSchema' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
  223 |   std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema() const {
      |                                                   ^
/Users/runner/work/valkey-search/valkey-search/src/query/predicate.h:181:59: note: overridden virtual function is here
  181 |   virtual std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
```