### PR TITLE
fix aggregate recursion depth

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -36,20 +36,6 @@ namespace valkey_search {
 
 namespace options {
 
-/// Register the "--query-string-depth" flag. Controls the depth of the query
-/// string parsing from the FT.SEARCH cmd.
-constexpr absl::string_view kQueryStringDepthConfig{"query-string-depth"};
-constexpr uint32_t kDefaultQueryStringDepth{1000};
-constexpr uint32_t kMinimumQueryStringDepth{1};
-static auto query_string_depth =
-    config::NumberBuilder(kQueryStringDepthConfig,   // name
-                          kDefaultQueryStringDepth,  // default size
-                          kMinimumQueryStringDepth,  // min size
-                          UINT_MAX)                  // max size
-        .WithValidationCallback(CHECK_RANGE(kMinimumQueryStringDepth, UINT_MAX,
-                                            kQueryStringDepthConfig))
-        .Build();
-
 /// Register the "query-string-terms-count" flag. Controls the size of the
 /// query string parsing from the FT.SEARCH cmd. The number of nodes in the
 /// predicate tree.
@@ -65,10 +51,6 @@ static auto query_terms_count =
         .WithValidationCallback(
             CHECK_RANGE(1, kMaxQueryTermsCount, kQueryStringTermsCountConfig))
         .Build();
-
-vmsdk::config::Number& GetQueryStringDepth() {
-  return dynamic_cast<vmsdk::config::Number&>(*query_string_depth);
-}
 
 vmsdk::config::Number& GetQueryStringTermsCount() {
   return dynamic_cast<vmsdk::config::Number&>(*query_terms_count);

--- a/src/expr/expr.cc
+++ b/src/expr/expr.cc
@@ -281,6 +281,8 @@ bool IsIdentifierChar(int c) {
 }
 
 struct Compiler {
+  int depth_ = 0;
+  static constexpr int kMaxDepth = 1000;
   utils::Scanner s_;
   Compiler(absl::string_view sv) : s_(sv) {}
 
@@ -349,6 +351,9 @@ struct Compiler {
   }
 
   absl::StatusOr<ExprPtr> Primary(CompileContext& ctx) {
+    if (++depth_ > kMaxDepth) {
+      return absl::InvalidArgumentError("Expression too complex");
+    }
     s_.SkipWhiteSpace();
     DBG << "Primary: '" << s_.GetUnscanned() << "'\n";
     switch (s_.PeekByte()) {

--- a/src/expr/expr.cc
+++ b/src/expr/expr.cc
@@ -14,6 +14,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "src/utils/scanner.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
@@ -280,9 +281,14 @@ bool IsIdentifierChar(int c) {
   return c != EOF && (std::isalnum(c) || c == '_');
 }
 
+struct DepthGuard {
+  int& depth;
+  DepthGuard(int& d) : depth(d) { ++depth; }
+  ~DepthGuard() { --depth; }
+};
+
 struct Compiler {
   int depth_ = 0;
-  static constexpr int kMaxDepth = 1000;
   utils::Scanner s_;
   Compiler(absl::string_view sv) : s_(sv) {}
 
@@ -351,7 +357,8 @@ struct Compiler {
   }
 
   absl::StatusOr<ExprPtr> Primary(CompileContext& ctx) {
-    if (++depth_ > kMaxDepth) {
+    DepthGuard guard(depth_);
+    if (depth_ > options::GetQueryStringDepth().GetValue()) {
       return absl::InvalidArgumentError("Expression too complex");
     }
     s_.SkipWhiteSpace();

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -527,6 +527,20 @@ static auto max_nonvector_search_results_fetched =
         kMaximumMaxNonVectorSearchResultsFetched)  // UINT32_MAX
         .Build();
 
+/// Register the "--query-string-depth" flag. Controls the depth of the query
+/// string parsing from the FT.SEARCH cmd.
+constexpr absl::string_view kQueryStringDepthConfig{"query-string-depth"};
+constexpr uint32_t kDefaultQueryStringDepth{1000};
+constexpr uint32_t kMinimumQueryStringDepth{1};
+static auto query_string_depth =
+    config::NumberBuilder(kQueryStringDepthConfig,   // name
+                          kDefaultQueryStringDepth,  // default size
+                          kMinimumQueryStringDepth,  // min size
+                          UINT_MAX)                  // max size
+        .WithValidationCallback(CHECK_RANGE(kMinimumQueryStringDepth, UINT_MAX,
+                                            kQueryStringDepthConfig))
+        .Build();
+
 uint32_t GetQueryStringBytes() { return query_string_bytes->GetValue(); }
 
 vmsdk::config::Number& GetHNSWBlockSize() {
@@ -660,6 +674,10 @@ config::Number& GetRaxTargetMutexPoolSize() {
 vmsdk::config::Number& GetMaxNonVectorSearchResultsFetched() {
   return dynamic_cast<vmsdk::config::Number&>(
       *max_nonvector_search_results_fetched);
+}
+
+vmsdk::config::Number& GetQueryStringDepth() {
+  return dynamic_cast<vmsdk::config::Number&>(*query_string_depth);
 }
 
 /// Register the "--mutation-weight-vector" flag. Controls the weight multiplier

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -142,5 +142,9 @@ config::Number& GetMutationWeightNumeric();
 /// Return the mutation weight for tag index types
 config::Number& GetMutationWeightTag();
 
+/// Return the recursion depth of the query string from FT.SEARCH and
+/// FT.AGGREGATE commands
+config::Number& GetQueryStringDepth();
+
 }  // namespace options
 }  // namespace valkey_search

--- a/testing/ft_aggregate_parser_test.cc
+++ b/testing/ft_aggregate_parser_test.cc
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "gtest/gtest.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/testing_infra/utils.h"
 
 std::ostream &operator<<(std::ostream &os, ValkeyModuleString *s) {
@@ -361,6 +362,28 @@ TEST_F(AggregateTest, GetSerializationRange_OtherStagesBeforeLimit) {
 
   auto range = params.GetSerializationRange();
   EXPECT_EQ(range, query::SerializationRange::All());
+}
+
+TEST_F(AggregateTest, ExpressionDepthAtLimit) {
+  auto limit = options::GetQueryStringDepth().GetValue();
+  std::string deep_expr(limit - 1, '(');
+  deep_expr += "1";
+  deep_expr += std::string(limit - 1, ')');
+
+  AggregateParameters params(0);
+  EXPECT_TRUE(expr::Expression::Compile(params, deep_expr).ok());
+}
+
+TEST_F(AggregateTest, ExpressionDepthExceedsLimit) {
+  auto limit = options::GetQueryStringDepth().GetValue();
+  std::string deep_expr(limit, '(');
+  deep_expr += "1";
+  deep_expr += std::string(limit, ')');
+
+  AggregateParameters params(0);
+  auto result = expr::Expression::Compile(params, deep_expr);
+  EXPECT_FALSE(result.ok());
+  EXPECT_TRUE(absl::IsInvalidArgument(result.status()));
 }
 
 }  // namespace aggregate


### PR DESCRIPTION
1. Moving query-string-depth config to valkey_search_options, enable reuse through multiple files
2. Use query-string-depth to limit aggregate query, prevent stack overflow
3. Added unit tests for aggregate query depth