### PR TITLE
Fix Tag Search's EntriesFetcherIterator logic to not rely on RootIterator (full tree walk) on standard cases

### DIFF
--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -240,6 +240,45 @@ def validate_bulk_limit_queries(client: Valkey):
     assert actual_results <= 3  # Should return at most 3 results
     assert actual_results == min(3, max(0, total_count - 2))  # Respect offset of 2
 
+def validate_tag_and_negate_queries(client: Valkey):
+    """
+        Test TAG and negated TAG queries using the bulk_products index (2500 docs, 10 categories).
+        Reuses the bulk data created by create_bulk_data_standalone: category = "cat0".."cat9",
+        each with 250 docs.
+    """
+    # Exact tag match
+    result = client.execute_command("FT.SEARCH", "bulk_products", "@category:{cat0}", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 250
+
+    # Tag OR
+    result = client.execute_command("FT.SEARCH", "bulk_products", "@category:{cat0|cat1}", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 500
+
+    # Nonexistent tag
+    result = client.execute_command("FT.SEARCH", "bulk_products", "@category:{nonexistent}", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 0
+
+    # Negate single category: 2500 - 250 = 2250
+    result = client.execute_command("FT.SEARCH", "bulk_products", "-@category:{cat0}", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 2250
+
+    # Negate two categories: 2500 - 500 = 2000
+    result = client.execute_command("FT.SEARCH", "bulk_products", "-@category:{cat0|cat1}", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 2000
+
+    # Positive tag AND negate: cat0 AND NOT rating=3.0
+    # cat0 = 250 docs. rating cycles 3.0/4.0/5.0, so 1/3 of cat0 has rating 3.0.
+    # cat0 docs are at indices 0,10,20,...2490. rating=3.0 when i%3==0.
+    # cat0 AND rating=3.0: i%10==0 AND i%3==0 => i%30==0 => 84 docs (0..2490 step 30 = 83+1=84)
+    # Result: 250 - 84 = 166
+    result = client.execute_command("FT.SEARCH", "bulk_products", "@category:{cat0} @rating:[4.0 +inf]", "NOCONTENT", "LIMIT", "0", "0")
+    assert result[0] == 166, f"Expected 166, got {result[0]}"
+
+    # Negate with LIMIT pagination
+    result = client.execute_command("FT.SEARCH", "bulk_products", "-@category:{cat0}", "NOCONTENT", "LIMIT", "0", "50")
+    assert result[0] == 2250
+    assert len(result) - 1 == 50
+
 def validate_aggregate_queries(client: Valkey):
     """
         Test FT.AGGREGATE with numeric and tag queries.
@@ -523,6 +562,14 @@ class TestNonVector(ValkeySearchTestCaseBase):
         client: Valkey = self.server.get_new_client()
         create_bulk_data_standalone(client)
         validate_bulk_limit_queries(client)
+
+    def test_tag_and_negate_at_scale(self):
+        """
+            Test TAG and negated TAG queries with bulk data to exercise the tag index at scale.
+        """
+        client: Valkey = self.server.get_new_client()
+        create_bulk_data_standalone(client)
+        validate_tag_and_negate_queries(client)
 
 class TestNonVectorCluster(ValkeySearchClusterTestCase):
 

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -263,15 +263,15 @@ Tag::EntriesFetcherIterator::EntriesFetcherIterator(
       untracked_keys_(untracked_keys),
       negate_(negate) {}
 
-void Tag::EntriesFetcherIterator::EnsureTreeIter() {
-  if (!tree_iter_.has_value()) {
-    tree_iter_.emplace(tree_.RootIterator());
+void Tag::EntriesFetcherIterator::EnsureNegateRootIter() {
+  if (!negate_root_iter_.has_value()) {
+    negate_root_iter_.emplace(tree_.RootIterator());
   }
 }
 
 bool Tag::EntriesFetcherIterator::Done() const {
   if (negate_) {
-    return tree_iter_.has_value() && tree_iter_->Done() &&
+    return negate_root_iter_.has_value() && negate_root_iter_->Done() &&
            (untracked_keys_.empty() ||
             (untracked_keys_iter_.has_value() &&
              untracked_keys_iter_.value() == untracked_keys_.end()));
@@ -280,22 +280,22 @@ bool Tag::EntriesFetcherIterator::Done() const {
 }
 
 void Tag::EntriesFetcherIterator::NextNegate() {
-  EnsureTreeIter();
+  EnsureNegateRootIter();
   if (next_node_) {
     ++next_iter_;
     if (next_iter_ != next_node_->value.value().end()) {
       return;
     }
-    tree_iter_->Next();
+    negate_root_iter_->Next();
   }
-  while (!tree_iter_->Done()) {
-    next_node_ = tree_iter_->Value();
+  while (!negate_root_iter_->Done()) {
+    next_node_ = negate_root_iter_->Value();
     if (next_node_ && !entries_.contains(next_node_) &&
         next_node_->value.has_value() && !next_node_->value.value().empty()) {
       next_iter_ = next_node_->value.value().begin();
       return;
     }
-    tree_iter_->Next();
+    negate_root_iter_->Next();
   }
   next_node_ = nullptr;
   if (!untracked_keys_iter_.has_value()) {
@@ -329,7 +329,7 @@ void Tag::EntriesFetcherIterator::Next() {
 }
 
 const InternedStringPtr& Tag::EntriesFetcherIterator::operator*() const {
-  if (negate_ && tree_iter_.has_value() && tree_iter_->Done()) {
+  if (negate_ && negate_root_iter_.has_value() && negate_root_iter_->Done()) {
     return *untracked_keys_iter_.value();
   }
   return *next_iter_;

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -258,14 +258,20 @@ Tag::EntriesFetcherIterator::EntriesFetcherIterator(
     const PatriciaTreeIndex& tree,
     absl::flat_hash_set<PatriciaNodeIndex*>& entries,
     const InternedStringSet& untracked_keys, bool negate)
-    : tree_iter_(tree.RootIterator()),
+    : tree_(tree),
       entries_(entries),
       untracked_keys_(untracked_keys),
       negate_(negate) {}
 
+void Tag::EntriesFetcherIterator::EnsureTreeIter() {
+  if (!tree_iter_.has_value()) {
+    tree_iter_.emplace(tree_.RootIterator());
+  }
+}
+
 bool Tag::EntriesFetcherIterator::Done() const {
   if (negate_) {
-    return tree_iter_.Done() &&
+    return tree_iter_.has_value() && tree_iter_->Done() &&
            (untracked_keys_.empty() ||
             (untracked_keys_iter_.has_value() &&
              untracked_keys_iter_.value() == untracked_keys_.end()));
@@ -274,21 +280,22 @@ bool Tag::EntriesFetcherIterator::Done() const {
 }
 
 void Tag::EntriesFetcherIterator::NextNegate() {
+  EnsureTreeIter();
   if (next_node_) {
     ++next_iter_;
     if (next_iter_ != next_node_->value.value().end()) {
       return;
     }
-    tree_iter_.Next();
+    tree_iter_->Next();
   }
-  while (!tree_iter_.Done()) {
-    next_node_ = tree_iter_.Value();
+  while (!tree_iter_->Done()) {
+    next_node_ = tree_iter_->Value();
     if (next_node_ && !entries_.contains(next_node_) &&
         next_node_->value.has_value() && !next_node_->value.value().empty()) {
       next_iter_ = next_node_->value.value().begin();
       return;
     }
-    tree_iter_.Next();
+    tree_iter_->Next();
   }
   next_node_ = nullptr;
   if (!untracked_keys_iter_.has_value()) {
@@ -322,7 +329,7 @@ void Tag::EntriesFetcherIterator::Next() {
 }
 
 const InternedStringPtr& Tag::EntriesFetcherIterator::operator*() const {
-  if (negate_ && tree_iter_.Done()) {
+  if (negate_ && tree_iter_.has_value() && tree_iter_->Done()) {
     return *untracked_keys_iter_.value();
   }
   return *next_iter_;

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -87,16 +87,28 @@ class Tag : public IndexBase {
     const InternedStringPtr& operator*() const override;
 
    private:
+    // Reference to the Patricia tree, held so we can lazily construct the
+    // root iterator on demand (only when negation requires it).
     const PatriciaTreeIndex& tree_;
-    std::optional<PatriciaTreeIndex::PrefixSubTreeIterator> tree_iter_;
+
+    // Full-tree root iterator used exclusively by the negated path.
+    // Lazily initialized by EnsureNegateRootIter() to avoid an O(N) DFS
+    // of the entire Patricia tree for non-negated queries, where N is the
+    // number of unique tag values in the index.
+    std::optional<PatriciaTreeIndex::PrefixSubTreeIterator> negate_root_iter_;
+
+    // The set of Patricia nodes matching the query tags. For non-negated
+    // queries, we iterate these directly. For negated queries, these are
+    // the nodes to *exclude* during the full-tree walk.
     absl::flat_hash_set<PatriciaNodeIndex*>& entries_;
+
     PatriciaNodeIndex* next_node_{nullptr};
     InternedStringSet::const_iterator next_iter_;
     const InternedStringSet& untracked_keys_;
     bool negate_;
     std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
     void NextNegate();
-    void EnsureTreeIter();
+    void EnsureNegateRootIter();
   };
 
   class EntriesFetcher : public EntriesFetcherBase {

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -87,14 +87,13 @@ class Tag : public IndexBase {
     const InternedStringPtr& operator*() const override;
 
    private:
-    // Reference to the Patricia tree, held so we can lazily construct the
+    // Reference to the Patricia tree, held so we can construct the
     // root iterator on demand (only when negation requires it).
     const PatriciaTreeIndex& tree_;
 
     // Full-tree root iterator used exclusively by the negated path.
-    // Lazily initialized by EnsureNegateRootIter() to avoid an O(N) DFS
-    // of the entire Patricia tree for non-negated queries, where N is the
-    // number of unique tag values in the index.
+    // Only constructed by EnsureNegateRootIter() on first negated
+    // iteration — non-negated queries never create this.
     std::optional<PatriciaTreeIndex::PrefixSubTreeIterator> negate_root_iter_;
 
     // The set of Patricia nodes matching the query tags. For non-negated

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -87,7 +87,8 @@ class Tag : public IndexBase {
     const InternedStringPtr& operator*() const override;
 
    private:
-    PatriciaTreeIndex::PrefixSubTreeIterator tree_iter_;
+    const PatriciaTreeIndex& tree_;
+    std::optional<PatriciaTreeIndex::PrefixSubTreeIterator> tree_iter_;
     absl::flat_hash_set<PatriciaNodeIndex*>& entries_;
     PatriciaNodeIndex* next_node_{nullptr};
     InternedStringSet::const_iterator next_iter_;
@@ -95,6 +96,7 @@ class Tag : public IndexBase {
     bool negate_;
     std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
     void NextNegate();
+    void EnsureTreeIter();
   };
 
   class EntriesFetcher : public EntriesFetcherBase {

--- a/src/utils/patricia_tree.h
+++ b/src/utils/patricia_tree.h
@@ -135,29 +135,45 @@ class PatriciaTree {
   // This iterator is used to iterate over all the values of a given prefix and
   // it's subtrees. In short, it will return all values that starts with a given
   // prefix.
+  // Iterates over all value-bearing nodes in the subtree rooted at the given
+  // node. Construction is O(1) — the DFS traversal is deferred until the
+  // first call to Done(), Next(), or Value().
   class PrefixSubTreeIterator {
    public:
-    PrefixSubTreeIterator(PatriciaNodeType *node) {
-      if (node == nullptr) {
-        return;
-      }
-      DfsHelper(node);
+    PrefixSubTreeIterator(PatriciaNodeType *node) : root_(node) {}
+
+    bool Done() const {
+      EnsureInitialized();
+      return values_.empty();
     }
 
-    bool Done() const { return values_.empty(); }
-
     void Next() {
+      EnsureInitialized();
       if (!values_.empty()) {
         values_.pop();
       }
     }
 
-    PatriciaNodeType *Value() const { return values_.top(); }
+    PatriciaNodeType *Value() const {
+      EnsureInitialized();
+      return values_.top();
+    }
 
    private:
-    std::stack<PatriciaNodeType *> values_;
+    PatriciaNodeType *root_;
+    mutable bool initialized_{false};
+    mutable std::stack<PatriciaNodeType *> values_;
 
-    void DfsHelper(PatriciaNodeType *node) {
+    void EnsureInitialized() const {
+      if (!initialized_) {
+        initialized_ = true;
+        if (root_ != nullptr) {
+          DfsHelper(root_);
+        }
+      }
+    }
+
+    void DfsHelper(PatriciaNodeType *node) const {
       if (node->value.has_value()) {
         values_.push(node);
       }


### PR DESCRIPTION
The Tag performance was looking pretty bad in comparison with Text and Numeric.... For Context, with NOCONTENT, we were getting ~50-70K RPS with text term / text prefix searches which had ~1000 matches. Tag was showing 44 RPS for queries with ~100 matches.


In particular, we noticed it was not scaling with the index size.

From looking at the code, we are always creating a root iterator which makes tag searches degrade as the index grows larger. This root iterator is only really needed in negate.

We used the amazon-science data set: https://github.com/amazon-science/esci-data
The Tag Searches were fair and were just having ~100 matches (as the COUNT) per FT.SEARCH command in both the index size of 100K and 1.2M cases.


---
### TAG Scaling: 100K vs 1.2M Documents
Standalone TAG query: `@brand:{brand}` (verified 5-100 matches)  
Tests whether TAG overhead scales with index size or result count.
#### 100K Documents (idx:products_100k)
| Instance | C=1 P50 | QPS C=1 | QPS C=300 | QPS C=1000 |
|----------|---------|---------|-----------|------------|
| **r7g.8xlarge** | 1.855 | 520 | 10,490 | 10,309 |
| **r7g.2xlarge** | 2.031 | 480 | 2,545 | 2,555 |
| **r7g.large** | 1.783 | 520 | 561 | 544 |
#### 1.2M Documents
| Instance | C=1 P50 | QPS C=1 | QPS C=300 | QPS C=1000 |
|----------|---------|---------|-----------|------------|
| **r7g.8xlarge** | 19.631 | 51 | 1,376 | 1,374 |
| **r7g.2xlarge** | 20.431 | 49 | 309 | 316 |
| **r7g.large** | 22.287 | 39 | 44 | 44 |
#### Scaling Impact
| Instance | 100K P50 | 1.2M P50 | Latency increase | 100K QPS (C=300) | 1.2M QPS (C=300) | QPS drop |
|----------|----------|----------|-----------------|-----------------|-----------------|----------|
| **r7g.8xlarge** | 1.855ms | 19.631ms | **10.6×** | 10,490 | 1,376 | **7.6×** |
| **r7g.2xlarge** | 2.031ms | 20.431ms | **10.1×** | 2,545 | 309 | **8.2×** |
| **r7g.large** | 1.783ms | 22.287ms | **12.5×** | 561 | 44 | **12.8×** |

------


From local testing, just with my PR's change of moving the root iterator off the constructor and only into negate path, we see this in perf with using 1000 clients:
```
Summary:
  throughput summary: 76923.08 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
       11.221     5.368    11.055    15.295    18.143    20.703
```

Without my change:
```
Summary:
  throughput summary: 1284.19 requests per second
  latency summary (msec):
          avg       min       p50       p95       p99       max
      739.236    28.848   772.095   798.207   801.791   803.327
```