### PR TITLE
Fix normalize json wildcard string-array values for TAG indexing

### DIFF
--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -517,6 +517,52 @@ class TestNonVector(ValkeySearchTestCaseBase):
         create_bulk_data_standalone(client)
         validate_bulk_limit_queries(client)
 
+    def test_json_tag_query_wildcard_path(self):
+        client: Valkey = self.server.get_new_client()
+
+        assert client.execute_command(
+            "FT.CREATE", "idx_wildcard_json_tag",
+            "ON", "JSON",
+            "PREFIX", "1", "user:",
+            "SCHEMA", "$.address[*].city", "AS", "address__city", "TAG"
+        ) == b"OK"
+
+        assert client.execute_command(
+            "JSON.SET", "user:1", "$",
+            '{"address":[{"city":"Seoul"},{"city":"New York"},{"city":"Seoul"},{"city":""}]}'
+        ) == b"OK"
+
+        assert client.execute_command(
+            "JSON.SET", "user:2", "$",
+            '{"address":[{"city":"Busan"}]}'
+        ) == b"OK"
+
+        time.sleep(1)
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{Seoul}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:1"
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{New York}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:1"
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{Busan}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:2"
+
 class TestNonVectorCluster(ValkeySearchClusterTestCase):
 
     def test_non_vector_cluster(self):
@@ -634,4 +680,3 @@ class TestNonVectorCluster(ValkeySearchClusterTestCase):
         # Verify fetch-limited queries metric
         client.execute_command("CONFIG SET search.info-developer-visible yes")
         assert client.info("search").get("search_nonvector_results_fetched_limited_count", 0) == 8
-

--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -1090,8 +1090,6 @@ class TestNonVector(ValkeySearchTestCaseBase):
 
     def test_json_tag_query_wildcard_path(self):
         client: Valkey = self.server.get_new_client()
-        assert client.execute_command(
-            "CONFIG", "SET", "search.emulate-release", "1.2.1") == b"OK"
 
         assert client.execute_command(
             "FT.CREATE", "idx_wildcard_json_tag",

--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -6,6 +6,7 @@ import json
 import random
 from valkey.cluster import ValkeyCluster
 from valkey_search_test_case import ValkeySearchClusterTestCase
+from utils import IndexingTestHelper
 import time
 import pytest
 from utils import IndexingTestHelper
@@ -1087,6 +1088,53 @@ class TestNonVector(ValkeySearchTestCaseBase):
         create_bulk_data_standalone(client)
         validate_tag_and_negate_queries(client)
 
+    def test_json_tag_query_wildcard_path(self):
+        client: Valkey = self.server.get_new_client()
+
+        assert client.execute_command(
+            "FT.CREATE", "idx_wildcard_json_tag",
+            "ON", "JSON",
+            "PREFIX", "1", "user:",
+            "SCHEMA", "$.address[*].city", "AS", "address__city", "TAG"
+        ) == b"OK"
+
+        assert client.execute_command(
+            "JSON.SET", "user:1", "$",
+            '{"address":[{"city":"Seoul"},{"city":"New York"},{"city":"Seoul"},{"city":""}]}'
+        ) == b"OK"
+
+        assert client.execute_command(
+            "JSON.SET", "user:2", "$",
+            '{"address":[{"city":"Busan"}]}'
+        ) == b"OK"
+
+        IndexingTestHelper.wait_for_indexing_complete_on_node(
+            client, "idx_wildcard_json_tag")
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{Seoul}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:1"
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{New York}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:1"
+
+        result = client.execute_command(
+            "FT.SEARCH", "idx_wildcard_json_tag",
+            "@address__city:{Busan}",
+            "NOCONTENT"
+        )
+        assert result[0] == 1
+        assert result[1] == b"user:2"
+
 class TestAggregateReducerAlias(ValkeySearchTestCaseDebugMode):
     """
         A REDUCE with no AS clause auto-generates its output name, and which form
@@ -1112,7 +1160,6 @@ class TestAggregateReducerAlias(ValkeySearchTestCaseDebugMode):
             for i in range(1, len(result)):
                 row = dict(zip(result[i][::2], result[i][1::2]))
                 assert alias in row, f"{release}: expected {alias} in {list(row)}"
-
 class TestNonVectorCluster(ValkeySearchClusterTestCase):
 
     def test_non_vector_cluster(self):

--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -1090,6 +1090,8 @@ class TestNonVector(ValkeySearchTestCaseBase):
 
     def test_json_tag_query_wildcard_path(self):
         client: Valkey = self.server.get_new_client()
+        assert client.execute_command(
+            "CONFIG", "SET", "search.emulate-release", "1.2.1") == b"OK"
 
         assert client.execute_command(
             "FT.CREATE", "idx_wildcard_json_tag",

--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -133,9 +133,14 @@ RecordsMap HashAttributeDataType::FetchSpecificFields(
 }
 
 absl::Status NormalizeJsonAttribute(absl::string_view attribute,
-                                    vmsdk::UniqueValkeyString &out_attribute) {
+                                    vmsdk::UniqueValkeyString &out_attribute,
+                                    bool preserve_json_array) {
   if (!attribute.empty() && attribute[0] != '[') {
     return absl::NotFoundError("Invalid attribute");
+  }
+  if (preserve_json_array) {
+    out_attribute = vmsdk::MakeUniqueValkeyString(attribute);
+    return absl::OkStatus();
   }
   bool was_string = false;
   if (absl::ConsumePrefix(&attribute, "[")) {
@@ -174,7 +179,8 @@ absl::Status NormalizeJsonAttribute(absl::string_view attribute,
 absl::Status GetJsonAttribute(ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
                               absl::string_view key,
                               absl::string_view identifier,
-                              vmsdk::UniqueValkeyString *attribute) {
+                              vmsdk::UniqueValkeyString *attribute,
+                              bool preserve_json_array = false) {
   vmsdk::VerifyMainThread();
   if (!IsJsonModuleSupported(ctx)) {
     return absl::UnavailableError("The JSON module is not supported");
@@ -194,7 +200,7 @@ absl::Status GetJsonAttribute(ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
       return absl::OkStatus();
     }
     return NormalizeJsonAttribute(vmsdk::ToStringView(attribute_tmp.get()),
-                                  *attribute);
+                                  *attribute, preserve_json_array);
   }
   auto reply = vmsdk::UniquePtrValkeyCallReply(ValkeyModule_Call(
       ctx, kJsonCmd.data(), "cc", key.data(), identifier.data()));
@@ -213,15 +219,16 @@ absl::Status GetJsonAttribute(ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
     return absl::OkStatus();
   }
   return NormalizeJsonAttribute(vmsdk::ToStringView(reply_str.get()),
-                                *attribute);
+                                *attribute, preserve_json_array);
 }
 
 absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetAttribute(
     ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
-    absl::string_view identifier) const {
+    absl::string_view identifier, bool preserve_json_array) const {
   vmsdk::UniqueValkeyString attribute;
   VMSDK_RETURN_IF_ERROR(
-      GetJsonAttribute(ctx, open_key, key, identifier, &attribute));
+      GetJsonAttribute(ctx, open_key, key, identifier, &attribute,
+                       preserve_json_array));
   return attribute;
 }
 

--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -31,8 +31,8 @@ void ResetJsonLoadedCache() { is_json_loaded = std::nullopt; }
 
 absl::StatusOr<vmsdk::UniqueValkeyString> HashAttributeDataType::GetAttribute(
     [[maybe_unused]] ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key,
-    [[maybe_unused]] absl::string_view key,
-    absl::string_view identifier) const {
+    [[maybe_unused]] absl::string_view key, absl::string_view identifier,
+    [[maybe_unused]] bool preserve_json_array) const {
   vmsdk::VerifyMainThread();
   ValkeyModuleString *attribute{nullptr};
   ValkeyModule_HashGet(open_key, VALKEYMODULE_HASH_CFIELDS, identifier.data(),
@@ -226,9 +226,8 @@ absl::StatusOr<vmsdk::UniqueValkeyString> JsonAttributeDataType::GetAttribute(
     ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
     absl::string_view identifier, bool preserve_json_array) const {
   vmsdk::UniqueValkeyString attribute;
-  VMSDK_RETURN_IF_ERROR(
-      GetJsonAttribute(ctx, open_key, key, identifier, &attribute,
-                       preserve_json_array));
+  VMSDK_RETURN_IF_ERROR(GetJsonAttribute(ctx, open_key, key, identifier,
+                                         &attribute, preserve_json_array));
   return attribute;
 }
 

--- a/src/attribute_data_type.h
+++ b/src/attribute_data_type.h
@@ -63,7 +63,7 @@ class AttributeDataType {
   virtual ~AttributeDataType() = default;
   virtual absl::StatusOr<vmsdk::UniqueValkeyString> GetAttribute(
       ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
-      absl::string_view identifier) const = 0;
+      absl::string_view identifier, bool preserve_json_array = false) const = 0;
   virtual int GetValkeyEventTypes() const {
     return VALKEYMODULE_NOTIFY_GENERIC | VALKEYMODULE_NOTIFY_EXPIRED |
            VALKEYMODULE_NOTIFY_EVICTED;
@@ -84,7 +84,8 @@ class HashAttributeDataType : public AttributeDataType {
  public:
   absl::StatusOr<vmsdk::UniqueValkeyString> GetAttribute(
       ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
-      absl::string_view identifier) const override;
+      absl::string_view identifier,
+      bool preserve_json_array = false) const override;
   inline int GetValkeyEventTypes() const override {
     return VALKEYMODULE_NOTIFY_HASH | AttributeDataType::GetValkeyEventTypes();
   }
@@ -118,7 +119,8 @@ class JsonAttributeDataType : public AttributeDataType {
  public:
   absl::StatusOr<vmsdk::UniqueValkeyString> GetAttribute(
       ValkeyModuleCtx *ctx, ValkeyModuleKey *open_key, absl::string_view key,
-      absl::string_view identifier) const override;
+      absl::string_view identifier,
+      bool preserve_json_array = false) const override;
   inline int GetValkeyEventTypes() const override {
     return VALKEYMODULE_NOTIFY_MODULE |
            AttributeDataType::GetValkeyEventTypes();

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -657,7 +657,10 @@ void IndexSchema::ProcessKeyspaceNotification(ValkeyModuleCtx *ctx,
     vmsdk::UniqueValkeyString attr_val =
         attribute_data_type_
             ->GetAttribute(ctx, key_obj.get(), key_cstr,
-                           attribute.GetIdentifier())
+                           attribute.GetIdentifier(),
+                           attribute.GetIndex()->GetIndexerType() ==
+                                   indexes::IndexerType::kTag &&
+                               options::EnabledInVersion(1, 2, 1))
             .value_or(vmsdk::UniqueValkeyString());
     if (attr_val && attribute_data_type_->AttributesProvidedAsString() &&
         attribute.GetIndex()) {

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -660,7 +660,7 @@ void IndexSchema::ProcessKeyspaceNotification(ValkeyModuleCtx *ctx,
                            attribute.GetIdentifier(),
                            attribute.GetIndex()->GetIndexerType() ==
                                    indexes::IndexerType::kTag &&
-                               options::EnabledInVersion(1, 2, 1))
+                               options::EnabledInVersion(1, 3, 0))
             .value_or(vmsdk::UniqueValkeyString());
     if (attr_val && attribute_data_type_->AttributesProvidedAsString() &&
         attribute.GetIndex()) {

--- a/src/indexes/index_base.h
+++ b/src/indexes/index_base.h
@@ -68,6 +68,9 @@ class IndexBase {
   virtual absl::Status ForEachUnTrackedKey(
       absl::AnyInvocable<absl::Status(const InternedStringPtr&)> fn) const = 0;
 
+  // Default behavior: no extra normalization.
+  // JSON-specific type handling should be implemented by overriding in concrete
+  // index types as needed.
   virtual vmsdk::UniqueValkeyString NormalizeStringRecord(
       vmsdk::UniqueValkeyString input) const {
     return input;

--- a/src/indexes/index_base.h
+++ b/src/indexes/index_base.h
@@ -104,6 +104,9 @@ class IndexBase {
   virtual absl::Status ForEachUnTrackedKey(
       absl::AnyInvocable<absl::Status(const InternedStringPtr &)> fn) const = 0;
 
+  // Default behavior: no extra normalization.
+  // JSON-specific type handling should be implemented by overriding in concrete
+  // index types as needed.
   virtual vmsdk::UniqueValkeyString NormalizeStringAttribute(
       vmsdk::UniqueValkeyString input) const {
     return input;

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -18,6 +18,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
@@ -26,6 +27,7 @@
 #include "src/utils/patricia_tree.h"
 #include "src/utils/string_interning.h"
 #include "src/valkey_search_options.h"
+#include "vmsdk/src/type_conversions.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::indexes {
@@ -179,6 +181,21 @@ absl::StatusOr<bool> Tag::ModifyRecord(const InternedStringPtr& key,
   tag_info.tags = new_parsed_tags;
   tag_info.raw_tag_string = std::move(interned_data);
   return true;
+}
+
+vmsdk::UniqueValkeyString Tag::NormalizeStringRecord(
+    vmsdk::UniqueValkeyString input) const {
+  if (!input) {
+    return input;
+  }
+  auto record = vmsdk::ToStringView(input.get());
+  if (record.find("\",\"") == absl::string_view::npos) {
+    return input;
+  }
+
+  std::string replacement(1, separator_);
+  return vmsdk::MakeUniqueValkeyString(
+      absl::StrReplaceAll(record, {{"\",\"", replacement}}));
 }
 
 absl::StatusOr<bool> Tag::RemoveRecord(const InternedStringPtr& key,

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -18,6 +18,7 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
 #include "absl/strings/str_cat.h"
+#include "absl/strings/str_replace.h"
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/mutex.h"
@@ -257,6 +258,21 @@ absl::StatusOr<RecordResult> Tag::ModifyRecord(const InternedStringPtr &key,
 
   tag_info.raw_tag_string = std::move(interned_data);
   return RecordResult::kAdded;
+}
+
+vmsdk::UniqueValkeyString Tag::NormalizeStringAttribute(
+    vmsdk::UniqueValkeyString input) const {
+  if (!input) {
+    return input;
+  }
+  auto record = vmsdk::ToStringView(input.get());
+  if (record.find("\",\"") == absl::string_view::npos) {
+    return input;
+  }
+
+  std::string replacement(1, separator_);
+  return vmsdk::MakeUniqueValkeyString(
+      absl::StrReplaceAll(record, {{"\",\"", replacement}}));
 }
 
 absl::StatusOr<bool> Tag::RemoveRecord(const InternedStringPtr &key,

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -323,7 +323,7 @@ vmsdk::UniqueValkeyString Tag::NormalizeStringAttribute(
       1, 2, 1, "json_tag_wildcard_array",
       [&] {
         if (!input) {
-          return input;
+          return std::move(input);
         }
         auto normalized =
             JoinJsonStringArray(vmsdk::ToStringView(input.get()), separator_);

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -29,6 +29,7 @@
 #include "src/utils/string_interning.h"
 #include "src/valkey_search_options.h"
 #include "vmsdk/src/type_conversions.h"
+#include "vmsdk/src/utils.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::indexes {
@@ -45,6 +46,62 @@ inline void *StorageToSlot(uintptr_t s) { return reinterpret_cast<void *>(s); }
 // letting it destruct frees any heap payload it owns.
 extern "C" void TagFreeCallback(void *p) {
   (void)BagOfInternedStringPtrs::Adopt(SlotToStorage(p));
+}
+
+std::optional<std::string> JoinJsonStringArray(absl::string_view record,
+                                               char separator) {
+  if (record.size() < 2 || record.front() != '[' || record.back() != ']') {
+    return std::nullopt;
+  }
+
+  size_t pos = 1;
+  std::string joined;
+  bool first = true;
+  while (true) {
+    while (pos < record.size() && absl::ascii_isspace(record[pos])) {
+      ++pos;
+    }
+    if (pos == record.size() - 1) {
+      return joined;
+    }
+    if (pos >= record.size() - 1 || record[pos++] != '"') {
+      return std::nullopt;
+    }
+
+    const size_t value_start = pos;
+    while (pos < record.size() - 1 && record[pos] != '"') {
+      if (record[pos] == '\\') {
+        if (++pos >= record.size() - 1) {
+          return std::nullopt;
+        }
+      }
+      ++pos;
+    }
+    if (pos >= record.size() - 1) {
+      return std::nullopt;
+    }
+    auto value =
+        vmsdk::JsonUnquote(record.substr(value_start, pos - value_start));
+    if (!value.has_value()) {
+      return std::nullopt;
+    }
+    if (!first) {
+      joined += separator;
+    }
+    joined += *value;
+    first = false;
+    ++pos;
+
+    while (pos < record.size() && absl::ascii_isspace(record[pos])) {
+      ++pos;
+    }
+    if (pos == record.size() - 1) {
+      return joined;
+    }
+    if (pos >= record.size() - 1 || record[pos++] != ',') {
+      return std::nullopt;
+    }
+  }
 }
 
 // Mutation trampoline for raxMutate.
@@ -262,17 +319,19 @@ absl::StatusOr<RecordResult> Tag::ModifyRecord(const InternedStringPtr &key,
 
 vmsdk::UniqueValkeyString Tag::NormalizeStringAttribute(
     vmsdk::UniqueValkeyString input) const {
-  if (!input) {
-    return input;
-  }
-  auto record = vmsdk::ToStringView(input.get());
-  if (record.find("\",\"") == absl::string_view::npos) {
-    return input;
-  }
-
-  std::string replacement(1, separator_);
-  return vmsdk::MakeUniqueValkeyString(
-      absl::StrReplaceAll(record, {{"\",\"", replacement}}));
+  return VALKEY_SEARCH_COMPATIBILITY_FIX(
+      1, 2, 1, "json_tag_wildcard_array",
+      [&] {
+        if (!input) {
+          return input;
+        }
+        auto normalized =
+            JoinJsonStringArray(vmsdk::ToStringView(input.get()), separator_);
+        return normalized.has_value()
+                   ? vmsdk::MakeUniqueValkeyString(*normalized)
+                   : std::move(input);
+      },
+      [&] { return std::move(input); });
 }
 
 absl::StatusOr<bool> Tag::RemoveRecord(const InternedStringPtr &key,

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -320,7 +320,7 @@ absl::StatusOr<RecordResult> Tag::ModifyRecord(const InternedStringPtr &key,
 vmsdk::UniqueValkeyString Tag::NormalizeStringAttribute(
     vmsdk::UniqueValkeyString input) const {
   return VALKEY_SEARCH_COMPATIBILITY_FIX(
-      1, 2, 1, "json_tag_wildcard_array",
+      1, 3, 0, "json_tag_wildcard_array",
       [&] {
         if (!input) {
           return std::move(input);

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -42,6 +42,8 @@ class Tag : public IndexBase {
   absl::StatusOr<bool> ModifyRecord(const InternedStringPtr& key,
                                     absl::string_view data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
+  vmsdk::UniqueValkeyString NormalizeStringRecord(
+      vmsdk::UniqueValkeyString input) const override;
   int RespondWithInfo(ValkeyModuleCtx* ctx) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -59,6 +59,8 @@ class Tag : public IndexBase {
   absl::StatusOr<RecordResult> ModifyRecord(const InternedStringPtr &key,
                                             AttributeData &&data) override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
+  vmsdk::UniqueValkeyString NormalizeStringAttribute(
+      vmsdk::UniqueValkeyString input) const override;
   int RespondWithInfo(ValkeyModuleCtx *ctx) const override
       ABSL_LOCKS_EXCLUDED(index_mutex_);
   absl::Status SaveIndex(RDBChunkOutputStream chunked_out) const override {

--- a/testing/common.h
+++ b/testing/common.h
@@ -308,7 +308,8 @@ class MockAttributeDataType : public AttributeDataType {
   }
   MOCK_METHOD(absl::StatusOr<vmsdk::UniqueValkeyString>, GetAttribute,
               (ValkeyModuleCtx * ctx, ValkeyModuleKey *open_key,
-               absl::string_view key, absl::string_view identifier),
+               absl::string_view key, absl::string_view identifier,
+               bool preserve_json_array),
               (override, const));
   MOCK_METHOD(int, GetValkeyEventTypes, (), (override, const));
   MOCK_METHOD((absl::StatusOr<RecordsMap>), FetchAllAttributes,

--- a/testing/tag_index_test.cc
+++ b/testing/tag_index_test.cc
@@ -18,6 +18,7 @@
 #include "src/query/predicate.h"
 #include "testing/common.h"
 #include "vmsdk/src/testing_infra/utils.h"
+#include "vmsdk/src/type_conversions.h"
 
 namespace valkey_search::indexes {
 
@@ -116,6 +117,20 @@ TEST_F(TagIndexTest, ModifyRecordWithEmptyString) {
 
   EXPECT_EQ(entries_fetcher->Size(), 0);
   EXPECT_EQ(index->GetTrackedKeyCount(), 0);
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordConvertsWildcardJsonArrayFormat) {
+  auto normalized = index->NormalizeStringRecord(
+      vmsdk::MakeUniqueValkeyString("Seoul\",\"New York"));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul,New York");
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordLeavesRegularStringUntouched) {
+  auto normalized =
+      index->NormalizeStringRecord(vmsdk::MakeUniqueValkeyString("Seoul"));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul");
 }
 
 TEST_F(TagIndexTest, KeyTrackingTest) {

--- a/testing/tag_index_test.cc
+++ b/testing/tag_index_test.cc
@@ -142,10 +142,31 @@ TEST_F(TagIndexTest, ModifyRecordWithEmptyString) {
 }
 
 TEST_F(TagIndexTest, NormalizeStringRecordConvertsWildcardJsonArrayFormat) {
+  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 2, 1}));
   auto normalized = index->NormalizeStringAttribute(
-      vmsdk::MakeUniqueValkeyString("Seoul\",\"New York"));
+      vmsdk::MakeUniqueValkeyString("[\"Seoul\",\"New York\"]"));
   ASSERT_TRUE(normalized);
   EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul,New York");
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordPreservesLiteralArrayDelimiter) {
+  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 2, 1}));
+  data_model::TagIndex tag_index_proto;
+  tag_index_proto.set_separator("|");
+  auto pipe_index =
+      std::make_unique<IndexTeser<Tag, data_model::TagIndex>>(tag_index_proto);
+  auto normalized = pipe_index->NormalizeStringAttribute(
+      vmsdk::MakeUniqueValkeyString("[\"foo\\\",\\\"bar\",\"baz\"]"));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "foo\",\"bar|baz");
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordUsesLegacyBehaviorBeforeFix) {
+  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 0, 0}));
+  auto input = vmsdk::MakeUniqueValkeyString("Seoul\",\"New York");
+  auto normalized = index->NormalizeStringAttribute(std::move(input));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul\",\"New York");
 }
 
 TEST_F(TagIndexTest, NormalizeStringRecordLeavesRegularStringUntouched) {

--- a/testing/tag_index_test.cc
+++ b/testing/tag_index_test.cc
@@ -142,7 +142,7 @@ TEST_F(TagIndexTest, ModifyRecordWithEmptyString) {
 }
 
 TEST_F(TagIndexTest, NormalizeStringRecordConvertsWildcardJsonArrayFormat) {
-  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 2, 1}));
+  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 3, 0}));
   auto normalized = index->NormalizeStringAttribute(
       vmsdk::MakeUniqueValkeyString("[\"Seoul\",\"New York\"]"));
   ASSERT_TRUE(normalized);
@@ -150,7 +150,7 @@ TEST_F(TagIndexTest, NormalizeStringRecordConvertsWildcardJsonArrayFormat) {
 }
 
 TEST_F(TagIndexTest, NormalizeStringRecordPreservesLiteralArrayDelimiter) {
-  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 2, 1}));
+  VMSDK_EXPECT_OK(options::GetEmulateRelease().SetValue({1, 3, 0}));
   data_model::TagIndex tag_index_proto;
   tag_index_proto.set_separator("|");
   auto pipe_index =

--- a/testing/tag_index_test.cc
+++ b/testing/tag_index_test.cc
@@ -18,6 +18,7 @@
 #include "src/query/predicate.h"
 #include "testing/common.h"
 #include "vmsdk/src/testing_infra/utils.h"
+#include "vmsdk/src/type_conversions.h"
 
 namespace valkey_search::indexes {
 
@@ -138,6 +139,20 @@ TEST_F(TagIndexTest, ModifyRecordWithEmptyString) {
 
   EXPECT_EQ(entries_fetcher->Size(), 0);
   EXPECT_EQ(index->GetTrackedKeyCount(), 0);
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordConvertsWildcardJsonArrayFormat) {
+  auto normalized = index->NormalizeStringAttribute(
+      vmsdk::MakeUniqueValkeyString("Seoul\",\"New York"));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul,New York");
+}
+
+TEST_F(TagIndexTest, NormalizeStringRecordLeavesRegularStringUntouched) {
+  auto normalized =
+      index->NormalizeStringAttribute(vmsdk::MakeUniqueValkeyString("Seoul"));
+  ASSERT_TRUE(normalized);
+  EXPECT_EQ(vmsdk::ToStringView(normalized.get()), "Seoul");
 }
 
 TEST_F(TagIndexTest, KeyTrackingTest) {


### PR DESCRIPTION
Fix normalize wildcard string-array values for TAG indexing

For JSON wildcard paths, `JSON.GET` returns an array string (e.g. `["Seoul","New York"]`).
The previous normalization incorrectly transformed this into `Seoul","New York` instead of a TAG-splittable format, causing lookup mismatches for values such as `New York`.

`["Seoul","New York"]`
Before: `Seoul","New York`
After:  `Seoul,New York`

issue : #907 