### PR TITLE
Implement Index Default Timeout

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -22,6 +22,7 @@ FT.CREATE <index-name>
     ON HASH
     [PREFIX <count> <prefix> [<prefix>...]]
     [SKIPINITIALSCAN]
+    [SEARCH_TIMEOUT <timeout>]
     SCHEMA
         (
             <field-identifier> [AS <field-alias>]
@@ -39,6 +40,8 @@ FT.CREATE <index-name>
 - **PREFIX \<prefix-count\> \<prefix\>** (optional): If this clause is specified, then only keys that begin with the same bytes as one or more of the specified prefixes will be included into this index. If this clause is omitted, all keys of the correct type will be included. A zero-length prefix would also match all keys of the correct type.
 
 - **SKIPINITIALSCAN** (optional): If this clause is specified, then no backfill operation is performed. This means that pre-existing keys which match the prefix clause will not be loaded into the index.
+
+- **SEARCH_TIMEOUT \<timeout\>** (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` on this index. A query-level `TIMEOUT` clause overrides this value.
 
 ### Field types
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -22,7 +22,7 @@ FT.CREATE <index-name>
     ON HASH
     [PREFIX <count> <prefix> [<prefix>...]]
     [SKIPINITIALSCAN]
-    [SEARCH_TIMEOUT <timeout>]
+    [QUERY_TIMEOUT <timeout>]
     SCHEMA
         (
             <field-identifier> [AS <field-alias>]
@@ -41,7 +41,7 @@ FT.CREATE <index-name>
 
 - **SKIPINITIALSCAN** (optional): If this clause is specified, then no backfill operation is performed. This means that pre-existing keys which match the prefix clause will not be loaded into the index.
 
-- **SEARCH_TIMEOUT \<timeout\>** (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` on this index. A query-level `TIMEOUT` clause overrides this value.
+- **QUERY_TIMEOUT \<timeout\>** (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` on this index. A query-level `TIMEOUT` clause overrides this value.
 
 ### Field types
 

--- a/docs/commands/ft.aggregate.md
+++ b/docs/commands/ft.aggregate.md
@@ -33,7 +33,7 @@ FT.AGGREGATE <index-name> <query>
 - `LOAD * | LOAD <count> <field> [<field> ...]` (optional): This controls which fields of those keys are loaded into the working set. A star (\*) indicates that all of the fields of the - `PARAMS <count> <name> <value> [<name> <value> ...]` (optional): `count` is of the number of arguments, i.e., twice the number of `name`/`value` pairs. `PARAMS` can be used in both the query string as well as within an expression context. See [Search - query language](../topics/search-query.md) for usage details.
   keys are loaded. The key itself can be loaded by specifying `@__key`. For vector queries, the distance can also be loaded by using the name of that field.
 - `SLOP <slop>` (Optional): Specifies a slop value for proximity matching of terms.
-- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If an index was created with `SEARCH_TIMEOUT`, this query-level `TIMEOUT` value takes precedence.
+- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If present, overrides the default `TIMEOUT` value. The default timeout can be specified by the `QUERY_TIMEOUT` option for this index or the global `search.default-timeout-ms` configuration value.
 - `VERBATIM` (Optional): If specified stemming is not applied to term searches.
 
 - `APPLY <expression> as <field>` (optional): An expression is computed and insert into the record. See [APPLY Stage](#apply-stage) below. See [Search - expressions](../topics/search-expressions.md) for details on the expression syntax.

--- a/docs/commands/ft.aggregate.md
+++ b/docs/commands/ft.aggregate.md
@@ -33,7 +33,7 @@ FT.AGGREGATE <index-name> <query>
 - `LOAD * | LOAD <count> <field> [<field> ...]` (optional): This controls which fields of those keys are loaded into the working set. A star (\*) indicates that all of the fields of the - `PARAMS <count> <name> <value> [<name> <value> ...]` (optional): `count` is of the number of arguments, i.e., twice the number of `name`/`value` pairs. `PARAMS` can be used in both the query string as well as within an expression context. See [Search - query language](../topics/search-query.md) for usage details.
   keys are loaded. The key itself can be loaded by specifying `@__key`. For vector queries, the distance can also be loaded by using the name of that field.
 - `SLOP <slop>` (Optional): Specifies a slop value for proximity matching of terms.
-- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds.
+- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If an index was created with `SEARCH_TIMEOUT`, this query-level `TIMEOUT` value takes precedence.
 - `VERBATIM` (Optional): If specified stemming is not applied to term searches.
 
 - `APPLY <expression> as <field>` (optional): An expression is computed and insert into the record. See [APPLY Stage](#apply-stage) below. See [Search - expressions](../topics/search-expressions.md) for details on the expression syntax.

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -48,7 +48,7 @@ FT.CREATE <index-name>
 
 - `SKIPINITIALSCAN` (optional): If specified, this option skips the normal backfill operation for an index. If this option is specified, pre-existing keys which match the `PREFIX` clause will not be loaded into the index during a backfill operation. This clause has no effect on processing of key mutations _after_ an index is created, i.e., keys which are mutated after an index is created and satisfy the data type and `PREFIX` clause will be inserted into that index.
 
-- `SEARCH_TIMEOUT <timeout>` (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` requests on this index. A query-level `TIMEOUT` argument overrides this value.
+- `QUERY_TIMEOUT <timeout>` (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` requests on this index. A query-level `TIMEOUT` argument overrides this value.
 
 - `SCORE` (optional): The current implementation only allows the value to be 1.0. This parameter is accepted to make valkey-search more interoperable with RediSearch. (default: 1.0)
 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -14,6 +14,7 @@ FT.CREATE <index-name>
     [SCORE default_value]
     [LANGUAGE <language>]
     [SKIPINITIALSCAN]
+    [SEARCH_TIMEOUT <timeout>]
     [MINSTEMSIZE <min_stem_size>]
     [WITHOFFSETS | NOOFFSETS]
     [NOSTOPWORDS | STOPWORDS <count> <word> word ...]
@@ -46,6 +47,8 @@ FT.CREATE <index-name>
 - `PUNCTUATION <punctuation>` (optional): A string of characters that define the separation points between words, in addition to whitespace characters (spaces, tabs, newlines, carriage returns, and control characters) which always break words. The default value is `,.<>{}[]"':;!@#$%^&\*()-+=~/\|?`.
 
 - `SKIPINITIALSCAN` (optional): If specified, this option skips the normal backfill operation for an index. If this option is specified, pre-existing keys which match the `PREFIX` clause will not be loaded into the index during a backfill operation. This clause has no effect on processing of key mutations _after_ an index is created, i.e., keys which are mutated after an index is created and satisfy the data type and `PREFIX` clause will be inserted into that index.
+
+- `SEARCH_TIMEOUT <timeout>` (optional): Sets the default timeout in milliseconds for `FT.SEARCH` and `FT.AGGREGATE` requests on this index. A query-level `TIMEOUT` argument overrides this value.
 
 - `SCORE` (optional): The current implementation only allows the value to be 1.0. This parameter is accepted to make valkey-search more interoperable with RediSearch. (default: 1.0)
 

--- a/docs/commands/ft.create.md
+++ b/docs/commands/ft.create.md
@@ -14,7 +14,7 @@ FT.CREATE <index-name>
     [SCORE default_value]
     [LANGUAGE <language>]
     [SKIPINITIALSCAN]
-    [SEARCH_TIMEOUT <timeout>]
+    [QUERY_TIMEOUT <timeout>]
     [MINSTEMSIZE <min_stem_size>]
     [WITHOFFSETS | NOOFFSETS]
     [NOSTOPWORDS | STOPWORDS <count> <word> word ...]

--- a/docs/commands/ft.search.md
+++ b/docs/commands/ft.search.md
@@ -32,7 +32,7 @@ FT.SEARCH <index> <query>
 - `VERBATIM` (Optional): If specified, stemming is not applied to text terms in the query.
 - `SOMESHARDS` (Optional): If specified, the command will generate a best-effort reply if all shards have not responded within the timeout interval.
 - `SORTBY <field> [ASC | DESC]` (Optional): If present, results are sorted according the value of the specified field and the optional sort-direction instruction. By default, vector results are sorted in distance order and non-vector results are not sorted in any particular order. Sorting is applied before the `LIMIT` clause is applied.
-- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If an index was created with `SEARCH_TIMEOUT`, this query-level `TIMEOUT` value takes precedence.
+- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If present, overrides the default `TIMEOUT` value. The default timeout can be specified by the `QUERY_TIMEOUT` option for this index or the global `search.default-timeout-ms` configuration value.
 - `WITHSORTKEYS` (Optional): If `SORTBY` is specified then enabling this option augments the output with the value of the field used for sorting.
 
 Response

--- a/docs/commands/ft.search.md
+++ b/docs/commands/ft.search.md
@@ -32,7 +32,7 @@ FT.SEARCH <index> <query>
 - `VERBATIM` (Optional): If specified, stemming is not applied to text terms in the query.
 - `SOMESHARDS` (Optional): If specified, the command will generate a best-effort reply if all shards have not responded within the timeout interval.
 - `SORTBY <field> [ASC | DESC]` (Optional): If present, results are sorted according the value of the specified field and the optional sort-direction instruction. By default, vector results are sorted in distance order and non-vector results are not sorted in any particular order. Sorting is applied before the `LIMIT` clause is applied.
-- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds.
+- `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds. If an index was created with `SEARCH_TIMEOUT`, this query-level `TIMEOUT` value takes precedence.
 - `WITHSORTKEYS` (Optional): If `SORTBY` is specified then enabling this option augments the output with the value of the field used for sorting.
 
 Response

--- a/integration/test_cancel.py
+++ b/integration/test_cancel.py
@@ -285,6 +285,92 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
             ["FT.SEARCH", "idx", "@tag:{value1}", "TIMEOUT", "5000"]
         )
 
+    def test_pausepoint_entries_fetcher_with_index_default_timeout(self):
+        """
+        Verify index-level SEARCH_TIMEOUT is used when FT.SEARCH has no TIMEOUT.
+        """
+        client = self.server.get_new_client()
+        assert (
+            client.execute_command("CONFIG SET search.default-timeout-ms 60000")
+            == b"OK"
+        )
+        assert (
+            client.execute_command(
+                "FT._DEBUG CONTROLLED_VARIABLE SET timeoutpollfrequency 1"
+            )
+            == b"OK"
+        )
+
+        try:
+            client.execute_command(
+                "FT.CREATE",
+                "idx",
+                "ON",
+                "HASH",
+                "PREFIX",
+                "1",
+                "doc:",
+                "SEARCH_TIMEOUT",
+                "50",
+                "SCHEMA",
+                "tag",
+                "TAG",
+                "n",
+                "NUMERIC",
+            )
+            for i in range(1000):
+                client.hset(f"doc:{i}", mapping={"tag": f"value{i % 10}", "n": i})
+
+            assert (
+                client.execute_command(
+                    "FT._DEBUG", "PAUSEPOINT", "SET", "search_entries_fetcher"
+                )
+                == b"OK"
+            )
+
+            error = [None]
+            result = [None]
+
+            def run_search():
+                tc = self.server.get_new_client()
+                try:
+                    result[0] = tc.execute_command(
+                        "FT.SEARCH", "idx", "@tag:{value1}", "ALLSHARDS"
+                    )
+                except ResponseError as e:
+                    error[0] = str(e)
+                finally:
+                    tc.close()
+
+            thread = threading.Thread(target=run_search)
+            thread.start()
+
+            assert wait_for_pausepoint(client, "search_entries_fetcher", timeout=10), \
+                "Pausepoint search_entries_fetcher was not hit"
+
+            # Hold the query at pausepoint long enough to exceed index timeout.
+            time.sleep(0.2)
+            assert (
+                client.execute_command(
+                    "FT._DEBUG", "PAUSEPOINT", "RESET", "search_entries_fetcher"
+                )
+                == b"OK"
+            )
+
+            thread.join(timeout=10)
+            assert not thread.is_alive(), "Search thread did not finish in time"
+            assert error[0] is not None, f"Expected timeout error, got result: {result[0]}"
+            assert "search operation cancelled due to timeout" in error[0].lower(), \
+                f"Expected timeout error, got: {error[0]}"
+        finally:
+            client.execute_command(
+                "FT._DEBUG", "PAUSEPOINT", "RESET", "search_entries_fetcher"
+            )
+            client.execute_command(
+                "FT._DEBUG CONTROLLED_VARIABLE SET timeoutpollfrequency 100"
+            )
+            client.execute_command("CONFIG SET search.default-timeout-ms 50000")
+
     def test_pausepoint_prefilter_eval(self):
         """
         Test timeout in prefilter evaluation loop

--- a/integration/test_cancel.py
+++ b/integration/test_cancel.py
@@ -287,7 +287,7 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
 
     def test_pausepoint_entries_fetcher_with_index_default_timeout(self):
         """
-        Verify index-level SEARCH_TIMEOUT is used when FT.SEARCH has no TIMEOUT.
+        Verify index-level QUERY_TIMEOUT is used when FT.SEARCH has no TIMEOUT.
         """
         client = self.server.get_new_client()
         assert (
@@ -310,7 +310,7 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
                 "PREFIX",
                 "1",
                 "doc:",
-                "SEARCH_TIMEOUT",
+                "QUERY_TIMEOUT",
                 "50",
                 "SCHEMA",
                 "tag",

--- a/integration/test_cancel.py
+++ b/integration/test_cancel.py
@@ -302,6 +302,7 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
         )
 
         try:
+            query_timeout_ms = 50
             client.execute_command(
                 "FT.CREATE",
                 "idx",
@@ -311,7 +312,7 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
                 "1",
                 "doc:",
                 "QUERY_TIMEOUT",
-                "50",
+                str(query_timeout_ms),
                 "SCHEMA",
                 "tag",
                 "TAG",
@@ -347,9 +348,17 @@ class TestCancelCMD(ValkeySearchTestCaseDebugMode):
 
             assert wait_for_pausepoint(client, "search_entries_fetcher", timeout=10), \
                 "Pausepoint search_entries_fetcher was not hit"
+            pausepoint_hit_time = time.monotonic()
 
             # Hold the query at pausepoint long enough to exceed index timeout.
-            time.sleep(0.2)
+            waiters.wait_for_true(
+                lambda: client.execute_command(
+                    "FT._DEBUG", "PAUSEPOINT", "TEST", "search_entries_fetcher"
+                ) > 0
+                and (time.monotonic() - pausepoint_hit_time) * 1000
+                >= query_timeout_ms + 150,
+                timeout=5,
+            )
             assert (
                 client.execute_command(
                     "FT._DEBUG", "PAUSEPOINT", "RESET", "search_entries_fetcher"

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -114,7 +114,6 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
   auto status = [&]() -> absl::Status {
     auto &schema_manager = SchemaManager::Instance();
     vmsdk::ArgsIterator itr{argv + 1, argc - 1};
-    parameters->timeout_ms = options::GetDefaultTimeoutMs().GetValue();
     VMSDK_RETURN_IF_ERROR(
         vmsdk::ParseParamValue(itr, parameters->index_schema_name));
 
@@ -124,6 +123,10 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
     VMSDK_ASSIGN_OR_RETURN(
         parameters->index_schema,
         schema_manager.GetIndexSchema(db_num, parameters->index_schema_name));
+    parameters->timeout_ms =
+        parameters->index_schema->GetSearchTimeoutMs() > 0
+            ? parameters->index_schema->GetSearchTimeoutMs()
+            : options::GetDefaultTimeoutMs().GetValue();
     VMSDK_RETURN_IF_ERROR(
         vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));
     VMSDK_RETURN_IF_ERROR(parameters->ParseCommand(itr));

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -123,10 +123,7 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
     VMSDK_ASSIGN_OR_RETURN(
         parameters->index_schema,
         schema_manager.GetIndexSchema(db_num, parameters->index_schema_name));
-    parameters->timeout_ms =
-        parameters->index_schema->GetQueryTimeoutMs() > 0
-            ? parameters->index_schema->GetQueryTimeoutMs()
-            : options::GetDefaultTimeoutMs().GetValue();
+    parameters->timeout_ms = parameters->index_schema->GetQueryTimeoutMs().value_or(options::GetDefaultTimeoutMs().GetValue());
     VMSDK_RETURN_IF_ERROR(
         vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));
     VMSDK_RETURN_IF_ERROR(parameters->ParseCommand(itr));

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -123,7 +123,9 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
     VMSDK_ASSIGN_OR_RETURN(
         parameters->index_schema,
         schema_manager.GetIndexSchema(db_num, parameters->index_schema_name));
-    parameters->timeout_ms = parameters->index_schema->GetQueryTimeoutMs().value_or(options::GetDefaultTimeoutMs().GetValue());
+    parameters->timeout_ms =
+        parameters->index_schema->GetQueryTimeoutMs().value_or(
+            options::GetDefaultTimeoutMs().GetValue());
     VMSDK_RETURN_IF_ERROR(
         vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));
     VMSDK_RETURN_IF_ERROR(parameters->ParseCommand(itr));

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -124,8 +124,8 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
         parameters->index_schema,
         schema_manager.GetIndexSchema(db_num, parameters->index_schema_name));
     parameters->timeout_ms =
-        parameters->index_schema->GetSearchTimeoutMs() > 0
-            ? parameters->index_schema->GetSearchTimeoutMs()
+        parameters->index_schema->GetQueryTimeoutMs() > 0
+            ? parameters->index_schema->GetQueryTimeoutMs()
             : options::GetDefaultTimeoutMs().GetValue();
     VMSDK_RETURN_IF_ERROR(
         vmsdk::ParseParamValue(itr, parameters->parse_vars.query_string));

--- a/src/commands/ft.create.json
+++ b/src/commands/ft.create.json
@@ -106,6 +106,22 @@
         "token": "SKIPINITIALSCAN"
       },
       {
+        "name": "SEARCH_TIMEOUT",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "search_timeout_token",
+            "type": "pure-token",
+            "token": "SEARCH_TIMEOUT"
+          },
+          {
+            "name": "search_timeout_ms",
+            "type": "integer"
+          }
+        ]
+      },
+      {
         "name": "MINSTEMSIZE",
         "type": "block",
         "optional": true,

--- a/src/commands/ft.create.json
+++ b/src/commands/ft.create.json
@@ -106,17 +106,17 @@
         "token": "SKIPINITIALSCAN"
       },
       {
-        "name": "SEARCH_TIMEOUT",
+        "name": "QUERY_TIMEOUT",
         "type": "block",
         "optional": true,
         "arguments": [
           {
-            "name": "search_timeout_token",
+            "name": "query_timeout_token",
             "type": "pure-token",
-            "token": "SEARCH_TIMEOUT"
+            "token": "QUERY_TIMEOUT"
           },
           {
-            "name": "search_timeout_ms",
+            "name": "query_timeout_ms",
             "type": "integer"
           }
         ]

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -58,6 +58,7 @@ const absl::string_view kCaseSensitiveParam{"CASESENSITIVE"};
 const absl::string_view kScoreParam{"SCORE"};
 constexpr absl::string_view kSchemaParam{"SCHEMA"};
 constexpr absl::string_view kSkipInitialScan("SKIPINITIALSCAN");
+constexpr absl::string_view kSearchTimeoutParam{"SEARCH_TIMEOUT"};
 constexpr size_t kDefaultAttributesCountLimit{1000};
 constexpr int kDefaultDimensionsCountLimit{32768};
 constexpr int kDefaultPrefixesCountLimit{8};
@@ -301,6 +302,26 @@ absl::Status ParseScore(vmsdk::ArgsIterator &itr,
   index_schema_proto.set_score(score);
   return absl::OkStatus();
 }
+
+absl::Status ParseSearchTimeout(vmsdk::ArgsIterator &itr,
+                                data_model::IndexSchema &index_schema_proto) {
+  uint32_t timeout_ms = 0;
+  VMSDK_ASSIGN_OR_RETURN(
+      auto res, vmsdk::ParseParam(kSearchTimeoutParam, false, itr, timeout_ms));
+  if (!res) {
+    return absl::OkStatus();
+  }
+  if (timeout_ms < kMinTimeoutMs || timeout_ms > kMaxTimeoutMs) {
+    return absl::InvalidArgumentError(
+        absl::StrCat(kSearchTimeoutParam,
+                     " must be a positive integer greater than 0 and cannot "
+                     "exceed ",
+                     kMaxTimeoutMs, "."));
+  }
+  index_schema_proto.set_search_timeout_ms(timeout_ms);
+  return absl::OkStatus();
+}
+
 vmsdk::KeyValueParser<HNSWParameters> CreateHNSWParser() {
   vmsdk::KeyValueParser<HNSWParameters> parser;
   parser.AddParamParser(kDimensionsParam,
@@ -685,6 +706,8 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
       return absl::InvalidArgumentError(
           NotSupportedParamErrorMsg(kPayloadFieldParam));
     }
+
+    VMSDK_RETURN_IF_ERROR(ParseSearchTimeout(itr, index_schema_proto));
 
     // Try schema text parameters using the KeyValue parser
     VMSDK_RETURN_IF_ERROR(

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -58,7 +58,7 @@ const absl::string_view kCaseSensitiveParam{"CASESENSITIVE"};
 const absl::string_view kScoreParam{"SCORE"};
 constexpr absl::string_view kSchemaParam{"SCHEMA"};
 constexpr absl::string_view kSkipInitialScan("SKIPINITIALSCAN");
-constexpr absl::string_view kSearchTimeoutParam{"SEARCH_TIMEOUT"};
+constexpr absl::string_view kQueryTimeoutParam{"QUERY_TIMEOUT"};
 constexpr size_t kDefaultAttributesCountLimit{1000};
 constexpr int kDefaultDimensionsCountLimit{32768};
 constexpr int kDefaultPrefixesCountLimit{8};
@@ -303,22 +303,22 @@ absl::Status ParseScore(vmsdk::ArgsIterator &itr,
   return absl::OkStatus();
 }
 
-absl::Status ParseSearchTimeout(vmsdk::ArgsIterator &itr,
-                                data_model::IndexSchema &index_schema_proto) {
+absl::Status ParseQueryTimeout(vmsdk::ArgsIterator &itr,
+                               data_model::IndexSchema &index_schema_proto) {
   uint32_t timeout_ms = 0;
   VMSDK_ASSIGN_OR_RETURN(
-      auto res, vmsdk::ParseParam(kSearchTimeoutParam, false, itr, timeout_ms));
+      auto res, vmsdk::ParseParam(kQueryTimeoutParam, false, itr, timeout_ms));
   if (!res) {
     return absl::OkStatus();
   }
   if (timeout_ms < kMinTimeoutMs || timeout_ms > kMaxTimeoutMs) {
     return absl::InvalidArgumentError(
-        absl::StrCat(kSearchTimeoutParam,
+        absl::StrCat(kQueryTimeoutParam,
                      " must be a positive integer greater than 0 and cannot "
                      "exceed ",
                      kMaxTimeoutMs, "."));
   }
-  index_schema_proto.set_search_timeout_ms(timeout_ms);
+  index_schema_proto.set_query_timeout_ms(timeout_ms);
   return absl::OkStatus();
 }
 
@@ -707,7 +707,7 @@ absl::StatusOr<data_model::IndexSchema> ParseFTCreateArgs(
           NotSupportedParamErrorMsg(kPayloadFieldParam));
     }
 
-    VMSDK_RETURN_IF_ERROR(ParseSearchTimeout(itr, index_schema_proto));
+    VMSDK_RETURN_IF_ERROR(ParseQueryTimeout(itr, index_schema_proto));
 
     // Try schema text parameters using the KeyValue parser
     VMSDK_RETURN_IF_ERROR(

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -295,10 +295,10 @@ IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
       stop_words_(index_schema_proto.stop_words().begin(),
                   index_schema_proto.stop_words().end()),
       skip_initial_scan_(index_schema_proto.skip_initial_scan()),
-      query_timeout_ms_(index_schema_proto.has_query_timeout_ms()
-                            ? std::make_optional(
-                                  index_schema_proto.query_timeout_ms())
-                            : std::nullopt),
+      query_timeout_ms_(
+          index_schema_proto.has_query_timeout_ms()
+              ? std::make_optional(index_schema_proto.query_timeout_ms())
+              : std::nullopt),
       min_stem_size_(index_schema_proto.min_stem_size() > 0
                          ? index_schema_proto.min_stem_size()
                          : 4),

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -295,6 +295,7 @@ IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
       stop_words_(index_schema_proto.stop_words().begin(),
                   index_schema_proto.stop_words().end()),
       skip_initial_scan_(index_schema_proto.skip_initial_scan()),
+      search_timeout_ms_(index_schema_proto.search_timeout_ms()),
       min_stem_size_(index_schema_proto.min_stem_size() > 0
                          ? index_schema_proto.min_stem_size()
                          : 4),
@@ -1197,6 +1198,7 @@ std::unique_ptr<data_model::IndexSchema> IndexSchema::ToProto() const {
   index_schema_proto->mutable_stop_words()->Assign(stop_words_.begin(),
                                                    stop_words_.end());
   index_schema_proto->set_skip_initial_scan(skip_initial_scan_);
+  index_schema_proto->set_search_timeout_ms(search_timeout_ms_);
 
   auto stats = index_schema_proto->mutable_stats();
   stats->set_documents_count(stats_.document_cnt);

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -295,7 +295,10 @@ IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
       stop_words_(index_schema_proto.stop_words().begin(),
                   index_schema_proto.stop_words().end()),
       skip_initial_scan_(index_schema_proto.skip_initial_scan()),
-      query_timeout_ms_(index_schema_proto.query_timeout_ms()),
+      query_timeout_ms_(index_schema_proto.has_query_timeout_ms()
+                            ? std::make_optional(
+                                  index_schema_proto.query_timeout_ms())
+                            : std::nullopt),
       min_stem_size_(index_schema_proto.min_stem_size() > 0
                          ? index_schema_proto.min_stem_size()
                          : 4),
@@ -1198,7 +1201,9 @@ std::unique_ptr<data_model::IndexSchema> IndexSchema::ToProto() const {
   index_schema_proto->mutable_stop_words()->Assign(stop_words_.begin(),
                                                    stop_words_.end());
   index_schema_proto->set_skip_initial_scan(skip_initial_scan_);
-  index_schema_proto->set_query_timeout_ms(query_timeout_ms_);
+  if (query_timeout_ms_.has_value()) {
+    index_schema_proto->set_query_timeout_ms(*query_timeout_ms_);
+  }
 
   auto stats = index_schema_proto->mutable_stats();
   stats->set_documents_count(stats_.document_cnt);

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -295,7 +295,7 @@ IndexSchema::IndexSchema(ValkeyModuleCtx *ctx,
       stop_words_(index_schema_proto.stop_words().begin(),
                   index_schema_proto.stop_words().end()),
       skip_initial_scan_(index_schema_proto.skip_initial_scan()),
-      search_timeout_ms_(index_schema_proto.search_timeout_ms()),
+      query_timeout_ms_(index_schema_proto.query_timeout_ms()),
       min_stem_size_(index_schema_proto.min_stem_size() > 0
                          ? index_schema_proto.min_stem_size()
                          : 4),
@@ -1198,7 +1198,7 @@ std::unique_ptr<data_model::IndexSchema> IndexSchema::ToProto() const {
   index_schema_proto->mutable_stop_words()->Assign(stop_words_.begin(),
                                                    stop_words_.end());
   index_schema_proto->set_skip_initial_scan(skip_initial_scan_);
-  index_schema_proto->set_search_timeout_ms(search_timeout_ms_);
+  index_schema_proto->set_query_timeout_ms(query_timeout_ms_);
 
   auto stats = index_schema_proto->mutable_stats();
   stats->set_documents_count(stats_.document_cnt);

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -174,7 +174,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   }
   inline uint64_t GetFingerprint() const { return fingerprint_; }
   inline uint32_t GetVersion() const { return version_; }
-  inline uint32_t GetSearchTimeoutMs() const { return search_timeout_ms_; }
+  inline uint32_t GetQueryTimeoutMs() const { return query_timeout_ms_; }
 
   inline void SetFingerprint(uint64_t fingerprint) {
     fingerprint_ = fingerprint;
@@ -398,7 +398,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   uint64_t fingerprint_{0};
   uint32_t version_{0};
   bool skip_initial_scan_{false};
-  uint32_t search_timeout_ms_{0};
+  uint32_t query_timeout_ms_{0};
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};
   std::vector<uint64_t> attributes_indexed_data_size_;

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -174,7 +174,9 @@ class IndexSchema : public KeyspaceEventSubscription,
   }
   inline uint64_t GetFingerprint() const { return fingerprint_; }
   inline uint32_t GetVersion() const { return version_; }
-  inline uint32_t GetQueryTimeoutMs() const { return query_timeout_ms_; }
+  inline const std::optional<uint32_t> &GetQueryTimeoutMs() const {
+    return query_timeout_ms_;
+  }
 
   inline void SetFingerprint(uint64_t fingerprint) {
     fingerprint_ = fingerprint;
@@ -398,7 +400,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   uint64_t fingerprint_{0};
   uint32_t version_{0};
   bool skip_initial_scan_{false};
-  uint32_t query_timeout_ms_{0};
+  std::optional<uint32_t> query_timeout_ms_;
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};
   std::vector<uint64_t> attributes_indexed_data_size_;

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -174,6 +174,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   }
   inline uint64_t GetFingerprint() const { return fingerprint_; }
   inline uint32_t GetVersion() const { return version_; }
+  inline uint32_t GetSearchTimeoutMs() const { return search_timeout_ms_; }
 
   inline void SetFingerprint(uint64_t fingerprint) {
     fingerprint_ = fingerprint;
@@ -397,6 +398,7 @@ class IndexSchema : public KeyspaceEventSubscription,
   uint64_t fingerprint_{0};
   uint32_t version_{0};
   bool skip_initial_scan_{false};
+  uint32_t search_timeout_ms_{0};
 
   vmsdk::ThreadPool *mutations_thread_pool_{nullptr};
   std::vector<uint64_t> attributes_indexed_data_size_;

--- a/src/index_schema.proto
+++ b/src/index_schema.proto
@@ -36,6 +36,7 @@ message IndexSchema {
   repeated string stop_words = 11;
   uint32 min_stem_size = 12;
   bool skip_initial_scan = 13;
+  uint32 search_timeout_ms = 14;
 }
 
 

--- a/src/index_schema.proto
+++ b/src/index_schema.proto
@@ -36,7 +36,7 @@ message IndexSchema {
   repeated string stop_words = 11;
   uint32 min_stem_size = 12;
   bool skip_initial_scan = 13;
-  uint32 query_timeout_ms = 14;
+  optional uint32 query_timeout_ms = 14;
 }
 
 

--- a/src/index_schema.proto
+++ b/src/index_schema.proto
@@ -36,7 +36,7 @@ message IndexSchema {
   repeated string stop_words = 11;
   uint32 min_stem_size = 12;
   bool skip_initial_scan = 13;
-  uint32 search_timeout_ms = 14;
+  uint32 query_timeout_ms = 14;
 }
 
 
@@ -113,4 +113,3 @@ message HNSWAlgorithm {
 message FlatAlgorithm {
   uint32 block_size = 1;
 }
-

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -64,7 +65,7 @@ struct FTCreateParameters {
   absl::string_view score_field;
   absl::string_view payload_field;
   bool skip_initial_scan{false};
-  uint32_t query_timeout_ms{0};
+  std::optional<uint32_t> query_timeout_ms;
   std::vector<AttributeParameters> attributes;
   ExpectedPerIndexTextParameters per_index_text_params;
 };
@@ -134,8 +135,12 @@ TEST_P(FTCreateParserTest, ParseParams) {
               test_case.expected.attributes.size());
     EXPECT_EQ(index_schema_proto->skip_initial_scan(),
               test_case.expected.skip_initial_scan);
-    EXPECT_EQ(index_schema_proto->query_timeout_ms(),
-              test_case.expected.query_timeout_ms);
+    EXPECT_EQ(index_schema_proto->has_query_timeout_ms(),
+              test_case.expected.query_timeout_ms.has_value());
+    if (test_case.expected.query_timeout_ms.has_value()) {
+      EXPECT_EQ(index_schema_proto->query_timeout_ms(),
+                *test_case.expected.query_timeout_ms);
+    }
 
     // Verify schema-level text parameters if we have text fields
     bool has_text_fields = false;

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -64,6 +64,7 @@ struct FTCreateParameters {
   absl::string_view score_field;
   absl::string_view payload_field;
   bool skip_initial_scan{false};
+  uint32_t search_timeout_ms{0};
   std::vector<AttributeParameters> attributes;
   ExpectedPerIndexTextParameters per_index_text_params;
 };
@@ -133,6 +134,8 @@ TEST_P(FTCreateParserTest, ParseParams) {
               test_case.expected.attributes.size());
     EXPECT_EQ(index_schema_proto->skip_initial_scan(),
               test_case.expected.skip_initial_scan);
+    EXPECT_EQ(index_schema_proto->search_timeout_ms(),
+              test_case.expected.search_timeout_ms);
 
     // Verify schema-level text parameters if we have text fields
     bool has_text_fields = false;
@@ -321,6 +324,45 @@ INSTANTIATE_TEST_SUITE_P(
                               .attribute_alias = "hash_field11",
                               .indexer_type = indexes::IndexerType::kFlat,
                           }}},
+         },
+         {
+             .test_name = "happy_path_search_timeout",
+             .success = true,
+             .command_str =
+                 " idx1 on HASH PREFIX 1 doc: SEARCH_TIMEOUT 1234 SCHEMA "
+                 "hash_field1 as hash_field11 vector hnsw 6 TYPE FLOAT32 DIM 3 "
+                 "DISTANCE_METRIC IP ",
+             .hnsw_parameters = {{
+                 {
+                     .dimensions = 3,
+                     .distance_metric = data_model::DISTANCE_METRIC_IP,
+                     .vector_data_type = data_model::VECTOR_DATA_TYPE_FLOAT32,
+                     .initial_cap = kDefaultInitialCap,
+                 },
+                 /* .m =*/kDefaultM,
+                 /* .ef_construction =*/kDefaultEFConstruction,
+                 /* .ef_runtime =*/kDefaultEFRuntime,
+             }},
+             .expected = {.index_schema_name = "idx1",
+                          .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
+                          .prefixes = {"doc:"},
+                          .search_timeout_ms = 1234,
+                          .attributes = {{
+                              .identifier = "hash_field1",
+                              .attribute_alias = "hash_field11",
+                              .indexer_type = indexes::IndexerType::kHNSW,
+                          }}},
+         },
+         {
+             .test_name = "search_timeout_too_large",
+             .success = false,
+             .command_str =
+                 " idx1 on HASH PREFIX 1 doc: SEARCH_TIMEOUT 60001 SCHEMA "
+                 "hash_field1 vector hnsw 6 TYPE FLOAT32 DIM 3 DISTANCE_METRIC "
+                 "IP ",
+             .expected_error_message =
+                 "SEARCH_TIMEOUT must be a positive integer greater than 0 and "
+                 "cannot exceed 60000.",
          },
          {
              .test_name = "happy_path_hnsw_and_numeric",

--- a/testing/ft_create_parser_test.cc
+++ b/testing/ft_create_parser_test.cc
@@ -64,7 +64,7 @@ struct FTCreateParameters {
   absl::string_view score_field;
   absl::string_view payload_field;
   bool skip_initial_scan{false};
-  uint32_t search_timeout_ms{0};
+  uint32_t query_timeout_ms{0};
   std::vector<AttributeParameters> attributes;
   ExpectedPerIndexTextParameters per_index_text_params;
 };
@@ -134,8 +134,8 @@ TEST_P(FTCreateParserTest, ParseParams) {
               test_case.expected.attributes.size());
     EXPECT_EQ(index_schema_proto->skip_initial_scan(),
               test_case.expected.skip_initial_scan);
-    EXPECT_EQ(index_schema_proto->search_timeout_ms(),
-              test_case.expected.search_timeout_ms);
+    EXPECT_EQ(index_schema_proto->query_timeout_ms(),
+              test_case.expected.query_timeout_ms);
 
     // Verify schema-level text parameters if we have text fields
     bool has_text_fields = false;
@@ -326,10 +326,10 @@ INSTANTIATE_TEST_SUITE_P(
                           }}},
          },
          {
-             .test_name = "happy_path_search_timeout",
+             .test_name = "happy_path_query_timeout",
              .success = true,
              .command_str =
-                 " idx1 on HASH PREFIX 1 doc: SEARCH_TIMEOUT 1234 SCHEMA "
+                 " idx1 on HASH PREFIX 1 doc: QUERY_TIMEOUT 1234 SCHEMA "
                  "hash_field1 as hash_field11 vector hnsw 6 TYPE FLOAT32 DIM 3 "
                  "DISTANCE_METRIC IP ",
              .hnsw_parameters = {{
@@ -346,7 +346,7 @@ INSTANTIATE_TEST_SUITE_P(
              .expected = {.index_schema_name = "idx1",
                           .on_data_type = data_model::ATTRIBUTE_DATA_TYPE_HASH,
                           .prefixes = {"doc:"},
-                          .search_timeout_ms = 1234,
+                          .query_timeout_ms = 1234,
                           .attributes = {{
                               .identifier = "hash_field1",
                               .attribute_alias = "hash_field11",
@@ -354,14 +354,14 @@ INSTANTIATE_TEST_SUITE_P(
                           }}},
          },
          {
-             .test_name = "search_timeout_too_large",
+             .test_name = "query_timeout_too_large",
              .success = false,
              .command_str =
-                 " idx1 on HASH PREFIX 1 doc: SEARCH_TIMEOUT 60001 SCHEMA "
+                 " idx1 on HASH PREFIX 1 doc: QUERY_TIMEOUT 60001 SCHEMA "
                  "hash_field1 vector hnsw 6 TYPE FLOAT32 DIM 3 DISTANCE_METRIC "
                  "IP ",
              .expected_error_message =
-                 "SEARCH_TIMEOUT must be a positive integer greater than 0 and "
+                 "QUERY_TIMEOUT must be a positive integer greater than 0 and "
                  "cannot exceed 60000.",
          },
          {


### PR DESCRIPTION
Implement default search timeout per index and setting default search timeout in FT.CREATE

in FT.SEARCH or FT.AGGREGATE, timeout is applied in the following order of priority
1. FT.SEARCH TIMEOUT 
2. FT.CREATE SEARCH_TIMEOUT
3. search.default-timeout-ms

issue : #383 