### PR TITLE
Test Configs

### DIFF
--- a/integration/test_configs.py
+++ b/integration/test_configs.py
@@ -1,0 +1,201 @@
+import random
+import pytest
+from valkey_search_test_case import (
+    ValkeySearchTestCaseBase, ValkeySearchClusterTestCase,
+    ValkeySearchTestCaseDebugMode, ValkeySearchClusterTestCaseDebugMode
+)
+from valkey.exceptions import ResponseError
+from valkeytestframework.conftest import resource_port_tracker
+
+# Module-level cache, populated by TestDiscoverConfigs.
+_discovered_configs = {}
+
+CONFIG_RANGES = {
+    "high-priority-weight": (0, 100),
+    "fuzzy-max-distance": (1, 50),
+    "max-prefixes": (1, 16),
+    "max-numeric-field-length": (1, 256),
+    "max-vector-attributes": (1, 100),
+    "max-indexes": (1, 10),
+    "reader-threads": (1, 1024),
+    "writer-threads": (1, 1024),
+    "utility-threads": (1, 1024),
+    "max-worker-suspension-secs": (0, 3600),
+    "max-vector-ef-construction": (1, 4096),
+    "coordinator-query-timeout-secs": (1, 3600),
+    "max-vector-ef-runtime": (1, 4096),
+    "max-search-result-fields-count": (1, 1000),
+    "local-fanout-queue-wait-threshold": (1, 10000),
+    "thread-pool-wait-time-samples": (10, 10000),
+    "max-search-result-record-size": (100, 10485760),
+    "search-result-buffer-multiplier": (1.0, 1000.0),
+    "query-string-terms-count": (1, 10000)
+}
+
+
+def parse_verbose_configs(response):
+    """Parse the VERBOSE response from FT._DEBUG LIST_CONFIGS into [(name, type)] tuples."""
+    configs = []
+    for entry in response:
+        it = iter(entry)
+        fields = {}
+        for key in it:
+            val = next(it)
+            if isinstance(key, bytes):
+                key = key.decode()
+            if isinstance(val, bytes):
+                val = val.decode()
+            fields[key] = val
+        configs.append((fields["name"], fields["type"]))
+    return configs
+
+
+def get_new_value(current_value, config_type, config_name=None):
+    """Generate a new value based on config type."""
+    if config_type == "Boolean":
+        return "no" if current_value in (b"yes", "yes", b"true", "true", b"1", "1") else "yes"
+    if config_type == "Number":
+        if config_name in CONFIG_RANGES:
+            return str(random.randint(*CONFIG_RANGES[config_name]))
+        return str(random.randint(1, 10240))
+    if config_type == "Enum":
+        return random.choice(["WARNING", "NOTICE", "DEBUG"])
+    if config_type == "String":
+        match config_name:
+            case "search-result-buffer-multiplier":
+                low, high = CONFIG_RANGES[config_name]
+                return str(round(random.uniform(low, high), 2))
+            case _:
+                assert False, f"Unknown config name {config_name}"
+    return str(random.randint(1, 100))
+
+
+class TestDiscoverConfigs(ValkeySearchTestCaseDebugMode):
+    """Must be the first test class in this file.
+    Discovers all configs via FT._DEBUG LIST_CONFIGS and caches them at module level."""
+
+    def test_discover_configs(self):
+        global _discovered_configs
+        for visibility in ("APP", "DEV", "HIDDEN"):
+            response = self.client.execute_command(
+                "FT._DEBUG", "LIST_CONFIGS", "VERBOSE", visibility
+            )
+            _discovered_configs[visibility] = parse_verbose_configs(response)
+        assert _discovered_configs["APP"], "No APP configs discovered"
+        assert _discovered_configs["DEV"], "No DEV configs discovered"
+        assert _discovered_configs["HIDDEN"], "No HIDDEN configs discovered"
+
+
+class ConfigTestMixin:
+    """Mixin providing common config test methods."""
+
+    def get_client(self):
+        return self.client
+
+    def get_configs(self, visibility):
+        """Get configs from the discovered config cache."""
+        if not _discovered_configs:
+            pytest.skip("TestDiscoverConfigs must run first — run the full test file")
+        return _discovered_configs[visibility]
+
+    def assert_config_get_set(self, configs):
+        """Test that configs can be read and written."""
+        client = self.get_client()
+        get_failures, set_failures = [], []
+
+        for name, config_type in configs:
+            full_name = f"search.{name}"
+            try:
+                result = client.execute_command("CONFIG", "GET", full_name)
+                if not result or len(result) < 2:
+                    get_failures.append((name, "empty result"))
+                    continue
+                current_value = result[1]
+            except Exception as e:
+                get_failures.append((name, str(e)))
+                continue
+
+            new_value = get_new_value(current_value, config_type, name)
+            try:
+                client.execute_command("CONFIG", "SET", full_name, new_value)
+            except Exception as e:
+                set_failures.append((name, str(e)))
+
+        assert not get_failures, f"CONFIG GET failures: {get_failures}"
+        assert not set_failures, f"CONFIG SET failures: {set_failures}"
+
+    def assert_config_readable_not_writable(self, configs):
+        """Test that configs can be read but not written."""
+        client = self.get_client()
+        for name, config_type in configs:
+            full_name = f"search.{name}"
+            result = client.execute_command("CONFIG", "GET", full_name)
+            assert result and len(result) >= 2, f"{name} should be readable"
+            current_config_value = result[1]
+            if config_type == "Boolean":
+                test_value = "no" if current_config_value in (b"yes", "yes", b"true", "true", b"1", "1") else "yes"
+            else:
+                test_value = "1"
+            set_failed = False
+            try:
+                client.execute_command("CONFIG", "SET", full_name, test_value)
+            except ResponseError:
+                set_failed = True
+            assert set_failed, f"{name} should not be writable"
+
+    def assert_config_not_accessible(self, configs):
+        """Test that configs cannot be read or written."""
+        client = self.get_client()
+        for name, config_type in configs:
+            full_name = f"search.{name}"
+            result = client.execute_command("CONFIG", "GET", full_name)
+            assert result == [] or len(result) == 0, f"{name} should not be readable"
+            set_failed = False
+            try:
+                client.execute_command("CONFIG", "SET", full_name, "yes")
+            except ResponseError:
+                set_failed = True
+            assert set_failed, f"{name} should not be writable"
+
+
+class TestAPPConfigsStandalone(ConfigTestMixin, ValkeySearchTestCaseBase):
+    def test_app_configs_get_set(self):
+        self.assert_config_get_set(self.get_configs("APP"))
+        self.assert_config_readable_not_writable(self.get_configs("DEV"))
+        self.assert_config_not_accessible(self.get_configs("HIDDEN"))
+
+
+class TestAPPConfigsCluster(ConfigTestMixin, ValkeySearchClusterTestCase):
+    def get_client(self):
+        return self.client_for_primary(0)
+
+    def test_app_configs_get_set(self):
+        self.assert_config_get_set(self.get_configs("APP"))
+        self.assert_config_readable_not_writable(self.get_configs("DEV"))
+        self.assert_config_not_accessible(self.get_configs("HIDDEN"))
+
+
+class TestDevConfigsStandalone(ConfigTestMixin, ValkeySearchTestCaseDebugMode):
+    def test_dev_configs_get_set(self):
+        self.assert_config_get_set(self.get_configs("DEV"))
+
+
+class TestDevConfigsCluster(ConfigTestMixin, ValkeySearchClusterTestCaseDebugMode):
+    def get_client(self):
+        return self.client_for_primary(0)
+
+    def test_dev_configs_get_set(self):
+        self.assert_config_get_set(self.get_configs("DEV"))
+
+
+class TestHiddenConfigsStandalone(ConfigTestMixin, ValkeySearchTestCaseDebugMode):
+    def test_hidden_configs_not_accessible(self):
+        self.assert_config_not_accessible(self.get_configs("HIDDEN"))
+
+
+class TestHiddenConfigsCluster(ConfigTestMixin, ValkeySearchClusterTestCaseDebugMode):
+    def get_client(self):
+        return self.client_for_primary(0)
+
+    def test_hidden_configs_not_accessible(self):
+        self.assert_config_not_accessible(self.get_configs("HIDDEN"))

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -43,7 +43,7 @@ constexpr absl::string_view kMaxSearchResultRecordSizeConfig{
 constexpr int kMaxSearchResultRecordSize{10 * 1024 * 1024};  // 10MB
 constexpr int kMinSearchResultRecordSize{100};
 constexpr absl::string_view kMaxSearchResultFieldsCountConfig{
-    "max-search-result-record-size"};
+    "max-search-result-fields-count"};
 constexpr int kMaxSearchResultFieldsCount{1000};
 
 /// Register the "--max-search-result-record-size" flag. Controls the max

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -98,7 +98,9 @@ ModuleConfigManager &ModuleConfigManager::Instance() {
 }
 
 void ModuleConfigManager::RegisterConfig(Registerable *config_item) {
-  entries_.insert({std::string{config_item->GetName()}, config_item});
+  auto [it, inserted] =
+      entries_.insert({std::string{config_item->GetName()}, config_item});
+  CHECK(inserted) << "Duplicate config entry: " << config_item->GetName();
 }
 
 void ModuleConfigManager::UnregisterConfig(Registerable *config_item) {


### PR DESCRIPTION
old pr https://github.com/valkey-io/valkey-search/pull/713
issue https://github.com/valkey-io/valkey-search/issues/689
1. Created a test for configs, using FT._DEBUG LIST_CONFIGS to get all configs in runtime
2. Fixed a bug of spelling error in config name
3. Added duplicate name check for configs