### PR TITLE
Backporting docker update test (#1007) to 1.2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,14 +8,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt update && \
     apt install -y --no-install-recommends \
         ca-certificates \
-        software-properties-common \
         lsb-release \
         curl \
         gpg \
         sudo \
         wget && \
-    # Add repositories
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
     # Add Redis repository
     curl -fsSL https://packages.redis.io/gpg | gpg --dearmor -o /usr/share/keyrings/redis-archive-keyring.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/redis-archive-keyring.gpg] https://packages.redis.io/deb $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/redis.list && \


### PR DESCRIPTION
Removed the ubuntu-toolchain-r/test PPA and software-properties-common from the Dockerfile because the PPA's Launchpad API call was consistently timing out in CI, and no installed package actually comes from that PPA — Ubuntu Noble already provides GCC 13 via build-essential

---------
Backporting https://github.com/valkey-io/valkey-search/pull/1007 to 1.2