### PR TITLE
Backporting docker update test (#1007) to 1.1

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -11,10 +11,6 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
-    software-properties-common
-RUN add-apt-repository ppa:ubuntu-toolchain-r/test && apt update
-
-RUN apt update && apt-get install -y \
     libssl-dev \
     build-essential \
     git \


### PR DESCRIPTION
Removed the ubuntu-toolchain-r/test PPA and software-properties-common from the Dockerfile because the PPA's Launchpad API call was consistently timing out in CI, and no installed package actually comes from that PPA — Ubuntu Noble already provides GCC 13 via build-essential

---------


Backporting https://github.com/valkey-io/valkey-search/pull/1007 to 1.1