### PR TITLE
Fix FT.SEARCH bare wildcard execution

### DIFF
--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -154,6 +154,25 @@ def validate_limit_queries(client: Valkey):
     assert result[0] == 4  # Total count only
     assert len(result) == 1
 
+def validate_bare_wildcard_queries(client: Valkey):
+    """
+        Test bare '*' match-all behavior for non-vector FT.SEARCH in DIALECT 2.
+    """
+    result = client.execute_command("FT.SEARCH", "products", "*", "DIALECT", "2")
+    assert result[0] == 4
+
+    result = client.execute_command("FT.SEARCH", "products", "*", "NOCONTENT", "DIALECT", "2")
+    assert result[0] == 4
+    assert len(result) == 5
+
+    result = client.execute_command("FT.SEARCH", "products", "*", "LIMIT", "0", "2", "NOCONTENT", "DIALECT", "2")
+    assert result[0] == 4
+    assert len(result) == 3
+
+    result = client.execute_command("FT.SEARCH", "products", "*", "SORTBY", "price", "ASC", "NOCONTENT", "DIALECT", "2")
+    assert result[0] == 4
+    assert len(result) == 5
+
 def create_bulk_data_standalone(client: Valkey):
     """
         Create bulk data for standalone testing.
@@ -477,6 +496,8 @@ class TestNonVector(ValkeySearchTestCaseBase):
         validate_non_vector_queries(client)
         # Test LIMIT functionality
         validate_limit_queries(client)
+        # Test bare wildcard functionality
+        validate_bare_wildcard_queries(client)
         # Test AGGREGATE functionality
         validate_aggregate_queries(client)
 
@@ -634,4 +655,3 @@ class TestNonVectorCluster(ValkeySearchClusterTestCase):
         # Verify fetch-limited queries metric
         client.execute_command("CONFIG SET search.info-developer-visible yes")
         assert client.info("search").get("search_nonvector_results_fetched_limited_count", 0) == 8
-

--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -432,6 +432,7 @@ absl::StatusOr<FilterParseResults> FilterParser::Parse() {
   VMSDK_ASSIGN_OR_RETURN(auto is_match_all_expression, IsMatchAllExpression());
   FilterParseResults results;
   if (is_match_all_expression) {
+    results.is_match_all = true;
     return results;
   }
   filter_identifiers_.clear();

--- a/src/commands/filter_parser.h
+++ b/src/commands/filter_parser.h
@@ -62,6 +62,7 @@ struct FilterParseResults {
   std::unique_ptr<query::Predicate> root_predicate;
   absl::flat_hash_set<std::string> filter_identifiers;
   QueryOperations query_operations = QueryOperations::kNone;
+  bool is_match_all = false;
 };
 class FilterParser {
  public:

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -564,9 +564,17 @@ absl::StatusOr<std::vector<indexes::Neighbor>> MaybeAddIndexedContent(
 absl::StatusOr<std::vector<indexes::Neighbor>> SearchNonVectorQuery(
     const SearchParameters &parameters) {
   std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> entries_fetchers;
-  size_t qualified_entries = EvaluateFilterAsPrimary(
-      parameters, parameters.filter_parse_results.root_predicate.get(),
-      entries_fetchers, false);
+  size_t qualified_entries = 0;
+  if (parameters.filter_parse_results.is_match_all) {
+    auto universal_fetcher = std::make_unique<indexes::UniversalSetFetcher>(
+        parameters.index_schema.get());
+    qualified_entries = universal_fetcher->Size();
+    entries_fetchers.push(std::move(universal_fetcher));
+  } else {
+    qualified_entries = EvaluateFilterAsPrimary(
+        parameters, parameters.filter_parse_results.root_predicate.get(),
+        entries_fetchers, false);
+  }
 
   // Get the config for maximum number of keys to accumulate before content
   // fetching
@@ -1024,7 +1032,8 @@ absl::Status query::SearchParameters::PreParseQueryString() {
   VMSDK_ASSIGN_OR_RETURN(
       filter_parse_results, ParsePreFilter(*index_schema, pre_filter, *this),
       _.SetPrepend() << "Invalid filter expression: `" << pre_filter << "`. ");
-  if (!filter_parse_results.root_predicate && vector_filter.empty()) {
+  if (!filter_parse_results.root_predicate && vector_filter.empty() &&
+      !filter_parse_results.is_match_all) {
     // Return an error if no valid pre-filter and no vector filter is provided.
     return absl::InvalidArgumentError("Invalid query string syntax");
   }

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -162,7 +162,11 @@ inline PredicateType EvaluateAsComposedPredicate(
 // search, meaning it requires prefilter evaluation Prefiltering is needed when
 // query contains an AND with numeric or tag predicates.
 // It is also needed when negate is involved.
-inline bool IsUnsolvedQuery(QueryOperations query_operations) {
+inline bool IsUnsolvedQuery(QueryOperations query_operations,
+                            bool is_match_all) {
+  if (is_match_all) {
+    return false;
+  }
   return query_operations & (QueryOperations::kContainsNumeric |
                              QueryOperations::kContainsTag) &&
              query_operations & QueryOperations::kContainsAnd ||
@@ -596,7 +600,8 @@ absl::StatusOr<std::vector<indexes::Neighbor>> SearchNonVectorQuery(
   };
   // Cannot skip evaluation if the query contains unsolved composed operations.
   bool requires_prefilter_evaluation =
-      IsUnsolvedQuery(parameters.filter_parse_results.query_operations);
+      IsUnsolvedQuery(parameters.filter_parse_results.query_operations,
+                      parameters.filter_parse_results.is_match_all);
   if (!requires_prefilter_evaluation) {
     bool needs_dedup =
         NeedsDeduplication(parameters.filter_parse_results.query_operations);

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -760,15 +760,6 @@ INSTANTIATE_TEST_SUITE_P(
                 "]`. Blob attribute "
                 "argument is missing",
         },
-        {
-            .test_name = "bad_message_query",
-            .success = false,
-            .params_str = "",
-            .filter_str = "*",
-            .attribute_alias = "",
-            .expected_error_message = "Invalid query string syntax",
-            .vector_query = false,
-        },
         // VERBATIM parameter tests
         {
             .test_name = "verbatim_vector_query",


### PR DESCRIPTION
Fix non-vector FT.SEARCH so a bare "*" query executes instead of failing with invalid syntax. Treat bare wildcard queries as match-all searches and run them through the universal key fetch path.

issue : #957 