### PR TITLE
Implement configuration for TAG wildcard minimum prefix length

### DIFF
--- a/docs/topics/search-configurables.md
+++ b/docs/topics/search-configurables.md
@@ -28,6 +28,7 @@ The search module uses the Valkey configuration mechanism. Thus each of the name
 | search.local-fanout-queue-wait-threshold      | Number  |               | Queue wait threshold in milliseconds for preferring local node in fanout operations                                               |
 | search.thread-pool-wait-time-samples          | Number  |               | Sample queue size for thread pool wait time tracking                                                                              |
 | search.max-term-expansions                    | Number  |               | Maximum number of words to search in text operations (prefix, suffix, fuzzy) to limit memory usage                                |
+| search.tag-min-prefix-length                  | Number  |               | Minimum number of characters required before trailing `*` in TAG wildcard queries (length excludes `*`)                          |
 | search.search-result-buffer-multiplier        | String  |               | Multiplier for search result buffer size allocation                                                                               |
 | search.drain-mutation-queue-on-save           | Boolean |               | Drain the mutation queue before RDB save                                                                                          |
 | search.query-string-depth                     | Number  |               | Controls the depth of the query string parsing from the FT.SEARCH cmd                                                             |

--- a/integration/test_query_parser.py
+++ b/integration/test_query_parser.py
@@ -218,3 +218,83 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         # OR operator
         result = client.execute_command("FT.SEARCH", "idx1", 'con*+ | word1!!')
         assert result[0] == 2
+
+    def test_tag_min_prefix_length_config(self):
+        """
+        Test that search.tag-min-prefix-length dynamically controls TAG wildcard
+        prefix validation (prefix length excludes the trailing '*').
+        """
+        client: Valkey = self.server.get_new_client()
+        config_name = "search.tag-min-prefix-length"
+        original = client.execute_command(f"CONFIG GET {config_name}")
+        assert original == [b"search.tag-min-prefix-length", b"2"]
+        original_value = int(original[1])
+
+        try:
+            # Ensure deterministic baseline for this test.
+            assert client.execute_command(f"CONFIG SET {config_name} 2") == b"OK"
+            assert client.execute_command(
+                "FT.CREATE", "tag_prefix_cfg_idx",
+                "ON", "HASH",
+                "PREFIX", "1", "tagcfg:",
+                "SCHEMA", "color", "TAG"
+            ) == b"OK"
+            assert client.execute_command("HSET", "tagcfg:1", "color", "blue") == 1
+            assert client.execute_command("HSET", "tagcfg:2", "color", "black") == 1
+            assert client.execute_command("HSET", "tagcfg:3", "color", "green") == 1
+
+            # Default min-prefix-length=2:
+            # "bl*" (2 chars before '*') works, "b*" is rejected.
+            result = client.execute_command(
+                "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{bl*}", "NOCONTENT"
+            )
+            assert result[0] == 2
+            with pytest.raises(ResponseError, match="too short for prefix wildcard"):
+                client.execute_command(
+                    "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{b*}", "NOCONTENT"
+                )
+
+            # Lowering to 1 allows "b*".
+            assert client.execute_command(f"CONFIG SET {config_name} 1") == b"OK"
+            result = client.execute_command(
+                "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{b*}", "NOCONTENT"
+            )
+            assert result[0] == 2
+
+            # Even at 1, "*" is still too short (0 chars before '*').
+            with pytest.raises(ResponseError, match="too short for prefix wildcard"):
+                client.execute_command(
+                    "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{*}", "NOCONTENT"
+                )
+
+            # Lowering to 0 allows wildcard-only query ("*" has 0 chars before
+            # trailing '*').
+            assert client.execute_command(f"CONFIG SET {config_name} 0") == b"OK"
+            result = client.execute_command(
+                "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{*}", "NOCONTENT"
+            )
+            assert result[0] == 3
+
+            # Raising to 3 makes "bl*" invalid; "blu*" remains valid.
+            assert client.execute_command(f"CONFIG SET {config_name} 3") == b"OK"
+            with pytest.raises(ResponseError, match="too short for prefix wildcard"):
+                client.execute_command(
+                    "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{bl*}", "NOCONTENT"
+                )
+            result = client.execute_command(
+                "FT.SEARCH", "tag_prefix_cfg_idx", "@color:{blu*}", "NOCONTENT"
+            )
+            assert result[0] == 1
+            assert result[1] == b"tagcfg:1"
+
+            # Lower bound validation: negative value is invalid.
+            with pytest.raises(
+                ResponseError,
+                match="argument must be between 0 and 4294967295 inclusive",
+            ):
+                client.execute_command(f"CONFIG SET {config_name} -1")
+        finally:
+            assert (
+                client.execute_command(f"CONFIG SET {config_name} {original_value}")
+                == b"OK"
+            )

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -25,13 +25,10 @@
 #include "src/query/predicate.h"
 #include "src/utils/patricia_tree.h"
 #include "src/utils/string_interning.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::indexes {
-
-// For performance reasons, a minimum term length is enforced. The default is 2,
-// but configurable.
-const int16_t kDefaultMinPrefixLength{2};
 
 static bool IsValidPrefix(absl::string_view str) {
   return str.length() < 2 || str[str.length() - 1] != '*' ||
@@ -96,8 +93,11 @@ absl::StatusOr<absl::flat_hash_set<absl::string_view>> Tag::ParseSearchTags(
         return absl::InvalidArgumentError(
             absl::StrCat("Tag string `", tag, "` ends with multiple *."));
       }
+      const auto min_prefix_length =
+          options::GetTagMinPrefixLength().GetValue();
+
       // Prefix tags shorter than min length are rejected.
-      if (tag.length() <= kDefaultMinPrefixLength) {
+      if (tag.length() <= min_prefix_length) {
         return absl::InvalidArgumentError(absl::StrCat(
             "Tag string `", tag, "` is too short for prefix wildcard."));
       }

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -318,6 +318,19 @@ static auto max_term_expansions =
                           kMaximumMaxTermExpansions)  // max limit (100k)
         .Build();
 
+/// Register the "--tag-min-prefix-length" flag. Controls the minimum number
+/// of characters required before trailing '*' in TAG wildcard queries.
+/// The length excludes the '*' character itself.
+constexpr absl::string_view kTagMinPrefixLengthConfig{"tag-min-prefix-length"};
+constexpr uint32_t kDefaultTagMinPrefixLength{2};
+constexpr uint32_t kMinimumTagMinPrefixLength{0};
+static auto tag_min_prefix_length =
+    config::NumberBuilder(kTagMinPrefixLengthConfig,   // name
+                          kDefaultTagMinPrefixLength,  // default limit (2)
+                          kMinimumTagMinPrefixLength,  // min limit (0)
+                          UINT_MAX)                    // max limit
+        .Build();
+
 /// Register the "--prefiltering-threshold-ratio" flag
 /// Controls when pre-filtering is used vs inline-filtering for hybrid queries
 constexpr absl::string_view kPrefilteringThresholdRatioConfig{
@@ -574,6 +587,10 @@ vmsdk::config::Number& GetThreadPoolWaitTimeSamples() {
 
 vmsdk::config::Number& GetMaxTermExpansions() {
   return dynamic_cast<vmsdk::config::Number&>(*max_term_expansions);
+}
+
+vmsdk::config::Number& GetTagMinPrefixLength() {
+  return dynamic_cast<vmsdk::config::Number&>(*tag_min_prefix_length);
 }
 
 const vmsdk::config::Boolean& GetDrainMutationQueueOnSave() {

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -85,6 +85,9 @@ config::Number& GetThreadPoolWaitTimeSamples();
 /// suffix, fuzzy)
 config::Number& GetMaxTermExpansions();
 
+/// Return the minimum TAG prefix length for wildcard queries (excluding '*')
+config::Number& GetTagMinPrefixLength();
+
 /// Return the search result buffer multiplier value
 double GetSearchResultBufferMultiplier();
 


### PR DESCRIPTION
kDefaultMinPrefixLength is annotated as “configurable”, but it is currently hardcoded and cannot be changed at runtime.
This PR adds a module config (search.tag-min-prefix-length) to control the minimum prefix length for TAG wildcard queries (e.g., @field:{prefix*}).

issue : #895 