### PR TITLE
Using absl::btree_map for PositionMap

### DIFF
--- a/src/indexes/text/flat_position_map.cc
+++ b/src/indexes/text/flat_position_map.cc
@@ -104,7 +104,8 @@ static inline std::pair<T, bool> DecodeValue(const char*& ptr) {
 
 // Static factory and destroyer
 FlatPositionMap* FlatPositionMap::Create(
-    const std::map<Position, FieldMask>& position_map, size_t num_text_fields) {
+    const absl::btree_map<Position, FieldMask>& position_map,
+    size_t num_text_fields) {
   CHECK(!position_map.empty())
       << "Cannot create FlatPositionMap from empty position_map";
 

--- a/src/indexes/text/flat_position_map.h
+++ b/src/indexes/text/flat_position_map.h
@@ -57,8 +57,9 @@ minimal state overhead, maintaining cumulative position for delta decoding.
 
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <memory>
+
+#include "absl/container/btree_map.h"
 
 namespace valkey_search::indexes::text {
 
@@ -72,7 +73,7 @@ class FlatPositionMap {
  public:
   // Factory: allocates single block [FlatPositionMap | data...]
   static FlatPositionMap* Create(
-      const std::map<Position, FieldMask>& position_map,
+      const absl::btree_map<Position, FieldMask>& position_map,
       size_t num_text_fields);
 
   // Destructor: frees the allocated memory

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -33,7 +33,6 @@ Key.
 */
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -68,7 +67,7 @@ struct FieldMask {
 
 static_assert(sizeof(FieldMask) == 16, "FieldMask should exactly be 16 bytes");
 
-using PositionMap = std::map<Position, FieldMask>;
+using PositionMap = absl::btree_map<Position, FieldMask>;
 
 struct Postings {
   struct KeyIterator;

--- a/testing/flat_position_map_test.cc
+++ b/testing/flat_position_map_test.cc
@@ -8,11 +8,11 @@
 #include "src/indexes/text/flat_position_map.h"
 
 #include <algorithm>
-#include <map>
 #include <memory>
 #include <random>
 #include <vector>
 
+#include "absl/container/btree_map.h"
 #include "gtest/gtest.h"
 #include "src/indexes/text/posting.h"
 
@@ -21,7 +21,7 @@ namespace valkey_search::indexes::text {
 // RAII wrapper for FlatPositionMap pointer
 class FlatPositionMapPtr {
  public:
-  FlatPositionMapPtr(const std::map<Position, FieldMask>& position_map,
+  FlatPositionMapPtr(const absl::btree_map<Position, FieldMask>& position_map,
                      size_t num_text_fields)
       : ptr_(FlatPositionMap::Create(position_map, num_text_fields)) {}
 
@@ -57,10 +57,10 @@ class FlatPositionMapPtr {
 
 class FlatPositionMapTest : public ::testing::Test {
  protected:
-  std::map<Position, FieldMask> CreatePositionMap(
+  absl::btree_map<Position, FieldMask> CreatePositionMap(
       const std::vector<std::pair<Position, uint64_t>>& positions,
       size_t num_fields) {
-    std::map<Position, FieldMask> position_map;
+    absl::btree_map<Position, FieldMask> position_map;
     for (const auto& [pos, mask] : positions) {
       FieldMask field_mask(num_fields);
       for (size_t i = 0; i < num_fields; ++i) {
@@ -97,7 +97,7 @@ class FlatPositionMapTest : public ::testing::Test {
 //=============================================================================
 
 TEST_F(FlatPositionMapTest, EmptyMap) {
-  std::map<Position, FieldMask> empty_map;
+  absl::btree_map<Position, FieldMask> empty_map;
   EXPECT_DEATH(FlatPositionMap::Create(empty_map, 1),
                "Cannot create FlatPositionMap from empty position_map");
 }


### PR DESCRIPTION
Switching to absl::btree_map (std::map earlier) for PositionMap for better performance. 