### PR TITLE
Refactor Index Methods to Use Template Method Pattern

### DIFF
--- a/src/indexes/numeric.h
+++ b/src/indexes/numeric.h
@@ -41,24 +41,24 @@ class BTreeNumeric {
   using ConstIterator =
       typename absl::btree_map<double, SetType>::const_iterator;
 
-  void Add(const T& value, double key) {
+  void Add(const T &value, double key) {
     btree_[key].insert(value);
     segment_tree_.Add(key);
   }
 
-  void Modify(const T& value, double old_key, double new_key) {
+  void Modify(const T &value, double old_key, double new_key) {
     Remove(value, old_key);
     Add(value, new_key);
   }
 
-  void Remove(const T& value, double key) {
+  void Remove(const T &value, double key) {
     btree_[key].erase(value);
     if (btree_[key].empty()) {
       btree_.erase(key);
     }
     segment_tree_.Remove(key);
   }
-  const absl::btree_map<double, SetType>& GetBtree() const { return btree_; }
+  const absl::btree_map<double, SetType> &GetBtree() const { return btree_; }
 
   size_t GetCount(double start, double end, bool start_inclusive,
                   bool end_inclusive) {
@@ -81,18 +81,18 @@ class BTreeNumeric {
 
 class Numeric : public IndexBase {
  public:
-  explicit Numeric(const data_model::NumericIndex& numeric_index_proto);
-  absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
-                                 absl::string_view data) override
+  explicit Numeric(const data_model::NumericIndex &numeric_index_proto);
+  absl::StatusOr<bool> AddRecordImpl(const InternedStringPtr &key,
+                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> RemoveRecord(
-      const InternedStringPtr& key,
+  absl::StatusOr<bool> RemoveRecordImpl(
+      const InternedStringPtr &key,
       DeletionType deletion_type = DeletionType::kNone) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
-                                    absl::string_view data) override
+  absl::StatusOr<bool> ModifyRecordImpl(const InternedStringPtr &key,
+                                        absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(ValkeyModuleCtx* ctx) const override
+  int RespondWithInfo(ValkeyModuleCtx *ctx) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
@@ -101,20 +101,20 @@ class Numeric : public IndexBase {
   size_t GetTrackedKeyCount() const override ABSL_LOCKS_EXCLUDED(index_mutex_);
   size_t GetUnTrackedKeyCount() const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  bool IsTracked(const InternedStringPtr& key) const override
+  bool IsTracked(const InternedStringPtr &key) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  bool IsUnTracked(const InternedStringPtr& key) const override
+  bool IsUnTracked(const InternedStringPtr &key) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status ForEachTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status ForEachUnTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override ABSL_LOCKS_EXCLUDED(index_mutex_);
 
   std::unique_ptr<data_model::Index> ToProto() const override;
 
-  const double* GetValue(const InternedStringPtr& key) const
+  const double *GetValue(const InternedStringPtr &key) const
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
   using BTreeNumericIndex = BTreeNumeric<InternedStringPtr>;
   using EntriesRange = std::pair<BTreeNumericIndex::ConstIterator,
@@ -122,35 +122,35 @@ class Numeric : public IndexBase {
   class EntriesFetcherIterator : public EntriesFetcherIteratorBase {
    public:
     EntriesFetcherIterator(
-        const EntriesRange& entries_range,
-        const std::optional<EntriesRange>& additional_entries_range,
-        const InternedStringSet* untracked_keys);
+        const EntriesRange &entries_range,
+        const std::optional<EntriesRange> &additional_entries_range,
+        const InternedStringSet *untracked_keys);
     bool Done() const override;
     void Next() override;
-    const InternedStringPtr& operator*() const override;
+    const InternedStringPtr &operator*() const override;
 
    private:
     static bool NextKeys(
-        const Numeric::EntriesRange& range,
-        BTreeNumericIndex::ConstIterator& iter,
-        std::optional<InternedStringSet::const_iterator>& keys_iter);
-    const EntriesRange& entries_range_;
+        const Numeric::EntriesRange &range,
+        BTreeNumericIndex::ConstIterator &iter,
+        std::optional<InternedStringSet::const_iterator> &keys_iter);
+    const EntriesRange &entries_range_;
     BTreeNumericIndex::ConstIterator entries_iter_;
     std::optional<InternedStringSet::const_iterator> entry_keys_iter_;
-    const std::optional<EntriesRange>& additional_entries_range_;
+    const std::optional<EntriesRange> &additional_entries_range_;
     BTreeNumericIndex::ConstIterator additional_entries_iter_;
     std::optional<InternedStringSet::const_iterator>
         additional_entry_keys_iter_;
-    const InternedStringSet* untracked_keys_;
+    const InternedStringSet *untracked_keys_;
     std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
   };
 
   class EntriesFetcher : public EntriesFetcherBase {
    public:
     EntriesFetcher(
-        const EntriesRange& entries_range, size_t size,
+        const EntriesRange &entries_range, size_t size,
         std::optional<EntriesRange> additional_entries_range = std::nullopt,
-        const InternedStringSet* untracked_keys = nullptr)
+        const InternedStringSet *untracked_keys = nullptr)
         : entries_range_(entries_range),
           size_(size),
           additional_entries_range_(additional_entries_range),
@@ -162,11 +162,11 @@ class Numeric : public IndexBase {
     EntriesRange entries_range_;
     size_t size_{0};
     std::optional<EntriesRange> additional_entries_range_;
-    const InternedStringSet* untracked_keys_;
+    const InternedStringSet *untracked_keys_;
   };
 
   virtual std::unique_ptr<EntriesFetcher> Search(
-      const query::NumericPredicate& predicate,
+      const query::NumericPredicate &predicate,
       bool negate) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  private:

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -32,18 +32,18 @@ namespace valkey_search::indexes {
 
 class Tag : public IndexBase {
  public:
-  explicit Tag(const data_model::TagIndex& tag_index_proto);
-  absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
-                                 absl::string_view data) override
+  explicit Tag(const data_model::TagIndex &tag_index_proto);
+  absl::StatusOr<bool> AddRecordImpl(const InternedStringPtr &key,
+                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> RemoveRecord(
-      const InternedStringPtr& key,
+  absl::StatusOr<bool> RemoveRecordImpl(
+      const InternedStringPtr &key,
       DeletionType deletion_type = DeletionType::kNone) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
-                                    absl::string_view data) override
+  absl::StatusOr<bool> ModifyRecordImpl(const InternedStringPtr &key,
+                                        absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(ValkeyModuleCtx* ctx) const override
+  int RespondWithInfo(ValkeyModuleCtx *ctx) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
@@ -52,43 +52,43 @@ class Tag : public IndexBase {
   size_t GetTrackedKeyCount() const override ABSL_LOCKS_EXCLUDED(index_mutex_);
   size_t GetUnTrackedKeyCount() const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  bool IsTracked(const InternedStringPtr& key) const override
+  bool IsTracked(const InternedStringPtr &key) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  bool IsUnTracked(const InternedStringPtr& key) const override
+  bool IsUnTracked(const InternedStringPtr &key) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status ForEachTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status ForEachUnTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override ABSL_LOCKS_EXCLUDED(index_mutex_);
   std::unique_ptr<data_model::Index> ToProto() const override;
 
-  InternedStringPtr GetRawValue(const InternedStringPtr& key) const
+  InternedStringPtr GetRawValue(const InternedStringPtr &key) const
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
-  const absl::flat_hash_set<absl::string_view>* GetValue(
-      const InternedStringPtr& key,
-      bool& case_sensitive) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  const absl::flat_hash_set<absl::string_view> *GetValue(
+      const InternedStringPtr &key,
+      bool &case_sensitive) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
   using PatriciaTreeIndex = PatriciaTree<InternedStringPtr>;
   using PatriciaNodeIndex = PatriciaNode<InternedStringPtr>;
 
   class EntriesFetcherIterator : public EntriesFetcherIteratorBase {
    public:
-    EntriesFetcherIterator(const PatriciaTreeIndex& tree,
-                           absl::flat_hash_set<PatriciaNodeIndex*>& entries,
-                           const InternedStringSet& untracked_keys,
+    EntriesFetcherIterator(const PatriciaTreeIndex &tree,
+                           absl::flat_hash_set<PatriciaNodeIndex *> &entries,
+                           const InternedStringSet &untracked_keys,
                            bool negate);
     bool Done() const override;
     void Next() override;
-    const InternedStringPtr& operator*() const override;
+    const InternedStringPtr &operator*() const override;
 
    private:
     PatriciaTreeIndex::PrefixSubTreeIterator tree_iter_;
-    absl::flat_hash_set<PatriciaNodeIndex*>& entries_;
-    PatriciaNodeIndex* next_node_{nullptr};
+    absl::flat_hash_set<PatriciaNodeIndex *> &entries_;
+    PatriciaNodeIndex *next_node_{nullptr};
     InternedStringSet::const_iterator next_iter_;
-    const InternedStringSet& untracked_keys_;
+    const InternedStringSet &untracked_keys_;
     bool negate_;
     std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
     void NextNegate();
@@ -96,9 +96,10 @@ class Tag : public IndexBase {
 
   class EntriesFetcher : public EntriesFetcherBase {
    public:
-    EntriesFetcher(const PatriciaTreeIndex& tree,
-                   absl::flat_hash_set<PatriciaNodeIndex*> entries, size_t size,
-                   bool negate, const InternedStringSet& untracked_keys)
+    EntriesFetcher(const PatriciaTreeIndex &tree,
+                   absl::flat_hash_set<PatriciaNodeIndex *> entries,
+                   size_t size, bool negate,
+                   const InternedStringSet &untracked_keys)
         : tree_(tree),
           size_(size),
           entries_(entries),
@@ -108,15 +109,15 @@ class Tag : public IndexBase {
     std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
 
    private:
-    const PatriciaTreeIndex& tree_;
+    const PatriciaTreeIndex &tree_;
     size_t size_{0};
-    absl::flat_hash_set<PatriciaNodeIndex*> entries_;
+    absl::flat_hash_set<PatriciaNodeIndex *> entries_;
     bool negate_;
-    const InternedStringSet& untracked_keys_;
+    const InternedStringSet &untracked_keys_;
   };
 
   virtual std::unique_ptr<EntriesFetcher> Search(
-      const query::TagPredicate& predicate,
+      const query::TagPredicate &predicate,
       bool negate) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
   char GetSeparator() const { return separator_; }
   bool IsCaseSensitive() const { return case_sensitive_; }

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -19,7 +19,7 @@
 
 namespace valkey_search::indexes {
 
-Text::Text(const data_model::TextIndex& text_index_proto,
+Text::Text(const data_model::TextIndex &text_index_proto,
            std::shared_ptr<text::TextIndexSchema> text_index_schema)
     : IndexBase(IndexerType::kText),
       text_index_schema_(text_index_schema),
@@ -34,8 +34,8 @@ Text::Text(const data_model::TextIndex& text_index_proto,
   }
 }
 
-absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
-                                     absl::string_view data) {
+absl::StatusOr<bool> Text::AddRecordImpl(const InternedStringPtr &key,
+                                         absl::string_view data) {
   // TODO: Key Tracking
 
   return text_index_schema_->StageAttributeData(key, data, text_field_number_,
@@ -43,8 +43,8 @@ absl::StatusOr<bool> Text::AddRecord(const InternedStringPtr& key,
                                                 with_suffix_trie_);
 }
 
-absl::StatusOr<bool> Text::RemoveRecord(const InternedStringPtr& key,
-                                        DeletionType deletion_type) {
+absl::StatusOr<bool> Text::RemoveRecordImpl(const InternedStringPtr &key,
+                                            DeletionType deletion_type) {
   // The old key value has already been removed from the index by a call to
   // TextIndexSchema::DeleteKey(), so there is no need to touch the index
   // structures here
@@ -54,8 +54,8 @@ absl::StatusOr<bool> Text::RemoveRecord(const InternedStringPtr& key,
   return true;
 }
 
-absl::StatusOr<bool> Text::ModifyRecord(const InternedStringPtr& key,
-                                        absl::string_view data) {
+absl::StatusOr<bool> Text::ModifyRecordImpl(const InternedStringPtr &key,
+                                            absl::string_view data) {
   // TODO: key tracking
 
   // The old key value has already been removed from the index by a call to
@@ -66,7 +66,7 @@ absl::StatusOr<bool> Text::ModifyRecord(const InternedStringPtr& key,
                                                 with_suffix_trie_);
 }
 
-int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
+int Text::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   ValkeyModule_ReplyWithSimpleString(ctx, "type");
   ValkeyModule_ReplyWithSimpleString(ctx, "TEXT");
   ValkeyModule_ReplyWithSimpleString(ctx, "WITH_SUFFIX_TRIE");
@@ -86,7 +86,7 @@ int Text::RespondWithInfo(ValkeyModuleCtx* ctx) const {
   return 6;
 }
 
-bool Text::IsTracked(const InternedStringPtr& key) const {
+bool Text::IsTracked(const InternedStringPtr &key) const {
   // TODO
   return false;
 }
@@ -98,7 +98,7 @@ size_t Text::GetTrackedKeyCount() const {
 
 std::unique_ptr<data_model::Index> Text::ToProto() const {
   auto index_proto = std::make_unique<data_model::Index>();
-  auto* text_index = index_proto->mutable_text_index();
+  auto *text_index = index_proto->mutable_text_index();
   text_index->set_with_suffix_trie(with_suffix_trie_);
   text_index->set_no_stem(no_stem_);
   text_index->set_min_stem_size(min_stem_size_);
@@ -136,15 +136,15 @@ class ProximityFetcher : public indexes::EntriesFetcherBase {
 };
 
 std::unique_ptr<indexes::EntriesFetcherBase> BuildExactPhraseFetcher(
-    const ComposedPredicate* composed_predicate) {
+    const ComposedPredicate *composed_predicate) {
   absl::InlinedVector<std::unique_ptr<indexes::text::TextIterator>,
                       indexes::text::kProximityTermsInlineCapacity>
       iters;
   FieldMaskPredicate field_mask = ~0ULL;
   size_t min_size = SIZE_MAX;
-  for (const auto& child : composed_predicate->GetChildren()) {
+  for (const auto &child : composed_predicate->GetChildren()) {
     CHECK(child->GetType() == PredicateType::kText);
-    auto text_pred = dynamic_cast<const TextPredicate*>(child.get());
+    auto text_pred = dynamic_cast<const TextPredicate *>(child.get());
     auto fetcher = std::make_unique<indexes::Text::EntriesFetcher>(
         0, text_pred->GetTextIndexSchema()->GetTextIndex(), nullptr,
         text_pred->GetFieldMask(), true);
@@ -160,7 +160,7 @@ std::unique_ptr<indexes::EntriesFetcherBase> BuildExactPhraseFetcher(
                                             min_size);
 }
 
-void* TextPredicate::Search(bool negate) const {
+void *TextPredicate::Search(bool negate) const {
   size_t estimated_size = EstimateSize();
   // We do not perform positional checks on the initial term/prefix/suffix/fuzzy
   // predicate fetchers from the entries fetcher search.
@@ -176,9 +176,9 @@ void* TextPredicate::Search(bool negate) const {
 }
 
 std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
-  const auto* fetcher =
-      static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
+    const void *fetcher_ptr) const {
+  const auto *fetcher =
+      static_cast<const indexes::Text::EntriesFetcher *>(fetcher_ptr);
   auto word_iter =
       fetcher->text_index_->GetPrefix().GetWordIterator(GetTextString());
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
@@ -196,9 +196,9 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
-  const auto* fetcher =
-      static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
+    const void *fetcher_ptr) const {
+  const auto *fetcher =
+      static_cast<const indexes::Text::EntriesFetcher *>(fetcher_ptr);
   auto word_iter =
       fetcher->text_index_->GetPrefix().GetWordIterator(GetTextString());
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
@@ -218,9 +218,9 @@ std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
-  const auto* fetcher =
-      static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
+    const void *fetcher_ptr) const {
+  const auto *fetcher =
+      static_cast<const indexes::Text::EntriesFetcher *>(fetcher_ptr);
   CHECK(fetcher->text_index_->GetSuffix().has_value())
       << "Text index does not have suffix trie enabled.";
   std::string reversed_word(GetTextString().rbegin(), GetTextString().rend());
@@ -244,14 +244,14 @@ std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> InfixPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
+    const void *fetcher_ptr) const {
   CHECK(false) << "Unsupported TextPredicate type";
 }
 
 std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
-    const void* fetcher_ptr) const {
-  const auto* fetcher =
-      static_cast<const indexes::Text::EntriesFetcher*>(fetcher_ptr);
+    const void *fetcher_ptr) const {
+  const auto *fetcher =
+      static_cast<const indexes::Text::EntriesFetcher *>(fetcher_ptr);
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   auto key_iterators = indexes::text::FuzzySearch::Search(

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -40,7 +40,7 @@ namespace valkey_search::indexes {
  */
 class Text : public IndexBase {
  public:
-  explicit Text(const data_model::TextIndex& text_index_proto,
+  explicit Text(const data_model::TextIndex &text_index_proto,
                 std::shared_ptr<text::TextIndexSchema> text_index_schema);
 
   std::shared_ptr<text::TextIndexSchema> GetTextIndexSchema() const {
@@ -49,24 +49,24 @@ class Text : public IndexBase {
   uint32_t GetMinStemSize() const { return min_stem_size_; }
   bool IsStemmingEnabled() const { return !no_stem_; }
   bool WithSuffixTrie() const { return with_suffix_trie_; }
-  absl::StatusOr<bool> AddRecord(const InternedStringPtr& key,
-                                 absl::string_view data) override
+  absl::StatusOr<bool> AddRecordImpl(const InternedStringPtr &key,
+                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> RemoveRecord(
-      const InternedStringPtr& key,
+  absl::StatusOr<bool> RemoveRecordImpl(
+      const InternedStringPtr &key,
       DeletionType deletion_type = DeletionType::kNone) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
-                                    absl::string_view data) override
+  absl::StatusOr<bool> ModifyRecordImpl(const InternedStringPtr &key,
+                                        absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
-  int RespondWithInfo(ValkeyModuleCtx* ctx) const override;
-  bool IsTracked(const InternedStringPtr& key) const override;
+  int RespondWithInfo(ValkeyModuleCtx *ctx) const override;
+  bool IsTracked(const InternedStringPtr &key) const override;
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {
     return absl::OkStatus();
   }
 
   inline absl::Status ForEachTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override {
     absl::MutexLock lock(&index_mutex_);
     // TODO: Implement proper key tracking
@@ -78,13 +78,13 @@ class Text : public IndexBase {
     return untracked_keys_.size();
   }
 
-  bool IsUnTracked(const InternedStringPtr& key) const override {
+  bool IsUnTracked(const InternedStringPtr &key) const override {
     absl::MutexLock lock(&index_mutex_);
     return untracked_keys_.contains(key);
   }
 
   absl::Status ForEachUnTrackedKey(
-      absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn)
+      absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn)
       const override {
     absl::MutexLock lock(&index_mutex_);
     // TODO
@@ -94,7 +94,7 @@ class Text : public IndexBase {
   size_t GetTrackedKeyCount() const override;
   std::unique_ptr<data_model::Index> ToProto() const override;
 
-  InternedStringPtr GetRawValue(const InternedStringPtr& key) const
+  InternedStringPtr GetRawValue(const InternedStringPtr &key) const
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  public:
@@ -102,8 +102,8 @@ class Text : public IndexBase {
   class EntriesFetcher : public EntriesFetcherBase {
    public:
     EntriesFetcher(size_t size,
-                   const std::shared_ptr<text::TextIndex>& text_index,
-                   const InternedStringSet* untracked_keys,
+                   const std::shared_ptr<text::TextIndex> &text_index,
+                   const InternedStringSet *untracked_keys,
                    text::FieldMaskPredicate field_mask, bool require_positions)
         : size_(size),
           text_index_(text_index),
@@ -114,16 +114,16 @@ class Text : public IndexBase {
     size_t Size() const override;
 
     std::unique_ptr<text::TextIterator> BuildTextIterator(
-        const query::TextPredicate* predicate);
+        const query::TextPredicate *predicate);
 
     // Factory method that creates the appropriate text iterator
     // based on the text predicate's operation type.
     std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
 
     size_t size_;
-    const InternedStringSet* untracked_keys_;
+    const InternedStringSet *untracked_keys_;
     std::shared_ptr<text::TextIndex> text_index_;
-    const query::TextPredicate* predicate_;
+    const query::TextPredicate *predicate_;
     text::FieldMaskPredicate field_mask_;
     bool require_positions_;
   };

--- a/testing/common.h
+++ b/testing/common.h
@@ -79,15 +79,15 @@ class MockIndex : public indexes::IndexBase {
  public:
   MockIndex() : indexes::IndexBase(indexes::IndexerType::kNone) {}
   MockIndex(indexes::IndexerType type) : indexes::IndexBase(type) {}
-  MOCK_METHOD(absl::StatusOr<bool>, AddRecord,
-              (const InternedStringPtr& key, absl::string_view data),
+  MOCK_METHOD(absl::StatusOr<bool>, AddRecordImpl,
+              (const InternedStringPtr &key, absl::string_view data),
               (override));
-  MOCK_METHOD(absl::StatusOr<bool>, RemoveRecord,
-              (const InternedStringPtr& key,
+  MOCK_METHOD(absl::StatusOr<bool>, RemoveRecordImpl,
+              (const InternedStringPtr &key,
                indexes::DeletionType deletion_type),
               (override));
-  MOCK_METHOD(absl::StatusOr<bool>, ModifyRecord,
-              (const InternedStringPtr& key, absl::string_view data),
+  MOCK_METHOD(absl::StatusOr<bool>, ModifyRecordImpl,
+              (const InternedStringPtr &key, absl::string_view data),
               (override));
   MOCK_METHOD(std::unique_ptr<data_model::Index>, ToProto, (),
               (const, override));
@@ -96,42 +96,42 @@ class MockIndex : public indexes::IndexBase {
               (const, override));
   MOCK_METHOD((size_t), GetTrackedKeyCount, (), (const, override));
   MOCK_METHOD((size_t), GetUnTrackedKeyCount, (), (const, override));
-  MOCK_METHOD(bool, IsTracked, (const InternedStringPtr& key),
+  MOCK_METHOD(bool, IsTracked, (const InternedStringPtr &key),
               (const, override));
-  MOCK_METHOD(bool, IsUnTracked, (const InternedStringPtr& key),
+  MOCK_METHOD(bool, IsUnTracked, (const InternedStringPtr &key),
               (const, override));
   MOCK_METHOD(
       (absl::Status), ForEachTrackedKey,
-      (absl::AnyInvocable<absl::Status(const InternedStringPtr& key)> fn),
+      (absl::AnyInvocable<absl::Status(const InternedStringPtr &key)> fn),
       (const, override));
   MOCK_METHOD(
       (absl::Status), ForEachUnTrackedKey,
-      (absl::AnyInvocable<absl::Status(const InternedStringPtr& key)> fn),
+      (absl::AnyInvocable<absl::Status(const InternedStringPtr &key)> fn),
       (const, override));
 };
 
 class MockKeyspaceEventSubscription : public KeyspaceEventSubscription {
  public:
-  MOCK_METHOD(AttributeDataType&, GetAttributeDataType, (), (override, const));
-  MOCK_METHOD(const std::vector<std::string>&, GetKeyPrefixes, (),
+  MOCK_METHOD(AttributeDataType &, GetAttributeDataType, (), (override, const));
+  MOCK_METHOD(const std::vector<std::string> &, GetKeyPrefixes, (),
               (override, const));
   MOCK_METHOD(void, OnKeyspaceNotification,
-              (ValkeyModuleCtx * ctx, int type, const char* event,
-               ValkeyModuleString* key),
+              (ValkeyModuleCtx * ctx, int type, const char *event,
+               ValkeyModuleString *key),
               (override));
 };
 
 class MockAttributeDataType : public AttributeDataType {
  public:
   MOCK_METHOD(absl::StatusOr<vmsdk::UniqueValkeyString>, GetRecord,
-              (ValkeyModuleCtx * ctx, ValkeyModuleKey* open_key,
+              (ValkeyModuleCtx * ctx, ValkeyModuleKey *open_key,
                absl::string_view key, absl::string_view identifier),
               (override, const));
   MOCK_METHOD(int, GetValkeyEventTypes, (), (override, const));
   MOCK_METHOD((absl::StatusOr<RecordsMap>), FetchAllRecords,
-              (ValkeyModuleCtx * ctx, const std::string& query_attribute_name,
-               ValkeyModuleKey* open_key, absl::string_view key,
-               const absl::flat_hash_set<absl::string_view>& identifiers),
+              (ValkeyModuleCtx * ctx, const std::string &query_attribute_name,
+               ValkeyModuleKey *open_key, absl::string_view key,
+               const absl::flat_hash_set<absl::string_view> &identifiers),
               (override, const));
   MOCK_METHOD((data_model::AttributeDataType), ToProto, (), (override, const));
   MOCK_METHOD((std::string), ToString, (), (override, const));
@@ -143,7 +143,7 @@ class FakeSafeRDB : public SafeRDB {
  public:
   FakeSafeRDB() = default;
   FakeSafeRDB(unsigned char dump_rdb[], size_t len) {
-    buffer_.write((const char*)dump_rdb, len);
+    buffer_.write((const char *)dump_rdb, len);
   }
   absl::StatusOr<size_t> LoadSizeT() override { return LoadPOD<size_t>(); }
   absl::StatusOr<unsigned int> LoadUnsigned() override {
@@ -192,14 +192,14 @@ class FakeSafeRDB : public SafeRDB {
   template <typename T>
   T LoadPOD() {
     T val;
-    buffer_.read((char*)&val, sizeof(T));
+    buffer_.read((char *)&val, sizeof(T));
     EXPECT_TRUE(buffer_);
     return val;
   }
 
   template <typename T>
   void SavePOD(const T val) {
-    buffer_.write((char*)&val, sizeof(T));
+    buffer_.write((char *)&val, sizeof(T));
     EXPECT_TRUE(buffer_);
   }
 };
@@ -214,7 +214,7 @@ data_model::VectorIndex CreateFlatVectorIndexProto(
 
 data_model::NumericIndex CreateNumericIndexProto();
 
-data_model::TagIndex CreateTagIndexProto(const std::string& separator = ",",
+data_model::TagIndex CreateTagIndexProto(const std::string &separator = ",",
                                          bool case_sensitive = false);
 
 data_model::TextIndex CreateTextIndexProto(bool with_suffix_trie, bool no_stem,
@@ -223,13 +223,13 @@ data_model::TextIndex CreateTextIndexProto(bool with_suffix_trie, bool no_stem,
 class MockIndexSchema : public IndexSchema {
  public:
   static absl::StatusOr<std::shared_ptr<MockIndexSchema>> Create(
-      ValkeyModuleCtx* ctx, absl::string_view key,
-      const std::vector<absl::string_view>& subscribed_key_prefixes,
+      ValkeyModuleCtx *ctx, absl::string_view key,
+      const std::vector<absl::string_view> &subscribed_key_prefixes,
       std::unique_ptr<AttributeDataType> attribute_data_type,
-      vmsdk::ThreadPool* mutations_thread_pool,
+      vmsdk::ThreadPool *mutations_thread_pool,
       data_model::Language language = data_model::Language::LANGUAGE_ENGLISH,
       std::string punctuation = ".", bool with_offsets = true,
-      const std::vector<std::string>& stop_words = {}) {
+      const std::vector<std::string> &stop_words = {}) {
     data_model::IndexSchema index_schema_proto;
     index_schema_proto.set_name(std::string(key));
     index_schema_proto.mutable_subscribed_key_prefixes()->Add(
@@ -246,21 +246,21 @@ class MockIndexSchema : public IndexSchema {
     VMSDK_RETURN_IF_ERROR(res->Init(ctx));
     return res;
   }
-  MockIndexSchema(ValkeyModuleCtx* ctx,
-                  const data_model::IndexSchema& index_schema_proto,
+  MockIndexSchema(ValkeyModuleCtx *ctx,
+                  const data_model::IndexSchema &index_schema_proto,
                   std::unique_ptr<AttributeDataType> attribute_data_type,
-                  vmsdk::ThreadPool* mutations_thread_pool, bool reload = false)
+                  vmsdk::ThreadPool *mutations_thread_pool, bool reload = false)
       : IndexSchema(ctx, index_schema_proto, std::move(attribute_data_type),
                     mutations_thread_pool, reload) {
     ON_CALL(*this, OnLoadingEnded(testing::_))
-        .WillByDefault([this](ValkeyModuleCtx* ctx) {
+        .WillByDefault([this](ValkeyModuleCtx *ctx) {
           return IndexSchema::OnLoadingEnded(ctx);
         });
     ON_CALL(*this, OnSwapDB(testing::_))
-        .WillByDefault([this](ValkeyModuleSwapDbInfo* swap_db_info) {
+        .WillByDefault([this](ValkeyModuleSwapDbInfo *swap_db_info) {
           return IndexSchema::OnSwapDB(swap_db_info);
         });
-    ON_CALL(*this, RDBSave(testing::_)).WillByDefault([this](SafeRDB* rdb) {
+    ON_CALL(*this, RDBSave(testing::_)).WillByDefault([this](SafeRDB *rdb) {
       return IndexSchema::RDBSave(rdb);
     });
     ON_CALL(*this, GetIdentifier(testing::_))
@@ -284,10 +284,10 @@ class TestableValkeySearch : public ValkeySearch {
                        std::optional<size_t> writers,
                        std::optional<size_t> utility);
 
-  vmsdk::ThreadPool* GetWriterThreadPool() const {
+  vmsdk::ThreadPool *GetWriterThreadPool() const {
     return writer_thread_pool_.get();
   }
-  vmsdk::ThreadPool* GetReaderThreadPool() const {
+  vmsdk::ThreadPool *GetReaderThreadPool() const {
     return reader_thread_pool_.get();
   }
 };
@@ -295,9 +295,9 @@ class TestableValkeySearch : public ValkeySearch {
 class TestableSchemaManager : public SchemaManager {
  public:
   TestableSchemaManager(
-      ValkeyModuleCtx* ctx,
+      ValkeyModuleCtx *ctx,
       absl::AnyInvocable<void()> server_events_callback = []() {},
-      vmsdk::ThreadPool* writer_thread_pool = nullptr,
+      vmsdk::ThreadPool *writer_thread_pool = nullptr,
       bool coordinator_enabled = false)
       : SchemaManager(ctx, std::move(server_events_callback),
                       writer_thread_pool, coordinator_enabled) {}
@@ -305,27 +305,27 @@ class TestableSchemaManager : public SchemaManager {
 
 class TestableMetadataManager : public coordinator::MetadataManager {
  public:
-  TestableMetadataManager(ValkeyModuleCtx* ctx,
-                          coordinator::ClientPool& client_pool)
+  TestableMetadataManager(ValkeyModuleCtx *ctx,
+                          coordinator::ClientPool &client_pool)
       : coordinator::MetadataManager(ctx, client_pool) {}
 };
 
 inline void InitThreadPools(std::optional<size_t> readers,
                             std::optional<size_t> writers,
                             std::optional<size_t> utility) {
-  ((TestableValkeySearch*)&ValkeySearch::Instance())
+  ((TestableValkeySearch *)&ValkeySearch::Instance())
       ->InitThreadPools(readers, writers, utility);
 }
 
 absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateIndexSchema(
-    std::string index_schema_key, ValkeyModuleCtx* fake_ctx = nullptr,
-    vmsdk::ThreadPool* writer_thread_pool = nullptr,
-    const std::vector<absl::string_view>* key_prefixes = nullptr,
+    std::string index_schema_key, ValkeyModuleCtx *fake_ctx = nullptr,
+    vmsdk::ThreadPool *writer_thread_pool = nullptr,
+    const std::vector<absl::string_view> *key_prefixes = nullptr,
     int32_t index_schema_db_num = 0);
 absl::StatusOr<std::shared_ptr<MockIndexSchema>> CreateVectorHNSWSchema(
-    std::string index_schema_key, ValkeyModuleCtx* fake_ctx = nullptr,
-    vmsdk::ThreadPool* writer_thread_pool = nullptr,
-    const std::vector<absl::string_view>* key_prefixes = nullptr,
+    std::string index_schema_key, ValkeyModuleCtx *fake_ctx = nullptr,
+    vmsdk::ThreadPool *writer_thread_pool = nullptr,
+    const std::vector<absl::string_view> *key_prefixes = nullptr,
     int32_t index_schema_db_num = 0);
 
 // TestableKeyspaceEventManager subclasses KeyspaceEventManager and makes it
@@ -337,7 +337,7 @@ class TestableKeyspaceEventManager : public KeyspaceEventManager {
 
 class MockThreadPool : public vmsdk::ThreadPool {
  public:
-  MockThreadPool(const std::string& name, size_t num_threads)
+  MockThreadPool(const std::string &name, size_t num_threads)
       : vmsdk::ThreadPool(name, num_threads) {
     ON_CALL(*this, Schedule(testing::_, testing::_))
         .WillByDefault(
@@ -363,7 +363,7 @@ class ValkeySearchTest : public vmsdk::ValkeyTest {
         &fake_ctx_, []() { server_events::SubscribeToServerEvents(); }, nullptr,
         false));
     ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
-        .WillByDefault([&](ValkeyModuleCtx* ctx) {
+        .WillByDefault([&](ValkeyModuleCtx *ctx) {
           return ctx == &registry_ctx_ ? ctx : nullptr;
         });
     VectorExternalizer::Instance().Init(&registry_ctx_);
@@ -383,28 +383,28 @@ struct TestReturnAttribute {
 };
 
 query::ReturnAttribute ToReturnAttribute(
-    const TestReturnAttribute& test_return_attribute);
+    const TestReturnAttribute &test_return_attribute);
 
-std::unordered_map<std::string, std::string> ToStringMap(const RecordsMap& map);
+std::unordered_map<std::string, std::string> ToStringMap(const RecordsMap &map);
 
 struct NeighborTest {
   std::string external_id;
   float distance;
   std::optional<std::unordered_map<std::string, std::string>>
       attribute_contents;
-  inline bool operator==(const NeighborTest& other) const {
+  inline bool operator==(const NeighborTest &other) const {
     return external_id == other.external_id && distance == other.distance &&
            attribute_contents == other.attribute_contents;
   }
 };
 
-indexes::Neighbor ToIndexesNeighbor(const NeighborTest& neighbor_test);
-NeighborTest ToNeighborTest(const indexes::Neighbor& neighbor_test);
+indexes::Neighbor ToIndexesNeighbor(const NeighborTest &neighbor_test);
+NeighborTest ToNeighborTest(const indexes::Neighbor &neighbor_test);
 
 template <typename T>
-std::vector<NeighborTest> ToVectorNeighborTest(const T& neighbors) {
+std::vector<NeighborTest> ToVectorNeighborTest(const T &neighbors) {
   std::vector<NeighborTest> neighbors_test(neighbors.size());
-  for (const auto& neighbor : neighbors) {
+  for (const auto &neighbor : neighbors) {
     neighbors_test.push_back(ToNeighborTest(neighbor));
   }
   return neighbors_test;
@@ -425,7 +425,7 @@ class ValkeySearchTestWithParam : public vmsdk::ValkeyTestWithParam<T> {
         &fake_ctx_, []() { server_events::SubscribeToServerEvents(); }, nullptr,
         false));
     ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
-        .WillByDefault([&](ValkeyModuleCtx* ctx) {
+        .WillByDefault([&](ValkeyModuleCtx *ctx) {
           return ctx == &registry_ctx_ ? ctx : nullptr;
         });
     VectorExternalizer::Instance().Init(&registry_ctx_);
@@ -446,20 +446,20 @@ struct RespReply {
   using RespArray = std::vector<RespReply>;
   std::variant<std::string, int64_t, RespArray> value;
 
-  static bool CompareArrays(const RespArray& array1, const RespArray& array2);
+  static bool CompareArrays(const RespArray &array1, const RespArray &array2);
 
   // Equality operator to compare two RespReply objects
-  bool operator==(const RespReply& other) const;
+  bool operator==(const RespReply &other) const;
 
   // Inequality operator
-  bool operator!=(const RespReply& other) const { return !(*this == other); }
+  bool operator!=(const RespReply &other) const { return !(*this == other); }
 };
 
 RespReply ParseRespReply(absl::string_view input);
-void WaitWorkerTasksAreCompleted(vmsdk::ThreadPool& mutations_thread_pool);
+void WaitWorkerTasksAreCompleted(vmsdk::ThreadPool &mutations_thread_pool);
 
-inline auto VectorToStr = [](const std::vector<float>& v) {
-  return absl::string_view((char*)v.data(), v.size() * sizeof(float));
+inline auto VectorToStr = [](const std::vector<float> &v) {
+  return absl::string_view((char *)v.data(), v.size() * sizeof(float));
 };
 
 }  // namespace valkey_search

--- a/testing/multi_exec_test.cc
+++ b/testing/multi_exec_test.cc
@@ -71,7 +71,7 @@ class MultiExecTest : public ValkeySearchTest {
           *value_out = value_valkey_str;
           return VALKEYMODULE_OK;
         });
-    EXPECT_CALL(*mock_index, AddRecord(testing::_, testing::_))
+    EXPECT_CALL(*mock_index, AddRecordImpl(testing::_, testing::_))
         .WillRepeatedly(
             [this](const InternedStringPtr &key, absl::string_view record) {
               absl::MutexLock lock(&mutex);


### PR DESCRIPTION
Introduce a template method pattern for index record operations by splitting the public AddRecord, RemoveRecord, and ModifyRecord methods into a public interface that calls Pre* hooks followed by the actual *Impl methods.

Update all index implementations (Text, Tag, Numeric, VectorBase) to rename their previous virtual methods from AddRecord/RemoveRecord/ModifyRecord to AddRecordImpl/RemoveRecordImpl/ModifyRecordImpl. Add default no-op implementations of PreAddRecord, PreRemoveRecord, and PreModifyRecord in the IndexBase class. Update all test mocks and test cases to reference the new *Impl method names.

The purpose of this change to introduce an accurate memory tracker for the various type of indexes.