### PR TITLE
Fix config name and add check for duplicate config names

### DIFF
--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -43,7 +43,7 @@ constexpr absl::string_view kMaxSearchResultRecordSizeConfig{
 constexpr int kMaxSearchResultRecordSize{10 * 1024 * 1024};  // 10MB
 constexpr int kMinSearchResultRecordSize{100};
 constexpr absl::string_view kMaxSearchResultFieldsCountConfig{
-    "max-search-result-record-size"};
+    "max-search-result-fields-count"};
 constexpr int kMaxSearchResultFieldsCount{1000};
 
 /// Register the "--max-search-result-record-size" flag. Controls the max

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -98,7 +98,9 @@ ModuleConfigManager &ModuleConfigManager::Instance() {
 }
 
 void ModuleConfigManager::RegisterConfig(Registerable *config_item) {
-  entries_.insert({std::string{config_item->GetName()}, config_item});
+  auto [it, inserted] =
+      entries_.insert({std::string{config_item->GetName()}, config_item});
+  CHECK(inserted) << "Duplicate config entry: " << config_item->GetName();
 }
 
 void ModuleConfigManager::UnregisterConfig(Registerable *config_item) {


### PR DESCRIPTION
1. Fix the config name "max-search-result-fields-count"
2. Add check for duplicate config names