### PR TITLE
Add debug command to print redacted overview of indexes

### DIFF
--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -442,7 +442,7 @@ absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
     return ListConfigsCmd(ctx, itr);
   } else {
     return absl::InvalidArgumentError(absl::StrCat(
-        "Unknown subcommand: ", *itr.GetStringView(), " try HELP subcommand"));
+        "Unknown subcommand: ", keyword, ", try HELP subcommand"));
   }
 }
 

--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -10,10 +10,10 @@
 #include <absl/strings/str_format.h>
 
 #include "module_config.h"
-#include "src/indexes/vector_flat.h"
-#include "src/indexes/vector_hnsw.h"
 #include "src/coordinator/metadata_manager.h"
 #include "src/index_schema.h"
+#include "src/indexes/vector_flat.h"
+#include "src/indexes/vector_hnsw.h"
 #include "src/schema_manager.h"
 #include "src/utils/string_interning.h"
 #include "vmsdk/src/command_parser.h"
@@ -273,36 +273,31 @@ absl::Status IndexInfoCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator &itr) {
   auto indexes = SchemaManager::Instance().GetIndexDebugInfo();
   // Reply with array of strings, one per index
   ValkeyModule_ReplyWithArray(ctx, indexes.size());
-  
+
   for (const auto &info : indexes) {
     std::string vector_details;
     // Get vector field details if any
     if (info.vector_count > 0 && info.schema) {
       const int attr_count = info.schema->GetAttributeCount();
       if (info.vector_count > 0) {
-        vector_details = absl::StrFormat("[Vector Fields:%d]", info.vector_count);
+        vector_details =
+            absl::StrFormat("[Vector Fields:%d]", info.vector_count);
       }
     }
-    std::string output = absl::StrFormat(
-      "db-%d:index_%lu %s Prefixes(%zu)",
-      info.db_num,
-      info.fingerprint,
-      info.datatype,
-      info.prefix_count
-    );
+    std::string output =
+        absl::StrFormat("db-%d:index_%lu %s Prefixes(%zu)", info.db_num,
+                        info.fingerprint, info.datatype, info.prefix_count);
     // Add vector details if present
     if (!vector_details.empty()) {
       output += " Vector: " + vector_details;
     }
     // Add non-vector field counts
-    output += absl::StrFormat(" NonVectorFields: Numerics:%d Tags:%d Text:%d",
-      info.numeric_count,
-      info.tag_count,
-      info.text_count
-    );
+    output +=
+        absl::StrFormat(" NonVectorFields: Numerics:%d Tags:%d Text:%d",
+                        info.numeric_count, info.tag_count, info.text_count);
     ValkeyModule_ReplyWithSimpleString(ctx, output.c_str());
   }
-  
+
   return absl::OkStatus();
 }
 
@@ -372,7 +367,7 @@ absl::Status HelpCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator &itr) {
        "control pause points"},
       {"FT._DEBUG TEXTINFO <index> ...", "show info about schema-level text"},
       {"FT._DEBUG STRINGPOOLSTATS", "Show InternStringPool Stats"},
-      {"FT._DEBUG INDEX_INFO", 
+      {"FT._DEBUG INDEX_INFO",
        "Show redacted overview of index information for all indexes"},
       {"FT_DEBUG SHOW_METADATA",
        "list internal metadata manager table namespace"},
@@ -441,8 +436,8 @@ absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
   } else if (keyword == "LIST_CONFIGS") {
     return ListConfigsCmd(ctx, itr);
   } else {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Unknown subcommand: ", keyword, ", try HELP subcommand"));
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unknown subcommand: ", keyword, ", try HELP subcommand"));
   }
 }
 

--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -17,6 +17,7 @@
 #include "src/indexes/vector_hnsw.h"
 #include "src/schema_manager.h"
 #include "src/utils/string_interning.h"
+#include "src/valkey_search.h"
 #include "vmsdk/src/command_parser.h"
 #include "vmsdk/src/debug.h"
 #include "vmsdk/src/info.h"
@@ -272,166 +273,12 @@ absl::Status IndexInfoCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator &itr) {
   VMSDK_RETURN_IF_ERROR(CheckEndOfArgs(itr));
   // Get index information from SchemaManager
   auto indexes = SchemaManager::Instance().GetIndexDebugInfo();
-  // Reply with array of strings, one per index
-  ValkeyModule_ReplyWithArray(ctx, indexes.size());
-  // Helper lambda to format bytes in human-readable form
-  auto format_bytes = [](uint64_t bytes) -> std::string {
-    if (bytes < 1024) {
-      return absl::StrFormat("%dB", bytes);
-    } else if (bytes < 1024 * 1024) {
-      return absl::StrFormat("%.1fKB", bytes / 1024.0);
-    } else if (bytes < 1024 * 1024 * 1024) {
-      return absl::StrFormat("%.1fMB", bytes / (1024.0 * 1024.0));
-    } else {
-      return absl::StrFormat("%.1fGB", bytes / (1024.0 * 1024.0 * 1024.0));
-    }
-  };
+  // Use shared formatting function (no sorting, no limit)
+  auto formatted = FormatIndexDebugInfo(indexes, false, 0);
 
-  for (const auto &info : indexes) {
-    std::string vector_details;
-    std::string text_details;
-    std::string tag_details;
-    uint64_t numeric_memory = 0;
-    
-    // Extract detailed information from proto if schema is available
-    if (info.schema) {
-      std::vector<std::string> vector_info_list;
-      std::vector<std::string> text_info_list;
-      std::vector<std::string> tag_info_list;
-      
-      // Get schema proto representation
-      auto schema_proto = info.schema->ToProto();
-      
-      // Iterate through attributes in proto
-      for (const auto& attr : schema_proto->attributes()) {
-        if (!attr.has_index()) {
-          continue;
-        }
-        
-        const auto& index = attr.index();
-        const std::string& alias = attr.alias();
-        
-        // Get memory usage for this attribute
-        uint64_t memory = info.schema->GetSize(alias);
-        std::string mem_str = format_bytes(memory);
-        
-        // Vector fields
-        if (index.has_vector_index()) {
-          const auto& vector_index = index.vector_index();
-          
-          // Determine algorithm type and build details
-          std::string algo_details;
-          if (vector_index.has_hnsw_algorithm()) {
-            const auto& hnsw = vector_index.hnsw_algorithm();
-            algo_details = absl::StrFormat("HNSW M:%d EfC:%d EfR:%d",
-                                          hnsw.m(), hnsw.ef_construction(), 
-                                          hnsw.ef_runtime());
-          } else if (vector_index.has_flat_algorithm()) {
-            const auto& flat = vector_index.flat_algorithm();
-            algo_details = absl::StrFormat("FLAT BlkSz:%d", flat.block_size());
-          } else {
-            algo_details = "UNKNOWN";
-          }
-          
-          // Get distance metric string
-          auto metric_str = indexes::LookupKeyByValue(
-              *indexes::kDistanceMetricByStr, vector_index.distance_metric());
-          
-          // Build complete vector info string with memory
-          vector_info_list.push_back(
-              absl::StrFormat("%s Dim:%d Metric:%s Mem:%s", 
-                            algo_details, vector_index.dimension_count(), 
-                            metric_str, mem_str));
-        }
-        
-        // Text fields
-        if (index.has_text_index()) {
-          const auto& text_index = index.text_index();
-          text_info_list.push_back(
-              absl::StrFormat("Weight:%.1f Stem:%s SuffixTrie:%s Mem:%s",
-                            text_index.weight(),
-                            text_index.no_stem() ? "false" : "true",
-                            text_index.with_suffix_trie() ? "true" : "false",
-                            mem_str));
-        }
-        
-        // Tag fields
-        if (index.has_tag_index()) {
-          const auto& tag_index = index.tag_index();
-          std::string sep = tag_index.separator().empty() ? "," : tag_index.separator();
-          tag_info_list.push_back(
-              absl::StrFormat("Sep:'%s' CaseSens:%s Mem:%s",
-                            sep,
-                            tag_index.case_sensitive() ? "true" : "false",
-                            mem_str));
-        }
-        
-        // Numeric fields - accumulate memory
-        if (index.has_numeric_index()) {
-          numeric_memory += memory;
-        }
-      }
-      
-      // Format vector fields
-      if (!vector_info_list.empty()) {
-        vector_details = absl::StrFormat("[%s]", 
-                                        absl::StrJoin(vector_info_list, ", "));
-      } else if (info.vector_count > 0) {
-        vector_details = absl::StrFormat("[Vector Fields:%d]", info.vector_count);
-      }
-      
-      // Format text fields
-      if (!text_info_list.empty()) {
-        text_details = absl::StrFormat("[%s]", 
-                                      absl::StrJoin(text_info_list, ", "));
-      }
-      
-      // Format tag fields
-      if (!tag_info_list.empty()) {
-        tag_details = absl::StrFormat("[%s]", 
-                                     absl::StrJoin(tag_info_list, ", "));
-      }
-    }
-    
-    // Build output string
-    std::string output =
-        absl::StrFormat("db-%d:index_%lu %s Prefixes(%zu)", info.db_num,
-                        info.fingerprint, info.datatype, info.prefix_count);
-    
-    // Add vector details if present
-    if (!vector_details.empty()) {
-      output += " Vector: " + vector_details;
-    }
-    
-    // Add text details if present
-    if (info.text_count > 0) {
-      if (!text_details.empty()) {
-        output += absl::StrFormat(" Text(%d): %s", info.text_count, text_details);
-      } else {
-        output += absl::StrFormat(" Text:%d", info.text_count);
-      }
-    }
-    
-    // Add tag details if present
-    if (info.tag_count > 0) {
-      if (!tag_details.empty()) {
-        output += absl::StrFormat(" Tag(%d): %s", info.tag_count, tag_details);
-      } else {
-        output += absl::StrFormat(" Tag:%d", info.tag_count);
-      }
-    }
-    
-    // Add numeric count with memory if present
-    if (info.numeric_count > 0) {
-      if (numeric_memory > 0) {
-        output += absl::StrFormat(" Numeric(%d): [Mem:%s]", 
-                                 info.numeric_count, 
-                                 format_bytes(numeric_memory));
-      } else {
-        output += absl::StrFormat(" Numeric:%d", info.numeric_count);
-      }
-    }
-    
+  // Reply with array of strings, one per index
+  ValkeyModule_ReplyWithArray(ctx, formatted.size());
+  for (const auto &output : formatted) {
     ValkeyModule_ReplyWithSimpleString(ctx, output.c_str());
   }
 

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -798,11 +798,12 @@ absl::Status SchemaManager::ShowIndexSchemas(ValkeyModuleCtx *ctx,
   return absl::OkStatus();
 }
 
-std::vector<SchemaManager::IndexDebugInfo> SchemaManager::GetIndexDebugInfo() const {
+std::vector<SchemaManager::IndexDebugInfo> SchemaManager::GetIndexDebugInfo()
+    const {
   std::vector<IndexDebugInfo> indexes;
-  
+
   absl::MutexLock lock(&db_to_index_schemas_mutex_);
-  
+
   for (const auto &[db_num, schema_map] : db_to_index_schemas_) {
     for (const auto &[name, schema] : schema_map) {
       IndexDebugInfo info;
@@ -810,7 +811,7 @@ std::vector<SchemaManager::IndexDebugInfo> SchemaManager::GetIndexDebugInfo() co
       info.fingerprint = schema->GetFingerprint();
       info.version = schema->GetVersion();
       info.schema = schema;
-      
+
       // Get datatype
       const auto &attr_data_type = schema->GetAttributeDataType();
       switch (attr_data_type.ToProto()) {
@@ -824,20 +825,20 @@ std::vector<SchemaManager::IndexDebugInfo> SchemaManager::GetIndexDebugInfo() co
           info.datatype = "UNKNOWN";
           break;
       }
-      
+
       // Get prefix count
       info.prefix_count = schema->GetKeyPrefixes().size();
-      
+
       // Count attributes by type
       info.numeric_count = schema->GetNumericAttributeCount();
       info.tag_count = schema->GetTagAttributeCount();
       info.text_count = schema->GetTextAttributeCount();
       info.vector_count = schema->GetVectorAttributeCount();
-      
+
       indexes.push_back(info);
     }
   }
-  
+
   return indexes;
 }
 

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -798,6 +798,49 @@ absl::Status SchemaManager::ShowIndexSchemas(ValkeyModuleCtx *ctx,
   return absl::OkStatus();
 }
 
+std::vector<SchemaManager::IndexDebugInfo> SchemaManager::GetIndexDebugInfo() const {
+  std::vector<IndexDebugInfo> indexes;
+  
+  absl::MutexLock lock(&db_to_index_schemas_mutex_);
+  
+  for (const auto &[db_num, schema_map] : db_to_index_schemas_) {
+    for (const auto &[name, schema] : schema_map) {
+      IndexDebugInfo info;
+      info.db_num = db_num;
+      info.fingerprint = schema->GetFingerprint();
+      info.version = schema->GetVersion();
+      info.schema = schema;
+      
+      // Get datatype
+      const auto &attr_data_type = schema->GetAttributeDataType();
+      switch (attr_data_type.ToProto()) {
+        case data_model::ATTRIBUTE_DATA_TYPE_HASH:
+          info.datatype = "HASH";
+          break;
+        case data_model::ATTRIBUTE_DATA_TYPE_JSON:
+          info.datatype = "JSON";
+          break;
+        default:
+          info.datatype = "UNKNOWN";
+          break;
+      }
+      
+      // Get prefix count
+      info.prefix_count = schema->GetKeyPrefixes().size();
+      
+      // Count attributes by type
+      info.numeric_count = schema->GetNumericAttributeCount();
+      info.tag_count = schema->GetTagAttributeCount();
+      info.text_count = schema->GetTextAttributeCount();
+      info.vector_count = schema->GetVectorAttributeCount();
+      
+      indexes.push_back(info);
+    }
+  }
+  
+  return indexes;
+}
+
 static vmsdk::info_field::Integer number_of_indexes(
     "index_stats", "number_of_indexes",
     vmsdk::info_field::IntegerBuilder().App().Computed([] {

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -121,6 +121,22 @@ class SchemaManager {
   absl::Status ShowIndexSchemas(ValkeyModuleCtx *ctx,
                                 vmsdk::ArgsIterator &itr) const;
 
+  // Structure for index information used by debug commands
+  struct IndexDebugInfo {
+    uint32_t db_num;
+    uint64_t fingerprint;
+    uint32_t version;
+    std::string datatype;
+    size_t prefix_count;
+    int numeric_count;
+    int tag_count;
+    int text_count;
+    int vector_count;
+    std::shared_ptr<IndexSchema> schema;
+  };
+  // Get debug information for all indexes
+  std::vector<IndexDebugInfo> GetIndexDebugInfo() const;
+
  private:
   absl::Status RemoveAll()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(db_to_index_schemas_mutex_);

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -21,6 +21,7 @@
 #include "src/coordinator/client_pool.h"
 #include "src/coordinator/server.h"
 #include "src/index_schema.h"
+#include "src/schema_manager.h"
 #include "src/valkey_search_options.h"
 #include "vmsdk/src/cluster_map.h"
 #include "vmsdk/src/thread_group_cpu_monitor.h"
@@ -29,6 +30,14 @@
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search {
+
+// Helper function to format index debug info as strings
+// Used by both FT._DEBUG INDEX_INFO and INFO DEV metrics
+// If sort_by_memory is true, returns indexes sorted by total memory descending
+// If limit > 0, returns at most that many indexes
+std::vector<std::string> FormatIndexDebugInfo(
+    const std::vector<SchemaManager::IndexDebugInfo> &indexes,
+    bool sort_by_memory = false, size_t limit = 0);
 
 constexpr char kEventEngine[] = "event_engine";
 


### PR DESCRIPTION
we can see redacted index info  using ft._debug command  
```
127.0.0.1:10263> ft._debug index_info
1) db-0:index_3188309866174672087 HASH Prefixes(1) Vector: [HNSW M:16 EfC:200 EfR:10 Dim:3 Metric:COSINE Mem:36B] Text(1): [Weight:1.0 Stem:true SuffixTrie:false Mem:34B] Tag(1): [Sep:',' CaseSens:false Mem:42B] Numeric(1): [Mem:9B]
2) db-0:index_12948348000370507749 HASH Prefixes(1) Vector: [HNSW M:16 EfC:200 EfR:10 Dim:3 Metric:COSINE Mem:36B] Text(1): [Weight:1.0 Stem:true SuffixTrie:true Mem:34B] Tag(1): [Sep:',' CaseSens:false Mem:42B] Numeric(1): [Mem:9B]
```


Alternately we can view the top 10 indexes (sorted by total field memory) in info search

```
127.0.0.1:10263> info search_index_info
# search_index_info
search_top_10_indexes_redacted:
 1. db-0:index_3188309866174672087 HASH Prefixes(1) Vector: [HNSW M:16 EfC:200 EfR:10 Dim:3 Metric:COSINE Mem:36B] Text(1): [Weight:1.0 Stem:true SuffixTrie:false Mem:34B] Tag(1): [Sep:',' CaseSens:false Mem:42B] Numeric(1): [Mem:9B]
 2. db-0:index_12948348000370507749 HASH Prefixes(1) Vector: [HNSW M:16 EfC:200 EfR:10 Dim:3 Metric:COSINE Mem:36B] Text(1): [Weight:1.0 Stem:true SuffixTrie:true Mem:34B] Tag(1): [Sep:',' CaseSens:false Mem:42B] Numeric(1): [Mem:9B]
 ```