### PR TITLE
fix: prevent infinite drain loop in forked BGSave child process

### DIFF
--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -410,3 +410,33 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         i = self.client.info("search")
         save_mutation_entries = i["search_rdb_save_mutation_entries"]
         assert save_mutation_entries == 0
+
+    def test_mutation_queue_drain_on_bgsave_child(self):
+        """BGSAVE forks a child — drain must not hang on a frozen queue."""
+        self.client.execute_command("CONFIG SET search.drain-mutation-queue-on-save yes")
+        self.client.execute_command("CONFIG SET search.writer-threads 1")
+        self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
+        index.create(self.client, True)
+        records = make_data(num_vectors=100)
+
+        # Load data with blocked mutation queue so entries stay queued
+        client_threads = []
+        for i in range(len(records)):
+            new_client = self.server.get_new_client()
+            t = threading.Thread(target=index.write_data, args=(new_client, i, records[i]))
+            t.start()
+            client_threads += [t]
+
+        waiters.wait_for_true(lambda: self.mutation_queue_size() == len(records))
+
+        # Unblock writer thread then immediately BGSAVE — fork will snapshot
+        # while queue is still non-empty. Child must not hang.
+        self.client.execute_command("ft._debug PAUSEPOINT RESET block_mutation_queue")
+        self.client.execute_command("BGSAVE")
+        waiters.wait_for_true(
+            lambda: self.client.info('persistence')['rdb_bgsave_in_progress'] == 0,
+            timeout=10
+        )
+
+        for t in client_threads:
+            t.join()

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -1226,20 +1226,20 @@ static absl::Status SaveSupplementalSection(
 }
 
 absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
-  // Drain mutation queue before save if configured.
-  // Skip draining in forked child (BGSave) — the queue is a frozen snapshot
-  // and will never drain, causing an infinite loop.
-  if (options::GetDrainMutationQueueOnSave().GetValue()) {
-    int flags = ValkeyModule_GetContextFlags(nullptr);
-    bool is_bgsave = (flags & VALKEYMODULE_CTX_FLAGS_IS_CHILD) != 0;
-    if (is_bgsave) {
-      return absl::InternalError(
-          "Cannot drain mutation queue in forked child process");
-    }
+  // Drain mutation queue before save if configured and queue is non-empty.
+  // In forked child (BGSave), the queue is a frozen snapshot that will never
+  // drain, so skip it instead.
+  int flags = ValkeyModule_GetContextFlags(nullptr);
+  bool is_bgsave = (flags & VALKEYMODULE_CTX_FLAGS_IS_CHILD) != 0;
+  if (options::GetDrainMutationQueueOnSave().GetValue() &&
+      !tracked_mutated_records_.empty() && !is_bgsave) {
     VMSDK_LOG(NOTICE, nullptr)
         << "Draining mutation queue before RDB save for index "
         << vmsdk::config::RedactIfNeeded(name_);
-    VMSDK_RETURN_IF_ERROR(DrainMutationQueue(detached_ctx_.get()));
+
+    VMSDK_RETURN_IF_ERROR(DrainMutationQueue(
+        detached_ctx_.get(),
+        options::GetDrainMutationQueueOnSaveTimeoutMs().GetValue()));
   }
 
   VMSDK_LOG(DEBUG, nullptr)
@@ -1643,11 +1643,11 @@ void IndexSchema::OnSwapDB(ValkeyModuleSwapDbInfo *swap_db_info) {
   }
 }
 
-absl::Status IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
+absl::Status IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx,
+                                             int64_t timeout_ms) const {
   static const auto max_sleep = std::chrono::milliseconds(100);
   auto sleep_duration = std::chrono::milliseconds(1);
-  auto timeout = std::chrono::milliseconds(
-      options::GetDrainMutationQueueTimeoutMs().GetValue());
+  auto timeout = std::chrono::milliseconds(timeout_ms);
   auto start = std::chrono::steady_clock::now();
 
   while (true) {
@@ -1687,12 +1687,7 @@ void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
                                    ? " Backfill still required."
                                    : " Backfill not needed.");
     if (options::GetDrainMutationQueueOnLoad().GetValue()) {
-      auto status = DrainMutationQueue(ctx);
-      if (!status.ok()) {
-        VMSDK_LOG(WARNING, ctx)
-            << "Failed to drain mutation queue on load for index "
-            << vmsdk::config::RedactIfNeeded(name_) << ": " << status;
-      }
+      DrainMutationQueue(ctx, 0).IgnoreError();
     }
     return;
   }

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -1226,12 +1226,20 @@ static absl::Status SaveSupplementalSection(
 }
 
 absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
-  // Drain mutation queue before save if configured
+  // Drain mutation queue before save if configured.
+  // Skip draining in forked child (BGSave) — the queue is a frozen snapshot
+  // and will never drain, causing an infinite loop.
   if (options::GetDrainMutationQueueOnSave().GetValue()) {
+    int flags = ValkeyModule_GetContextFlags(nullptr);
+    bool is_bgsave = (flags & VALKEYMODULE_CTX_FLAGS_IS_CHILD) != 0;
+    if (is_bgsave) {
+      return absl::InternalError(
+          "Cannot drain mutation queue in forked child process");
+    }
     VMSDK_LOG(NOTICE, nullptr)
         << "Draining mutation queue before RDB save for index "
         << vmsdk::config::RedactIfNeeded(name_);
-    DrainMutationQueue(detached_ctx_.get());
+    VMSDK_RETURN_IF_ERROR(DrainMutationQueue(detached_ctx_.get()));
   }
 
   VMSDK_LOG(DEBUG, nullptr)
@@ -1635,9 +1643,12 @@ void IndexSchema::OnSwapDB(ValkeyModuleSwapDbInfo *swap_db_info) {
   }
 }
 
-void IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
+absl::Status IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
   static const auto max_sleep = std::chrono::milliseconds(100);
   auto sleep_duration = std::chrono::milliseconds(1);
+  auto timeout = std::chrono::milliseconds(
+      options::GetDrainMutationQueueTimeoutMs().GetValue());
+  auto start = std::chrono::steady_clock::now();
 
   while (true) {
     size_t queue_size;
@@ -1645,8 +1656,15 @@ void IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
       absl::MutexLock lock(&mutated_records_mutex_);
       queue_size = tracked_mutated_records_.size();
       if (queue_size == 0) {
-        break;
+        return absl::OkStatus();
       }
+    }
+    if (timeout.count() > 0 &&
+        std::chrono::steady_clock::now() - start >= timeout) {
+      VMSDK_LOG(WARNING, ctx) << "Drain mutation queue timed out for index "
+                              << vmsdk::config::RedactIfNeeded(name_)
+                              << ", entries remaining: " << queue_size;
+      return absl::DeadlineExceededError("Drain mutation queue timed out");
     }
     VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 10)
         << "Draining Mutation Queue for index "
@@ -1669,7 +1687,12 @@ void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
                                    ? " Backfill still required."
                                    : " Backfill not needed.");
     if (options::GetDrainMutationQueueOnLoad().GetValue()) {
-      DrainMutationQueue(ctx);
+      auto status = DrainMutationQueue(ctx);
+      if (!status.ok()) {
+        VMSDK_LOG(WARNING, ctx)
+            << "Failed to drain mutation queue on load for index "
+            << vmsdk::config::RedactIfNeeded(name_) << ": " << status;
+      }
     }
     return;
   }

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -451,7 +451,7 @@ class IndexSchema : public KeyspaceEventSubscription,
                         vmsdk::ThreadPool::Priority priority,
                         absl::BlockingCounter *blocking_counter);
   void EnqueueMultiMutation(const Key &key);
-  void DrainMutationQueue(ValkeyModuleCtx *ctx) const
+  absl::Status DrainMutationQueue(ValkeyModuleCtx *ctx) const
       ABSL_LOCKS_EXCLUDED(mutated_records_mutex_);
 
   void SyncProcessMutation(ValkeyModuleCtx *ctx,

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -451,7 +451,8 @@ class IndexSchema : public KeyspaceEventSubscription,
                         vmsdk::ThreadPool::Priority priority,
                         absl::BlockingCounter *blocking_counter);
   void EnqueueMultiMutation(const Key &key);
-  absl::Status DrainMutationQueue(ValkeyModuleCtx *ctx) const
+  absl::Status DrainMutationQueue(ValkeyModuleCtx *ctx,
+                                  int64_t timeout_ms) const
       ABSL_LOCKS_EXCLUDED(mutated_records_mutex_);
 
   void SyncProcessMutation(ValkeyModuleCtx *ctx,

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -408,6 +408,17 @@ constexpr absl::string_view kDrainMutationQueueOnSaveConfig{
 static auto drain_mutation_queue_on_save =
     config::BooleanBuilder(kDrainMutationQueueOnSaveConfig, false).Build();
 
+/// Register the "drain-mutation-queue-timeout-ms" flag
+/// Timeout for draining the mutation queue in milliseconds
+constexpr absl::string_view kDrainMutationQueueTimeoutMsConfig{
+    "drain-mutation-queue-timeout-ms"};
+static auto drain_mutation_queue_timeout_ms =
+    config::NumberBuilder(kDrainMutationQueueTimeoutMsConfig,
+                          5000,       // default 5 seconds
+                          0,          // min
+                          INT64_MAX)  // max
+        .Build();
+
 /// Register the "fanout-data-uniformity" flag
 /// U = uniformity (0-100): 100 = uniform distribution, 0 = all data in one
 /// shard Formula: limit_per_shard = ceil(K/N) + ((100-U) * (K - ceil(K/N)) /
@@ -584,6 +595,10 @@ const vmsdk::config::Boolean& GetDrainMutationQueueOnSave() {
 const vmsdk::config::Boolean& GetDrainMutationQueueOnLoad() {
   return dynamic_cast<const vmsdk::config::Boolean&>(
       *drain_mutation_queue_on_load);
+}
+
+vmsdk::config::Number& GetDrainMutationQueueTimeoutMs() {
+  return dynamic_cast<vmsdk::config::Number&>(*drain_mutation_queue_timeout_ms);
 }
 
 vmsdk::config::Number& GetFanoutDataUniformity() {

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -408,12 +408,12 @@ constexpr absl::string_view kDrainMutationQueueOnSaveConfig{
 static auto drain_mutation_queue_on_save =
     config::BooleanBuilder(kDrainMutationQueueOnSaveConfig, false).Build();
 
-/// Register the "drain-mutation-queue-timeout-ms" flag
+/// Register the "drain-mutation-queue-on-save-timeout-ms" flag
 /// Timeout for draining the mutation queue in milliseconds
-constexpr absl::string_view kDrainMutationQueueTimeoutMsConfig{
-    "drain-mutation-queue-timeout-ms"};
-static auto drain_mutation_queue_timeout_ms =
-    config::NumberBuilder(kDrainMutationQueueTimeoutMsConfig,
+constexpr absl::string_view kDrainMutationQueueOnSaveTimeoutMsConfig{
+    "drain-mutation-queue-on-save-timeout-ms"};
+static auto drain_mutation_queue_on_save_timeout_ms =
+    config::NumberBuilder(kDrainMutationQueueOnSaveTimeoutMsConfig,
                           5000,       // default 5 seconds
                           0,          // min
                           INT64_MAX)  // max
@@ -597,8 +597,9 @@ const vmsdk::config::Boolean& GetDrainMutationQueueOnLoad() {
       *drain_mutation_queue_on_load);
 }
 
-vmsdk::config::Number& GetDrainMutationQueueTimeoutMs() {
-  return dynamic_cast<vmsdk::config::Number&>(*drain_mutation_queue_timeout_ms);
+vmsdk::config::Number& GetDrainMutationQueueOnSaveTimeoutMs() {
+  return dynamic_cast<vmsdk::config::Number&>(
+      *drain_mutation_queue_on_save_timeout_ms);
 }
 
 vmsdk::config::Number& GetFanoutDataUniformity() {

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -97,8 +97,8 @@ const config::Boolean& GetDrainMutationQueueOnSave();
 /// Return the configuration entry for draining mutation queue on load
 const config::Boolean& GetDrainMutationQueueOnLoad();
 
-/// Return the drain mutation queue timeout in milliseconds
-config::Number& GetDrainMutationQueueTimeoutMs();
+/// Return the drain mutation queue on save timeout in milliseconds
+config::Number& GetDrainMutationQueueOnSaveTimeoutMs();
 
 /// Return the fanout data uniformity configuration (0-100)
 config::Number& GetFanoutDataUniformity();

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -97,6 +97,9 @@ const config::Boolean& GetDrainMutationQueueOnSave();
 /// Return the configuration entry for draining mutation queue on load
 const config::Boolean& GetDrainMutationQueueOnLoad();
 
+/// Return the drain mutation queue timeout in milliseconds
+config::Number& GetDrainMutationQueueTimeoutMs();
+
 /// Return the fanout data uniformity configuration (0-100)
 config::Number& GetFanoutDataUniformity();
 


### PR DESCRIPTION
DrainMutationQueue spins forever in the BGSave forked child process because the mutation queue is a frozen snapshot that will never be drained by writer threads. Check VALKEYMODULE_CTX_FLAGS_IS_CHILD and return an error instead of attempting to drain.

Also adds a configurable timeout (drain-mutation-queue-timeout-ms, default 5s) to DrainMutationQueue as a safety net, and an integration test covering the BGSAVE with non-empty mutation queue scenario.