### PR TITLE
Make the build of snowball stemmer use optimal compile flags

### DIFF
--- a/third_party/snowball/CMakeLists.txt
+++ b/third_party/snowball/CMakeLists.txt
@@ -28,14 +28,10 @@ target_include_directories(snowball PRIVATE
   ${SNOWBALL_SOURCE_DIR}
 )
 
-# Optimization: -O3 -march=native -flto
-# Rationale: Benchmarking confirmed a ~30% overall and ~48% peak speedup over
-# default builds. -O3 enables aggressive auto-vectorization and inlining,
-# while -march=native allows the compiler to utilize hardware-specific
-# instructions (AVX2/BMI) for string manipulation. -flto (Link Time
-# Optimization) mitigates code bloat by optimizing across translation units,
-# ensuring maximum instruction cache efficiency.
-target_compile_options(snowball PRIVATE -O3 -march=native -flto)
+# Optimization: -O3 -flto
+# Rationale: Benchmarking confirmed a ~26% overall and ~42% peak speedup over
+# default builds.
+target_compile_options(snowball PRIVATE -O3 -flto)
 
 # Set compile flags to match the original build
 target_compile_options(snowball PRIVATE -w) # Suppress warnings from third-party code


### PR DESCRIPTION



Make the build of snowball stemmer use valkey_search_add_static_library for default optimizers 


Before:
```
add_library(snowball STATIC ...)  # Raw CMake function
target_compile_options(snowball PRIVATE -w)  # Only -w flag
```
No optimization flags (CMake default)

After:
```
# Optimization: -O3 -march=native -flto
target_compile_options(snowball PRIVATE -O3 -march=native -flto)
```


Benchmarking confirmed a ~30% overall and ~48% peak speedup over default builds
https://docs.google.com/spreadsheets/d/1xjfAhLUdBAUErFvQr3kf4SCN1o3UpqcT_8E_yqmXG5c/edit?gid=811395221#gid=811395221


But march=native is not portable across machines even on the same architecture.

So I am planning on just using "-O3 ftlo" and it becomes a ~26% overall and ~42% peak improvement over default builds
```
# Optimization: -O3 -flto
# Rationale: Benchmarking confirmed a ~26% overall and ~42% peak speedup over
# default builds.
target_compile_options(snowball PRIVATE -O3 -flto)
```


The linking chain:

```
snowball (static lib)
    ↓ linked by
text (static lib) 
    ↓ linked by
index_schema (static lib)
    ↓ linked by
commands (static lib)
    ↓ linked by
libsearch.so (shared module)
```