### PR TITLE
Replace AGGREGATE.SORTBY.sort_params with array containing expression and order.

### DIFF
--- a/src/commands/ft.aggregate.json
+++ b/src/commands/ft.aggregate.json
@@ -326,9 +326,32 @@
             "type": "integer"
           },
           {
-            "name": "sort_params",
-            "type": "string",
-            "multiple": true
+            "name": "expression",
+            "type": "block",
+            "multiple": true,
+            "arguments": [
+              {
+                "name": "expression",
+                "type": "string"
+              },
+              {
+                "name": "direction",
+                "type": "oneof",
+                "optional": true,
+                "arguments": [
+                  {
+                    "name": "ASC",
+                    "type": "pure-token",
+                    "token": "ASC"
+                  },
+                  {
+                    "name": "DESC",
+                    "type": "pure-token",
+                    "token": "DESC"
+                  }
+                ]
+              }
+            ]
           },
           {
             "name": "max",


### PR DESCRIPTION
In the json file for FT.AGGREGATE the SORTBY expression is defined as follows
```
SORTBY <count> <expression> [<expression ...] [MAX <num>]
```
This PR fixes it to be defined as in the documentation
```
SORTBY <count> <expression> [ASC | DESC] [<expression [ASC | DESC] ...] [MAX <num>]
```
