### PR TITLE
Update search_number_of_indexes while restoring

### DIFF
--- a/integration/test_number_of_indexes_on_restore.py
+++ b/integration/test_number_of_indexes_on_restore.py
@@ -1,0 +1,61 @@
+"""
+Verify search_number_of_indexes is updated during RDB restore if search indexes exist instead of after restore
+"""
+
+import time
+import threading
+from valkeytestframework.conftest import resource_port_tracker
+from valkey_search_test_case import ValkeySearchTestCaseDebugMode
+from indexes import *
+from util import waiters
+
+index_1 = Index("idx_1", [Vector("v", 3, type="HNSW", m=2, efc=1), Text("txt")])
+index_2 = Index("idx_2", [Vector("v", 3, type="HNSW", m=2, efc=1), Numeric("n"), Tag("t"), Text("description")])
+NUM_DOCS = 10000
+
+
+class TestNumberOfIndexesOnRestore(ValkeySearchTestCaseDebugMode):
+
+    def append_startup_args(self, args):
+        args = super().append_startup_args(args)
+        # Small queue creates backpressure during V2 key loading, slowing
+        # LoadIndexExtension enough to observe rdb_restore_in_progress=1.
+        args["search.max-mutation-queue-size-on-restore"] = "1"
+        return args
+
+    def test_number_of_indexes_after_restore(self):
+        index_1.create(self.client, True)
+        index_2.create(self.client, True)
+        index_1.load_data(self.client, NUM_DOCS)
+        index_2.load_data(self.client, NUM_DOCS)
+        assert self.client.info("search")["search_number_of_indexes"] == 2
+
+        self.client.execute_command("SAVE")
+
+        # Monitor INFO from a separate connection during DEBUG RELOAD
+        monitor_client = self.server.get_new_client()
+        done = threading.Event()
+        violation = [None]
+
+        def monitor():
+            while not done.is_set():
+                try:
+                    info = monitor_client.info("search")
+                    if info.get("search_rdb_restore_in_progress", 0) and \
+                       info["search_number_of_indexes"] < 2:
+                        violation[0] = info["search_number_of_indexes"]
+                        return
+                except Exception:
+                    pass
+                time.sleep(0.001)
+
+        threading.Thread(target=monitor, daemon=True).start()
+        self.client.execute_command("DEBUG", "RELOAD")
+        done.set()
+
+        assert violation[0] is None, \
+            f"number_of_indexes was {violation[0]} during rdb_restore_in_progress=1"
+
+        waiters.wait_for_true(lambda: index_1.backfill_complete(self.client))
+        waiters.wait_for_true(lambda: index_2.backfill_complete(self.client))
+        assert self.client.info("search")["search_number_of_indexes"] == 2

--- a/integration/test_number_of_indexes_on_restore.py
+++ b/integration/test_number_of_indexes_on_restore.py
@@ -11,7 +11,7 @@ from util import waiters
 
 index_1 = Index("idx_1", [Vector("v", 3, type="HNSW", m=2, efc=1), Text("txt")])
 index_2 = Index("idx_2", [Vector("v", 3, type="HNSW", m=2, efc=1), Numeric("n"), Tag("t"), Text("description")])
-NUM_DOCS = 10000
+NUM_DOCS = 500
 
 
 class TestNumberOfIndexesOnRestore(ValkeySearchTestCaseDebugMode):

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -64,8 +64,6 @@ class Metrics {
     std::atomic<bool> rdb_restore_in_progress{false};
     std::atomic<uint64_t> rdb_restore_backpressure_wait_cycles{0};
     std::atomic<uint64_t> rdb_last_restore_aux_load_duration_ms{0};
-    std::atomic<uint64_t> rdb_last_restore_backfill_duration_ms{0};
-    std::atomic<int64_t> rdb_last_restore_backfill_start_ms{0};
 
     // FT.INTERNAL_UPDATE error handling metrics
     std::atomic<uint64_t> ft_internal_update_parse_failures_cnt{0};

--- a/src/metrics.h
+++ b/src/metrics.h
@@ -63,6 +63,9 @@ class Metrics {
     std::atomic<uint64_t> rdb_restore_current_index_keys_loaded{0};
     std::atomic<bool> rdb_restore_in_progress{false};
     std::atomic<uint64_t> rdb_restore_backpressure_wait_cycles{0};
+    std::atomic<uint64_t> rdb_last_restore_aux_load_duration_ms{0};
+    std::atomic<uint64_t> rdb_last_restore_backfill_duration_ms{0};
+    std::atomic<int64_t> rdb_last_restore_backfill_start_ms{0};
 
     // FT.INTERNAL_UPDATE error handling metrics
     std::atomic<uint64_t> ft_internal_update_parse_failures_cnt{0};

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -16,6 +16,7 @@
 #include "absl/strings/str_cat.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
 #include "src/metrics.h"
 #include "src/rdb_section.pb.h"
 #include "src/valkey_search.h"
@@ -166,6 +167,7 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
                          << " with " << rdb_section_count << " sections.";
 
   // Initialize restore progress tracking
+  auto rdb_load_start = absl::Now();
   Metrics::GetStats().rdb_restore_in_progress = true;
   Metrics::GetStats().rdb_restore_total_indexes = rdb_section_count;
   Metrics::GetStats().rdb_restore_completed_indexes = 0;
@@ -200,6 +202,12 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
 
   // Mark restore as complete (all indexes loaded successfully)
   Metrics::GetStats().rdb_restore_in_progress = false;
+  Metrics::GetStats().rdb_last_restore_aux_load_duration_ms =
+      absl::ToInt64Milliseconds(absl::Now() - rdb_load_start);
+  Metrics::GetStats().rdb_last_restore_backfill_start_ms =
+      absl::ToUnixMillis(absl::Now());
+  Metrics::GetStats().rdb_last_restore_backfill_duration_ms = 0;
+  
 
   return absl::OkStatus();
 }

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -204,9 +204,6 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
   Metrics::GetStats().rdb_restore_in_progress = false;
   Metrics::GetStats().rdb_last_restore_aux_load_duration_ms =
       absl::ToInt64Milliseconds(absl::Now() - rdb_load_start);
-  Metrics::GetStats().rdb_last_restore_backfill_start_ms =
-      absl::ToUnixMillis(absl::Now());
-  Metrics::GetStats().rdb_last_restore_backfill_duration_ms = 0;
 
   return absl::OkStatus();
 }

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -207,7 +207,6 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
   Metrics::GetStats().rdb_last_restore_backfill_start_ms =
       absl::ToUnixMillis(absl::Now());
   Metrics::GetStats().rdb_last_restore_backfill_duration_ms = 0;
-  
 
   return absl::OkStatus();
 }

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -392,10 +392,9 @@ uint64_t SchemaManager::GetNumberOfIndexSchemas() const {
   // Use rdb_restore_total_indexes while rdb_restore_in_progress
   if (Metrics::GetStats().rdb_restore_in_progress.load(
           std::memory_order_relaxed)) {
-    num_schemas = std::max(
-        static_cast<uint64_t>(num_schemas),
-        Metrics::GetStats().rdb_restore_total_indexes.load(
-            std::memory_order_relaxed));
+    num_schemas = std::max(static_cast<uint64_t>(num_schemas),
+                           Metrics::GetStats().rdb_restore_total_indexes.load(
+                               std::memory_order_relaxed));
   }
   return num_schemas;
 }

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -32,6 +32,7 @@
 #include "src/coordinator/metadata_manager.h"
 #include "src/index_schema.h"
 #include "src/index_schema.pb.h"
+#include "src/metrics.h"
 #include "src/rdb_section.pb.h"
 #include "src/rdb_serialization.h"
 #include "src/valkey_search.h"
@@ -387,6 +388,14 @@ uint64_t SchemaManager::GetNumberOfIndexSchemas() const {
   auto num_schemas = 0;
   for (const auto &[db_num, schema_map] : db_to_index_schemas_) {
     num_schemas += schema_map.size();
+  }
+  // Use rdb_restore_total_indexes while rdb_restore_in_progress
+  if (Metrics::GetStats().rdb_restore_in_progress.load(
+          std::memory_order_relaxed)) {
+    num_schemas = std::max(
+        static_cast<uint64_t>(num_schemas),
+        Metrics::GetStats().rdb_restore_total_indexes.load(
+            std::memory_order_relaxed));
   }
   return num_schemas;
 }

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -389,13 +389,6 @@ uint64_t SchemaManager::GetNumberOfIndexSchemas() const {
   for (const auto &[db_num, schema_map] : db_to_index_schemas_) {
     num_schemas += schema_map.size();
   }
-  // Use rdb_restore_total_indexes while rdb_restore_in_progress
-  if (Metrics::GetStats().rdb_restore_in_progress.load(
-          std::memory_order_relaxed)) {
-    num_schemas = std::max(static_cast<uint64_t>(num_schemas),
-                           Metrics::GetStats().rdb_restore_total_indexes.load(
-                               std::memory_order_relaxed));
-  }
   return num_schemas;
 }
 
@@ -816,8 +809,13 @@ absl::Status SchemaManager::ShowIndexSchemas(ValkeyModuleCtx *ctx,
 
 static vmsdk::info_field::Integer number_of_indexes(
     "index_stats", "number_of_indexes",
-    vmsdk::info_field::IntegerBuilder().App().Computed([] {
-      return SchemaManager::Instance().GetNumberOfIndexSchemas();
+    vmsdk::info_field::IntegerBuilder().App().Computed([]() -> long long {
+      // Consider indexes pending RDB load
+      auto &stats = Metrics::GetStats();
+      return SchemaManager::Instance().GetNumberOfIndexSchemas() +
+             std::max(stats.rdb_restore_total_indexes.load() -
+                          stats.rdb_restore_completed_indexes.load(),
+                      uint64_t{0});
     }));
 static vmsdk::info_field::Integer number_of_attributes(
     "index_stats", "number_of_attributes",

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -373,9 +373,11 @@ static vmsdk::info_field::Integer rdb_last_restore_backfill_duration_ms(
         .Dev()
         .Units(vmsdk::info_field::Units::kMilliSeconds)
         .Computed([]() -> long long {
-          auto start_ms = Metrics::GetStats().rdb_last_restore_backfill_start_ms.load();
+          auto start_ms =
+              Metrics::GetStats().rdb_last_restore_backfill_start_ms.load();
           if (start_ms == 0) return 0;
-          auto stored = Metrics::GetStats().rdb_last_restore_backfill_duration_ms.load();
+          auto stored =
+              Metrics::GetStats().rdb_last_restore_backfill_duration_ms.load();
           if (stored > 0) return stored;
           // In progress - compute elapsed
           if (SchemaManager::Instance().IsIndexingInProgress()) {

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -21,6 +21,7 @@
 #include "absl/strings/numbers.h"
 #include "absl/strings/str_format.h"
 #include "absl/strings/string_view.h"
+#include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "src/attribute_data_type.h"
 #include "src/coordinator/client_pool.h"
@@ -356,6 +357,35 @@ static vmsdk::info_field::Integer rdb_restore_backpressure_wait_cycles(
     vmsdk::info_field::IntegerBuilder().Dev().Computed([]() -> long long {
       return Metrics::GetStats().rdb_restore_backpressure_wait_cycles;
     }));
+
+static vmsdk::info_field::Integer rdb_last_restore_aux_load_duration_ms(
+    "rdb", "rdb_last_restore_aux_load_duration_ms",
+    vmsdk::info_field::IntegerBuilder()
+        .Dev()
+        .Units(vmsdk::info_field::Units::kMilliSeconds)
+        .Computed([]() -> long long {
+          return Metrics::GetStats().rdb_last_restore_aux_load_duration_ms;
+        }));
+
+static vmsdk::info_field::Integer rdb_last_restore_backfill_duration_ms(
+    "rdb", "rdb_last_restore_backfill_duration_ms",
+    vmsdk::info_field::IntegerBuilder()
+        .Dev()
+        .Units(vmsdk::info_field::Units::kMilliSeconds)
+        .Computed([]() -> long long {
+          auto start_ms = Metrics::GetStats().rdb_last_restore_backfill_start_ms.load();
+          if (start_ms == 0) return 0;
+          auto stored = Metrics::GetStats().rdb_last_restore_backfill_duration_ms.load();
+          if (stored > 0) return stored;
+          // In progress - compute elapsed
+          if (SchemaManager::Instance().IsIndexingInProgress()) {
+            return absl::ToUnixMillis(absl::Now()) - start_ms;
+          }
+          // Finished
+          auto duration = absl::ToUnixMillis(absl::Now()) - start_ms;
+          Metrics::GetStats().rdb_last_restore_backfill_duration_ms = duration;
+          return duration;
+        }));
 
 static vmsdk::info_field::Integer ft_internal_update_parse_failures_cnt(
     "coordinator", "ft_internal_update_parse_failures_cnt",

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -367,28 +367,6 @@ static vmsdk::info_field::Integer rdb_last_restore_aux_load_duration_ms(
           return Metrics::GetStats().rdb_last_restore_aux_load_duration_ms;
         }));
 
-static vmsdk::info_field::Integer rdb_last_restore_backfill_duration_ms(
-    "rdb", "rdb_last_restore_backfill_duration_ms",
-    vmsdk::info_field::IntegerBuilder()
-        .Dev()
-        .Units(vmsdk::info_field::Units::kMilliSeconds)
-        .Computed([]() -> long long {
-          auto start_ms =
-              Metrics::GetStats().rdb_last_restore_backfill_start_ms.load();
-          if (start_ms == 0) return 0;
-          auto stored =
-              Metrics::GetStats().rdb_last_restore_backfill_duration_ms.load();
-          if (stored > 0) return stored;
-          // In progress - compute elapsed
-          if (SchemaManager::Instance().IsIndexingInProgress()) {
-            return absl::ToUnixMillis(absl::Now()) - start_ms;
-          }
-          // Finished
-          auto duration = absl::ToUnixMillis(absl::Now()) - start_ms;
-          Metrics::GetStats().rdb_last_restore_backfill_duration_ms = duration;
-          return duration;
-        }));
-
 static vmsdk::info_field::Integer ft_internal_update_parse_failures_cnt(
     "coordinator", "ft_internal_update_parse_failures_cnt",
     vmsdk::info_field::IntegerBuilder().Dev().Computed([]() -> long long {

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -18,6 +18,7 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 #include "src/coordinator/metadata_manager.h"
+#include "src/metrics.h"
 #include "testing/common.h"
 #include "testing/coordinator/common.h"
 #include "vmsdk/src/testing_infra/module.h"
@@ -354,6 +355,72 @@ TEST_F(SchemaManagerTest, TestLoadIndexNoReplication) {
       &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   VMSDK_EXPECT_OK(
       SchemaManager::Instance().GetIndexSchema(db_num_, index_name_));
+}
+
+TEST_F(SchemaManagerTest, TestNumberOfIndexSchemasDuringReplication) {
+  // Verify that during replication, rdb_restore_total_indexes covers the
+  // staging gap where indexes are in the staged map but not the live map.
+  ValkeyModuleEvent eid;
+  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
+      .WillByDefault(testing::Return(&fake_ctx_));
+
+  auto &stats = Metrics::GetStats();
+  auto old_in_progress = stats.rdb_restore_in_progress.load();
+  auto old_total = stats.rdb_restore_total_indexes.load();
+
+  // Simulate RDB restore starting with 1 index (replication scenario)
+  stats.rdb_restore_in_progress.store(true);
+  stats.rdb_restore_total_indexes.store(1);
+
+  SchemaManager::Instance().OnLoadingCallback(
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_REPL_START, nullptr);
+
+  // No indexes in live map yet, but rdb_restore_total_indexes = 1
+  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
+
+  FakeSafeRDB fake_rdb;
+  auto section = std::make_unique<data_model::RDBSection>();
+  section->set_type(data_model::RDB_SECTION_INDEX_SCHEMA);
+  section->mutable_index_schema_contents()->CopyFrom(test_index_schema_proto_);
+  section->set_supplemental_count(0);
+
+  VMSDK_EXPECT_OK(SchemaManager::Instance().LoadIndex(
+      &fake_ctx_, std::move(section), SupplementalContentIter(&fake_rdb, 0)));
+
+  // Index is staged (not in live map), rdb_restore_total_indexes still covers
+  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
+
+  // Simulate restore completed
+  stats.rdb_restore_in_progress.store(false);
+
+  // Apply the staged schemas.
+  SchemaManager::Instance().OnLoadingCallback(
+      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
+
+  // Now in live map, no restore fallback needed
+  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
+
+  // Restore original metric state
+  stats.rdb_restore_in_progress.store(old_in_progress);
+  stats.rdb_restore_total_indexes.store(old_total);
+}
+
+TEST_F(SchemaManagerTest,
+       TestNumberOfIndexSchemasNotInflatedWhenNotRestoring) {
+  // When rdb_restore_in_progress is false, stale rdb_restore_total_indexes
+  // should NOT inflate the count.
+  auto &stats = Metrics::GetStats();
+  auto old_in_progress = stats.rdb_restore_in_progress.load();
+  auto old_total = stats.rdb_restore_total_indexes.load();
+
+  stats.rdb_restore_in_progress.store(false);
+  stats.rdb_restore_total_indexes.store(5);  // stale from a previous load
+
+  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 0);
+
+  // Restore original metric state
+  stats.rdb_restore_in_progress.store(old_in_progress);
+  stats.rdb_restore_total_indexes.store(old_total);
 }
 
 TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -18,7 +18,6 @@
 #include "google/protobuf/text_format.h"
 #include "gtest/gtest.h"
 #include "src/coordinator/metadata_manager.h"
-#include "src/metrics.h"
 #include "testing/common.h"
 #include "testing/coordinator/common.h"
 #include "vmsdk/src/testing_infra/module.h"
@@ -355,71 +354,6 @@ TEST_F(SchemaManagerTest, TestLoadIndexNoReplication) {
       &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
   VMSDK_EXPECT_OK(
       SchemaManager::Instance().GetIndexSchema(db_num_, index_name_));
-}
-
-TEST_F(SchemaManagerTest, TestNumberOfIndexSchemasDuringReplication) {
-  // Verify that during replication, rdb_restore_total_indexes covers the
-  // staging gap where indexes are in the staged map but not the live map.
-  ValkeyModuleEvent eid;
-  ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))
-      .WillByDefault(testing::Return(&fake_ctx_));
-
-  auto &stats = Metrics::GetStats();
-  auto old_in_progress = stats.rdb_restore_in_progress.load();
-  auto old_total = stats.rdb_restore_total_indexes.load();
-
-  // Simulate RDB restore starting with 1 index (replication scenario)
-  stats.rdb_restore_in_progress.store(true);
-  stats.rdb_restore_total_indexes.store(1);
-
-  SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_REPL_START, nullptr);
-
-  // No indexes in live map yet, but rdb_restore_total_indexes = 1
-  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
-
-  FakeSafeRDB fake_rdb;
-  auto section = std::make_unique<data_model::RDBSection>();
-  section->set_type(data_model::RDB_SECTION_INDEX_SCHEMA);
-  section->mutable_index_schema_contents()->CopyFrom(test_index_schema_proto_);
-  section->set_supplemental_count(0);
-
-  VMSDK_EXPECT_OK(SchemaManager::Instance().LoadIndex(
-      &fake_ctx_, std::move(section), SupplementalContentIter(&fake_rdb, 0)));
-
-  // Index is staged (not in live map), rdb_restore_total_indexes still covers
-  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
-
-  // Simulate restore completed
-  stats.rdb_restore_in_progress.store(false);
-
-  // Apply the staged schemas.
-  SchemaManager::Instance().OnLoadingCallback(
-      &fake_ctx_, eid, VALKEYMODULE_SUBEVENT_LOADING_ENDED, nullptr);
-
-  // Now in live map, no restore fallback needed
-  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 1);
-
-  // Restore original metric state
-  stats.rdb_restore_in_progress.store(old_in_progress);
-  stats.rdb_restore_total_indexes.store(old_total);
-}
-
-TEST_F(SchemaManagerTest, TestNumberOfIndexSchemasNotInflatedWhenNotRestoring) {
-  // When rdb_restore_in_progress is false, stale rdb_restore_total_indexes
-  // should NOT inflate the count.
-  auto &stats = Metrics::GetStats();
-  auto old_in_progress = stats.rdb_restore_in_progress.load();
-  auto old_total = stats.rdb_restore_total_indexes.load();
-
-  stats.rdb_restore_in_progress.store(false);
-  stats.rdb_restore_total_indexes.store(5);  // stale from a previous load
-
-  EXPECT_EQ(SchemaManager::Instance().GetNumberOfIndexSchemas(), 0);
-
-  // Restore original metric state
-  stats.rdb_restore_in_progress.store(old_in_progress);
-  stats.rdb_restore_total_indexes.store(old_total);
 }
 
 TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -405,8 +405,7 @@ TEST_F(SchemaManagerTest, TestNumberOfIndexSchemasDuringReplication) {
   stats.rdb_restore_total_indexes.store(old_total);
 }
 
-TEST_F(SchemaManagerTest,
-       TestNumberOfIndexSchemasNotInflatedWhenNotRestoring) {
+TEST_F(SchemaManagerTest, TestNumberOfIndexSchemasNotInflatedWhenNotRestoring) {
   // When rdb_restore_in_progress is false, stale rdb_restore_total_indexes
   // should NOT inflate the count.
   auto &stats = Metrics::GetStats();


### PR DESCRIPTION
During RDB restore `search_number_of_indexes` INFO metric reported 0 because indexes are not added to the live schema map until after the restore completes. Changing this behaviour so that during restore we use `rdb_restore_total_indexes`  - `rdb_restore_completed_indexes` i.e indexes pending rdb load to update it. Will allow us to identify clusters with search indexes early and ensures the metric never drops to 0 while indexes are mid-load.

Added integration test to confirm if above works. 

Added a Dev metric as well to give us more visibility on search RDB restore overhead duration

- `rdb_last_restore_aux_load_duration_ms` — Duration of the last search index schema deserialization from RDB                       
