### PR TITLE
Serialize position map before lock context

### DIFF
--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -185,8 +185,7 @@ unsigned int count_num_terms(const PositionMap& pos_map) {
 }
 
 void Postings::InsertKey(const Key& key, FlatPositionMap* flat_map) {
-  // Insert pre-created FlatPositionMap pointer into map
-  // Metadata updates are done by the caller before this point
+  // Insert FlatPositionMap pointer into map
   key_to_positions_.emplace(key, flat_map);
 }
 

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -77,7 +77,7 @@ struct Postings {
   // Are there any postings in this object?
   bool IsEmpty() const;
 
-  // Insert the key with its pre-created FlatPositionMap
+  // Insert the key with FlatPositionMap
   void InsertKey(const Key& key, FlatPositionMap* flat_map);
 
   // Remove a key and all positions for it

--- a/testing/posting_test.cc
+++ b/testing/posting_test.cc
@@ -82,8 +82,7 @@ TEST_F(PostingTest, InsertionCounters) {
   postings_ = std::make_unique<Postings>();
   metadata_ = std::make_unique<TextIndexMetadata>();
   InsertKeyWithPositionMap(
-      InternKey("doc1"),
-      CreatePositionMap({{10, {0}}, {20, {0}}, {30, {1}}}));
+      InternKey("doc1"), CreatePositionMap({{10, {0}}, {20, {0}}, {30, {1}}}));
   EXPECT_EQ(postings_->GetKeyCount(), 1);
   EXPECT_EQ(postings_->GetPositionCount(), 3);
   EXPECT_EQ(postings_->GetTotalTermFrequency(), 3);
@@ -167,8 +166,7 @@ TEST_F(PostingTest, KeyIteratorSkipForward) {
 TEST_F(PostingTest, PositionIteratorBasic) {
   // Add test data with multiple positions for one key
   InsertKeyWithPositionMap(
-      InternKey("doc1"),
-      CreatePositionMap({{10, {0}}, {20, {1}}, {30, {2}}}));
+      InternKey("doc1"), CreatePositionMap({{10, {0}}, {20, {1}}, {30, {2}}}));
 
   // Get key iterator and position iterator
   auto key_iter = postings_->GetKeyIterator();
@@ -199,8 +197,7 @@ TEST_F(PostingTest, PositionIteratorBasic) {
 TEST_F(PostingTest, PositionIteratorSkipForward) {
   // Add test data with gaps in positions
   InsertKeyWithPositionMap(
-      InternKey("doc1"),
-      CreatePositionMap({{10, {0}}, {30, {1}}, {50, {2}}}));
+      InternKey("doc1"), CreatePositionMap({{10, {0}}, {30, {1}}, {50, {2}}}));
 
   auto key_iter = postings_->GetKeyIterator();
   auto pos_iter = key_iter.GetPositionIterator();
@@ -330,9 +327,8 @@ TEST_F(PostingTest, LargeScaleOperations) {
 TEST_F(PostingTest, FieldMaskImplementations) {
   InsertKeyWithPositionMap(InternKey("doc1"),
                            CreatePositionMap({{10, {0}}, {20, {0}}}, 1), 1);
-  InsertKeyWithPositionMap(InternKey("doc2"),
-                           CreatePositionMap({{15, {0, 2}}, {25, {1, 3}}}, 5),
-                           5);
+  InsertKeyWithPositionMap(
+      InternKey("doc2"), CreatePositionMap({{15, {0, 2}}, {25, {1, 3}}}, 5), 5);
   InsertKeyWithPositionMap(InternKey("doc3"),
                            CreatePositionMap({{30, {0, 8}}, {40, {5}}}, 9), 9);
 


### PR DESCRIPTION
Moving serialization of position map outside of the text index lock context 