### PR TITLE
Drop indexes on test teardown

### DIFF
--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -259,7 +259,6 @@ class ValkeySearchTestCaseBase(ValkeySearchTestCaseCommon):
         yield
 
         # Cleanup
-        self.client.execute_command("FLUSHALL", "SYNC") # Prevent ASAN false reporting
         ReplicationGroup.cleanup(self.rg)
 
     def get_config_file_lines(self, testdir, port) -> List[str]:
@@ -472,8 +471,6 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
         yield
 
         # Cleanup
-        for rg in self.replication_groups:
-            rg.primary.client.execute_command("FLUSHALL", "SYNC") # Prevent ASAN false reporting
         for rg in self.replication_groups:
             ReplicationGroup.cleanup(rg)
 


### PR DESCRIPTION
Addresses a chunk of the memory leaks being reported in #792 

> I’m not seeing any memory leaks in a simple test with a single ingestion and search if I drop the index at the end. Ownership of the shared pointers (InvasivePtr) containing the postings object is passed as an opaque pointer to the Rax tree. They’re called out as leaks by ASAN at process exit if ownership hasn’t been passed back to the C++ construct. So luckily there doesn’t seem to be an actual leak. We need to instrument all our integration tests to drop the indexes in teardown unless anyone has a better strategy to suppress this