### PR TITLE
Add backport workflow for automated cherry-pick PRs

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -59,13 +59,15 @@ jobs:
 
           git push origin "${BACKPORT_BRANCH}"
 
+          BODY="Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`.
+          Original author: @${PR_AUTHOR}
+
+          > ⚠️ If this cherry-pick had conflicts, look for conflict markers in the diff."
+
           gh pr create \
             --base "${TARGET_BRANCH}" \
             --head "${BACKPORT_BRANCH}" \
             --title "[Backport ${TARGET_BRANCH}] ${PR_TITLE}" \
             --assignee "${PR_AUTHOR}" \
             --label "backport/${TARGET_BRANCH}" \
-            --body "Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`.
-Original author: @${PR_AUTHOR}
-
-> ⚠️ If this cherry-pick had conflicts, look for conflict markers in the diff."
+            --body "${BODY}"

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -58,8 +58,15 @@ jobs:
 
           git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
 
+          # Detect if merge commit (has 2+ parents) and use -m 1 accordingly
+          PARENT_COUNT=$(git cat-file -p "${MERGE_SHA}" | grep -c "^parent")
+          CHERRY_PICK_ARGS="--signoff"
+          if [ "${PARENT_COUNT}" -gt 1 ]; then
+            CHERRY_PICK_ARGS="--signoff -m 1"
+          fi
+
           CONFLICT_COUNT=0
-          if git cherry-pick --signoff "${MERGE_SHA}"; then
+          if git cherry-pick ${CHERRY_PICK_ARGS} "${MERGE_SHA}"; then
             echo "Cherry-pick succeeded cleanly"
           else
             CONFLICT_COUNT=$(git diff --name-only --diff-filter=U | wc -l)
@@ -69,12 +76,12 @@ jobs:
               -m "backport #${PR_NUMBER} to ${TARGET_BRANCH} (CONFLICTS — needs manual resolution)"
           fi
 
+          FILES_CHANGED=$(git diff --name-only "origin/${TARGET_BRANCH}" HEAD | wc -l)
+
           if ! git push origin "${BACKPORT_BRANCH}"; then
             echo "::error::Failed to push branch '${BACKPORT_BRANCH}'. Check permissions."
             exit 1
           fi
-
-          FILES_CHANGED=$(git diff --name-only "origin/${TARGET_BRANCH}" HEAD | wc -l)
 
           BODY="## Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`
 

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,68 @@
+name: Backport
+on:
+  pull_request:
+    types: [closed, labeled]
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'backport/')
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        label: ${{ github.event.pull_request.labels.*.name }}
+    steps:
+      - name: Check if backport label
+        id: check
+        run: |
+          if [[ "${{ matrix.label }}" =~ ^backport/(.+)$ ]]; then
+            echo "branch=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout
+        if: steps.check.outputs.should_run == 'true'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cherry-pick and create PR
+        if: steps.check.outputs.should_run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ steps.check.outputs.branch }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          BACKPORT_BRANCH="backport/${PR_NUMBER}-to-${TARGET_BRANCH}"
+
+          git checkout "origin/${TARGET_BRANCH}"
+          git checkout -b "${BACKPORT_BRANCH}"
+
+          if git cherry-pick --signoff "${MERGE_SHA}"; then
+            echo "Cherry-pick succeeded cleanly"
+          else
+            echo "Cherry-pick had conflicts — committing with markers"
+            git add -A
+            git commit --signoff --no-edit --allow-empty \
+              -m "backport #${PR_NUMBER} to ${TARGET_BRANCH} (CONFLICTS — needs manual resolution)"
+          fi
+
+          git push origin "${BACKPORT_BRANCH}"
+
+          gh pr create \
+            --base "${TARGET_BRANCH}" \
+            --head "${BACKPORT_BRANCH}" \
+            --title "[Backport ${TARGET_BRANCH}] ${PR_TITLE}" \
+            --assignee "${PR_AUTHOR}" \
+            --label "backport/${TARGET_BRANCH}" \
+            --body "Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`.
+Original author: @${PR_AUTHOR}
+
+> ⚠️ If this cherry-pick had conflicts, look for conflict markers in the diff."

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -37,6 +37,7 @@ jobs:
           TARGET_BRANCH: ${{ matrix.branch }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
@@ -45,29 +46,57 @@ jobs:
 
           BACKPORT_BRANCH="backport/${PR_NUMBER}-to-${TARGET_BRANCH}"
 
-          git fetch origin "${TARGET_BRANCH}"
+          if [ -z "${MERGE_SHA}" ]; then
+            echo "::error::No merge commit SHA found. PR may have been rebased-merged (unsupported)."
+            exit 1
+          fi
+
+          if ! git fetch origin "${TARGET_BRANCH}" 2>/dev/null; then
+            echo "::error::Branch '${TARGET_BRANCH}' does not exist on remote. Cannot backport."
+            exit 1
+          fi
+
           git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
 
+          CONFLICT_COUNT=0
           if git cherry-pick --signoff "${MERGE_SHA}"; then
             echo "Cherry-pick succeeded cleanly"
           else
-            echo "Cherry-pick had conflicts — committing with markers"
+            CONFLICT_COUNT=$(git diff --name-only --diff-filter=U | wc -l)
+            echo "Cherry-pick had conflicts in ${CONFLICT_COUNT} file(s)"
             git add -A
             git commit --signoff --no-edit --allow-empty \
               -m "backport #${PR_NUMBER} to ${TARGET_BRANCH} (CONFLICTS — needs manual resolution)"
           fi
 
-          git push origin "${BACKPORT_BRANCH}"
+          if ! git push origin "${BACKPORT_BRANCH}"; then
+            echo "::error::Failed to push branch '${BACKPORT_BRANCH}'. Check permissions."
+            exit 1
+          fi
 
-          BODY="Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`.
-          Original author: @${PR_AUTHOR}
+          FILES_CHANGED=$(git diff --name-only "origin/${TARGET_BRANCH}" HEAD | wc -l)
 
-          > ⚠️ If this cherry-pick had conflicts, look for conflict markers in the diff."
+          BODY="## Backport of #${PR_NUMBER} to \`${TARGET_BRANCH}\`
 
-          gh pr create \
+          **Original title:** ${PR_TITLE}
+          **Original author:** @${PR_AUTHOR}
+          **Files changed:** ${FILES_CHANGED}
+          **Conflicts:** ${CONFLICT_COUNT}
+
+          ### Original PR description
+
+          ${PR_BODY:-_No description provided._}
+
+          ---
+          > If conflicts > 0, look for conflict markers in the diff and resolve manually."
+
+          if ! gh pr create \
             --base "${TARGET_BRANCH}" \
             --head "${BACKPORT_BRANCH}" \
             --title "[Backport ${TARGET_BRANCH}] ${PR_TITLE}" \
             --assignee "${PR_AUTHOR}" \
             --label "backport/${TARGET_BRANCH}" \
-            --body "${BODY}"
+            --body "${BODY}"; then
+            echo "::error::Failed to create backport PR. A PR for this backport may already exist."
+            exit 1
+          fi

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,34 +4,37 @@ on:
     types: [closed, labeled]
 
 jobs:
+  filter:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    outputs:
+      branches: ${{ steps.extract.outputs.branches }}
+    steps:
+      - name: Extract backport branches
+        id: extract
+        run: |
+          BRANCHES=$(echo '${{ toJSON(github.event.pull_request.labels.*.name) }}' | \
+            jq -c '[.[] | select(startswith("backport/")) | ltrimstr("backport/")]')
+          echo "branches=${BRANCHES}" >> "$GITHUB_OUTPUT"
+
   backport:
-    if: github.event.pull_request.merged == true && contains(join(github.event.pull_request.labels.*.name, ','), 'backport/')
+    needs: filter
+    if: needs.filter.outputs.branches != '[]'
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        label: ${{ github.event.pull_request.labels.*.name }}
+        branch: ${{ fromJSON(needs.filter.outputs.branches) }}
     steps:
-      - name: Check if backport label
-        id: check
-        run: |
-          if [[ "${{ matrix.label }}" =~ ^backport/(.+)$ ]]; then
-            echo "branch=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
-            echo "should_run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_run=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Checkout
-        if: steps.check.outputs.should_run == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Cherry-pick and create PR
-        if: steps.check.outputs.should_run == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TARGET_BRANCH: ${{ steps.check.outputs.branch }}
+          TARGET_BRANCH: ${{ matrix.branch }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -42,8 +45,8 @@ jobs:
 
           BACKPORT_BRANCH="backport/${PR_NUMBER}-to-${TARGET_BRANCH}"
 
-          git checkout "origin/${TARGET_BRANCH}"
-          git checkout -b "${BACKPORT_BRANCH}"
+          git fetch origin "${TARGET_BRANCH}"
+          git checkout -b "${BACKPORT_BRANCH}" "origin/${TARGET_BRANCH}"
 
           if git cherry-pick --signoff "${MERGE_SHA}"; then
             echo "Cherry-pick succeeded cleanly"

--- a/backport-pr-description.md
+++ b/backport-pr-description.md
@@ -5,14 +5,14 @@ Adds a GitHub Actions workflow that automatically creates backport PRs when a la
 ### How it works
 
 1. Merge a PR to `main`
-2. Add a label like `backport/1.0` (before or after merge)
+2. Add a label (e.g. `backport/1.0`) before or after the original PR's merge
 3. Workflow cherry-picks the squashed commit onto the target branch
 4. A new PR is created targeting that release branch
 5. If conflicts exist, the PR is still created with conflict markers for manual resolution
 
-### Labels needed
+### Backport Labels
 
-Create these labels in the repo:
+Use the following labels to automate the backport to the respective branch:
 - `backport/1.0`
 - `backport/1.1`
 - `backport/1.2`
@@ -22,5 +22,5 @@ Create these labels in the repo:
 - Triggers on: PR merged + `backport/<branch>` label present
 - Commits use `--signoff` for DCO compliance
 - Backport PRs are assigned to the original author
-- No auto-merge — all backport PRs require manual review
-- No third-party services — runs entirely on GitHub Actions with `GITHUB_TOKEN`
+- No auto-merge — all backport PRs require manual review even if no conflicts arise.
+- No third-party services / apps — runs entirely on GitHub Actions with `GITHUB_TOKEN`

--- a/backport-pr-description.md
+++ b/backport-pr-description.md
@@ -1,0 +1,26 @@
+## Automated Backport Workflow
+
+Adds a GitHub Actions workflow that automatically creates backport PRs when a label is applied.
+
+### How it works
+
+1. Merge a PR to `main`
+2. Add a label like `backport/1.0` (before or after merge)
+3. Workflow cherry-picks the squashed commit onto the target branch
+4. A new PR is created targeting that release branch
+5. If conflicts exist, the PR is still created with conflict markers for manual resolution
+
+### Labels needed
+
+Create these labels in the repo:
+- `backport/1.0`
+- `backport/1.1`
+- `backport/1.2`
+
+### Details
+
+- Triggers on: PR merged + `backport/<branch>` label present
+- Commits use `--signoff` for DCO compliance
+- Backport PRs are assigned to the original author
+- No auto-merge — all backport PRs require manual review
+- No third-party services — runs entirely on GitHub Actions with `GITHUB_TOKEN`


### PR DESCRIPTION
Add backport workflow for automated cherry-pick PRs


```
## Automated Backport Workflow

Adds a GitHub Actions workflow that automatically creates backport PRs when a label is applied.

### How it works

1. Merge a PR to `main`
2. Add a label (e.g. `backport/1.0`) before or after the original PR's merge
3. Workflow cherry-picks the squashed commit onto the target branch
4. A new PR is created targeting that release branch
5. If conflicts exist, the PR is still created with conflict markers for manual resolution

### Backport Labels

Use the following labels to automate the backport to the respective branch:
- `backport/1.0`
- `backport/1.1`
- `backport/1.2`

### Details

- Triggers on: PR merged + `backport/<branch>` label present
- Commits use `--signoff` for DCO compliance
- Backport PRs are assigned to the original author
- No auto-merge — all backport PRs require manual review even if no conflicts arise.
- No third-party services / apps — runs entirely on GitHub Actions with `GITHUB_TOKEN`
```


Example of a test "original PR": https://github.com/KarthikSubbarao/valkey-search/pull/7
Example of a test "backport PR": https://github.com/KarthikSubbarao/valkey-search/pull/9

<img width="1661" height="778" alt="image" src="https://github.com/user-attachments/assets/bb37ec72-c88f-4705-adbd-e09eb1b5d2d0" />

