### PR TITLE
Allow python integ tests to be run with integration/run.sh

### DIFF
--- a/integration/run.sh
+++ b/integration/run.sh
@@ -167,7 +167,7 @@ function run_pytest() {
 
 function run_with_retries() {
   counter=1
-  retries=${INTEG_RETRIES}
+  retries=${INTEG_RETRIES:-1}
   if ((retries == 1)); then
     # Avoid the clutter and run it once.
     run_pytest


### PR DESCRIPTION
It helps to have a way to run just the python integ tests. This allow running python integ tests to be run with `./integration/run.sh`. It defaults the `INTEG_RETRIES` to 1 when not specified.

Without this, running just the script causes this error:
```
"Retries exhausted"
```