### PR TITLE
Slot Ownership check

### DIFF
--- a/integration/test_multidb_search.py
+++ b/integration/test_multidb_search.py
@@ -10,13 +10,19 @@ from valkey_search_test_case import (
 from valkeytestframework.conftest import resource_port_tracker
 from valkeytestframework.util import waiters
 from indexes import Index, Text, Tag, Numeric, Vector, float_to_bytes
-
+import time
 
 def verify_common_keys_results(clients, num_dbs, key_names, index):
     """Verify search isolation across all DBs for text, numeric, tag, and vector searches."""
     for db_num in range(num_dbs):
         # Text search
         for key_idx, key_name in enumerate(key_names):
+            print(clients[db_num].execute_command(
+                'INFO SEARCH'
+            ))
+            print(clients[db_num].execute_command(
+                'FT.INFO ' + str(index.name)
+            ))
             result = clients[db_num].execute_command(
                 'FT.SEARCH', 'idx', f'@name:product{db_num}_key{key_idx}'
             )
@@ -382,5 +388,6 @@ class TestMultiDBCME(ValkeySearchClusterTestCaseDebugMode):
                 len(key_names),
                 timeout=10
             )
-
+        # Wait longer than cluster map expiration (250ms default) plus some buffer
+        time.sleep(1)
         verify_common_keys_results(dest_clients, num_dbs, key_names, index)

--- a/integration/test_multidb_search.py
+++ b/integration/test_multidb_search.py
@@ -17,12 +17,6 @@ def verify_common_keys_results(clients, num_dbs, key_names, index):
     for db_num in range(num_dbs):
         # Text search
         for key_idx, key_name in enumerate(key_names):
-            print(clients[db_num].execute_command(
-                'INFO SEARCH'
-            ))
-            print(clients[db_num].execute_command(
-                'FT.INFO ' + str(index.name)
-            ))
             result = clients[db_num].execute_command(
                 'FT.SEARCH', 'idx', f'@name:product{db_num}_key{key_idx}'
             )

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -184,12 +184,12 @@ bool VerifyFilter(const query::SearchParameters &parameters,
 }
 
 // Check if this node owns the slot for the given key in cluster mode
-bool CheckSlotOwnership(absl::string_view key) {
+bool CheckSlotOwnership(ValkeyModuleCtx *ctx, absl::string_view key) {
   // In standalone mode, we own all keys.
   if (!ValkeySearch::Instance().IsCluster()) {
     return true;
   }
-  auto cluster_map = ValkeySearch::Instance().GetClusterMap();
+  auto cluster_map = ValkeySearch::Instance().GetOrRefreshClusterMap(ctx);
   auto key_str = vmsdk::MakeUniqueValkeyString(key);
   unsigned int slot = ValkeyModule_ClusterKeySlot(key_str.get());
   return cluster_map->IOwnSlot(static_cast<uint16_t>(slot));
@@ -381,13 +381,15 @@ void ProcessNeighborsForReply(
   const auto max_content_fields =
       options::GetMaxSearchResultFieldsCount().GetValue();
   for (auto &neighbor : neighbors) {
-    // neighbors which were added from remote nodes already have attribute
-    // content
+    // Remote neighbors (from fanout) always have attribute_contents populated,
+    // so they skip this entire block. Only local neighbors without content
+    // reach the slot ownership check below.
     if (neighbor.attribute_contents.has_value()) {
       continue;
     }
-    // Check slot ownership for local neighbors before fetching content
-    if (!CheckSlotOwnership(neighbor.external_id->Str())) {
+    // Check slot ownership for local neighbors before fetching content.
+    // Remote neighbors are never checked since they always have content.
+    if (!CheckSlotOwnership(ctx, neighbor.external_id->Str())) {
       // Skip this neighbor - we don't own its slot.
       continue;
     }

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -27,6 +27,7 @@
 #include "src/metrics.h"
 #include "src/query/predicate.h"
 #include "src/query/search.h"
+#include "src/valkey_search.h"
 #include "vmsdk/src/info.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/managed_pointers.h"
@@ -180,6 +181,18 @@ bool VerifyFilter(const query::SearchParameters &parameters,
       records, parameters.filter_parse_results.query_operations);
   EvaluationResult result = predicate->Evaluate(evaluator);
   return result.matches;
+}
+
+// Check if this node owns the slot for the given key in cluster mode
+bool CheckSlotOwnership(absl::string_view key) {
+  // In standalone mode, we own all keys.
+  if (!ValkeySearch::Instance().IsCluster()) {
+    return true;
+  }
+  auto cluster_map = ValkeySearch::Instance().GetClusterMap();
+  auto key_str = vmsdk::MakeUniqueValkeyString(key);
+  unsigned int slot = ValkeyModule_ClusterKeySlot(key_str.get());
+  return cluster_map->IOwnSlot(static_cast<uint16_t>(slot));
 }
 
 absl::StatusOr<RecordsMap> GetContentNoReturnJson(
@@ -371,6 +384,11 @@ void ProcessNeighborsForReply(
     // neighbors which were added from remote nodes already have attribute
     // content
     if (neighbor.attribute_contents.has_value()) {
+      continue;
+    }
+    // Check slot ownership for local neighbors before fetching content
+    if (!CheckSlotOwnership(neighbor.external_id->Str())) {
+      // Skip this neighbor - we don't own its slot.
       continue;
     }
     auto content = GetContent(ctx, attribute_data_type, parameters, neighbor,

--- a/src/query/response_generator.h
+++ b/src/query/response_generator.h
@@ -31,6 +31,9 @@ vmsdk::config::Number &GetMaxSearchResultFieldsCount();
 }  // namespace valkey_search::options
 namespace valkey_search::query {
 
+// Check if this node owns the slot for the given key in cluster mode
+bool CheckSlotOwnership(absl::string_view key);
+
 // Adds all local content for neighbors to the list of neighbors.
 // Skipping neighbors if one of the following:
 // Neighbor already contained in the attribute content map.

--- a/src/query/response_generator.h
+++ b/src/query/response_generator.h
@@ -32,7 +32,7 @@ vmsdk::config::Number &GetMaxSearchResultFieldsCount();
 namespace valkey_search::query {
 
 // Check if this node owns the slot for the given key in cluster mode
-bool CheckSlotOwnership(absl::string_view key);
+bool CheckSlotOwnership(ValkeyModuleCtx *ctx, absl::string_view key);
 
 // Adds all local content for neighbors to the list of neighbors.
 // Skipping neighbors if one of the following:


### PR DESCRIPTION
Slot Ownership check in the search path.

This PR adds a "Slot Ownership check" in the search path for FT.SEARCH and FT.AGGREGATE commands and ensures we are only include the keys which are owned by this shard. This helps avoid a double counted key (from source and target) during slot migration when the indexes are applying the mutations from the slot purge.

It uses the `GetOrRefreshClusterMap` functionality to obtain the slot map and checks if the node owns the slot containing the key. It is important to know that this is controlled by `search.cluster-map-expiration-ms` which has a default refresh rate of 0.25 seconds.
```
// configurable variable for cluster map expiration time
static auto cluster_map_expiration_ms =
    vmsdk::config::Number("cluster-map-expiration-ms",
                          250,       // default: 0.25 second
                          0,         // min: 0 (no cache)
                          3600000);  // max: 1 hour
```

Note: The change will not work without Atomic Slot Migration
If we migrated a slot, and we are still indexing keys on the target, we will not include them in the source (because it is not owned by the old source) and we will not include on the target node because it is not indexed yet. So, we get back partial search results. This will be addressed once we correctly hook into Atomic Slot Migration hooks

https://github.com/valkey-io/valkey-search/issues/897