### PR TITLE
Fix crash on empty FT.AGGREGATE expressions

### DIFF
--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -258,6 +258,13 @@ def validate_aggregate_queries(client: Valkey):
     )
     assert result[0] == 2
 
+    for command in (
+        ("FT.AGGREGATE", "products", "@price:[1 +inf]", "APPLY", "", "AS", "result"),
+        ("FT.AGGREGATE", "products", "@price:[1 +inf]", "FILTER", ""),
+    ):
+        with pytest.raises(ResponseError, match=r"Invalid or missing expression"):
+            client.execute_command(*command)
+
 def validate_aggregate_complex_queries(client: Valkey):
     """
         Test complex FT.AGGREGATE queries with numeric and tag.
@@ -634,4 +641,3 @@ class TestNonVectorCluster(ValkeySearchClusterTestCase):
         # Verify fetch-limited queries metric
         client.execute_command("CONFIG SET search.info-developer-visible yes")
         assert client.info("search").get("search_nonvector_results_fetched_limited_count", 0) == 8
-

--- a/src/expr/expr.cc
+++ b/src/expr/expr.cc
@@ -24,6 +24,8 @@ namespace valkey_search {
 namespace expr {
 
 using ExprPtr = std::unique_ptr<Expression>;
+constexpr absl::string_view kInvalidOrMissingExpression{
+    "Invalid or missing expression"};
 
 struct Constant : Expression {
   Constant(std::string constant) : constant_(std::move(constant)) {}
@@ -345,6 +347,9 @@ struct Compiler {
   absl::StatusOr<ExprPtr> Invert(CompileContext& ctx) {
     CHECK(s_.PopByte('!'));
     VMSDK_ASSIGN_OR_RETURN(auto expr, Primary(ctx));
+    if (!expr) {
+      return absl::InvalidArgumentError(kInvalidOrMissingExpression);
+    }
     return std::make_unique<Not>(std::move(expr));
   }
 
@@ -514,6 +519,9 @@ struct Compiler {
 
   absl::StatusOr<ExprPtr> Compile(CompileContext& ctx) {
     VMSDK_ASSIGN_OR_RETURN(auto result, ParseExpression(ctx));
+    if (!result) {
+      return absl::InvalidArgumentError(kInvalidOrMissingExpression);
+    }
     if (s_.SkipWhiteSpacePeekByte() != EOF) {
       return absl::InvalidArgumentError(absl::StrCat(
           "Extra characters at or near position ", s_.GetPosition()));

--- a/testing/expr/expr_test.cc
+++ b/testing/expr/expr_test.cc
@@ -175,5 +175,21 @@ TEST_F(ExprTest, TypesTest) {
   }
 }
 
+TEST_F(ExprTest, EmptyExpressionIsRejected) {
+  for (absl::string_view expr : {"", " "}) {
+    auto compiled = Expression::Compile(cc, expr);
+    EXPECT_FALSE(compiled.ok())
+        << "Expression unexpectedly compiled: '" << expr << "'";
+  }
+}
+
+TEST_F(ExprTest, NotOperatorRequiresOperand) {
+  for (absl::string_view expr : {"!", "! ", "!()"}) {
+    auto compiled = Expression::Compile(cc, expr);
+    EXPECT_FALSE(compiled.ok())
+        << "Expression unexpectedly compiled: '" << expr << "'";
+  }
+}
+
 }  // namespace expr
 }  // namespace valkey_search

--- a/testing/ft_aggregate_parser_test.cc
+++ b/testing/ft_aggregate_parser_test.cc
@@ -280,6 +280,27 @@ TEST_F(AggregateTest, StageParserTest) {
   }
 }
 
+TEST_F(AggregateTest, EmptyApplyAndFilterExpressionsAreRejected) {
+  for (absl::string_view test_case :
+       {"FILTER ''", "FILTER ' '", "APPLY '' AS r", "APPLY ' ' AS r"}) {
+    auto argv = vmsdk::ToValkeyStringVector(test_case);
+    vmsdk::ArgsIterator itr(argv.data(), argv.size());
+
+    AggregateParameters params(0);
+    params.timeout_ms = 0;
+    params.parse_vars_.index_interface_ = &fake_index;
+
+    auto parser = CreateAggregateParser();
+    auto result = parser.Parse(params, itr);
+
+    EXPECT_FALSE(result.ok()) << "Parser unexpectedly accepted: " << test_case;
+
+    for (auto arg : argv) {
+      ValkeyModule_FreeString(nullptr, arg);
+    }
+  }
+}
+
 TEST_F(AggregateTest, GetSerializationRange_NoStages) {
   AggregateParameters params(0);
   auto range = params.GetSerializationRange();


### PR DESCRIPTION
Reject empty aggregate expressions at compile time to prevent null AST evaluation in FT.AGGREGATE.
This fixes crashes for empty APPLY/FILTER expressions and also guards unary `!` without an operand.

issue : #964 