### PR TITLE
Refactor support for lua/multi on single slot indexes

### DIFF
--- a/integration/test_multi_lua.py
+++ b/integration/test_multi_lua.py
@@ -25,6 +25,30 @@ def _lua_call(cmd: str, *args: str) -> str:
     return f"return redis.call('{cmd}', {quoted})"
 
 
+def _find_owner_primary_for_slot(primaries, slot: int) -> Valkey:
+    slot_ranges = primaries[0].execute_command("CLUSTER", "SLOTS")
+    owner_port = None
+    for slot_range in slot_ranges:
+        if slot_range[0] <= slot <= slot_range[1]:
+            owner_port = slot_range[2][1]
+            break
+    if owner_port is None:
+        raise RuntimeError(f"Failed to find owner for slot {slot}")
+
+    for node in primaries:
+        if node.connection_pool.connection_kwargs["port"] == owner_port:
+            return node
+    raise RuntimeError(f"No local client found for owner port {owner_port}")
+
+
+def _find_non_owner_primary(primaries, owner: Valkey) -> Valkey:
+    owner_port = owner.connection_pool.connection_kwargs["port"]
+    for node in primaries:
+        if node.connection_pool.connection_kwargs["port"] != owner_port:
+            return node
+    raise RuntimeError("Failed to find a non-owner primary node")
+
+
 class TestMultiLuaCMD(ValkeySearchTestCaseBase):
     """Test all search commands in MULTI/EXEC and Lua contexts for standalone (CMD) mode."""
 
@@ -174,6 +198,43 @@ class TestMultiLuaCME(ValkeySearchClusterTestCase):
         assert client.execute_command("EXEC")[0] == OK
         assert client.execute_command("FT._LIST") == []
 
+        # Single-slot index: owner node should allow FT.SEARCH/FT.AGGREGATE in MULTI/EXEC
+        single_slot_index = "idx{multi_local}"
+        single_slot_prefix = "doc:{multi_local}:"
+        slot = client.execute_command("CLUSTER", "KEYSLOT", single_slot_index)
+        primaries = self.get_all_primary_clients()
+        owner_client = _find_owner_primary_for_slot(primaries, slot)
+        non_owner_client = _find_non_owner_primary(primaries, owner_client)
+
+        assert owner_client.execute_command(
+            "FT.CREATE", single_slot_index, "PREFIX", "1", single_slot_prefix,
+            "SCHEMA", "price", "NUMERIC", "title", "TEXT") == OK
+
+        local_key = f"{single_slot_prefix}1"
+        cluster.execute_command("HSET", local_key, "price", "42", "title",
+                                "hello world")
+
+        assert owner_client.execute_command("MULTI") == OK
+        assert owner_client.execute_command(
+            "FT.SEARCH", single_slot_index, "@price:[42 42]") == QUEUED
+        assert owner_client.execute_command("EXEC")[0][0] == 1
+
+        assert owner_client.execute_command("MULTI") == OK
+        assert owner_client.execute_command(
+            "FT.AGGREGATE", single_slot_index, "@price:[0 100]", "LOAD", "1",
+            "price") == QUEUED
+        assert owner_client.execute_command("EXEC")[0][0] == 1
+
+        assert non_owner_client.execute_command("MULTI") == OK
+        assert non_owner_client.execute_command(
+            "FT.SEARCH", single_slot_index, "@price:[42 42]") == QUEUED
+        results = non_owner_client.execute_command("EXEC")
+        assert isinstance(results[0],
+                          ResponseError) and FANOUT_NOT_SUPPORTED_ERR in str(
+            results[0])
+        assert owner_client.execute_command("FT.DROPINDEX",
+                                            single_slot_index) == OK
+
     @wait_for_background_tasks()
     def test_lua_all_commands(self):
         client: Valkey = self.new_client_for_primary(0)
@@ -218,3 +279,39 @@ class TestMultiLuaCME(ValkeySearchClusterTestCase):
         # FT.DROPINDEX in Lua (skips fanout, succeeds)
         assert client.execute_command("EVAL", _lua_call("FT.DROPINDEX", INDEX), "0") == OK
         assert client.execute_command("FT._LIST") == []
+
+        # Single-slot index: owner node should allow FT.SEARCH/FT.AGGREGATE in Lua
+        single_slot_index = "idx{lua_local}"
+        single_slot_prefix = "doc:{lua_local}:"
+        slot = client.execute_command("CLUSTER", "KEYSLOT", single_slot_index)
+        primaries = self.get_all_primary_clients()
+        owner_client = _find_owner_primary_for_slot(primaries, slot)
+        non_owner_client = _find_non_owner_primary(primaries, owner_client)
+
+        assert owner_client.execute_command(
+            "FT.CREATE", single_slot_index, "PREFIX", "1", single_slot_prefix,
+            "SCHEMA", "price", "NUMERIC", "title", "TEXT") == OK
+
+        local_key = f"{single_slot_prefix}1"
+        cluster.execute_command("HSET", local_key, "price", "42", "title",
+                                "hello world")
+
+        result = owner_client.execute_command(
+            "EVAL", _lua_call("FT.SEARCH", single_slot_index,
+                              "@price:[42 42]"), "0")
+        assert result[0] == 1
+
+        result = owner_client.execute_command(
+            "EVAL",
+            _lua_call("FT.AGGREGATE", single_slot_index, "@price:[0 100]",
+                      "LOAD", "1", "price"), "0")
+        assert result[0] == 1
+
+        with pytest.raises(ResponseError) as exc_info:
+            non_owner_client.execute_command(
+                "EVAL", _lua_call("FT.SEARCH", single_slot_index,
+                                  "@price:[42 42]"), "0")
+        assert FANOUT_NOT_SUPPORTED_ERR in str(exc_info.value)
+
+        assert owner_client.execute_command("FT.DROPINDEX",
+                                            single_slot_index) == OK

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -81,6 +81,22 @@ void Free([[maybe_unused]] ValkeyModuleCtx *ctx, void *privdata) {
 CONTROLLED_BOOLEAN(ForceReplicasOnly, false);
 DEV_INTEGER_COUNTER(stats, single_slot_queries);
 
+bool IsSingleSlotQueryRoutedToLocalNode(ValkeyModuleCtx *ctx,
+                                        const QueryCommand &parameters) {
+  if (!parameters.index_schema) {
+    return false;
+  }
+
+  const auto &single_slot_number =
+      parameters.index_schema->GetSingleSlotNumber();
+  if (!single_slot_number.has_value()) {
+    return false;
+  }
+
+  const auto cluster_map = ValkeySearch::Instance().GetOrRefreshClusterMap(ctx);
+  return cluster_map && cluster_map->IOwnSlot(*single_slot_number);
+}
+
 std::vector<vmsdk::cluster_map::NodeInfo> ComputeSearchTargets(
     ValkeyModuleCtx *ctx, const QueryCommand &parameters) {
   auto mode = /* !vmsdk::IsReadOnly(ctx) ? query::fanout::kPrimaries ? */
@@ -91,12 +107,13 @@ std::vector<vmsdk::cluster_map::NodeInfo> ComputeSearchTargets(
   // refresh cluster map if needed
   auto cluster_map = ValkeySearch::Instance().GetOrRefreshClusterMap(ctx);
 
-  if (vmsdk::ParseHashTag(parameters.index_schema_name).has_value()) {
-    auto key = vmsdk::MakeUniqueValkeyString(parameters.index_schema_name);
-    auto this_slot = ValkeyModule_ClusterKeySlot(key.get());
+  const auto &single_slot_number =
+      parameters.index_schema->GetSingleSlotNumber();
+  if (single_slot_number.has_value()) {
     single_slot_queries.Increment();
     return cluster_map->GetTargetsForSlot(
-        mode, query::fanout::IsSystemUnderLowUtilization(), this_slot);
+        mode, query::fanout::IsSystemUnderLowUtilization(),
+        *single_slot_number);
   } else {
     return cluster_map->GetTargets(
         mode, query::fanout::IsSystemUnderLowUtilization());
@@ -141,7 +158,8 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
                            ValkeySearch::Instance().IsCluster() &&
                            !parameters->local_only;
 
-    if (ABSL_PREDICT_FALSE(inside_multi_exec && do_fanout)) {
+    if (ABSL_PREDICT_FALSE(inside_multi_exec && do_fanout) &&
+        !IsSingleSlotQueryRoutedToLocalNode(ctx, *parameters)) {
       return absl::InvalidArgumentError(
           "MULTI/EXEC or Lua script are not supported in CME mode.");
     }

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -112,6 +112,15 @@ static bool RDBValidateOnWrite() {
       .GetValue();
 }
 
+std::optional<uint16_t> ComputeSingleSlotNumber(absl::string_view index_name) {
+  if (!vmsdk::ParseHashTag(index_name).has_value()) {
+    return std::nullopt;
+  }
+
+  auto key = vmsdk::MakeUniqueValkeyString(index_name);
+  return ValkeyModule_ClusterKeySlot(key.get());
+}
+
 DEV_INTEGER_COUNTER(rdb_stats, rdb_save_keys);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_load_keys);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_save_sections);
@@ -291,6 +300,7 @@ IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
       attribute_data_type_(std::move(attribute_data_type)),
       name_(std::string(index_schema_proto.name())),
       db_num_(index_schema_proto.db_num()),
+      single_slot_number_(ComputeSingleSlotNumber(index_schema_proto.name())),
       language_(index_schema_proto.language()),
       punctuation_(index_schema_proto.punctuation()),
       with_offsets_(index_schema_proto.with_offsets()),

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -175,6 +175,9 @@ class IndexSchema : public KeyspaceEventSubscription,
 
   inline const std::string &GetName() const { return name_; }
   inline std::uint32_t GetDBNum() const { return db_num_; }
+  inline const std::optional<uint16_t> &GetSingleSlotNumber() const {
+    return single_slot_number_;
+  }
   inline float GetScore() const { return score_; }
   inline const std::string &GetScoreField() const {
     CHECK(score_field_.has_value())
@@ -417,6 +420,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   std::unique_ptr<AttributeDataType> attribute_data_type_;
   std::string name_;
   uint32_t db_num_{0};
+  std::optional<uint16_t> single_slot_number_;
   data_model::Language language_{data_model::LANGUAGE_ENGLISH};
   std::string punctuation_;
   bool with_offsets_{true};

--- a/testing/index_schema_test.cc
+++ b/testing/index_schema_test.cc
@@ -1193,6 +1193,51 @@ class IndexSchemaRDBTest : public ValkeySearchTest {
   }
 };
 
+TEST_F(IndexSchemaRDBTest, SingleSlotNumberComputedOnCreate) {
+  std::vector<absl::string_view> key_prefixes = {"doc:{slot1}:"};
+  std::string single_slot_index_name("index_schema_name{slot1}");
+  auto single_slot_schema =
+      MockIndexSchema::Create(&fake_ctx_, single_slot_index_name, key_prefixes,
+                              std::make_unique<HashAttributeDataType>(),
+                              nullptr)
+          .value();
+
+  ASSERT_TRUE(single_slot_schema->GetSingleSlotNumber().has_value());
+
+  std::string multi_slot_index_name("index_schema_name");
+  auto multi_slot_schema =
+      MockIndexSchema::Create(&fake_ctx_, multi_slot_index_name, key_prefixes,
+                              std::make_unique<HashAttributeDataType>(),
+                              nullptr)
+          .value();
+  EXPECT_FALSE(multi_slot_schema->GetSingleSlotNumber().has_value());
+}
+
+TEST_F(IndexSchemaRDBTest, SaveAndLoadSingleSlotNumber) {
+  std::vector<absl::string_view> key_prefixes = {"doc:{slot2}:"};
+  std::string index_schema_name_str("index_schema_name{slot2}");
+
+  auto index_schema = MockIndexSchema::Create(
+                          &fake_ctx_, index_schema_name_str, key_prefixes,
+                          std::make_unique<HashAttributeDataType>(), nullptr)
+                          .value();
+  ASSERT_TRUE(index_schema->GetSingleSlotNumber().has_value());
+  auto slot_number = index_schema->GetSingleSlotNumber();
+  auto proto = index_schema->ToProto();
+
+  ValkeyModuleCtx load_ctx;
+  EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&load_ctx))
+      .WillRepeatedly(Return(&load_ctx));
+  auto loaded_schema_or =
+      IndexSchema::Create(&load_ctx, *proto, /*mutations_thread_pool=*/nullptr,
+                          /*skip_attributes=*/false, /*reload=*/true);
+  VMSDK_EXPECT_OK_STATUSOR(loaded_schema_or);
+  auto loaded_schema = loaded_schema_or.value();
+
+  ASSERT_TRUE(loaded_schema->GetSingleSlotNumber().has_value());
+  EXPECT_EQ(*loaded_schema->GetSingleSlotNumber(), *slot_number);
+}
+
 TEST_F(IndexSchemaRDBTest, SaveAndLoad) ABSL_NO_THREAD_SAFETY_ANALYSIS {
   std::vector<absl::string_view> key_prefixes = {"prefix1", "prefix2"};
   std::string index_schema_name_str("index_schema_name");

--- a/vmsdk/src/testing_infra/module.h
+++ b/vmsdk/src/testing_infra/module.h
@@ -231,6 +231,7 @@ class MockValkeyModule {
   MOCK_METHOD(void *, Calloc, (size_t nmemb, size_t size));
   MOCK_METHOD(size_t, MallocUsableSize, (void *ptr));
   MOCK_METHOD(size_t, GetClusterSize, ());
+  MOCK_METHOD(unsigned int, ClusterKeySlot, (ValkeyModuleString * key));
   MOCK_METHOD(ValkeyModuleCallReply *, Call,
               (ValkeyModuleCtx * ctx, const char *cmd, const char *fmt,
                const char *arg1, const char *arg2));
@@ -1211,6 +1212,33 @@ inline size_t TestValkeyModule_MallocUsableSize(void *ptr) {
 inline size_t TestValkeyModule_GetClusterSize() {
   return kMockValkeyModule->GetClusterSize();
 }
+
+inline unsigned int TestValkeyModule_ClusterKeySlotImpl(
+    ValkeyModuleString *key) {
+  if (key == nullptr) {
+    return 0;
+  }
+
+  absl::string_view key_view = vmsdk::ToStringView(key);
+  absl::string_view slot_key = key_view;
+  auto hash_tag = vmsdk::ParseHashTag(key_view);
+  if (hash_tag.has_value()) {
+    slot_key = *hash_tag;
+  }
+
+  // Use a lightweight deterministic hash for tests.
+  uint32_t hash = 2166136261u;
+  for (char c : slot_key) {
+    hash ^= static_cast<unsigned char>(c);
+    hash *= 16777619u;
+  }
+  return hash % 16384;
+}
+
+inline unsigned int TestValkeyModule_ClusterKeySlot(ValkeyModuleString *key) {
+  return kMockValkeyModule->ClusterKeySlot(key);
+}
+
 inline void *TestValkeyModule_GetSharedAPI(ValkeyModuleCtx *ctx,
                                            const char *arg1) {
   return kMockValkeyModule->GetSharedAPI(ctx, arg1);
@@ -1609,6 +1637,7 @@ inline void TestValkeyModule_Init() {
   ValkeyModule_Calloc = &TestValkeyModule_Calloc;
   ValkeyModule_MallocUsableSize = &TestValkeyModule_MallocUsableSize;
   ValkeyModule_GetClusterSize = &TestValkeyModule_GetClusterSize;
+  ValkeyModule_ClusterKeySlot = &TestValkeyModule_ClusterKeySlot;
   ValkeyModule_GetSharedAPI = &TestValkeyModule_GetSharedAPI;
   ValkeyModule_Call = &TestValkeyModule_Call;
   ValkeyModule_CallReplyArrayElement = &TestValkeyModule_CallReplyArrayElement;
@@ -1664,6 +1693,8 @@ inline void TestValkeyModule_Init() {
   ON_CALL(*kMockValkeyModule,
           HashExternalize(testing::_, testing::_, testing::_, testing::_))
       .WillByDefault(TestValkeyModule_HashExternalizeDefaultImpl);
+  ON_CALL(*kMockValkeyModule, ClusterKeySlot(testing::_))
+      .WillByDefault(TestValkeyModule_ClusterKeySlotImpl);
   ON_CALL(*kMockValkeyModule, GetApi(testing::_, testing::_))
       .WillByDefault(TestValkeyModule_GetApiDefaultImpl);
 


### PR DESCRIPTION
Enabled FT.SEARCH/FT.AGGREGATE in MULTI/EXEC and Lua for CME only when the index is single-slot (hash-tagged) and the current node owns that slot

issue : #798 