### PR TITLE
fix: add null check for thread_monitor_ in GetAvgCPUPercentage

### DIFF
--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -73,12 +73,13 @@ absl::StatusOr<double> ThreadPool::GetAvgCPUPercentage() {
     if (!err.ok()) {
       return;
     }
-    if (!thread->thread_monitor_) {
-      return;
-    }
-    auto status = thread->thread_monitor_->GetThreadCPUPercentage();
+    auto status = thread->GetThreadCPUPercentage();
     if (!status.ok()) {
-      err = status.status();
+      if (!absl::IsUnavailable(status.status())) {
+        // Only if the error is not related to unavailable result,
+        // we return the error. Otherwise we continue to accumulate results.
+        err = status.status();
+      }
       return;
     }
     cpu_results.push_back(status.value());

--- a/vmsdk/src/thread_pool.h
+++ b/vmsdk/src/thread_pool.h
@@ -96,6 +96,13 @@ class ThreadPool {
       }
     }
 
+    absl::StatusOr<double> GetThreadCPUPercentage() {
+      if (!thread_monitor_) {
+        return absl::UnavailableError("Thread monitor not initialized");
+      }
+      return thread_monitor_->GetThreadCPUPercentage();
+    }
+
     void InitThreadMonitor() {
       thread_monitor_ = std::make_unique<ThreadMonitor>(thread_id);
     }

--- a/vmsdk/testing/thread_pool_test.cc
+++ b/vmsdk/testing/thread_pool_test.cc
@@ -355,6 +355,9 @@ TEST_F(ThreadPoolTest, TestCPUUsage) {
   ThreadPool thread_pool("test-pool", thread_count);
   std::atomic_bool atomic_flag{true};
   int modulo{0};
+  // Workers did not start, thread monitor not initialized,
+  // so it should return 0
+  EXPECT_EQ(thread_pool.GetAvgCPUPercentage().value(), 0.0);
   // Initializing the threads with first simple tasks
   auto blocking_counter = ScheduleTasks(thread_pool, atomic_flag, modulo);
   thread_pool.StartWorkers();


### PR DESCRIPTION
The `thread_monitor_` may not be initialized when `GetAvgCPUPercentage` is called, leading to potential null pointer dereference. This adds a guard to skip threads with uninitialized monitors, ensuring the function safely calculates the average CPU percentage across only the threads with valid monitors.