### PR TITLE
Use consistent + performant casefolding logic in both query/ingestion

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -27,6 +27,7 @@
 #include "src/indexes/numeric.h"
 #include "src/indexes/tag.h"
 #include "src/indexes/text.h"
+#include "src/indexes/text/lexer.h"
 #include "src/query/predicate.h"
 #include "src/valkey_search_options.h"
 #include "vmsdk/src/status/status_macros.h"
@@ -603,7 +604,7 @@ absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseQuotedTextToken(
   if (processed_content.empty()) {
     return FilterParser::TokenResult{nullptr, false};
   }
-  std::string token = absl::AsciiStrToLower(processed_content);
+  std::string token = lexer.NormalizeLowerCase(processed_content);
   FieldMaskPredicate field_mask;
   VMSDK_RETURN_IF_ERROR(
       SetupTextFieldConfiguration(field_mask, field_or_default, false));
@@ -702,7 +703,7 @@ absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseUnquotedTextToken(
     processed_content.push_back(ch);
     ++pos_;
   }
-  std::string token = absl::AsciiStrToLower(processed_content);
+  std::string token = lexer.NormalizeLowerCase(processed_content);
   FieldMaskPredicate field_mask;
   // Build predicate directly based on detected pattern
   if (leading_percent_count > 0) {

--- a/src/indexes/text/lexer.cc
+++ b/src/indexes/text/lexer.cc
@@ -137,7 +137,7 @@ absl::StatusOr<std::vector<std::string>> Lexer::Tokenize(
     }
 
     if (!word_buffer.empty()) {
-      std::string word = UnicodeNormalizer::CaseFold(word_buffer);
+      std::string word = NormalizeLowerCase(word_buffer);
 
       if (IsStopWord(word)) {
         continue;  // Skip stop words
@@ -205,5 +205,11 @@ bool Lexer::IsValidUtf8(absl::string_view text) const {
   // If any invalid UTF-8 sequences were encountered, text is invalid
   return scanner.GetInvalidUtf8Count() == 0 &&
          scanner.GetPosition() == text.size();
+}
+
+std::string Lexer::NormalizeLowerCase(absl::string_view str) const {
+  return absl::c_all_of(str, absl::ascii_isascii)
+             ? absl::AsciiStrToLower(str)
+             : UnicodeNormalizer::CaseFold(str);
 }
 }  // namespace valkey_search::indexes::text

--- a/src/indexes/text/lexer.h
+++ b/src/indexes/text/lexer.h
@@ -57,6 +57,7 @@ struct Lexer {
     return stop_words_set_.contains(lowercase_word);
   }
   sb_stemmer* GetStemmer() const;
+  std::string NormalizeLowerCase(absl::string_view str) const;
 
  private:
   data_model::Language language_;


### PR DESCRIPTION
Use consistent + performant casefolding logic in both query/ingestion.


The PR fixes two things:
1. We were only using ICU Unicode based Case folding normalization (`UnicodeNormalizer::CaseFold`) in ingestion and this was not done in query/search paths. This PR fixes that. Without this, we can have missed search results.
2. We were always using ICU Unicode based Case folding normalization (`UnicodeNormalizer::CaseFold`) even when we did not have to (when the string is pure ASCII). This PR fixes that by using a performant function (`Lexer::NormalizeLowerCase`) which checks whether it needs to use ICU Unicode based Case (if it contains ASCII characters) and otherwise uses a performant `absl::AsciiStrToLower` call for case folding.

From our perf tests (end to end workloads), we saw a decent amount of CPU time on ingestion spent on ICU's `UnicodeNormalizer::CaseFold`. Micro benchmarking (see below) also shows the same. This PR addresses that by using a wrapper function that detects when it needs to use it.


Microbenchmarking perf tests:

```
====================
PERFORMANCE SUMMARY
====================

len=5:
  absl::AsciiStrToLower:       10.16 ns
  Lexer::NormalizeLowerCase:    14.63 ns  (1.44x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             136.29 ns  (9.31x slower)

len=10:
  absl::AsciiStrToLower:       15.03 ns
  Lexer::NormalizeLowerCase:    19.98 ns  (1.33x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             166.95 ns  (8.35x slower)

len=16:
  absl::AsciiStrToLower:       26.69 ns
  Lexer::NormalizeLowerCase:    33.66 ns  (1.26x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             228.81 ns  (6.80x slower)

len=26:
  absl::AsciiStrToLower:       36.49 ns
  Lexer::NormalizeLowerCase:    46.99 ns  (1.29x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             292.44 ns  (6.22x slower)

len=34:
  absl::AsciiStrToLower:       29.52 ns
  Lexer::NormalizeLowerCase:    42.08 ns  (1.43x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             352.45 ns  (8.38x slower)

len=37:
  absl::AsciiStrToLower:       32.18 ns
  Lexer::NormalizeLowerCase:    46.08 ns  (1.43x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             369.44 ns  (8.02x slower)

len=39:
  absl::AsciiStrToLower:       34.22 ns
  Lexer::NormalizeLowerCase:    48.32 ns  (1.41x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             375.07 ns  (7.76x slower)

len=70:
  absl::AsciiStrToLower:       35.92 ns
  Lexer::NormalizeLowerCase:    57.28 ns  (1.59x vs ASCII)
  ICU UnicodeNormalizer::CaseFold:             1121.31 ns  (19.58x slower)
```