### PR TITLE
Shard the radix into small trees

### DIFF
--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -150,7 +150,8 @@ bool TryAddWordKeyIterator(
     absl::InlinedVector<indexes::text::Postings::KeyIterator,
                         indexes::text::kWordExpansionInlineCapacity>
         &key_iterators) {
-  auto word_iter = text_index->GetPrefix().GetWordIterator(word);
+  size_t shard = text_index->GetShardIndex(word);
+  auto word_iter = text_index->GetPrefixShard(shard).GetWordIterator(word);
   if (!word_iter.Done() && word_iter.GetWord() == word) {
     key_iterators.emplace_back(word_iter.GetPostingsTarget()->GetKeyIterator());
     return true;
@@ -206,18 +207,22 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
 std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
-  auto word_iter = text_index->GetPrefix().GetWordIterator(GetTextString());
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       key_iterators;
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
+
+  size_t shard = text_index->GetShardIndex(GetTextString());
+  auto word_iter =
+      text_index->GetPrefixShard(shard).GetWordIterator(GetTextString());
   while (!word_iter.Done() && word_count < max_words) {
     key_iterators.emplace_back(word_iter.GetPostingsTarget()->GetKeyIterator());
     word_iter.Next();
     ++word_count;
   }
+
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), field_mask, require_positions);
 }
@@ -228,19 +233,30 @@ std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
   CHECK(text_index->GetSuffix().has_value())
       << "Text index does not have suffix trie enabled.";
   std::string reversed_word(GetTextString().rbegin(), GetTextString().rend());
-  auto word_iter =
-      text_index->GetSuffix().value().get().GetWordIterator(reversed_word);
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       key_iterators;
-  // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
-  while (!word_iter.Done() && word_count < max_words) {
-    key_iterators.emplace_back(word_iter.GetPostingsTarget()->GetKeyIterator());
-    word_iter.Next();
-    ++word_count;
-  }
+
+  // Suffix search routes to SINGLE shard using the reversed word's prefix.
+  // The suffix tree stores reversed words, so "running" -> "gnirunr" is in
+  // shard hash("gni"). Query "*ing" -> reverse to "gni" -> shard hash("gni") ->
+  // prefix search finds all "*ing" words.
+  size_t shard = text_index->GetShardIndex(reversed_word);
+  {
+    auto suffix_shard = text_index->GetSuffixShard(shard);
+    if (suffix_shard) {
+      auto word_iter = suffix_shard->get().GetWordIterator(reversed_word);
+      while (!word_iter.Done() && word_count < max_words) {
+        key_iterators.emplace_back(
+            word_iter.GetPostingsTarget()->GetKeyIterator());
+        word_iter.Next();
+        ++word_count;
+      }
+    }  // end if suffix_shard
+  }  // end single shard block
+
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), field_mask, require_positions);
 }
@@ -256,10 +272,28 @@ std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
     FieldMaskPredicate field_mask, bool require_positions) const {
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
-  auto key_iterators = indexes::text::FuzzySearch::Search(
-      text_index->GetPrefix(), GetTextString(), GetDistance(), max_words);
+
+  // Fuzzy search MUST query ALL shards: words within edit distance can be in
+  // any shard since they may have different 3-letter prefixes
+  absl::InlinedVector<indexes::text::Postings::KeyIterator,
+                      indexes::text::kWordExpansionInlineCapacity>
+      all_key_iterators;
+
+  for (size_t shard = 0; shard < text_index->GetNumShards(); ++shard) {
+    uint32_t shard_max = max_words - all_key_iterators.size();
+    if (shard_max == 0) break;
+
+    auto key_iterators = indexes::text::FuzzySearch::Search(
+        text_index->GetPrefixShard(shard), GetTextString(), GetDistance(),
+        shard_max);
+
+    all_key_iterators.insert(all_key_iterators.end(),
+                             std::make_move_iterator(key_iterators.begin()),
+                             std::make_move_iterator(key_iterators.end()));
+  }
+
   return std::make_unique<indexes::text::TermIterator>(
-      std::move(key_iterators), field_mask, require_positions);
+      std::move(all_key_iterators), field_mask, require_positions);
 }
 
 /*
@@ -271,8 +305,10 @@ std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
  */
 
 size_t TermPredicate::EstimateSize() const {
+  size_t shard = text_index_schema_->GetTextIndex()->GetShardIndex(term_);
   auto iter =
-      text_index_schema_->GetTextIndex()->GetPrefix().GetWordIterator(term_);
+      text_index_schema_->GetTextIndex()->GetPrefixShard(shard).GetWordIterator(
+          term_);
   if (!iter.Done() && iter.GetWord() == term_) {
     return iter.GetPostingsTarget()->GetKeyCount();
   }
@@ -281,8 +317,10 @@ size_t TermPredicate::EstimateSize() const {
 
 size_t PrefixPredicate::EstimateSize() const {
   if (text_index_schema_->TrackSubtreeItemsCountEnabled()) {
-    return text_index_schema_->GetTextIndex()->GetPrefix().GetSubtreeItemCount(
-        term_);
+    size_t shard = text_index_schema_->GetTextIndex()->GetShardIndex(term_);
+    return text_index_schema_->GetTextIndex()
+        ->GetPrefixShard(shard)
+        .GetSubtreeItemCount(term_);
   } else {
     return text_index_schema_->GetTrackedKeyCount();
   }
@@ -290,9 +328,12 @@ size_t PrefixPredicate::EstimateSize() const {
 
 size_t SuffixPredicate::EstimateSize() const {
   if (text_index_schema_->TrackSubtreeItemsCountEnabled()) {
-    auto suffix_tree = text_index_schema_->GetTextIndex()->GetSuffix();
-    CHECK(suffix_tree) << "Suffix estimation not supported";
-    return suffix_tree.value().get().GetSubtreeItemCount(term_);
+    std::string reversed(term_.rbegin(), term_.rend());
+    size_t shard = text_index_schema_->GetTextIndex()->GetShardIndex(reversed);
+    auto suffix_shard =
+        text_index_schema_->GetTextIndex()->GetSuffixShard(shard);
+    CHECK(suffix_shard.has_value()) << "Suffix estimation not supported";
+    return suffix_shard->get().GetSubtreeItemCount(reversed);
   } else {
     return text_index_schema_->GetTrackedKeyCount();
   }

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -145,8 +145,10 @@ namespace {
 
 // Helper to search for a word in the text index and add its key iterator
 // Returns true if the word was found and added
+template <size_t NumShards>
 bool TryAddWordKeyIterator(
-    const indexes::text::TextIndex *text_index, absl::string_view word,
+    const indexes::text::TextIndex<NumShards> *text_index,
+    absl::string_view word,
     absl::InlinedVector<indexes::text::Postings::KeyIterator,
                         indexes::text::kWordExpansionInlineCapacity>
         &key_iterators) {
@@ -162,7 +164,9 @@ bool TryAddWordKeyIterator(
 }  // namespace
 
 std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
-    const std::shared_ptr<indexes::text::TextIndex> &text_index,
+    const std::shared_ptr<
+        indexes::text::TextIndex<indexes::text::kSchemaTextIndexShards>>
+        &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
@@ -205,7 +209,9 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
-    const std::shared_ptr<indexes::text::TextIndex> &text_index,
+    const std::shared_ptr<
+        indexes::text::TextIndex<indexes::text::kSchemaTextIndexShards>>
+        &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
@@ -228,7 +234,9 @@ std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
-    const std::shared_ptr<indexes::text::TextIndex> &text_index,
+    const std::shared_ptr<
+        indexes::text::TextIndex<indexes::text::kSchemaTextIndexShards>>
+        &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
   CHECK(text_index->GetSuffix().has_value())
       << "Text index does not have suffix trie enabled.";
@@ -262,13 +270,17 @@ std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
 }
 
 std::unique_ptr<indexes::text::TextIterator> InfixPredicate::BuildTextIterator(
-    const std::shared_ptr<indexes::text::TextIndex> &text_index,
+    const std::shared_ptr<
+        indexes::text::TextIndex<indexes::text::kSchemaTextIndexShards>>
+        &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
   CHECK(false) << "Unsupported TextPredicate type";
 }
 
 std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
-    const std::shared_ptr<indexes::text::TextIndex> &text_index,
+    const std::shared_ptr<
+        indexes::text::TextIndex<indexes::text::kSchemaTextIndexShards>>
+        &text_index,
     FieldMaskPredicate field_mask, bool require_positions) const {
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -110,9 +110,11 @@ class Text : public IndexBase {
   // Common EntriesFetcher impl for all Text operations.
   class EntriesFetcher : public EntriesFetcherBase {
    public:
-    EntriesFetcher(size_t size,
-                   const std::shared_ptr<text::TextIndex>& text_index,
-                   text::FieldMaskPredicate field_mask, bool require_positions)
+    EntriesFetcher(
+        size_t size,
+        const std::shared_ptr<text::TextIndex<text::kSchemaTextIndexShards>>&
+            text_index,
+        text::FieldMaskPredicate field_mask, bool require_positions)
         : size_(size),
           text_index_(text_index),
           field_mask_(field_mask),
@@ -128,7 +130,7 @@ class Text : public IndexBase {
     std::unique_ptr<EntriesFetcherIteratorBase> Begin() override;
 
     size_t size_;
-    std::shared_ptr<text::TextIndex> text_index_;
+    std::shared_ptr<text::TextIndex<text::kSchemaTextIndexShards>> text_index_;
     const query::TextPredicate* predicate_;
     text::FieldMaskPredicate field_mask_;
     bool require_positions_;

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -20,21 +20,6 @@ namespace valkey_search::indexes::text {
 
 namespace {
 
-// InvasivePtrRaw<Postings> deletion
-static void FreePostingsCallback(void *target) {
-  if (target) {
-    auto raw = static_cast<InvasivePtrRaw<Postings>>(target);
-    InvasivePtr<Postings>::AdoptRaw(raw);
-  }
-}
-
-static void FreeStemParentsCallback(void *target) {
-  if (target) {
-    auto raw = static_cast<InvasivePtrRaw<StemParents>>(target);
-    InvasivePtr<StemParents>::AdoptRaw(raw);
-  }
-}
-
 InvasivePtr<Postings> AddKeyToPostings(InvasivePtr<Postings> existing_postings,
                                        const InternedStringPtr &key,
                                        FlatPositionMap *flat_map,
@@ -98,98 +83,6 @@ std::function<void *(void *)> CreateSimpleTargetMutateFn(MutateFn mutate_fn) {
 
 }  // namespace
 
-/*** TextIndex ***/
-
-// Sharded constructor (for schema-level index)
-TextIndex::TextIndex(bool suffix, size_t num_shards) : num_shards_(num_shards) {
-  CHECK_GT(num_shards, 0) << "Must have at least one shard";
-  shards_.reserve(num_shards);  // Safe now with unique_ptr
-  for (size_t i = 0; i < num_shards; ++i) {
-    shards_.push_back(std::make_unique<Shard>(FreePostingsCallback, suffix));
-  }
-}
-
-// Non-sharded constructor (for per-key indexes)
-TextIndex::TextIndex(bool suffix)
-    : num_shards_(1) {  // Single shard = non-sharded
-  shards_.push_back(std::make_unique<Shard>(FreePostingsCallback, suffix));
-}
-
-size_t TextIndex::GetShardIndex(absl::string_view word) const {
-  // Use first byte for deterministic sharding
-  // This allows short prefixes (< 3 chars) to route to a single shard
-  unsigned char first_byte =
-      word.empty() ? 0 : static_cast<unsigned char>(word[0]);
-  return first_byte % num_shards_;
-}
-
-Rax &TextIndex::GetPrefixShard(size_t shard_index) {
-  CHECK_LT(shard_index, num_shards_);
-  return shards_[shard_index]->prefix_tree;
-}
-
-const Rax &TextIndex::GetPrefixShard(size_t shard_index) const {
-  CHECK_LT(shard_index, num_shards_);
-  return shards_[shard_index]->prefix_tree;
-}
-
-std::optional<std::reference_wrapper<Rax>> TextIndex::GetSuffixShard(
-    size_t shard_index) {
-  CHECK_LT(shard_index, num_shards_);
-  if (!shards_[shard_index]->suffix_tree) {
-    return std::nullopt;
-  }
-  return std::ref(*shards_[shard_index]->suffix_tree);
-}
-
-std::optional<std::reference_wrapper<const Rax>> TextIndex::GetSuffixShard(
-    size_t shard_index) const {
-  CHECK_LT(shard_index, num_shards_);
-  if (!shards_[shard_index]->suffix_tree) {
-    return std::nullopt;
-  }
-  return std::ref(*shards_[shard_index]->suffix_tree);
-}
-
-void TextIndex::MutateTarget(absl::string_view word,
-                             const InvasivePtr<Postings> &target,
-                             const std::optional<std::string> &reverse_word,
-                             item_count_op op) {
-  size_t prefix_shard = GetShardIndex(word);
-  auto target_set_fn = CreateTargetSetFn(target);
-
-  size_t suffix_shard = prefix_shard;
-  if (reverse_word.has_value() && shards_[0]->suffix_tree) {
-    suffix_shard = GetShardIndex(*reverse_word);
-  }
-
-  // Lock shards in sorted order to prevent deadlock
-  if (reverse_word.has_value() && suffix_shard != prefix_shard) {
-    size_t first = std::min(prefix_shard, suffix_shard);
-    size_t second = std::max(prefix_shard, suffix_shard);
-    absl::MutexLock lock1(&shards_[first]->mutex);
-    absl::MutexLock lock2(&shards_[second]->mutex);
-    shards_[prefix_shard]->prefix_tree.MutateTarget(word, target_set_fn, op);
-    shards_[suffix_shard]->suffix_tree->MutateTarget(*reverse_word,
-                                                     target_set_fn, op);
-  } else {
-    absl::MutexLock lock(&shards_[prefix_shard]->mutex);
-    shards_[prefix_shard]->prefix_tree.MutateTarget(word, target_set_fn, op);
-    if (reverse_word.has_value() && shards_[prefix_shard]->suffix_tree) {
-      shards_[prefix_shard]->suffix_tree->MutateTarget(*reverse_word,
-                                                       target_set_fn, op);
-    }
-  }
-}
-
-absl::Mutex &TextIndex::GetShardMutex(absl::string_view word) {
-  return shards_[GetShardIndex(word)]->mutex;
-}
-
-const absl::Mutex &TextIndex::GetShardMutex(absl::string_view word) const {
-  return shards_[GetShardIndex(word)]->mutex;
-}
-
 /*** TextIndexSchema ***/
 
 #define ITEM_COUNT_TRACKING_ENABLED(op) \
@@ -205,8 +98,7 @@ TextIndexSchema::TextIndexSchema(data_model::Language language,
       stem_tree_(FreeStemParentsCallback),
       min_stem_size_(min_stem_size),
       rax_target_mutex_pool_(options::GetRaxTargetMutexPoolSize().GetValue()) {
-  size_t num_shards = options::GetRaxTargetMutexPoolSize().GetValue();
-  text_index_ = std::make_shared<TextIndex>(false, num_shards);
+  text_index_ = std::make_shared<TextIndex<kSchemaTextIndexShards>>(false);
 }
 
 absl::StatusOr<bool> TextIndexSchema::StageAttributeData(
@@ -273,8 +165,8 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
   }
 
-  // Per-key index is non-sharded (single tree) - only schema index is sharded
-  TextIndex key_index{with_suffix_trie_};
+  // Create local per-key index (lightweight, moveable)
+  PerKeyTextIndex key_index{with_suffix_trie_};
 
   // Index the key's tokens
   for (auto &entry : token_positions) {
@@ -303,7 +195,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       absl::MutexLock word_lock(&rax_target_mutex_pool_.Get(token));
 
       size_t shard = text_index_->GetShardIndex(token);
-      auto &shard_obj = *text_index_->shards_[shard];
+      auto &shard_obj = text_index_->shards_[shard];
 
       // Read tree structure under shard_lock
       InvasivePtr<Postings> existing;
@@ -323,7 +215,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       }
     }
 
-    // Update per-key index (no locking needed — local to this call).
+    // Update local per-key index
     key_index.MutateTarget(token, updated_target, reverse_token);
   }
 
@@ -345,7 +237,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
   }
 
-  // Map the key to the newly created per-key index
+  // Move per-key index into map (PerKeyTextIndex is moveable)
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
@@ -354,7 +246,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
 void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
   // Extract the per-key index
-  absl::node_hash_map<Key, TextIndex>::node_type node;
+  absl::node_hash_map<Key, PerKeyTextIndex>::node_type node;
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     node = per_key_text_indexes_.extract(key);
@@ -362,7 +254,7 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
       return;
     }
   }
-  TextIndex &key_index = node.mapped();
+  PerKeyTextIndex &key_index = node.mapped();
 
   std::vector<std::string> empty_words;
 
@@ -377,7 +269,7 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
       absl::MutexLock word_lock(&rax_target_mutex_pool_.Get(word_str));
 
       size_t shard = text_index_->GetShardIndex(word_str);
-      auto &shard_obj = *text_index_->shards_[shard];
+      auto &shard_obj = text_index_->shards_[shard];
 
       // Read tree structure under shard_lock
       InvasivePtr<Postings> existing;
@@ -444,8 +336,7 @@ uint64_t TextIndexSchema::GetTotalTermFrequency() const {
 void TextIndexSchema::EnableSuffix() {
   if (with_suffix_trie_) return;
   with_suffix_trie_ = true;
-  size_t num_shards = options::GetRaxTargetMutexPoolSize().GetValue();
-  text_index_ = std::make_shared<TextIndex>(true, num_shards);
+  text_index_ = std::make_shared<TextIndex<kSchemaTextIndexShards>>(true);
 }
 
 std::string TextIndexSchema::GetAllStemVariants(

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -100,38 +100,94 @@ std::function<void *(void *)> CreateSimpleTargetMutateFn(MutateFn mutate_fn) {
 
 /*** TextIndex ***/
 
+// Sharded constructor (for schema-level index)
+TextIndex::TextIndex(bool suffix, size_t num_shards) : num_shards_(num_shards) {
+  CHECK_GT(num_shards, 0) << "Must have at least one shard";
+  shards_.reserve(num_shards);  // Safe now with unique_ptr
+  for (size_t i = 0; i < num_shards; ++i) {
+    shards_.push_back(std::make_unique<Shard>(FreePostingsCallback, suffix));
+  }
+}
+
+// Non-sharded constructor (for per-key indexes)
 TextIndex::TextIndex(bool suffix)
-    : prefix_tree_(FreePostingsCallback),
-      suffix_tree_(suffix ? std::make_unique<Rax>(FreePostingsCallback)
-                          : nullptr) {}
+    : num_shards_(1) {  // Single shard = non-sharded
+  shards_.push_back(std::make_unique<Shard>(FreePostingsCallback, suffix));
+}
+
+size_t TextIndex::GetShardIndex(absl::string_view word) const {
+  // Use first byte for deterministic sharding
+  // This allows short prefixes (< 3 chars) to route to a single shard
+  unsigned char first_byte =
+      word.empty() ? 0 : static_cast<unsigned char>(word[0]);
+  return first_byte % num_shards_;
+}
+
+Rax &TextIndex::GetPrefixShard(size_t shard_index) {
+  CHECK_LT(shard_index, num_shards_);
+  return shards_[shard_index]->prefix_tree;
+}
+
+const Rax &TextIndex::GetPrefixShard(size_t shard_index) const {
+  CHECK_LT(shard_index, num_shards_);
+  return shards_[shard_index]->prefix_tree;
+}
+
+std::optional<std::reference_wrapper<Rax>> TextIndex::GetSuffixShard(
+    size_t shard_index) {
+  CHECK_LT(shard_index, num_shards_);
+  if (!shards_[shard_index]->suffix_tree) {
+    return std::nullopt;
+  }
+  return std::ref(*shards_[shard_index]->suffix_tree);
+}
+
+std::optional<std::reference_wrapper<const Rax>> TextIndex::GetSuffixShard(
+    size_t shard_index) const {
+  CHECK_LT(shard_index, num_shards_);
+  if (!shards_[shard_index]->suffix_tree) {
+    return std::nullopt;
+  }
+  return std::ref(*shards_[shard_index]->suffix_tree);
+}
 
 void TextIndex::MutateTarget(absl::string_view word,
                              const InvasivePtr<Postings> &target,
                              const std::optional<std::string> &reverse_word,
                              item_count_op op) {
+  size_t prefix_shard = GetShardIndex(word);
   auto target_set_fn = CreateTargetSetFn(target);
-  prefix_tree_.MutateTarget(word, target_set_fn, op);
-  if (suffix_tree_ && reverse_word.has_value()) {
-    suffix_tree_->MutateTarget(*reverse_word, target_set_fn, op);
+
+  size_t suffix_shard = prefix_shard;
+  if (reverse_word.has_value() && shards_[0]->suffix_tree) {
+    suffix_shard = GetShardIndex(*reverse_word);
+  }
+
+  // Lock shards in sorted order to prevent deadlock
+  if (reverse_word.has_value() && suffix_shard != prefix_shard) {
+    size_t first = std::min(prefix_shard, suffix_shard);
+    size_t second = std::max(prefix_shard, suffix_shard);
+    absl::MutexLock lock1(&shards_[first]->mutex);
+    absl::MutexLock lock2(&shards_[second]->mutex);
+    shards_[prefix_shard]->prefix_tree.MutateTarget(word, target_set_fn, op);
+    shards_[suffix_shard]->suffix_tree->MutateTarget(*reverse_word,
+                                                     target_set_fn, op);
+  } else {
+    absl::MutexLock lock(&shards_[prefix_shard]->mutex);
+    shards_[prefix_shard]->prefix_tree.MutateTarget(word, target_set_fn, op);
+    if (reverse_word.has_value() && shards_[prefix_shard]->suffix_tree) {
+      shards_[prefix_shard]->suffix_tree->MutateTarget(*reverse_word,
+                                                       target_set_fn, op);
+    }
   }
 }
 
-Rax &TextIndex::GetPrefix() { return prefix_tree_; }
-
-const Rax &TextIndex::GetPrefix() const { return prefix_tree_; }
-
-std::optional<std::reference_wrapper<Rax>> TextIndex::GetSuffix() {
-  if (!suffix_tree_) {
-    return std::nullopt;
-  }
-  return std::ref(*suffix_tree_);
+absl::Mutex &TextIndex::GetShardMutex(absl::string_view word) {
+  return shards_[GetShardIndex(word)]->mutex;
 }
 
-std::optional<std::reference_wrapper<const Rax>> TextIndex::GetSuffix() const {
-  if (!suffix_tree_) {
-    return std::nullopt;
-  }
-  return std::ref(*suffix_tree_);
+const absl::Mutex &TextIndex::GetShardMutex(absl::string_view word) const {
+  return shards_[GetShardIndex(word)]->mutex;
 }
 
 /*** TextIndexSchema ***/
@@ -148,7 +204,10 @@ TextIndexSchema::TextIndexSchema(data_model::Language language,
       lexer_(language, punctuation, stop_words),
       stem_tree_(FreeStemParentsCallback),
       min_stem_size_(min_stem_size),
-      rax_target_mutex_pool_(options::GetRaxTargetMutexPoolSize().GetValue()) {}
+      rax_target_mutex_pool_(options::GetRaxTargetMutexPoolSize().GetValue()) {
+  size_t num_shards = options::GetRaxTargetMutexPoolSize().GetValue();
+  text_index_ = std::make_shared<TextIndex>(false, num_shards);
+}
 
 absl::StatusOr<bool> TextIndexSchema::StageAttributeData(
     const InternedStringPtr &key, absl::string_view data,
@@ -214,6 +273,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
   }
 
+  // Per-key index is non-sharded (single tree) - only schema index is sharded
   TextIndex key_index{with_suffix_trie_};
 
   // Index the key's tokens
@@ -242,19 +302,21 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     {
       absl::MutexLock word_lock(&rax_target_mutex_pool_.Get(token));
 
+      size_t shard = text_index_->GetShardIndex(token);
+      auto &shard_obj = *text_index_->shards_[shard];
+
+      // Read tree structure under shard_lock
       InvasivePtr<Postings> existing;
       {
-        // Tree read lock prevents rax node reallocation racing with FindTarget.
-        absl::ReaderMutexLock tree_read(&text_index_mutex_);
-        existing = text_index_->GetPrefix().FindPostingsTarget(token);
+        absl::ReaderMutexLock shard_lock(&shard_obj.mutex);
+        existing = shard_obj.prefix_tree.FindPostingsTarget(token);
       }
-      bool is_new_word = !existing;
 
+      bool is_new_word = !existing;
       updated_target =
           AddKeyToPostings(std::move(existing), key, flat_map, &metadata_);
 
       if (is_new_word) {
-        absl::WriterMutexLock tree_lock(&text_index_mutex_);
         text_index_->MutateTarget(
             token, updated_target, reverse_token,
             ITEM_COUNT_TRACKING_ENABLED(item_count_op::ADD));
@@ -301,7 +363,6 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
     }
   }
   TextIndex &key_index = node.mapped();
-  auto suffix_opt = text_index_->GetSuffix();
 
   std::vector<std::string> empty_words;
 
@@ -315,18 +376,20 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
     {
       absl::MutexLock word_lock(&rax_target_mutex_pool_.Get(word_str));
 
+      size_t shard = text_index_->GetShardIndex(word_str);
+      auto &shard_obj = *text_index_->shards_[shard];
+
+      // Read tree structure under shard_lock
       InvasivePtr<Postings> existing;
       {
-        absl::ReaderMutexLock tree_read(&text_index_mutex_);
-        existing = text_index_->GetPrefix().FindPostingsTarget(word_str);
+        absl::ReaderMutexLock shard_lock(&shard_obj.mutex);
+        existing = shard_obj.prefix_tree.FindPostingsTarget(word_str);
       }
 
-      InvasivePtr<Postings> updated_target;
-      updated_target =
+      InvasivePtr<Postings> updated_target =
           RemoveKeyFromPostings(std::move(existing), key, &metadata_);
 
       if (!updated_target) {
-        absl::WriterMutexLock tree_lock(&text_index_mutex_);
         text_index_->MutateTarget(
             word_str, updated_target, reverse_word,
             ITEM_COUNT_TRACKING_ENABLED(item_count_op::SUBTRACT));
@@ -376,6 +439,13 @@ uint64_t TextIndexSchema::GetNumUniqueTerms() const {
 
 uint64_t TextIndexSchema::GetTotalTermFrequency() const {
   return metadata_.total_term_frequency.load();
+}
+
+void TextIndexSchema::EnableSuffix() {
+  if (with_suffix_trie_) return;
+  with_suffix_trie_ = true;
+  size_t num_shards = options::GetRaxTargetMutexPoolSize().GetValue();
+  text_index_ = std::make_shared<TextIndex>(true, num_shards);
 }
 
 std::string TextIndexSchema::GetAllStemVariants(

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -8,6 +8,8 @@
 #ifndef VALKEY_SEARCH_INDEXES_TEXT_INDEX_H_
 #define VALKEY_SEARCH_INDEXES_TEXT_INDEX_H_
 
+#include <algorithm>
+#include <array>
 #include <atomic>
 #include <bitset>
 #include <cctype>
@@ -33,8 +35,43 @@ struct sb_stemmer;
 
 namespace valkey_search::indexes::text {
 
+// Forward declarations for helper functions
+static void FreePostingsCallback(void *target);
+static void FreeStemParentsCallback(void *target);
+
+// Helper functions implementation
+inline void FreePostingsCallback(void *target) {
+  if (target) {
+    auto raw = static_cast<InvasivePtrRaw<Postings>>(target);
+    InvasivePtr<Postings>::AdoptRaw(raw);
+  }
+}
+
+inline void FreeStemParentsCallback(void *target) {
+  if (target) {
+    auto raw = static_cast<InvasivePtrRaw<StemParents>>(target);
+    InvasivePtr<StemParents>::AdoptRaw(raw);
+  }
+}
+
+// Helper to create target set function for Rax mutations
+inline auto CreatePostingsTargetSetFn(const InvasivePtr<Postings> &target) {
+  return [&target](void *old_val) -> void * {
+    if (old_val) {
+      InvasivePtr<Postings>::AdoptRaw(
+          static_cast<InvasivePtrRaw<Postings>>(old_val));
+    }
+    if (!target) return nullptr;
+    InvasivePtr<Postings> copy = target;
+    return static_cast<void *>(std::move(copy).ReleaseRaw());
+  };
+}
+
 // Inline capacity for stem variants extracted from stem tree
 constexpr size_t kStemVariantsInlineCapacity = 20;
+
+// Compile-time shard counts
+constexpr size_t kSchemaTextIndexShards = 256;  // Schema-level: many shards
 
 // token -> (PositionMap, suffix support)
 using TokenPositions =
@@ -54,6 +91,10 @@ struct TextIndexMetadata {
   MemoryPool text_index_memory_pool_{0};
 };
 
+// Template TextIndex for compile-time shard optimization
+// Schema-level: TextIndex<256> (many shards)
+// Per-key: TextIndex<1> (single shard, zero overhead)
+template <size_t NumShards>
 class TextIndex {
   //
   // Sharded radix trees: words with same first byte share a shard.
@@ -63,17 +104,21 @@ class TextIndex {
   //
 
  public:
-  // Constructor for sharded index (schema-level)
-  explicit TextIndex(bool suffix, size_t num_shards);
-
-  // Constructor for non-sharded index (per-key)
-  explicit TextIndex(bool suffix);
+  // Constructor
+  explicit TextIndex(bool suffix) : shards_{} {
+    static_assert(NumShards > 1,
+                  "Use PerKeyTextIndex for single-shard instances, not "
+                  "TextIndex<1> (avoids 40-byte mutex overhead)");
+    for (size_t i = 0; i < NumShards; ++i) {
+      shards_[i].Initialize(FreePostingsCallback, suffix);
+    }
+  }
 
   // Get shard index for a word (based on first byte)
   size_t GetShardIndex(absl::string_view word) const;
 
   // Check if this is a sharded index
-  bool IsSharded() const { return num_shards_ > 1; }
+  bool IsSharded() const { return NumShards > 1; }
 
   // Accessors for specific shard
   Rax &GetPrefixShard(size_t shard_index);
@@ -93,9 +138,9 @@ class TextIndex {
   absl::Mutex &GetShardMutex(absl::string_view word);
   const absl::Mutex &GetShardMutex(absl::string_view word) const;
 
-  size_t GetNumShards() const { return num_shards_; }
+  size_t GetNumShards() const { return NumShards; }
 
-  // API compatibility: delegate to shard[0] for non-sharded/per-key access
+  // API compatibility: delegate to shard[0] - NEEDED for BuildTextIterator
   Rax &GetPrefix() { return GetPrefixShard(0); }
   const Rax &GetPrefix() const { return GetPrefixShard(0); }
   std::optional<std::reference_wrapper<Rax>> GetSuffix() {
@@ -105,28 +150,148 @@ class TextIndex {
     return GetSuffixShard(0);
   }
 
-  // Convenience method for suffix queries
-  Rax::WordIterator GetSuffixWordIterator(absl::string_view word) const {
-    size_t shard = GetShardIndex(word);
-    auto suffix_shard = GetSuffixShard(shard);
-    CHECK(suffix_shard.has_value()) << "Suffix not enabled";
-    return suffix_shard->get().GetWordIterator(word);
-  }
-
   struct Shard {
     Rax prefix_tree;
     std::unique_ptr<Rax> suffix_tree;
     mutable absl::Mutex mutex;
 
-    explicit Shard(void (*free_callback)(void *), bool with_suffix)
-        : prefix_tree(free_callback),
-          suffix_tree(with_suffix ? std::make_unique<Rax>(free_callback)
-                                  : nullptr) {}
+    // Default constructor for std::array compatibility
+    Shard() : prefix_tree(FreePostingsCallback), suffix_tree(nullptr) {}
+
+    // Initialize method called after default construction
+    void Initialize(void (*free_callback)(void *), bool with_suffix) {
+      // Rax already constructed with FreePostingsCallback in default ctor
+      // Just need to create suffix tree if requested
+      if (with_suffix) {
+        suffix_tree = std::make_unique<Rax>(free_callback);
+      }
+    }
   };
 
-  // Use unique_ptr for indirection - Shard contains non-movable Mutex
-  std::vector<std::unique_ptr<Shard>> shards_;
-  size_t num_shards_;
+  // Compile-time sized array - eliminates per-instance overhead
+  // For TextIndex<1>: just one Shard inline, no heap allocation
+  // For TextIndex<256>: 256 Shards, but only one schema instance
+  std::array<Shard, NumShards> shards_;
+};
+
+// Template member function implementations (must be in header)
+template <size_t NumShards>
+size_t TextIndex<NumShards>::GetShardIndex(absl::string_view word) const {
+  // Use first byte for deterministic sharding
+  // Modulo mathematically guarantees result < NumShards (no runtime check
+  // needed)
+  unsigned char first_byte =
+      word.empty() ? 0 : static_cast<unsigned char>(word[0]);
+  return first_byte % NumShards;
+}
+
+template <size_t NumShards>
+Rax &TextIndex<NumShards>::GetPrefixShard(size_t shard_index) {
+  return shards_[shard_index].prefix_tree;
+}
+
+template <size_t NumShards>
+const Rax &TextIndex<NumShards>::GetPrefixShard(size_t shard_index) const {
+  return shards_[shard_index].prefix_tree;
+}
+
+template <size_t NumShards>
+std::optional<std::reference_wrapper<Rax>> TextIndex<NumShards>::GetSuffixShard(
+    size_t shard_index) {
+  if (!shards_[shard_index].suffix_tree) {
+    return std::nullopt;
+  }
+  return std::ref(*shards_[shard_index].suffix_tree);
+}
+
+template <size_t NumShards>
+std::optional<std::reference_wrapper<const Rax>>
+TextIndex<NumShards>::GetSuffixShard(size_t shard_index) const {
+  if (!shards_[shard_index].suffix_tree) {
+    return std::nullopt;
+  }
+  return std::ref(*shards_[shard_index].suffix_tree);
+}
+
+template <size_t NumShards>
+void TextIndex<NumShards>::MutateTarget(
+    absl::string_view word, const InvasivePtr<Postings> &target,
+    const std::optional<std::string> &reverse_word, item_count_op op) {
+  auto CreateTargetSetFn = CreatePostingsTargetSetFn(target);
+
+  size_t prefix_shard = GetShardIndex(word);
+  size_t suffix_shard = prefix_shard;
+  if (reverse_word.has_value() && shards_[0].suffix_tree) {
+    suffix_shard = GetShardIndex(*reverse_word);
+  }
+
+  // Lock shards in sorted order to prevent deadlock
+  if (reverse_word.has_value() && suffix_shard != prefix_shard) {
+    size_t first = std::min(prefix_shard, suffix_shard);
+    size_t second = std::max(prefix_shard, suffix_shard);
+    absl::MutexLock lock1(&shards_[first].mutex);
+    absl::MutexLock lock2(&shards_[second].mutex);
+    shards_[prefix_shard].prefix_tree.MutateTarget(word, CreateTargetSetFn, op);
+    shards_[suffix_shard].suffix_tree->MutateTarget(*reverse_word,
+                                                    CreateTargetSetFn, op);
+  } else {
+    absl::MutexLock lock(&shards_[prefix_shard].mutex);
+    shards_[prefix_shard].prefix_tree.MutateTarget(word, CreateTargetSetFn, op);
+    if (reverse_word.has_value() && shards_[prefix_shard].suffix_tree) {
+      shards_[prefix_shard].suffix_tree->MutateTarget(*reverse_word,
+                                                      CreateTargetSetFn, op);
+    }
+  }
+}
+
+template <size_t NumShards>
+absl::Mutex &TextIndex<NumShards>::GetShardMutex(absl::string_view word) {
+  return shards_[GetShardIndex(word)].mutex;
+}
+
+template <size_t NumShards>
+const absl::Mutex &TextIndex<NumShards>::GetShardMutex(
+    absl::string_view word) const {
+  return shards_[GetShardIndex(word)].mutex;
+}
+
+// Lightweight per-key text index: ~56 bytes (Rax + unique_ptr), no mutex,
+// moveable Separate from template TextIndex<N> to avoid Shard mutex overhead
+class PerKeyTextIndex {
+ public:
+  explicit PerKeyTextIndex(bool suffix)
+      : prefix_tree_(FreePostingsCallback),
+        suffix_tree_(suffix ? std::make_unique<Rax>(FreePostingsCallback)
+                            : nullptr) {}
+
+  Rax &GetPrefix() { return prefix_tree_; }
+  const Rax &GetPrefix() const { return prefix_tree_; }
+
+  std::optional<std::reference_wrapper<Rax>> GetSuffix() {
+    if (!suffix_tree_) return std::nullopt;
+    return std::ref(*suffix_tree_);
+  }
+
+  std::optional<std::reference_wrapper<const Rax>> GetSuffix() const {
+    if (!suffix_tree_) return std::nullopt;
+    return std::ref(*suffix_tree_);
+  }
+
+  void MutateTarget(
+      absl::string_view word, const InvasivePtr<Postings> &target,
+      const std::optional<std::string> &reverse_word = std::nullopt,
+      item_count_op op = NONE) {
+    auto CreateTargetSetFn = CreatePostingsTargetSetFn(target);
+
+    prefix_tree_.MutateTarget(word, CreateTargetSetFn, op);
+    if (suffix_tree_ && reverse_word.has_value()) {
+      suffix_tree_->MutateTarget(*reverse_word, CreateTargetSetFn, op);
+    }
+  }
+
+ private:
+  Rax prefix_tree_;
+  std::unique_ptr<Rax> suffix_tree_;
 };
 
 class TextIndexSchema {
@@ -145,7 +310,9 @@ class TextIndexSchema {
   uint8_t AllocateTextFieldNumber() { return num_text_fields_++; }
   bool HasTextOffsets() const { return with_offsets_; }
   uint8_t GetNumTextFields() const { return num_text_fields_; }
-  std::shared_ptr<TextIndex> GetTextIndex() const { return text_index_; }
+  std::shared_ptr<TextIndex<kSchemaTextIndexShards>> GetTextIndex() const {
+    return text_index_;
+  }
   Lexer GetLexer() const { return lexer_; }
 
   // Access to metadata for memory pool usage
@@ -183,8 +350,9 @@ class TextIndexSchema {
   //
   // This is the main index of all Text fields in this index schema
   // Sharded by first byte for parallel writes (per-shard locks in TextIndex)
+  // Uses TextIndex<256> for many shards
   //
-  std::shared_ptr<TextIndex> text_index_;
+  std::shared_ptr<TextIndex<kSchemaTextIndexShards>> text_index_;
 
   //
   // Stem tree: maps stem roots to their parent words
@@ -201,11 +369,13 @@ class TextIndexSchema {
   //
   // To support the Delete record and the post-filtering case, there is a
   // separate table of postings that are indexed by Key.
+  // Uses lightweight PerKeyTextIndex (no mutex, same as current merged ~56
+  // bytes)
   //
   // This object must also ensure that updates of this object are multi-thread
   // safe.
   //
-  absl::node_hash_map<Key, TextIndex> per_key_text_indexes_;
+  absl::node_hash_map<Key, PerKeyTextIndex> per_key_text_indexes_;
 
   // Prevent concurrent mutations to per-key text index map
   std::mutex per_key_text_indexes_mutex_;
@@ -268,7 +438,8 @@ class TextIndexSchema {
 
   // Direct accessor for per-key text indexes.
   // Assumes that lock is already acquired earlier.
-  const absl::node_hash_map<Key, TextIndex> &GetPerKeyTextIndexes() const {
+  const absl::node_hash_map<Key, PerKeyTextIndex> &GetPerKeyTextIndexes()
+      const {
     return per_key_text_indexes_;
   }
 
@@ -277,8 +448,8 @@ class TextIndexSchema {
   size_t GetTrackedKeyCount() const { return per_key_text_indexes_.size(); }
 
   // Helper function to lookup text index for a key
-  static const TextIndex *LookupTextIndex(
-      const absl::node_hash_map<Key, TextIndex> &per_key_indexes,
+  static const PerKeyTextIndex *LookupTextIndex(
+      const absl::node_hash_map<Key, PerKeyTextIndex> &per_key_indexes,
       const Key &key) {
     if (!key) {
       CHECK(false) << "Invalid null key passed to LookupTextIndex";

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -56,34 +56,77 @@ struct TextIndexMetadata {
 
 class TextIndex {
   //
-  // The main query data structure maps Words into Postings objects. This
-  // is always done with a prefix tree. Optionally, a suffix tree can also be
-  // maintained. But in any case for the same word the two trees must point to
-  // the same Postings object, which is owned by this pair of trees. Plus,
-  // updates to these two trees need to be atomic when viewed externally. The
-  // locking provided by the RadixTree object is NOT quite sufficient to
-  // guarantee that the two trees are always in lock step. thus this object
-  // becomes responsible for cross-tree locking issues. Multiple locking
-  // strategies are possible. TBD (a shared-ed word lock table should work well)
+  // Sharded radix trees: words with same first byte share a shard.
+  // Each shard has independent tree + mutex, enabling true write parallelism.
+  // Words with different first bytes can modify their shards concurrently
+  // without blocking. Eliminates global text_index_mutex_ bottleneck.
   //
 
  public:
-  explicit TextIndex(bool suffix);
-  Rax &GetPrefix();
-  const Rax &GetPrefix() const;
-  std::optional<std::reference_wrapper<Rax>> GetSuffix();
-  std::optional<std::reference_wrapper<const Rax>> GetSuffix() const;
+  // Constructor for sharded index (schema-level)
+  explicit TextIndex(bool suffix, size_t num_shards);
 
-  // Applies target mutation to both prefix tree for |word| and, if the index
-  // has a suffix tree, to the suffix tree for reverse(word).
+  // Constructor for non-sharded index (per-key)
+  explicit TextIndex(bool suffix);
+
+  // Get shard index for a word (based on first byte)
+  size_t GetShardIndex(absl::string_view word) const;
+
+  // Check if this is a sharded index
+  bool IsSharded() const { return num_shards_ > 1; }
+
+  // Accessors for specific shard
+  Rax &GetPrefixShard(size_t shard_index);
+  const Rax &GetPrefixShard(size_t shard_index) const;
+  std::optional<std::reference_wrapper<Rax>> GetSuffixShard(size_t shard_index);
+  std::optional<std::reference_wrapper<const Rax>> GetSuffixShard(
+      size_t shard_index) const;
+
+  // Applies target mutation to appropriate shard for |word|
+  // If reverse_word is provided, also adds to suffix tree (if enabled)
   void MutateTarget(
       absl::string_view word, const InvasivePtr<Postings> &target,
       const std::optional<std::string> &reverse_word = std::nullopt,
       item_count_op op = NONE);
 
- private:
-  Rax prefix_tree_;
-  std::unique_ptr<Rax> suffix_tree_;
+  // Get mutex for shard protecting this word
+  absl::Mutex &GetShardMutex(absl::string_view word);
+  const absl::Mutex &GetShardMutex(absl::string_view word) const;
+
+  size_t GetNumShards() const { return num_shards_; }
+
+  // API compatibility: delegate to shard[0] for non-sharded/per-key access
+  Rax &GetPrefix() { return GetPrefixShard(0); }
+  const Rax &GetPrefix() const { return GetPrefixShard(0); }
+  std::optional<std::reference_wrapper<Rax>> GetSuffix() {
+    return GetSuffixShard(0);
+  }
+  std::optional<std::reference_wrapper<const Rax>> GetSuffix() const {
+    return GetSuffixShard(0);
+  }
+
+  // Convenience method for suffix queries
+  Rax::WordIterator GetSuffixWordIterator(absl::string_view word) const {
+    size_t shard = GetShardIndex(word);
+    auto suffix_shard = GetSuffixShard(shard);
+    CHECK(suffix_shard.has_value()) << "Suffix not enabled";
+    return suffix_shard->get().GetWordIterator(word);
+  }
+
+  struct Shard {
+    Rax prefix_tree;
+    std::unique_ptr<Rax> suffix_tree;
+    mutable absl::Mutex mutex;
+
+    explicit Shard(void (*free_callback)(void *), bool with_suffix)
+        : prefix_tree(free_callback),
+          suffix_tree(with_suffix ? std::make_unique<Rax>(free_callback)
+                                  : nullptr) {}
+  };
+
+  // Use unique_ptr for indirection - Shard contains non-movable Mutex
+  std::vector<std::unique_ptr<Shard>> shards_;
+  size_t num_shards_;
 };
 
 class TextIndexSchema {
@@ -127,10 +170,7 @@ class TextIndexSchema {
   uint64_t GetStemTextFieldMask() const { return stem_text_field_mask_; }
 
   // Enable suffix trie.
-  void EnableSuffix() {
-    with_suffix_trie_ = true;
-    text_index_ = std::make_shared<TextIndex>(true);
-  }
+  void EnableSuffix();
 
   void EnableSubtreeItemCountTracking() { track_subtree_item_counts_ = true; }
 
@@ -142,13 +182,9 @@ class TextIndexSchema {
 
   //
   // This is the main index of all Text fields in this index schema
+  // Sharded by first byte for parallel writes (per-shard locks in TextIndex)
   //
-  std::shared_ptr<TextIndex> text_index_ = std::make_shared<TextIndex>(false);
-
-  // Guards rax tree structural changes during concurrent writes.
-  // Used exclusively by CommitKeyData/DeleteKeyData when inserting or removing
-  // tree nodes.
-  mutable absl::Mutex text_index_mutex_;
+  std::shared_ptr<TextIndex> text_index_;
 
   //
   // Stem tree: maps stem roots to their parent words

--- a/src/indexes/text/textinfocmd.cc
+++ b/src/indexes/text/textinfocmd.cc
@@ -92,22 +92,24 @@ absl::Status IndexSchema::TextInfoCmd(ValkeyModuleCtx* ctx,
   if (subcommand == "PREFIX") {
     std::string word;
     VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, word));
-    auto wi = index_schema->GetTextIndexSchema()
-                  ->GetTextIndex()
-                  ->GetPrefix()
-                  .GetWordIterator(word);
+    auto text_index = index_schema->GetTextIndexSchema()->GetTextIndex();
+    size_t shard = text_index->GetShardIndex(word);
+    auto wi = text_index->GetPrefixShard(shard).GetWordIterator(word);
     bool with_keys = itr.PopIfNextIgnoreCase("WITHKEYS");
     bool with_positions = itr.PopIfNextIgnoreCase("WITHPOSITIONS");
     return DumpWordIterator(ctx, wi, with_keys, with_positions);
   } else if (subcommand == "SUFFIX") {
     std::string word;
     VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, word));
-    auto suffix =
-        index_schema->GetTextIndexSchema()->GetTextIndex()->GetSuffix();
-    if (!suffix) {
+    auto text_index = index_schema->GetTextIndexSchema()->GetTextIndex();
+    if (!text_index->GetSuffix().has_value()) {
       return absl::InvalidArgumentError("Suffix is not enabled");
     }
-    auto wi = suffix->get().GetWordIterator(word);
+    std::string reversed_word(word.rbegin(), word.rend());
+    size_t shard = text_index->GetShardIndex(reversed_word);
+    auto suffix_shard = text_index->GetSuffixShard(shard);
+    CHECK(suffix_shard.has_value()) << "Suffix not enabled";
+    auto wi = suffix_shard->get().GetWordIterator(reversed_word);
     bool with_keys = itr.PopIfNextIgnoreCase("WITHKEYS");
     bool with_positions = itr.PopIfNextIgnoreCase("WITHPOSITIONS");
     return DumpWordIterator(ctx, wi, with_keys, with_positions);

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -271,7 +271,7 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
 class PrefilterEvaluator : public query::Evaluator {
  public:
   explicit PrefilterEvaluator(
-      const valkey_search::indexes::text::TextIndex* text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex* text_index,
       QueryOperations query_operations)
       : query::Evaluator(query_operations), text_index_(text_index) {}
   bool Evaluate(const query::Predicate& predicate,
@@ -289,7 +289,7 @@ class PrefilterEvaluator : public query::Evaluator {
       const query::NumericPredicate& predicate) override;
   query::EvaluationResult EvaluateText(const query::TextPredicate& predicate,
                                        bool require_positions) override;
-  const valkey_search::indexes::text::TextIndex* text_index_;
+  const valkey_search::indexes::text::PerKeyTextIndex* text_index_;
   const InternedStringPtr* key_{nullptr};
 };
 

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -64,15 +64,14 @@ namespace {
 // for prefilter Returns true if the word was found and a valid key iterator was
 // added
 bool TryAddWordKeyIteratorForPrefilter(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     absl::string_view word, const InternedStringPtr &target_key,
     uint64_t field_mask, bool require_positions,
     absl::InlinedVector<
         valkey_search::indexes::text::Postings::KeyIterator,
         valkey_search::indexes::text::kWordExpansionInlineCapacity>
         &key_iterators) {
-  size_t shard = text_index.GetShardIndex(word);
-  auto word_iter = text_index.GetPrefixShard(shard).GetWordIterator(word);
+  auto word_iter = text_index.GetPrefix().GetWordIterator(word);
   if (!word_iter.Done() && word_iter.GetWord() == word) {
     auto postings = word_iter.GetPostingsTarget();
     if (postings) {
@@ -93,7 +92,7 @@ bool TryAddWordKeyIteratorForPrefilter(
 
 // TermPredicate: Exact term match in the text index.
 EvaluationResult TermPredicate::Evaluate(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
@@ -155,7 +154,7 @@ EvaluationResult PrefixPredicate::Evaluate(Evaluator &evaluator) const {
 
 // PrefixPredicate: Matches all terms that start with the given prefix.
 EvaluationResult PrefixPredicate::Evaluate(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
@@ -165,8 +164,7 @@ EvaluationResult PrefixPredicate::Evaluate(
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
 
-  size_t shard = text_index.GetShardIndex(term_);
-  auto word_iter = text_index.GetPrefixShard(shard).GetWordIterator(term_);
+  auto word_iter = text_index.GetPrefix().GetWordIterator(term_);
   while (!word_iter.Done() && word_count < max_words) {
     std::string_view word = word_iter.GetWord();
     auto postings = word_iter.GetPostingsTarget();
@@ -206,10 +204,11 @@ EvaluationResult SuffixPredicate::Evaluate(Evaluator &evaluator) const {
 
 // SuffixPredicate: Matches terms that end with the given suffix
 EvaluationResult SuffixPredicate::Evaluate(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
-  if (!text_index.GetSuffix().has_value()) {
+  auto suffix_opt = text_index.GetSuffix();
+  if (!suffix_opt.has_value()) {
     return EvaluationResult(false);
   }
   std::string reversed_term(term_.rbegin(), term_.rend());
@@ -219,32 +218,24 @@ EvaluationResult SuffixPredicate::Evaluate(
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
 
-  // Suffix routes to SINGLE shard using reversed term's prefix hash.
-  // "*ing" reversed = "gni" → shard hash("gni")
-  size_t shard = text_index.GetShardIndex(reversed_term);
-  {
-    auto suffix_shard = text_index.GetSuffixShard(shard);
-    if (suffix_shard) {
-      auto word_iter = suffix_shard->get().GetWordIterator(reversed_term);
-      while (!word_iter.Done() && word_count < max_words) {
-        std::string_view word = word_iter.GetWord();
-        if (!word.starts_with(reversed_term)) {
-          break;
-        }
-        auto postings = word_iter.GetPostingsTarget();
-        if (postings) {
-          auto key_iter = postings->GetKeyIterator();
-          // Skip to target key and verify it contains the required fields
-          if (key_iter.SkipForwardKey(target_key) &&
-              key_iter.ContainsFields(field_mask)) {
-            key_iterators.emplace_back(std::move(key_iter));
-          }
-        }
-        word_iter.Next();
-        ++word_count;
+  auto word_iter = suffix_opt->get().GetWordIterator(reversed_term);
+  while (!word_iter.Done() && word_count < max_words) {
+    std::string_view word = word_iter.GetWord();
+    if (!word.starts_with(reversed_term)) {
+      break;
+    }
+    auto postings = word_iter.GetPostingsTarget();
+    if (postings) {
+      auto key_iter = postings->GetKeyIterator();
+      // Skip to target key and verify it contains the required fields
+      if (key_iter.SkipForwardKey(target_key) &&
+          key_iter.ContainsFields(field_mask)) {
+        key_iterators.emplace_back(std::move(key_iter));
       }
-    }  // end if suffix_shard
-  }  // end single shard block
+    }
+    word_iter.Next();
+    ++word_count;
+  }
 
   if (key_iterators.empty()) {
     return EvaluationResult(false);
@@ -269,7 +260,7 @@ EvaluationResult InfixPredicate::Evaluate(Evaluator &evaluator) const {
 }
 
 EvaluationResult InfixPredicate::Evaluate(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   // TODO: Implement infix evaluation
   CHECK(false) << "Infix Search - Not implemented";
@@ -289,31 +280,25 @@ EvaluationResult FuzzyPredicate::Evaluate(Evaluator &evaluator) const {
 }
 
 EvaluationResult FuzzyPredicate::Evaluate(
-    const valkey_search::indexes::text::TextIndex &text_index,
+    const valkey_search::indexes::text::PerKeyTextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
 
+  // Fuzzy search on single per-key tree
+  auto key_iters = indexes::text::FuzzySearch::Search(
+      text_index.GetPrefix(), term_, distance_, max_words);
+
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       filtered_key_iterators;
 
-  // Fuzzy search MUST query ALL shards - words within edit distance can be in
-  // any shard
-  for (size_t shard = 0; shard < text_index.GetNumShards(); ++shard) {
-    uint32_t shard_max = max_words - filtered_key_iterators.size();
-    if (shard_max == 0) break;
-
-    auto key_iters = indexes::text::FuzzySearch::Search(
-        text_index.GetPrefixShard(shard), term_, distance_, shard_max);
-
-    // Filter and add to result
-    for (auto &key_iter : key_iters) {
-      if (key_iter.SkipForwardKey(target_key) &&
-          key_iter.ContainsFields(field_mask)) {
-        filtered_key_iterators.emplace_back(std::move(key_iter));
-      }
+  // Filter and add to result
+  for (auto &key_iter : key_iters) {
+    if (key_iter.SkipForwardKey(target_key) &&
+        key_iter.ContainsFields(field_mask)) {
+      filtered_key_iterators.emplace_back(std::move(key_iter));
     }
   }
 

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -71,7 +71,8 @@ bool TryAddWordKeyIteratorForPrefilter(
         valkey_search::indexes::text::Postings::KeyIterator,
         valkey_search::indexes::text::kWordExpansionInlineCapacity>
         &key_iterators) {
-  auto word_iter = text_index.GetPrefix().GetWordIterator(word);
+  size_t shard = text_index.GetShardIndex(word);
+  auto word_iter = text_index.GetPrefixShard(shard).GetWordIterator(word);
   if (!word_iter.Done() && word_iter.GetWord() == word) {
     auto postings = word_iter.GetPostingsTarget();
     if (postings) {
@@ -157,13 +158,15 @@ EvaluationResult PrefixPredicate::Evaluate(
     const valkey_search::indexes::text::TextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
-  auto word_iter = text_index.GetPrefix().GetWordIterator(term_);
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       key_iterators;
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
+
+  size_t shard = text_index.GetShardIndex(term_);
+  auto word_iter = text_index.GetPrefixShard(shard).GetWordIterator(term_);
   while (!word_iter.Done() && word_count < max_words) {
     std::string_view word = word_iter.GetWord();
     auto postings = word_iter.GetPostingsTarget();
@@ -178,6 +181,7 @@ EvaluationResult PrefixPredicate::Evaluate(
     word_iter.Next();
     ++word_count;
   }
+
   if (key_iterators.empty()) {
     return EvaluationResult(false);
   }
@@ -205,35 +209,43 @@ EvaluationResult SuffixPredicate::Evaluate(
     const valkey_search::indexes::text::TextIndex &text_index,
     const InternedStringPtr &target_key, bool require_positions) const {
   uint64_t field_mask = field_mask_;
-  auto suffix_opt = text_index.GetSuffix();
-  if (!suffix_opt.has_value()) {
+  if (!text_index.GetSuffix().has_value()) {
     return EvaluationResult(false);
   }
   std::string reversed_term(term_.rbegin(), term_.rend());
-  auto word_iter = suffix_opt.value().get().GetWordIterator(reversed_term);
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       key_iterators;
-  // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   uint32_t word_count = 0;
-  while (!word_iter.Done() && word_count < max_words) {
-    std::string_view word = word_iter.GetWord();
-    if (!word.starts_with(reversed_term)) {
-      break;
-    }
-    auto postings = word_iter.GetPostingsTarget();
-    if (postings) {
-      auto key_iter = postings->GetKeyIterator();
-      // Skip to target key and verify it contains the required fields
-      if (key_iter.SkipForwardKey(target_key) &&
-          key_iter.ContainsFields(field_mask)) {
-        key_iterators.emplace_back(std::move(key_iter));
+
+  // Suffix routes to SINGLE shard using reversed term's prefix hash.
+  // "*ing" reversed = "gni" → shard hash("gni")
+  size_t shard = text_index.GetShardIndex(reversed_term);
+  {
+    auto suffix_shard = text_index.GetSuffixShard(shard);
+    if (suffix_shard) {
+      auto word_iter = suffix_shard->get().GetWordIterator(reversed_term);
+      while (!word_iter.Done() && word_count < max_words) {
+        std::string_view word = word_iter.GetWord();
+        if (!word.starts_with(reversed_term)) {
+          break;
+        }
+        auto postings = word_iter.GetPostingsTarget();
+        if (postings) {
+          auto key_iter = postings->GetKeyIterator();
+          // Skip to target key and verify it contains the required fields
+          if (key_iter.SkipForwardKey(target_key) &&
+              key_iter.ContainsFields(field_mask)) {
+            key_iterators.emplace_back(std::move(key_iter));
+          }
+        }
+        word_iter.Next();
+        ++word_count;
       }
-    }
-    word_iter.Next();
-    ++word_count;
-  }
+    }  // end if suffix_shard
+  }  // end single shard block
+
   if (key_iterators.empty()) {
     return EvaluationResult(false);
   }
@@ -282,19 +294,29 @@ EvaluationResult FuzzyPredicate::Evaluate(
   uint64_t field_mask = field_mask_;
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
-  // Get all KeyIterators for words within edit distance
-  auto key_iters = indexes::text::FuzzySearch::Search(
-      text_index.GetPrefix(), term_, distance_, max_words);
-  // Filter to only include KeyIterators that match target_key and field_mask
+
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       filtered_key_iterators;
-  for (auto &key_iter : key_iters) {
-    if (key_iter.SkipForwardKey(target_key) &&
-        key_iter.ContainsFields(field_mask)) {
-      filtered_key_iterators.emplace_back(std::move(key_iter));
+
+  // Fuzzy search MUST query ALL shards - words within edit distance can be in
+  // any shard
+  for (size_t shard = 0; shard < text_index.GetNumShards(); ++shard) {
+    uint32_t shard_max = max_words - filtered_key_iterators.size();
+    if (shard_max == 0) break;
+
+    auto key_iters = indexes::text::FuzzySearch::Search(
+        text_index.GetPrefixShard(shard), term_, distance_, shard_max);
+
+    // Filter and add to result
+    for (auto &key_iter : key_iters) {
+      if (key_iter.SkipForwardKey(target_key) &&
+          key_iter.ContainsFields(field_mask)) {
+        filtered_key_iterators.emplace_back(std::move(key_iter));
+      }
     }
   }
+
   if (filtered_key_iterators.empty()) {
     return EvaluationResult(false);
   }

--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -15,6 +15,7 @@
 
 #include "absl/container/flat_hash_set.h"
 #include "absl/strings/string_view.h"
+#include "src/indexes/text/text_index.h"
 #include "src/indexes/text/text_iterator.h"
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/type_conversions.h"
@@ -25,12 +26,6 @@ class Numeric;
 class Tag;
 class EntriesFetcherBase;
 }  // namespace valkey_search::indexes
-
-namespace valkey_search::indexes::text {
-class TextIterator;
-class TextIndexSchema;
-class TextIndex;
-}  // namespace valkey_search::indexes::text
 
 namespace valkey_search {
 enum class QueryOperations : uint64_t;
@@ -185,15 +180,16 @@ class TextPredicate : public Predicate {
  public:
   TextPredicate() : Predicate(PredicateType::kText) {}
   ~TextPredicate() override = default;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   virtual EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key, bool require_positions) const = 0;
   virtual std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
       const = 0;
   virtual const FieldMaskPredicate GetFieldMask() const = 0;
   virtual std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const = 0;
   virtual size_t EstimateSize() const = 0;
 };
@@ -209,13 +205,14 @@ class TermPredicate : public TextPredicate {
   }
   absl::string_view GetTextString() const { return term_; }
   EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key,
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   bool IsExact() const { return exact_; }
@@ -239,13 +236,14 @@ class PrefixPredicate : public TextPredicate {
   }
   absl::string_view GetTextString() const { return term_; }
   EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key,
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize() const override;
@@ -267,13 +265,14 @@ class SuffixPredicate : public TextPredicate {
   }
   absl::string_view GetTextString() const { return term_; }
   EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key,
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize() const override;
@@ -295,13 +294,14 @@ class InfixPredicate : public TextPredicate {
   }
   absl::string_view GetTextString() const { return term_; }
   EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key,
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize() const override;
@@ -324,13 +324,14 @@ class FuzzyPredicate : public TextPredicate {
   absl::string_view GetTextString() const { return term_; }
   uint32_t GetDistance() const { return distance_; }
   EvaluationResult Evaluate(Evaluator& evaluator) const override;
-  // Evaluate against per-key TextIndex
+  // Evaluate against per-key PerKeyTextIndex
   EvaluationResult Evaluate(
-      const valkey_search::indexes::text::TextIndex& text_index,
+      const valkey_search::indexes::text::PerKeyTextIndex& text_index,
       const InternedStringPtr& target_key,
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
-      const std::shared_ptr<indexes::text::TextIndex>& text_index,
+      const std::shared_ptr<indexes::text::TextIndex<
+          indexes::text::kSchemaTextIndexShards>>& text_index,
       FieldMaskPredicate field_mask, bool require_positions) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize() const override;

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -88,10 +88,10 @@ class PredicateEvaluator : public query::Evaluator {
                      QueryOperations query_operations)
       : Evaluator(query_operations), records_(records), text_index_(nullptr) {}
 
-  PredicateEvaluator(const RecordsMap &records,
-                     const valkey_search::indexes::text::TextIndex *text_index,
-                     InternedStringPtr target_key,
-                     QueryOperations query_operations)
+  PredicateEvaluator(
+      const RecordsMap &records,
+      const valkey_search::indexes::text::PerKeyTextIndex *text_index,
+      InternedStringPtr target_key, QueryOperations query_operations)
       : Evaluator(query_operations),
         records_(records),
         text_index_(text_index),
@@ -145,7 +145,7 @@ class PredicateEvaluator : public query::Evaluator {
 
  private:
   const RecordsMap &records_;
-  const valkey_search::indexes::text::TextIndex *text_index_ = nullptr;
+  const valkey_search::indexes::text::PerKeyTextIndex *text_index_ = nullptr;
   InternedStringPtr target_key_;
 };
 

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -70,8 +70,8 @@ class InlineVectorFilter : public hnswlib::BaseFilterFunctor {
  public:
   InlineVectorFilter(
       query::Predicate *filter_predicate, indexes::VectorBase *vector_index,
-      const InternedStringNodeHashMap<valkey_search::indexes::text::TextIndex>
-          *per_key_indexes,
+      const InternedStringNodeHashMap<
+          valkey_search::indexes::text::PerKeyTextIndex> *per_key_indexes,
       QueryOperations query_operations)
       : filter_predicate_(filter_predicate),
         vector_index_(vector_index),
@@ -84,7 +84,7 @@ class InlineVectorFilter : public hnswlib::BaseFilterFunctor {
     if (!key.ok()) {
       return false;
     }
-    const valkey_search::indexes::text::TextIndex *text_index = nullptr;
+    const valkey_search::indexes::text::PerKeyTextIndex *text_index = nullptr;
     if (per_key_indexes_) {
       text_index =
           valkey_search::indexes::text::TextIndexSchema::LookupTextIndex(
@@ -97,7 +97,7 @@ class InlineVectorFilter : public hnswlib::BaseFilterFunctor {
  private:
   query::Predicate *filter_predicate_;
   indexes::VectorBase *vector_index_;
-  const InternedStringNodeHashMap<valkey_search::indexes::text::TextIndex>
+  const InternedStringNodeHashMap<valkey_search::indexes::text::PerKeyTextIndex>
       *per_key_indexes_;
   QueryOperations query_operations_;
 };
@@ -105,8 +105,9 @@ absl::StatusOr<std::vector<indexes::Neighbor>> PerformVectorSearch(
     indexes::VectorBase *vector_index, const SearchParameters &parameters) {
   std::unique_ptr<InlineVectorFilter> inline_filter;
   if (parameters.filter_parse_results.root_predicate != nullptr) {
-    const InternedStringNodeHashMap<valkey_search::indexes::text::TextIndex>
-        *per_key_indexes = nullptr;
+    const InternedStringNodeHashMap<
+        valkey_search::indexes::text::PerKeyTextIndex> *per_key_indexes =
+        nullptr;
     if (parameters.index_schema->GetTextIndexSchema()) {
       per_key_indexes = &parameters.index_schema->GetTextIndexSchema()
                              ->GetPerKeyTextIndexes();
@@ -382,7 +383,7 @@ void EvaluatePrefilteredKeys(
     result_keys.reserve(max_keys);
   }
   // Get per-key text indexes directly since we have reader lock
-  const InternedStringNodeHashMap<valkey_search::indexes::text::TextIndex>
+  const InternedStringNodeHashMap<valkey_search::indexes::text::PerKeyTextIndex>
       *per_key_indexes = nullptr;
   if (parameters.index_schema &&
       parameters.index_schema->GetTextIndexSchema()) {
@@ -400,7 +401,7 @@ void EvaluatePrefilteredKeys(
         iterator->Next();
         continue;
       }
-      const valkey_search::indexes::text::TextIndex *text_index = nullptr;
+      const valkey_search::indexes::text::PerKeyTextIndex *text_index = nullptr;
       if (per_key_indexes) {
         text_index =
             valkey_search::indexes::text::TextIndexSchema::LookupTextIndex(

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -86,6 +86,68 @@ TEST_F(TextIndexSchemaTest, FieldAllocationAcrossMultipleTexts) {
   // Schema correctly tracks field allocation for posting list identification
 }
 
+// Validate first-byte sharding routes words correctly
+TEST_F(TextIndexSchemaTest, ShardRoutingByFirstByte) {
+  auto schema = CreateSchema();
+  auto text_index = schema->GetTextIndex();
+
+  // Verify different first bytes go to different shards
+  EXPECT_NE(text_index->GetShardIndex("apple"),
+            text_index->GetShardIndex("banana"));
+  EXPECT_NE(text_index->GetShardIndex("cat"), text_index->GetShardIndex("dog"));
+  EXPECT_NE(text_index->GetShardIndex("test"),
+            text_index->GetShardIndex("zebra"));
+
+  // Same first byte = same shard
+  EXPECT_EQ(text_index->GetShardIndex("apple"),
+            text_index->GetShardIndex("avocado"));
+  EXPECT_EQ(text_index->GetShardIndex("test"),
+            text_index->GetShardIndex("tennis"));
+
+  // Verify deterministic routing
+  EXPECT_EQ(text_index->GetShardIndex("word"),
+            text_index->GetShardIndex("word"));
+}
+
+// Validate cross-shard suffix indexing (prefix and suffix in different shards)
+TEST_F(TextIndexSchemaTest, CrossShardSuffixIndexing) {
+  auto schema = CreateSchema();
+  schema->EnableSuffix();
+
+  // Allocate field number before staging data
+  uint8_t field_num = schema->AllocateTextFieldNumber();
+
+  auto text_index = schema->GetTextIndex();
+  auto key = StringInternStore::Intern("test_key");
+
+  // Index word where reversed word routes to different shard
+  // "forest" → shard['f'], reversed "tserof" → shard['t']
+  auto result =
+      schema->StageAttributeData(key, "forest", field_num, false, true);
+  EXPECT_TRUE(result.ok());
+  EXPECT_TRUE(*result);
+  schema->CommitKeyData(key);
+
+  // Verify word exists in prefix tree
+  size_t prefix_shard = text_index->GetShardIndex("forest");
+  auto prefix_iter =
+      text_index->GetPrefixShard(prefix_shard).GetWordIterator("forest");
+  EXPECT_FALSE(prefix_iter.Done());
+  EXPECT_EQ(prefix_iter.GetWord(), "forest");
+
+  // Verify reversed word exists in suffix tree
+  std::string reversed("tserof");
+  size_t suffix_shard = text_index->GetShardIndex(reversed);
+  auto suffix_shard_opt = text_index->GetSuffixShard(suffix_shard);
+  ASSERT_TRUE(suffix_shard_opt.has_value());
+  auto suffix_iter = suffix_shard_opt->get().GetWordIterator(reversed);
+  EXPECT_FALSE(suffix_iter.Done());
+  EXPECT_EQ(suffix_iter.GetWord(), reversed);
+
+  // Verify they're in different shards (key property of first-byte sharding)
+  EXPECT_NE(prefix_shard, suffix_shard);
+}
+
 }  // namespace text
 }  // namespace indexes
 }  // namespace valkey_search

--- a/testing/text_test.cc
+++ b/testing/text_test.cc
@@ -75,22 +75,24 @@ class TextTest : public ::testing::Test {
         data_model::LANGUAGE_ENGLISH, punct, with_offsets, stop_words, 4);
   }
 
-  // Helper to check if a token exists in the prefix tree
+  // Helper to check if a token exists in the prefix tree (shard-aware)
   bool TokenExists(const std::string& token,
                    std::shared_ptr<text::TextIndexSchema> schema = nullptr) {
     auto active_schema = schema ? schema : text_index_schema_;
-    auto iter =
-        active_schema->GetTextIndex()->GetPrefix().GetWordIterator(token);
+    auto text_index = active_schema->GetTextIndex();
+    size_t shard = text_index->GetShardIndex(token);
+    auto iter = text_index->GetPrefixShard(shard).GetWordIterator(token);
     return !iter.Done();
   }
 
-  // Helper to get postings for a token
+  // Helper to get postings for a token (shard-aware)
   text::InvasivePtr<text::Postings> GetPostingsForToken(
       const std::string& token,
       std::shared_ptr<text::TextIndexSchema> schema = nullptr) {
     auto active_schema = schema ? schema : text_index_schema_;
-    auto iter =
-        active_schema->GetTextIndex()->GetPrefix().GetWordIterator(token);
+    auto text_index = active_schema->GetTextIndex();
+    size_t shard = text_index->GetShardIndex(token);
+    auto iter = text_index->GetPrefixShard(shard).GetWordIterator(token);
     if (iter.Done()) {
       return nullptr;
     }
@@ -384,18 +386,22 @@ TEST_F(TextTest, StemmingBehavior) {
 
   // Stemming behavior depends on the stemmer implementation
   // This test ensures stemming doesn't break the indexing pipeline
-  auto& prefix_tree = stemming_schema->GetTextIndex()->GetPrefix();
-
-  // Should create some tokens (exact form depends on stemmer)
   bool has_tokens = false;
-  // We can't easily iterate over all tokens, but we know at least some should
-  // exist
-  auto run_iter = prefix_tree.GetWordIterator("run");
-  if (!run_iter.Done()) {
+  auto text_index = stemming_schema->GetTextIndex();
+
+  // Check if "run" exists
+  size_t shard1 = text_index->GetShardIndex("run");
+  auto run_postings =
+      text_index->GetPrefixShard(shard1).FindPostingsTarget("run");
+  if (run_postings) {
     has_tokens = true;
   }
-  auto running_iter = prefix_tree.GetWordIterator("running");
-  if (!running_iter.Done()) {
+
+  // Check if "running" exists
+  size_t shard2 = text_index->GetShardIndex("running");
+  auto running_postings =
+      text_index->GetPrefixShard(shard2).FindPostingsTarget("running");
+  if (running_postings) {
     has_tokens = true;
   }
 


### PR DESCRIPTION
Shard the radix into small trees. Previously, we just had one big tree for prefix/suffix each at schema. We had to acquire lock at global level on entire tree for any writes. Break into small configurable trees and lock the tree at shard level. Use first byte of the word to hash the tree. Allows parallel writes on different sharded tree