### PR TITLE
Stem search terms regardless of stemsize - Bug fix

### DIFF
--- a/integration/test_fulltext.py
+++ b/integration/test_fulltext.py
@@ -663,12 +663,68 @@ class TestFullText(ValkeySearchTestCaseDebugMode):
         assert result[0] == 1, f"Expected 1 result for 'happi', got {result[0]}"
         assert set(result[1::2]) == {b"product:3"}, f"Expected {{product:3}}, got {set(result[1::2])}"
         
-        # Searching for "happy" should match both product:4 and product:5 (exact match)
+        # Searching for "happy" matches product:3 (happiness stems to happi), product:4 and product:5 (exact match)
         result = client.execute_command("FT.SEARCH", "testindex2", "happy", "DIALECT", "2")
-        assert result[0] == 2, f"Expected 2 results for 'happy', got {result[0]}"
-        assert set(result[1::2]) == {b"product:4", b"product:5"}, f"Expected {{product:4, product:5}}, got {set(result[1::2])}"
+        assert result[0] == 3, f"Expected 3 results for 'happy', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:4", b"product:5"}, f"Expected {{product:3, product:4, product:5}}, got {set(result[1::2])}"
         
-        # Test 13: NOSTEM fields with stem expansion from other fields
+        # Test 13: Stem variants with words under min stem size (3 letters)
+        # Words like "cry", "cri", "cries" test stem behavior for short words
+        client.execute_command("FT.CREATE", "testindex3", "ON", "HASH", "PREFIX", "1", "product:", "SCHEMA", "title", "TEXT")
+        
+        client.execute_command("HSET", "product:3", "title", "cri")
+        client.execute_command("HSET", "product:4", "title", "cry")
+        
+        IndexingTestHelper.wait_for_backfill_complete_on_node(client, "testindex3")
+        
+        # "cri" should only match exact "cri" (3 letters, at min stem threshold)
+        result = client.execute_command("FT.SEARCH", "testindex3", "cri", "DIALECT", "2")
+        assert result[0] == 1, f"Expected 1 result for 'cri', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3"}
+        
+        # "cry" should match both "cry" and "cri" (they stem to same root)
+        result = client.execute_command("FT.SEARCH", "testindex3", "cry", "DIALECT", "2")
+        assert result[0] == 2, f"Expected 2 results for 'cry', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:4"}
+        
+        # Now add "cries"
+        client.execute_command("HSET", "product:5", "title", "cries")
+        IndexingTestHelper.wait_for_backfill_complete_on_node(client, "testindex3")
+        
+        # "cries" should match "cries" and "cri" (they share stem)
+        result = client.execute_command("FT.SEARCH", "testindex3", "cries", "DIALECT", "2")
+        assert result[0] == 2, f"Expected 2 results for 'cries', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:5"}
+        
+        # "cry" should now match all three: "cry", "cri", and "cries"
+        result = client.execute_command("FT.SEARCH", "testindex3", "cry", "DIALECT", "2")
+        assert result[0] == 3, f"Expected 3 results for 'cry', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:4", b"product:5"}
+        
+        # "cri" should match "cri" and "cries" (updated from single match)
+        result = client.execute_command("FT.SEARCH", "testindex3", "cri", "DIALECT", "2")
+        assert result[0] == 2, f"Expected 2 results for 'cri' after adding cries, got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:5"}
+        
+        # Test 14: Two-letter words below min stem size
+        client.execute_command("FT.CREATE", "testindex4", "ON", "HASH", "PREFIX", "1", "product:", "SCHEMA", "title", "TEXT")
+        
+        client.execute_command("HSET", "product:3", "title", "ai")
+        client.execute_command("HSET", "product:4", "title", "ais")
+        
+        IndexingTestHelper.wait_for_backfill_complete_on_node(client, "testindex4")
+        
+        # "ai" (2 letters, below min stem size of 3) should only match exact "ai"
+        result = client.execute_command("FT.SEARCH", "testindex4", "ai", "DIALECT", "2")
+        assert result[0] == 1, f"Expected 1 result for 'ai', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3"}
+        
+        # "ais" (3 letters, at min stem size) should match both "ais" and "ai"
+        result = client.execute_command("FT.SEARCH", "testindex4", "ais", "DIALECT", "2")
+        assert result[0] == 2, f"Expected 2 results for 'ais', got {result[0]}"
+        assert set(result[1::2]) == {b"product:3", b"product:4"}
+        
+        # Test 15: NOSTEM fields with stem expansion from other fields
         client.execute_command("FT.CREATE", "testindex_nostem", "ON", "HASH", "PREFIX", "1", "product:", "SCHEMA", "title", "TEXT", "NOSTEM", "desc", "TEXT", "NOSTEM")
         
         client.execute_command("HSET", "product:3", "title", "abc", "desc", "happiness")
@@ -2246,4 +2302,3 @@ class TestFullTextCluster(ValkeySearchClusterTestCaseDebugMode):
                     f"Shard {i}: Both metrics must increment together by 1, got text={text_delta}, nonvector={nonvector_delta}"
                 shards_incremented += 1
         assert shards_incremented == 1, f"Expected exactly 1 shard to increment, got {shards_incremented}"
-        

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -159,8 +159,7 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
                         indexes::text::kStemVariantsInlineCapacity>
         stem_variants;
     std::string stemmed = GetTextIndexSchema()->GetAllStemVariants(
-        text_string, stem_variants, GetTextIndexSchema()->GetMinStemSize(),
-        stem_field_mask, false);
+        text_string, stem_variants, stem_field_mask, false);
     // Search for the stemmed word itself - may or may not exist in corpus
     if (stemmed != text_string) {
       TryAddWordKeyIterator(fetcher->text_index_.get(), stemmed, key_iterators);

--- a/src/indexes/text/lexer.cc
+++ b/src/indexes/text/lexer.cc
@@ -144,7 +144,7 @@ absl::StatusOr<std::vector<std::string>> Lexer::Tokenize(
       }
 
       if (stemming_enabled) {
-        std::string stemmed_word = StemWord(word, min_stem_size, stemmer);
+        std::string stemmed_word = StemWord(word, stemmer, min_stem_size);
         if (word != stemmed_word) {
           CHECK(stem_mappings) << "stem_mappings must not be null";
           (*stem_mappings)[stemmed_word].insert(word);
@@ -170,8 +170,8 @@ sb_stemmer* Lexer::GetStemmer() const {
   return it->second.get();
 }
 
-std::string Lexer::StemWord(const std::string& word, uint32_t min_stem_size,
-                            sb_stemmer* stemmer) const {
+std::string Lexer::StemWord(const std::string& word, sb_stemmer* stemmer,
+                            uint32_t min_stem_size) const {
   if (word.empty() || word.length() < min_stem_size) {
     return word;
   }

--- a/src/indexes/text/lexer.h
+++ b/src/indexes/text/lexer.h
@@ -47,8 +47,8 @@ struct Lexer {
       absl::flat_hash_map<std::string, absl::flat_hash_set<std::string>>*
           stem_mappings = nullptr) const;
 
-  std::string StemWord(const std::string& word, uint32_t min_stem_size,
-                       sb_stemmer* stemmer) const;
+  std::string StemWord(const std::string& word, sb_stemmer* stemmer,
+                       uint32_t min_stem_size = 0) const;
   bool IsPunctuation(char c) const {
     return punct_bitmap_[static_cast<unsigned char>(c)];
   }

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -347,8 +347,8 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
     // If the postings are now empty, remove from stem tree if it was a parent
     if (!updated_target && stem_text_field_mask_) {
       // Check if this word has a stem mapping using schema-level minimum
-      std::string stemmed = lexer_.StemWord(std::string(word), min_stem_size_,
-                                            lexer_.GetStemmer());
+      std::string stemmed = lexer_.StemWord(
+          std::string(word), lexer_.GetStemmer(), min_stem_size_);
       if (stemmed != word) {
         // This word was a stem parent, remove it from stem tree
         std::lock_guard<std::mutex> stem_guard(stem_tree_mutex_);
@@ -412,10 +412,10 @@ std::string TextIndexSchema::GetAllStemVariants(
     absl::string_view search_term,
     absl::InlinedVector<absl::string_view, kStemVariantsInlineCapacity>
         &words_to_search,
-    uint32_t min_stem_size, uint64_t stem_enabled_mask, bool lock_needed) {
-  // Stem the search term with the provided min_stem_size
-  std::string stemmed = lexer_.StemWord(std::string(search_term), min_stem_size,
-                                        lexer_.GetStemmer());
+    uint64_t stem_enabled_mask, bool lock_needed) {
+  // Stem the search term
+  std::string stemmed =
+      lexer_.StemWord(std::string(search_term), lexer_.GetStemmer());
 
   // Conditionally acquire lock - use unique_lock with defer_lock for
   // conditional locking

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -105,7 +105,7 @@ class TextIndexSchema {
       absl::string_view search_term,
       absl::InlinedVector<absl::string_view, kStemVariantsInlineCapacity>
           &words_to_search,
-      uint32_t min_stem_size, uint64_t stem_enabled_mask, bool lock_needed);
+      uint64_t stem_enabled_mask, bool lock_needed);
 
   // Get the minimum stem size across all fields
   uint32_t GetMinStemSize() const { return min_stem_size_; }

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -112,8 +112,7 @@ EvaluationResult TermPredicate::Evaluate(
                         indexes::text::kStemVariantsInlineCapacity>
         stem_variants;
     std::string stemmed = text_index_schema_->GetAllStemVariants(
-        term_, stem_variants, text_index_schema_->GetMinStemSize(),
-        stem_field_mask, true);
+        term_, stem_variants, stem_field_mask, true);
     // Search for the stemmed word itself - may or may not exist in corpus
     if (stemmed != term_) {
       if (TryAddWordKeyIteratorForPrefilter(text_index, stemmed, target_key,


### PR DESCRIPTION
Small functionality fix in Stemming. After some research on how we should handle smaller words . Examples below. Earlier i was going to add it with the Composite query followup PR but this should get before RC1.

Earlier for words less than minstemsize we didn't use to stem them during search. But we missed that this word could have other stem variants which have length greater than minstemsize. So now we stem the search term we get its stem root and get all the stem variants in the which would have stemmed to that stem root.

---------
On ingestion (Unchanged in this PR)

```
if word > minstemsize: 
   we add it to stem tree
else :
   don't add  it to stem tree
```

--------

On search (before this PR)

```
for all search_terms:
   if search_term > minstemsize : 
       stem them and get the stem root and get all stem variants
```

 
On search (after this PR)

```
for all search_terms:
   stem them and get the stem root and get all stem variants
```




-----------
```
127.0.0.1:6379>  HSET product:4 title "cry"
(integer) 0
127.0.0.1:6379>  HSET product:3 title "cri"
(integer) 0
127.0.0.1:6379> FT.SEARCH testindex cri dialect 2
1) (integer) 1
2) "product:3"
3) 1) "title"
   2) "cri"
127.0.0.1:6379> FT.SEARCH testindex cry dialect 2
1) (integer) 2
2) "product:4"
3) 1) "title"
   2) "cry"
4) "product:3"
5) 1) "title"
   2) "cri"
127.0.0.1:6379> FT.SEARCH testindex cries dialect 2
1) (integer) 1
2) "product:3"
3) 1) "title"
127.0.0.1:6379> HSET product:5 title "cries"
(integer) 1
127.0.0.1:6379> FT.SEARCH testindex cries dialect 2
1) (integer) 2
2) "product:5"
3) 1) "title"
   2) "cries"
4) "product:3"
5) 1) "title"
   2) "cri"
127.0.0.1:6379> FT.SEARCH testindex cry dialect 2
1) (integer) 3
2) "product:5"
3) 1) "title"
   2) "cries"
4) "product:4"
5) 1) "title"
   2) "cry"
6) "product:3"
7) 1) "title"
   2) "cri"
127.0.0.1:6379> FT.SEARCH testindex cri dialect 2
1) (integer) 2
2) "product:5"
3) 1) "title"
   2) "cries"
4) "product:3"
5) 1) "title"
   2) "cri"


127.0.0.1:6379>  HSET product:4 title "ais"
(integer) 0
127.0.0.1:6379>  HSET product:3 title "ai"
(integer) 0
127.0.0.1:6379> FT.SEARCH testindex ai dialect 2
1) (integer) 1
2) "product:3"
3) 1) "title"
   2) "ai"
127.0.0.1:6379> FT.SEARCH testindex ais dialect 2
1) (integer) 2
2) "product:4"
3) 1) "title"
   2) "ais"
4) "product:3"
5) 1) "title"
   2) "ai"
```