### PR TITLE
Remove incorrect evaluation stemming assertion

### DIFF
--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -127,10 +127,9 @@ EvaluationResult TermPredicate::Evaluate(
     }
     // Search for stem variants - these should all exist from ingestion
     for (const auto &variant : stem_variants) {
-      bool found = TryAddWordKeyIteratorForPrefilter(
-          text_index, variant, target_key, stem_field_mask, require_positions,
-          key_iterators);
-      CHECK(found) << "Word in stem tree not found in index - ingestion issue";
+      TryAddWordKeyIteratorForPrefilter(text_index, variant, target_key,
+                                        stem_field_mask, require_positions,
+                                        key_iterators);
     }
   }
   if (key_iterators.empty()) {


### PR DESCRIPTION
Resolves #767.


I initially expected this was a result of the bug in the current text evaluation retry logic:

> We check in the RunByMain that there are no conflicting key updates and unblock the client if there are none. The unblocked client leads to a later asynchronous callback execution on the main thread to process the unblocked client, and I believe this is where we do the evaluation. It's possible for a conflicting key mutation to have arrived in the meantime for one of the keys being evaluated, which can lead to unexpected conflicting ingestion and main thread evaluation concurrency.

While there is a bit of a weird condition where the main thread could see the effects of a key being ingested in the stem tree before it's put in the per-key TextIndex map, it doesn't actually impact anything. The stem tree won't be looked at by the evaluation if the key's TextIndex doesn't exist. 

The real root cause is simple: it's expected there may be variants in the stem tree that are not in the per-key TextIndex, because the stem tree operates at the schema level and can contain variants only present in other keys.

Let's simply remove the CHECK.
