### PR TITLE
Bug: Fix out of bound access in pagination with LIMIT offset

### DIFF
--- a/src/commands/ft_search.cc
+++ b/src/commands/ft_search.cc
@@ -76,8 +76,10 @@ void ReplyAvailNeighbors(RedisModuleCtx *ctx,
 
 size_t CalcEndIndex(const std::deque<indexes::Neighbor> &neighbors,
                     const query::VectorSearchParameters &parameters) {
-  return std::min(static_cast<size_t>(parameters.k),
-                  std::min(parameters.limit.number, neighbors.size()));
+  size_t offset = std::min(parameters.limit.first_index, neighbors.size());
+  size_t remaining_neighbors = neighbors.size() - offset;
+  size_t remaining_k = static_cast<size_t>(parameters.k) - offset;
+  return std::min({remaining_k, parameters.limit.number, remaining_neighbors});
 }
 
 size_t CalcStartIndex(const std::deque<indexes::Neighbor> &neighbors,

--- a/testing/ft_search_test.cc
+++ b/testing/ft_search_test.cc
@@ -441,6 +441,29 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_output_no_content =
                 "*3\r\n:2\r\n$3\r\nabc\r\n$3\r\ndef\r\n",
         },
+        {
+            .test_name = "pagination_offset_exceeds_remaining",
+            .input =
+                {
+                    .neighbors =
+                        {{.external_id = "ext_1", .distance = 0.00999999977648},
+                         {.external_id = "ext_2", .distance = 0.019999999553},
+                         {.external_id = "ext_3", .distance = 0.0299999993294}},
+                    .attribute_alias = "attribute_alias_1",
+                    .score_as = "score_as_1",
+                    .limit = {.first_index = 1, .number = 5},
+                },
+            .expected_output =
+                "*5\r\n:3\r\n$5\r\next_2\r\n*6\r\n$10\r\nscore_as_1\r\n$"
+                "14\r\n0.019999999553\r\n$17\r\nattribute_alias_1\r\n$"
+                "28\r\nattribute_alias_1_hash_value\r\n$6\r\nfield1\r\n$"
+                "6\r\nvalue1\r\n$5\r\next_3\r\n*6\r\n$10\r\nscore_as_1\r\n$"
+                "15\r\n0.0299999993294\r\n$17\r\nattribute_alias_1\r\n$"
+                "28\r\nattribute_alias_1_hash_value\r\n$6\r\nfield1\r\n$"
+                "6\r\nvalue1\r\n",
+            .expected_output_no_content =
+                "*3\r\n:3\r\n$5\r\next_2\r\n$5\r\next_3\r\n",
+        },
     }),
     [](const TestParamInfo<SendReplyTestCase> &info) {
       return info.param.test_name;


### PR DESCRIPTION
### In 1.0 version
`CalcEndIndex` function did not account for the pagination offset when calculating the number of results to return. This caused `end_index` to exceed `neighbors.size()` when using LIMIT with a non-zero offset, leading to out-of-bounds array access and the server crashes.

```
127.0.0.1:6379> FT.CREATE idx ON HASH PREFIX 1 d: SCHEMA v VECTOR HNSW 6 TYPE FLOAT32 DIM 4 DISTANCE_METRIC COSINE
OK
127.0.0.1:6379> HSET d:0 v "\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
(integer) 1
127.0.0.1:6379> HSET d:1 v "\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00"
(integer) 1
127.0.0.1:6379> HSET d:2 v "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80\x3f\x00\x00\x00\x00"
(integer) 1
127.0.0.1:6379> FT.SEARCH idx "*=>[KNN 3 @v $q AS s]" PARAMS 2 q "\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" LIMIT 1 5 DIALECT 2
Error: Server closed the connection
(1.89s)
not connected> exit
```
#### With the fix:
```
127.0.0.1:6379> FT.SEARCH idx "*=>[KNN 3 @v $q AS s]" PARAMS 2 q "\x00\x00\x80\x3f\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00" LIMIT 1 5 DIALECT 2
1) (integer) 3
2) "d:1"
3) 1) "s"
   2) "1"
   3) "v"
   4) "\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00\x00\x00\x00\x00"
4) "d:2"
5) 1) "s"
   2) "1"
   3) "v"
   4) "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x80?\x00\x00\x00\x00"
   ```

#### Crash logs

```
dev-dsk-baswanth-2a-f7a52999 % 6228:M 13 Feb 2026 01:04:51.172 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
6228:M 13 Feb 2026 01:04:51.172 * oO0OoO0OoO0Oo Valkey is starting oO0OoO0OoO0Oo
6228:M 13 Feb 2026 01:04:51.172 * Valkey version=255.255.255, bits=64, commit=cd6faaa7, modified=0, pid=6228, just started
6228:M 13 Feb 2026 01:04:51.172 * Configuration loaded
6228:M 13 Feb 2026 01:04:51.172 * monotonic clock: POSIX clock_gettime
                .+^+.                                                
            .+#########+.                                            
        .+########+########+.           Valkey 255.255.255 (cd6faaa7/0) 64 bit
    .+########+'     '+########+.                                    
 .########+'     .+.     '+########.    Running in standalone mode
 |####+'     .+#######+.     '+####|    Port: 6379
 |###|   .+###############+.   |###|    PID: 6228                     
 |###|   |#####*'' ''*#####|   |###|                                 
 |###|   |####'  .-.  '####|   |###|                                 
 |###|   |###(  (@@@)  )###|   |###|          https://valkey.io      
 |###|   |####.  '-'  .####|   |###|                                 
 |###|   |#####*.   .*#####|   |###|                                 
 |###|   '+#####|   |#####+'   |###|                                 
 |####+.     +##|   |#+'     .+####|                                 
 '#######+   |##|        .+########'                                 
    '+###|   |##|    .+########+'                                    
        '|   |####+########+'                                        
             +#########+'                                            
                '+v+'                                                

6228:M 13 Feb 2026 01:04:51.206 * Legacy Redis Module /home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so found
6228:M 13 Feb 2026 01:04:51.209 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/valkey_search.cc:466: use_coordinator: false, IsCluster: false
6228:M 13 Feb 2026 01:04:51.209 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/valkey_search.cc:470: Reader workers count: 24
6228:M 13 Feb 2026 01:04:51.209 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/valkey_search.cc:472: Writer workers count: 24
6228:M 13 Feb 2026 01:04:51.209 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/valkey_search.cc:543: Json module is not loaded!
6228:M 13 Feb 2026 01:04:51.209 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/vmsdk/src/module.cc:129: search module was successfully loaded!
6228:M 13 Feb 2026 01:04:51.209 * Module 'search' loaded from /home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so
6228:M 13 Feb 2026 01:04:51.209 * Server initialized
6228:M 13 Feb 2026 01:04:51.209 * Ready to accept connections tcp
6228:M 13 Feb 2026 01:04:59.046 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/index_schema.cc:88: Starting backfill for index schema in DB 0: idx
6228:M 13 Feb 2026 01:04:59.055 # <search> [notice], tid: 140586273526272, /workplace/baswanth/valkey-search-1.0-repro/src/index_schema.cc:632: Index schema idx finished backfill. Scanned 0 keys in 9.222234ms


=== VALKEY BUG REPORT START: Cut & paste starting from here ===
6228:M 13 Feb 2026 01:06:00.332 # valkey 255.255.255 crashed by signal: 11, si_code: 1
6228:M 13 Feb 2026 01:06:00.332 # Accessing address: 0x8
6228:M 13 Feb 2026 01:06:00.332 # Crashed running the instruction at: 0x7fdcc17c1915

------ STACK TRACE ------
EIP:
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x1d9915)[0x7fdcc17c1915]

6241 read-worker-12
/lib64/libc.so.6(syscall+0x19)[0x7fdcca0112a9]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x4cfafa)[0x7fdcc1ab7afa]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x4cfb73)[0x7fdcc1ab7b73]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x4cfa21)[0x7fdcc1ab7a21]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x4cf57b)[0x7fdcc1ab757b]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x2e02f3)[0x7fdcc18c82f3]
/home/baswanth/workplace/valkey-search-1.0-repro/.build-release/libsearch.so(+0x2e1fbc)[0x7fdcc18c9fbc]
/lib64/libpthread.so.0(+0x744b)[0x7fdcca2db44b]

```