### PR TITLE
Add test for Hash Field Expiration (HFE) compatibility

### DIFF
--- a/integration/test_expired.py
+++ b/integration/test_expired.py
@@ -33,3 +33,30 @@ class TestExpired(ValkeySearchTestCaseBase):
             num_of_docs / 2,
             timeout=5,
         )
+
+    def test_hash_field_expiration_should_update_index(self):
+        """
+        Test that HEXPIRE on indexed fields triggers keyspace notification
+        and updates the index correctly (Hash Field Expiration - HFE)
+        """
+        index_name = "my_index"
+        key_name = "test_key"
+        client: Valkey = self.server.get_new_client()
+        index = Index(index_name, [Tag("t"), Numeric("n")])
+
+        index.create(client)
+        client.hset(key_name, mapping={"t": "mytag", "n": "1"})
+        assert index.info(client).num_docs == 1
+
+        result = client.execute_command("FT.SEARCH", index_name, "@t:{mytag}")
+        assert result[0] == 1
+
+        # Expire the indexed tag field using HEXPIRE
+        client.execute_command("HEXPIRE", key_name, 1, "FIELDS", 1, "t")
+
+        waiters.wait_for_equal(
+            lambda: client.execute_command("FT.SEARCH", index_name, "@t:{mytag}")[0],
+            0,
+            timeout=5,
+        )
+        assert index.info(client).num_docs == 1


### PR DESCRIPTION
Adds test to verify that when hash fields expire via HEXPIRE, the expired field is correctly removed from the search index while the document remains indexed.