### PR TITLE
fix test_dropindex_with_background_queries heap-use-after-free leak

### DIFF
--- a/integration/test_fulltext_inflight_blocking.py
+++ b/integration/test_fulltext_inflight_blocking.py
@@ -273,9 +273,8 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
         # Drop the index
         client.execute_command("FT.DROPINDEX", "idx")
 
-        # Complete the search and mutation
+        # Complete the search
         client.execute_command("FT._DEBUG PAUSEPOINT RESET background_search_completing")
-        client.execute_command("FT._DEBUG PAUSEPOINT RESET mutation_processing")
         hset_thread.join()
         search_thread.join()
 

--- a/integration/test_fulltext_inflight_blocking.py
+++ b/integration/test_fulltext_inflight_blocking.py
@@ -273,8 +273,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
         # Drop the index
         client.execute_command("FT.DROPINDEX", "idx")
 
-        # Complete the search
+        # Complete the search and mutation
         client.execute_command("FT._DEBUG PAUSEPOINT RESET background_search_completing")
+        client.execute_command("FT._DEBUG PAUSEPOINT RESET mutation_processing")
         hset_thread.join()
         search_thread.join()
 

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -54,9 +54,8 @@ void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
 
 void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                         uint64_t subevent, void *data) {
-  // Mark the module as shutting down so that RunByMain() calls from
-  // background threads execute their callbacks directly instead of
-  // posting to the (now-dead) event loop.
+  // Mark the module as shutting down so that RunByMain() stops
+  // scheduling new tasks.
   vmsdk::MarkAsShuttingDown();
   // Clear all PausePoints so any waiting worker threads wake up and exit
   // their spin loops, then join all thread pools so every in-flight task

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -13,6 +13,7 @@
 #include "src/schema_manager.h"
 #include "src/valkey_search.h"
 #include "vmsdk/src/debug.h"
+#include "vmsdk/src/utils.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::server_events {
@@ -53,9 +54,20 @@ void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
 
 void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                         uint64_t subevent, void *data) {
-  // Clear all PausePoints first so any waiting worker threads wake up and
-  // exit their spin loops before global destructors destroy the map.
+  // Mark the module as shutting down so that RunByMain() calls from
+  // background threads execute their callbacks directly instead of
+  // posting to the (now-dead) event loop.
+  vmsdk::MarkAsShuttingDown();
+  // Clear all PausePoints so any waiting worker threads wake up and exit
+  // their spin loops, then join all thread pools so every in-flight task
+  // completes before we tear down index schemas.  This ordering matters:
+  //   1. ClearAllPausePoints  – unblocks workers stuck in PausePoint().
+  //   2. JoinAllThreadPools   – drains task queues and waits for every
+  //      worker thread to exit.
+  //   3. OnShutdownCallback   – removes all index schemas on the main
+  //      thread.
   vmsdk::debug::ClearAllPausePoints();
+  ValkeySearch::Instance().JoinAllThreadPools();
   SchemaManager::Instance().OnShutdownCallback(ctx, eid, subevent, data);
 }
 

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -54,6 +54,16 @@ class ValkeySearch {
   vmsdk::ThreadPool *GetUtilityThreadPool() const {
     return utility_thread_pool_.get();
   }
+
+  // Stop and join all owned thread pools so no worker threads remain alive.
+  // Intended for use during module shutdown before global destructors run,
+  // to avoid worker threads racing with destruction of global state.
+  void JoinAllThreadPools() {
+    if (reader_thread_pool_) reader_thread_pool_->JoinWorkers();
+    if (writer_thread_pool_) writer_thread_pool_->JoinWorkers();
+    if (utility_thread_pool_) utility_thread_pool_->JoinWorkers();
+  }
+
   std::shared_ptr<vmsdk::ThreadGroupCPUMonitor> GetCoordinatorThreadsMonitor()
       const {
     return coordinator_thread_monitor_;

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -70,9 +70,23 @@ void TrackCurrentAsMainThread() {
 
 bool IsMainThread() { return is_main_thread; }
 
+static std::atomic<bool> shutting_down{false};
+
+void MarkAsShuttingDown() { shutting_down.store(true); }
+
+bool IsShuttingDown() { return shutting_down.load(); }
+
 int RunByMain(absl::AnyInvocable<void()> fn, bool force_async) {
   if (IsMainThread() && !force_async) {
     fn();
+    return VALKEYMODULE_OK;
+  }
+  // During shutdown the event loop is no longer processing one-shot
+  // callbacks.  Execute the function directly to avoid leaking the
+  // allocation.  At this point IO threads are inactive so it is safe
+  // to call ValkeyModule_FreeThreadSafeContext from a worker thread.
+  if (IsShuttingDown()) {
+    VMSDK_LOG(DEBUG, nullptr) << "RunByMain: dropping callback during shutdown";
     return VALKEYMODULE_OK;
   }
   auto call_by_main = new absl::AnyInvocable<void()>(std::move(fn));

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -82,9 +82,7 @@ int RunByMain(absl::AnyInvocable<void()> fn, bool force_async) {
     return VALKEYMODULE_OK;
   }
   // During shutdown the event loop is no longer processing one-shot
-  // callbacks.  Execute the function directly to avoid leaking the
-  // allocation.  At this point IO threads are inactive so it is safe
-  // to call ValkeyModule_FreeThreadSafeContext from a worker thread.
+  // callbacks.
   if (IsShuttingDown()) {
     VMSDK_LOG(DEBUG, nullptr) << "RunByMain: dropping callback during shutdown";
     return VALKEYMODULE_OK;

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -55,6 +55,9 @@ void TrackCurrentAsMainThread();
 bool IsMainThread();
 inline void VerifyMainThread() { CHECK(IsMainThread()); }
 
+void MarkAsShuttingDown();
+bool IsShuttingDown();
+
 // MainThreadAccessGuard ensures that all access to the underlying data
 // structure is done on the main thread.
 template <typename T>


### PR DESCRIPTION
The `mutation_processing` pause point was never reset. Added reset to fix heap-use-after-free leak.

```
PASSED [ 61%]=================================================================
==17560==ERROR: AddressSanitizer: heap-use-after-free on address 0xffffb2319c48 at pc 0xffff95c0dc30 bp 0xffff89eeb450 sp 0xffff89eeb440
READ of size 8 at 0xffffb2319c48 thread T20
ASAN:DEADLYSIGNAL
AddressSanitizer: nested bug in the same thread, aborting.
```