### PR TITLE
Implement clean up index schemas on SHUTDOWN event

### DIFF
--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -748,6 +748,23 @@ void SchemaManager::OnServerCronCallback(ValkeyModuleCtx *ctx,
       ctx, options::GetBackfillBatchSize().GetValue());
 }
 
+void SchemaManager::OnShutdownCallback(ValkeyModuleCtx *ctx,
+                                       [[maybe_unused]] ValkeyModuleEvent eid,
+                                       [[maybe_unused]] uint64_t subevent,
+                                       [[maybe_unused]] void *data) {
+  absl::MutexLock lock(&db_to_index_schemas_mutex_);
+  if (db_to_index_schemas_.empty()) {
+    return;
+  }
+  VMSDK_LOG(NOTICE, ctx) << "Deleting all index schemas on SHUTDOWN event";
+  auto status = RemoveAll();
+  if (!status.ok()) {
+    VMSDK_LOG(WARNING, ctx)
+        << "Failed to delete all index schemas on SHUTDOWN event: "
+        << status.message();
+  }
+}
+
 void SchemaManager::PopulateFingerprintVersionFromMetadata(
     uint32_t db_num, absl::string_view name, uint64_t fingerprint,
     uint32_t version) {

--- a/src/schema_manager.h
+++ b/src/schema_manager.h
@@ -100,6 +100,9 @@ class SchemaManager {
 
   void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                             uint64_t subevent, void *data);
+  void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
+                          uint64_t subevent, void *data)
+      ABSL_LOCKS_EXCLUDED(db_to_index_schemas_mutex_);
 
   void PopulateFingerprintVersionFromMetadata(uint32_t db_num,
                                               absl::string_view name,

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -50,6 +50,11 @@ void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
   }
 }
 
+void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
+                        uint64_t subevent, void *data) {
+  SchemaManager::Instance().OnShutdownCallback(ctx, eid, subevent, data);
+}
+
 void AtForkPrepare() { ValkeySearch::Instance().AtForkPrepare(); }
 
 void AfterForkParent() { ValkeySearch::Instance().AfterForkParent(); }
@@ -72,6 +77,8 @@ void SubscribeToServerEvents() {
                                       &OnSwapDBCallback);
   ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_FlushDB,
                                       &OnFlushDBCallback);
+  ValkeyModule_SubscribeToServerEvent(ctx, ValkeyModuleEvent_Shutdown,
+                                      &OnShutdownCallback);
 }
 
 }  // namespace valkey_search::server_events

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -247,6 +247,24 @@ TEST_F(SchemaManagerTest, TestOnFlushDB) {
   }
 }
 
+TEST_F(SchemaManagerTest, TestOnShutdownCallback) {
+  for (bool coordinator_enabled : {true, false}) {
+    if (coordinator_enabled) {
+      coordinator::MetadataManager::InitInstance(
+          std::move(test_metadata_manager_));
+    }
+    SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
+        &fake_ctx_, []() {}, nullptr, coordinator_enabled));
+    VMSDK_EXPECT_OK(SchemaManager::Instance()
+                        .CreateIndexSchema(&fake_ctx_, test_index_schema_proto_)
+                        .status());
+    EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
+    ValkeyModuleEvent eid;
+    SchemaManager::Instance().OnShutdownCallback(&fake_ctx_, eid, 0, nullptr);
+    EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 0);
+  }
+}
+
 TEST_F(SchemaManagerTest, TestSaveIndexesBeforeRDB) {
   ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
       .WillByDefault(testing::Return(&fake_ctx_));

--- a/testing/server_events_test.cc
+++ b/testing/server_events_test.cc
@@ -67,6 +67,12 @@ TEST_F(ServerEventsTest, SubscribesToServerEvents) {
           testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_FlushDB),
           testing::_))
       .WillOnce(testing::Return(1));
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      SubscribeToServerEvent(
+          testing::_, vmsdk::IsValkeyModuleEvent(ValkeyModuleEvent_Shutdown),
+          testing::_))
+      .WillOnce(testing::Return(1));
   SubscribeToServerEvents();
 }
 


### PR DESCRIPTION
Implement cleaning up all index schema objects on `VALKEYMODULE_EVENT_SHUTDOWN`.
This avoids relying on unload callbacks, which are not invoked for modules exporting module data types.
Includes unit test updates for shutdown event subscription and shutdown cleanup behavior.

issue : #812 