### PR TITLE
Allow FT._debug to use when client is admin

### DIFF
--- a/integration/test_debug.py
+++ b/integration/test_debug.py
@@ -1,6 +1,7 @@
 from valkey import ResponseError
 from valkey.client import Valkey
 from valkey_search_test_case import (
+    ValkeySearchTestCaseBase,
     ValkeySearchTestCaseDebugMode,
     ValkeySearchClusterTestCaseDebugMode,
 )
@@ -79,3 +80,17 @@ class TestFtDebugCommand(ValkeySearchTestCaseDebugMode):
         assert byref[6] == {'Count': 10, 'Bytes': 140, 'AvgSize': b'14', 'Allocated': 320, 'AvgAllocated': b'32', 'Utilization': 43}
         assert bysize[-12] == {'Count': 10, 'Bytes': 120, 'AvgSize': b'12', 'Allocated': 280, 'AvgAllocated': b'28', 'Utilization': 42}
         assert bysize[14] == {'Count': 10, 'Bytes': 140, 'AvgSize': b'14', 'Allocated': 320, 'AvgAllocated': b'32', 'Utilization': 43}
+
+    def test_ft_debug_denied_without_admin_permissions(self):
+        self.client.execute_command(
+            "ACL", "SETUSER", "debug_user", "on", ">password",
+            "~*", "&*", "-@all", "+@read"
+        )
+
+        restricted_client = self.server.get_new_client()
+        restricted_client.execute_command("AUTH", "debug_user", "password")
+
+        with pytest.raises(ResponseError, match="has no permissions to run"):
+            restricted_client.execute_command("FT._DEBUG", "HELP")
+
+        self.client.execute_command("ACL", "DELUSER", "debug_user")

--- a/integration/test_valkey_search_acl.py
+++ b/integration/test_valkey_search_acl.py
@@ -15,35 +15,88 @@ class TestCommandsACLs(ValkeySearchTestCaseBase):
     def _verify_user_permissions(
         self, client: Valkey, cmd: List[str], should_access: bool
     ):
-        try:
+        if should_access:
+            try:
+                client.execute_command(*cmd)
+            except ResponseError as e:
+                # Non-ACL errors are acceptable here, such as missing indexes.
+                error = str(e).lower()
+                assert "no permissions" not in error
+                assert "permission to access" not in error
+            return
+
+        with pytest.raises(ResponseError) as exc_info:
             client.execute_command(*cmd)
-        except ResponseError as e:
-            if should_access:
-                # Make sure the error is not related to permission issues
-                assert "has no permissions to run" not in str(e)
-        except Exception as e:
-            # Any other error is acceptable. This is done to avoid errors
-            # Of missing index
-            assert True
+        error = str(exc_info.value).lower()
+        assert "no permissions" in error or "permission to access" in error
 
     @pytest.mark.parametrize(
-        "user,should_access_read,should_access_write",
+        "user,should_access_search,should_access_info,should_access_write,should_access_list,should_access_debug",
         [
-            ("ACL SETUSER user1 on >search_pass -@search", False, False),
-            ("ACL SETUSER user1 on >search_pass -@all", False, False),
-            ("ACL SETUSER user1 on >search_pass ~* &* +@all", True, True),
-            ("ACL SETUSER user1 on >search_pass ~* &* -@all +@search", True, True),
+            ("ACL SETUSER user1 on >search_pass -@search", False, False, False, False, False),
+            ("ACL SETUSER user1 on >search_pass -@all", False, False, False, False, False),
+            ("ACL SETUSER user1 on >search_pass ~* &* +@all", True, True, True, True, True),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@search",
+                True,
+                True,
+                True,
+                True,
+                True,
+            ),
             (
                 "ACL SETUSER user1 on >search_pass ~* &* -@all +@write +@read",
                 True,
                 True,
+                True,
+                True,
+                False,
             ),
-            ("ACL SETUSER user1 on >search_pass ~* &* -@all +@write", False, True),
-            ("ACL SETUSER user1 on >search_pass ~* &* -@all +@read", True, False),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@write",
+                False,
+                False,
+                True,
+                False,
+                False,
+            ),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@read",
+                True,
+                True,
+                False,
+                True,
+                False,
+            ),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@slow",
+                True,
+                False,
+                False,
+                True,
+                True,
+            ),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@dangerous",
+                False,
+                False,
+                False,
+                False,
+                True,
+            ),
+            (
+                "ACL SETUSER user1 on >search_pass ~* &* -@all +@admin",
+                False,
+                False,
+                False,
+                True,
+                True,
+            ),
         ],
     )
     def test_acl_category_permissions(
-        self, user, should_access_read, should_access_write
+        self, user, should_access_search, should_access_info, should_access_write,
+        should_access_list, should_access_debug
     ):
         search_vector = struct.pack("<3f", *[1.0, 2.0, 3.0])
         # List of search commands
@@ -76,11 +129,11 @@ class TestCommandsACLs(ValkeySearchTestCaseBase):
                     "query_vector",
                     search_vector,
                 ],
-                should_access_read,
+                should_access_search,
             ),
-            (["FT.INFO", INDEX_NAME], should_access_read),
-            (["FT._LIST"], should_access_read),
-            (["FT._DEBUG", "SHOW_INFO"], should_access_read),
+            (["FT.INFO", INDEX_NAME], should_access_info),
+            (["FT._LIST"], should_access_list),
+            (["FT._DEBUG", "SHOW_INFO"], should_access_debug),
             (["FT.DROPINDEX", INDEX_NAME], should_access_write),
         ]
         client: Valkey = self.server.get_new_client()
@@ -224,17 +277,18 @@ class TestCommandsACLs(ValkeySearchTestCaseBase):
             ),
             (
                 "FT._DEBUG",
-                [b"readonly", b"module", b"admin"],
-                [b"@read", b"@slow", b"@search", b"@admin"],
+                [
+                    b"module",
+                    b"admin",
+                    b"noscript",
+                    b"loading",
+                    b"stale",
+                ],
+                [b"@admin", b"@slow", b"@dangerous", b"@search"],
             ),
         ]
         for cmd in valkey_search_commands:
             # Get the info of the commands and compare the acl categories
             cmd_info = client.execute_command(f"COMMAND INFO {cmd[0]}")
-            for flag in cmd[1]:
-                import logging
-
-                logging.info(cmd_info[0][2])
-                assert flag in cmd_info[0][2]
-            for category in cmd[2]:
-                assert category in cmd_info[0][6]
+            assert set(cmd_info[0][2]) == set(cmd[1])
+            assert set(cmd_info[0][6]) == set(cmd[2])

--- a/src/commands/commands.h
+++ b/src/commands/commands.h
@@ -32,6 +32,7 @@ constexpr absl::string_view kWriteCategory{"@write"};
 constexpr absl::string_view kFastCategory{"@fast"};
 constexpr absl::string_view kSlowCategory{"@slow"};
 constexpr absl::string_view kAdminCategory{"@admin"};
+constexpr absl::string_view kDangerousCategory{"@dangerous"};
 
 constexpr absl::string_view kCreateCommand{"FT.CREATE"};
 constexpr absl::string_view kDropIndexCommand{"FT.DROPINDEX"};
@@ -55,7 +56,7 @@ const absl::flat_hash_set<absl::string_view> kInfoCmdPermissions{
 const absl::flat_hash_set<absl::string_view> kListCmdPermissions{
     kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
 const absl::flat_hash_set<absl::string_view> kDebugCmdPermissions{
-    kSearchCategory, kReadCategory, kSlowCategory, kAdminCategory};
+    kSearchCategory, kSlowCategory, kAdminCategory, kDangerousCategory};
 
 inline absl::flat_hash_set<absl::string_view> PrefixACLPermissions(
     const absl::flat_hash_set<absl::string_view> &cmd_permissions,

--- a/src/commands/ft._debug.json
+++ b/src/commands/ft._debug.json
@@ -3,7 +3,7 @@
     "acl_categories": [
       "ADMIN",
       "SLOW",
-      "READ",
+      "DANGEROUS",
       "SEARCH"
     ],
     "arguments": [],

--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -347,19 +347,6 @@ absl::Status HelpCmd(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator &itr) {
 absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                         int argc) {
   std::string msg;
-  if (!vmsdk::config::IsDebugModeEnabled()) {
-    // Pretend like we don't exist
-    msg = "ERR unknown command '";
-    msg += vmsdk::ToStringView(argv[0]);
-    msg += "', with args beginning with:";
-    for (int i = 1; i < argc; ++i) {
-      msg += " '";
-      msg += vmsdk::ToStringView(argv[i]);
-      msg += "'";
-    }
-    ValkeyModule_ReplyWithError(ctx, msg.data());
-    return absl::OkStatus();
-  }
   for (int i = 1; i < argc; ++i) {
     msg += " ";
     msg += vmsdk::ToStringView(argv[i]);

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -84,8 +84,10 @@ vmsdk::module::Options options = {
                 .cmd_name = valkey_search::kDebugCommand,
                 .permissions =
                     ACLPermissionFormatter(valkey_search::kDebugCmdPermissions),
-                .flags = {vmsdk::module::kReadOnlyFlag,
-                          vmsdk::module::kAdminFlag},
+                .flags = {vmsdk::module::kAdminFlag,
+                          vmsdk::module::kDenyScriptFlag,
+                          vmsdk::module::kLoadingFlag,
+                          vmsdk::module::kStaleFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTDebugCmd>,
             },
             {

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -56,6 +56,9 @@ constexpr absl::string_view kReadOnlyFlag{"readonly"};
 constexpr absl::string_view kFastFlag{"fast"};
 constexpr absl::string_view kAdminFlag{"admin"};
 constexpr absl::string_view kDenyOOMFlag{"deny-oom"};
+constexpr absl::string_view kDenyScriptFlag{"deny-script"};
+constexpr absl::string_view kLoadingFlag{"allow-loading"};
+constexpr absl::string_view kStaleFlag{"allow-stale"};
 
 struct CommandOptions {
   absl::string_view cmd_name;


### PR DESCRIPTION
Implement an admin check function and, through it, allow the use of FT._debug if the user is an admin.

issue : #779 