### PR TITLE
Sanitize module logging: DEBUG logs

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -248,7 +248,9 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::Create(
   if (!reload && index_schema_proto.skip_initial_scan()) {
     // Creating a new Index with SkipInitialScan. Mark the backfill as done
     // since we are skipping it.
-    VMSDK_LOG(DEBUG, ctx) << "Index " << index_schema_proto.name()
+    VMSDK_LOG(DEBUG, ctx) << "Index "
+                          << vmsdk::config::RedactIfNeeded(
+                                 index_schema_proto.name())
                           << " created with skip_initial_scan. "
                              "Marking backfill as done.";
     res->backfill_job_.Get()->MarkScanAsDone();
@@ -720,7 +722,8 @@ void IndexSchema::ProcessMultiQueue() {
 void IndexSchema::EnqueueMultiMutation(const Key &key) {
   auto &multi_mutations_keys = multi_mutations_keys_.Get();
   multi_mutations_keys.push_back(key);
-  VMSDK_LOG(DEBUG, nullptr) << "Enqueueing multi mutation for key: " << key
+  VMSDK_LOG(DEBUG, nullptr) << "Enqueueing multi mutation for key: "
+                            << vmsdk::config::RedactIfNeeded(key->Str())
                             << " Size is now " << multi_mutations_keys.size();
   if (multi_mutations_keys.size() >= mutations_thread_pool_->Size() &&
       !schedule_multi_exec_processing_.Get()) {
@@ -1239,8 +1242,9 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
   }
 
   VMSDK_LOG(DEBUG, nullptr)
-      << "Starting RDB save for index schema: " << name_
-      << " Saving in version " << (RDBWriteV2() ? "2" : "1") << " format";
+      << "Starting RDB save for index schema: "
+      << vmsdk::config::RedactIfNeeded(name_) << " Saving in version "
+      << (RDBWriteV2() ? "2" : "1") << " format";
 
   auto index_schema_proto = ToProto();
   auto rdb_section = std::make_unique<data_model::RDBSection>();
@@ -1270,7 +1274,8 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
 
   for (auto &attribute : attributes_) {
     VMSDK_LOG(DEBUG, nullptr)
-        << "Starting to save attribute: " << attribute.second.GetAlias();
+        << "Starting to save attribute: "
+        << vmsdk::config::RedactIfNeeded(attribute.second.GetAlias());
     // Note that the serialized attribute proto is also stored as part of the
     // serialized index schema proto above. We store here again to avoid any
     // dependencies on the ordering of multiple attributes.
@@ -1539,7 +1544,8 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
           auto &attribute =
               supplemental_content->index_content_header().attribute();
           VMSDK_LOG(DEBUG, nullptr)
-              << "Loading Index Content for attribute: " << attribute.alias();
+              << "Loading Index Content for attribute: "
+              << vmsdk::config::RedactIfNeeded(attribute.alias());
           VMSDK_ASSIGN_OR_RETURN(
               std::shared_ptr<indexes::IndexBase> index,
               IndexFactory(ctx, index_schema.get(), attribute,
@@ -1554,7 +1560,7 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
               supplemental_content->key_to_id_map_header().attribute();
           VMSDK_LOG(DEBUG, nullptr)
               << "Loading Key to ID Map Content for attribute: "
-              << attribute.alias();
+              << vmsdk::config::RedactIfNeeded(attribute.alias());
           VMSDK_ASSIGN_OR_RETURN(
               auto index, index_schema->GetIndex(attribute.alias()),
               _ << "Key to ID mapping found before index definition.");
@@ -1689,8 +1695,11 @@ void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
     });
     VMSDK_LOG(DEBUG, ctx) << "Deleting " << stale_entries
                           << " stale entries of " << key_size
-                          << " total keys for {Index: " << name_
-                          << ", Attribute: " << attribute.first << "}";
+                          << " total keys for {Index: "
+                          << vmsdk::config::RedactIfNeeded(name_)
+                          << ", Attribute: "
+                          << vmsdk::config::RedactIfNeeded(attribute.first)
+                          << "}";
   }
   VMSDK_LOG(NOTICE, ctx) << "Deleting " << deletion_attributes.size()
                          << " stale entries for {Index: "

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -980,7 +980,9 @@ absl::Status query::SearchParameters::PreParseQueryString() {
                      options::GetQueryStringBytes(), " bytes."));
   }
   auto filter_expression = absl::string_view(parse_vars.query_string);
-  VMSDK_LOG(DEBUG, nullptr) << "Query: '" << parse_vars.query_string << "'";
+  VMSDK_LOG(DEBUG, nullptr)
+      << "Query: '" << vmsdk::config::RedactIfNeeded(parse_vars.query_string)
+      << "'";
   auto pos = filter_expression.find(kVectorFilterDelimiter);
   absl::string_view pre_filter;
   absl::string_view vector_filter;

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -516,12 +516,10 @@ void SchemaManager::OnFlushDBEnded(ValkeyModuleCtx *ctx) {
   auto to_delete = GetIndexSchemasInDBInternal(selected_db);
   VMSDK_LOG(NOTICE, ctx) << "Deleting index schema on FLUSHDB of DB "
                          << selected_db;
-  if (coordinator_enabled_) {
-    VMSDK_LOG(NOTICE, ctx) << "Recreating index schema on FLUSHDB of DB "
-                           << selected_db;
-  }
+  absl::once_flag log_recreate_once;
   for (const auto &name : to_delete) {
-    VMSDK_LOG(DEBUG, ctx) << "Deleting index schema " << name
+    VMSDK_LOG(DEBUG, ctx) << "Deleting index schema "
+                          << vmsdk::config::RedactIfNeeded(name)
                           << " on FLUSHDB of DB " << selected_db;
     auto old_schema = RemoveIndexSchemaInternal(selected_db, name);
     if (!old_schema.ok()) {
@@ -535,9 +533,14 @@ void SchemaManager::OnFlushDBEnded(ValkeyModuleCtx *ctx) {
       // In coordinated mode - we recreate the indices, since they are a
       // cluster-level construct, not a node-level construct. To delete,
       // FT.DROPINDEX must be done explicitly.
+      absl::call_once(log_recreate_once, [&]() {
+        VMSDK_LOG(NOTICE, ctx)
+            << "Recreating index schema on FLUSHDB of DB " << selected_db;
+      });
       auto to_add = old_schema.value()->ToProto();
-      VMSDK_LOG(DEBUG, ctx) << "Recreating index schema " << name
-                            << " on FLUSHDB of DB " << selected_db;
+      VMSDK_LOG(DEBUG, ctx)
+          << "Recreating index schema " << vmsdk::config::RedactIfNeeded(name)
+          << " on FLUSHDB of DB " << selected_db;
       auto add_status = CreateIndexSchemaInternal(ctx, *to_add);
       if (!add_status.ok()) {
         VMSDK_LOG(WARNING, ctx)
@@ -802,8 +805,9 @@ absl::Status SchemaManager::ShowIndexSchemas(ValkeyModuleCtx *ctx,
     ValkeyModule_ReplyWithArray(ctx, inner_map.size());
     for (const auto &[name, schema] : inner_map) {
       auto proto = schema->ToProto()->DebugString();
-      VMSDK_LOG(DEBUG, ctx)
-          << "Index Schema in DB " << db_num << ": " << name << " " << proto;
+      VMSDK_LOG(DEBUG, ctx) << "Index Schema in DB " << db_num << ": "
+                            << vmsdk::config::RedactIfNeeded(name) << " "
+                            << vmsdk::config::RedactIfNeeded(proto);
       ValkeyModule_ReplyWithStringBuffer(ctx, proto.data(), proto.size());
     }
   }


### PR DESCRIPTION
This PR aims in sanitizing Valkey Search module logging at DEBUG level. 

Uses `--hide-user-data-from-log` configuration option to control whether to include data in DEBUG log level messages.

