### PR TITLE
Fix concurrency groups for integration asan and unit mac os tests

### DIFF
--- a/.github/workflows/integration_tests-asan.yml
+++ b/.github/workflows/integration_tests-asan.yml
@@ -12,7 +12,7 @@ on:
   workflow_dispatch: # allow manual triggering
 
 concurrency:
-  group: integration-tests-${{ github.head_ref || github.ref }}
+  group: integration-tests-asan-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch: # allow manual triggering
 
 concurrency:
-  group: unittests-${{ github.head_ref || github.ref }}
+  group: unittests-macos-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
integration tests asan/ integration tests and unit tests / unit tests macos were under same concurrency group. sometimes causing one of them to not run sometimes or be blocked. This also blocked them from running parallely. causing long running workflows

This change should also help with this https://github.com/valkey-io/valkey-search/issues/650