### PR TITLE
fix(expr): prevent infinite loop in timefmt with empty format string

### DIFF
--- a/src/expr/value.cc
+++ b/src/expr/value.cc
@@ -516,11 +516,16 @@ Value FuncTimefmt(const Value& ts, const Value& fmt) {
   time_t timestamp = (time_t)*timestampd;
   ::gmtime_r(&timestamp, &tm);
 
+  const std::string_view fmt_view = fmt.AsStringView();
+  if (fmt_view.empty()) {
+    return Value(std::string{});
+  }
+
   std::string result;
   result.resize(100);
   size_t result_bytes = 0;
   while ((result_bytes = strftime(result.data(), result.size(),
-                                  fmt.AsStringView().data(), &tm)) == 0) {
+                                  fmt_view.data(), &tm)) == 0) {
     result.resize(result.size() * 2);
   }
   result.resize(result_bytes);


### PR DESCRIPTION
## Summary

When an empty format string is passed to `timefmt()`, `strftime()` returns 0 because there are no format specifiers to process. The existing resize loop interprets this return value as "buffer too small" and doubles the buffer indefinitely, causing memory exhaustion and a server crash (SIGSEGV/termination).

**Reproduction (from #962):**
```
FT.CREATE testidx ON HASH PREFIX 1 doc: SCHEMA title TEXT ts NUMERIC
HSET doc:1 title "test" ts 1700000000
FT.AGGREGATE testidx "test" LOAD 1 @ts APPLY 'timefmt(@ts, "")' AS fmt
-- Error: Server closed the connection (crash)
```

## Fix

Add an early return in `FuncTimefmt()` when the format string is empty, returning an empty string result instead of entering the infinite buffer-resize loop. Also cache `AsStringView()` to avoid redundant calls.

Fixes #962