### PR TITLE
Rename utility-worker to util-worker to adhere to 15 char name limit in linux

### DIFF
--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -1167,7 +1167,7 @@ absl::Status ValkeySearch::Startup(ValkeyModuleCtx *ctx) {
       options::GetThreadPoolWaitTimeSamples().GetValue());
   writer_thread_pool_->StartWorkers();
   utility_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
-      "utility-worker-", options::GetUtilityThreadCount().GetValue(),
+      "util-worker-", options::GetUtilityThreadCount().GetValue(),
       options::GetThreadPoolWaitTimeSamples().GetValue());
   utility_thread_pool_->StartWorkers();
 


### PR DESCRIPTION
Rename utility-worker to util-worker to adhere to 15 char name limit in linux. Without this change, the utility-thread pool's name does not show up clearly when listing threads and also in flamegraphs. Instead, it takes the name of valkey-server which makes graphs hard to read