### PR TITLE
Space optimization for Numeric and Tag Indexes

### DIFF
--- a/src/indexes/numeric.cc
+++ b/src/indexes/numeric.cc
@@ -171,7 +171,7 @@ std::unique_ptr<Numeric::EntriesFetcher> Numeric::Search(
 
 bool Numeric::EntriesFetcherIterator::NextKeys(
     const Numeric::EntriesRange& range, BTreeNumericIndex::ConstIterator& iter,
-    std::optional<InternedStringSet::const_iterator>& keys_iter) {
+    std::optional<KeySet::const_iterator>& keys_iter) {
   while (iter != range.second) {
     if (!keys_iter.has_value()) {
       keys_iter = iter->second.begin();
@@ -190,7 +190,7 @@ bool Numeric::EntriesFetcherIterator::NextKeys(
 Numeric::EntriesFetcherIterator::EntriesFetcherIterator(
     const EntriesRange& entries_range,
     const std::optional<EntriesRange>& additional_entries_range,
-    const InternedStringSet* untracked_keys)
+    const KeySet* untracked_keys)
     : entries_range_(entries_range),
       entries_iter_(entries_range_.first),
       additional_entries_range_(additional_entries_range),

--- a/src/indexes/numeric.h
+++ b/src/indexes/numeric.h
@@ -33,10 +33,11 @@
 namespace valkey_search::indexes {
 
 template <typename T, typename Hasher = absl::Hash<T>,
-          typename Equalizer = std::equal_to<T>>
+          typename Equalizer = std::equal_to<T>,
+          typename SetType_ = absl::flat_hash_set<T, Hasher, Equalizer>>
 class BTreeNumeric {
  public:
-  using SetType = absl::flat_hash_set<T, Hasher, Equalizer>;
+  using SetType = SetType_;
   using ConstIterator =
       typename absl::btree_map<double, SetType>::const_iterator;
 
@@ -120,7 +121,11 @@ class Numeric : public IndexBase {
 
   const double* GetValue(const InternedStringPtr& key) const
       ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  using BTreeNumericIndex = BTreeNumeric<InternedStringPtr>;
+  using BTreeNumericIndex =
+      BTreeNumeric<InternedStringPtr, absl::Hash<InternedStringPtr>,
+                   std::equal_to<InternedStringPtr>,
+                   BagOfInternedStringPtrs>;
+  using KeySet = BagOfInternedStringPtrs;
   using EntriesRange = std::pair<BTreeNumericIndex::ConstIterator,
                                  BTreeNumericIndex::ConstIterator>;
   class EntriesFetcherIterator : public EntriesFetcherIteratorBase {
@@ -128,7 +133,7 @@ class Numeric : public IndexBase {
     EntriesFetcherIterator(
         const EntriesRange& entries_range,
         const std::optional<EntriesRange>& additional_entries_range,
-        const InternedStringSet* untracked_keys);
+        const KeySet* untracked_keys);
     bool Done() const override;
     void Next() override;
     const InternedStringPtr& operator*() const override;
@@ -137,16 +142,15 @@ class Numeric : public IndexBase {
     static bool NextKeys(
         const Numeric::EntriesRange& range,
         BTreeNumericIndex::ConstIterator& iter,
-        std::optional<InternedStringSet::const_iterator>& keys_iter);
+        std::optional<KeySet::const_iterator>& keys_iter);
     const EntriesRange& entries_range_;
     BTreeNumericIndex::ConstIterator entries_iter_;
-    std::optional<InternedStringSet::const_iterator> entry_keys_iter_;
+    std::optional<KeySet::const_iterator> entry_keys_iter_;
     const std::optional<EntriesRange>& additional_entries_range_;
     BTreeNumericIndex::ConstIterator additional_entries_iter_;
-    std::optional<InternedStringSet::const_iterator>
-        additional_entry_keys_iter_;
-    const InternedStringSet* untracked_keys_;
-    std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
+    std::optional<KeySet::const_iterator> additional_entry_keys_iter_;
+    const KeySet* untracked_keys_;
+    std::optional<KeySet::const_iterator> untracked_keys_iter_;
   };
 
   class EntriesFetcher : public EntriesFetcherBase {
@@ -154,7 +158,7 @@ class Numeric : public IndexBase {
     EntriesFetcher(
         const EntriesRange& entries_range, size_t size,
         std::optional<EntriesRange> additional_entries_range = std::nullopt,
-        const InternedStringSet* untracked_keys = nullptr)
+        const KeySet* untracked_keys = nullptr)
         : entries_range_(entries_range),
           size_(size),
           additional_entries_range_(additional_entries_range),
@@ -166,7 +170,7 @@ class Numeric : public IndexBase {
     EntriesRange entries_range_;
     size_t size_{0};
     std::optional<EntriesRange> additional_entries_range_;
-    const InternedStringSet* untracked_keys_;
+    const KeySet* untracked_keys_;
   };
 
   virtual std::unique_ptr<EntriesFetcher> Search(
@@ -177,7 +181,7 @@ class Numeric : public IndexBase {
   mutable absl::Mutex index_mutex_;
   InternedStringHashMap<double> tracked_keys_ ABSL_GUARDED_BY(index_mutex_);
   // untracked keys is needed to support negate filtering
-  InternedStringSet untracked_keys_ ABSL_GUARDED_BY(index_mutex_);
+  KeySet untracked_keys_ ABSL_GUARDED_BY(index_mutex_);
   std::unique_ptr<BTreeNumericIndex> index_ ABSL_GUARDED_BY(index_mutex_);
 };
 }  // namespace valkey_search::indexes

--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -257,7 +257,7 @@ const absl::flat_hash_set<absl::string_view>* Tag::GetValue(
 Tag::EntriesFetcherIterator::EntriesFetcherIterator(
     const PatriciaTreeIndex& tree,
     absl::flat_hash_set<PatriciaNodeIndex*>& entries,
-    const InternedStringSet& untracked_keys, bool negate)
+    const KeySet& untracked_keys, bool negate)
     : tree_(tree),
       entries_(entries),
       untracked_keys_(untracked_keys),

--- a/src/indexes/tag.h
+++ b/src/indexes/tag.h
@@ -73,15 +73,19 @@ class Tag : public IndexBase {
   const absl::flat_hash_set<absl::string_view>* GetValue(
       const InternedStringPtr& key,
       bool& case_sensitive) const ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  using PatriciaTreeIndex = PatriciaTree<InternedStringPtr>;
-  using PatriciaNodeIndex = PatriciaNode<InternedStringPtr>;
+  using KeySet = BagOfInternedStringPtrs;
+  using PatriciaTreeIndex =
+      PatriciaTree<InternedStringPtr, absl::Hash<InternedStringPtr>,
+                   std::equal_to<InternedStringPtr>, KeySet>;
+  using PatriciaNodeIndex =
+      PatriciaNode<InternedStringPtr, absl::Hash<InternedStringPtr>,
+                   std::equal_to<InternedStringPtr>, KeySet>;
 
   class EntriesFetcherIterator : public EntriesFetcherIteratorBase {
    public:
     EntriesFetcherIterator(const PatriciaTreeIndex& tree,
                            absl::flat_hash_set<PatriciaNodeIndex*>& entries,
-                           const InternedStringSet& untracked_keys,
-                           bool negate);
+                           const KeySet& untracked_keys, bool negate);
     bool Done() const override;
     void Next() override;
     const InternedStringPtr& operator*() const override;
@@ -102,10 +106,10 @@ class Tag : public IndexBase {
     absl::flat_hash_set<PatriciaNodeIndex*>& entries_;
 
     PatriciaNodeIndex* next_node_{nullptr};
-    InternedStringSet::const_iterator next_iter_;
-    const InternedStringSet& untracked_keys_;
+    KeySet::const_iterator next_iter_;
+    const KeySet& untracked_keys_;
     bool negate_;
-    std::optional<InternedStringSet::const_iterator> untracked_keys_iter_;
+    std::optional<KeySet::const_iterator> untracked_keys_iter_;
     void NextNegate();
     void EnsureNegateRootIter();
   };
@@ -114,7 +118,7 @@ class Tag : public IndexBase {
    public:
     EntriesFetcher(const PatriciaTreeIndex& tree,
                    absl::flat_hash_set<PatriciaNodeIndex*> entries, size_t size,
-                   bool negate, const InternedStringSet& untracked_keys)
+                   bool negate, const KeySet& untracked_keys)
         : tree_(tree),
           size_(size),
           entries_(entries),
@@ -128,7 +132,7 @@ class Tag : public IndexBase {
     size_t size_{0};
     absl::flat_hash_set<PatriciaNodeIndex*> entries_;
     bool negate_;
-    const InternedStringSet& untracked_keys_;
+    const KeySet& untracked_keys_;
   };
 
   virtual std::unique_ptr<EntriesFetcher> Search(
@@ -153,7 +157,7 @@ class Tag : public IndexBase {
   InternedStringHashMap<TagInfo> tracked_tags_by_keys_
       ABSL_GUARDED_BY(index_mutex_);
   // untracked and tracked_ keys are mutually exclusive.
-  InternedStringSet untracked_keys_ ABSL_GUARDED_BY(index_mutex_);
+  KeySet untracked_keys_ ABSL_GUARDED_BY(index_mutex_);
   const char separator_;
   const bool case_sensitive_;
   PatriciaTreeIndex tree_ ABSL_GUARDED_BY(index_mutex_);

--- a/src/utils/patricia_tree.h
+++ b/src/utils/patricia_tree.h
@@ -29,24 +29,27 @@
 namespace valkey_search {
 
 template <typename T, typename Hasher = absl::Hash<T>,
-          typename Equaler = std::equal_to<T>>
+          typename Equaler = std::equal_to<T>,
+          typename SetType_ = absl::flat_hash_set<T, Hasher, Equaler>>
 class PatriciaNode {
  public:
   PatriciaNode() = default;
-  absl::flat_hash_map<std::string,
-                      std::unique_ptr<PatriciaNode<T, Hasher, Equaler>>>
+  absl::flat_hash_map<
+      std::string,
+      std::unique_ptr<PatriciaNode<T, Hasher, Equaler, SetType_>>>
       children;
   int64_t subtree_values_count = 0;
-  std::optional<absl::flat_hash_set<T, Hasher, Equaler>> value;
+  std::optional<SetType_> value;
   void PrintValue() {}
 };
 
 template <typename T, typename Hasher = absl::Hash<T>,
-          typename Equaler = std::equal_to<T>>
+          typename Equaler = std::equal_to<T>,
+          typename SetType_ = absl::flat_hash_set<T, Hasher, Equaler>>
 class PatriciaTree {
  public:
-  using SetType = absl::flat_hash_set<T, Hasher, Equaler>;
-  using PatriciaNodeType = PatriciaNode<T, Hasher, Equaler>;
+  using SetType = SetType_;
+  using PatriciaNodeType = PatriciaNode<T, Hasher, Equaler, SetType_>;
   PatriciaTree(bool case_sensitive)
       : root_(std::make_unique<PatriciaNodeType>()),
         case_sensitive_(case_sensitive) {}
@@ -57,10 +60,9 @@ class PatriciaTree {
       node->subtree_values_count++;
       if (remaining_key.empty()) {
         if (!node->value.has_value()) {
-          node->value.emplace(std::move(SetType{value}));
-        } else {
-          node->value.value().insert(value);
+          node->value.emplace();
         }
+        node->value->insert(value);
         return;
       }
       bool found = false;

--- a/src/utils/string_interning.h
+++ b/src/utils/string_interning.h
@@ -11,6 +11,9 @@
 #include <absl/container/btree_map.h>
 
 #include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <utility>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
@@ -171,12 +174,361 @@ inline std::ostream &operator<<(std::ostream &os,
   return str ? os << str->Str() : os << "<null>";
 }
 
+}  // namespace valkey_search
+
+// std::hash specialization for InternedStringPtr. Defined here, before any
+// flat_hash_set<InternedStringPtr> instantiation, so the BagOfInternedStringPtrs
+// definition below (which references InternedStringSet) can compile.
+template <>
+struct std::hash<valkey_search::InternedStringPtr> {
+  std::size_t operator()(const valkey_search::InternedStringPtr &sp) const {
+    return sp.Hash();
+  }
+};
+
+namespace valkey_search {
+
 template <typename T>
 using InternedStringHashMap = absl::flat_hash_map<InternedStringPtr, T>;
 using InternedStringSet = absl::flat_hash_set<InternedStringPtr>;
 
 template <typename T>
 using InternedStringNodeHashMap = absl::node_hash_map<InternedStringPtr, T>;
+
+//
+// BagOfInternedStringPtrs is a space-optimized drop-in replacement for
+// InternedStringSet (i.e. absl::flat_hash_set<InternedStringPtr>) tuned for the
+// extremely common case of zero or one elements. The whole object is exactly
+// 8 bytes:
+//
+//   storage_ == 0                   -> empty
+//   storage_ != 0, bit 0 clear      -> single-element mode; the slot IS a
+//                                      clean InternedStringPtr (no tag bits
+//                                      anywhere -- usable in place via
+//                                      reinterpret_cast)
+//   storage_ has bit 0 set          -> multi-element mode; (storage_ & ~1)
+//                                      is the InternedStringSet*
+//
+// Tag location: bit 0 is free because absl::flat_hash_set allocated via `new`
+// has alignment 8. The tag must be stripped before dereferencing the multi
+// pointer (a tagged value is misaligned and points one byte past the real
+// allocation). Single mode, by contrast, stores a clean InternedStringPtr
+// directly, so the bag can hand out a stable reference to it without any
+// masking or copying.
+//
+// AddressSanitizer note: the tagged value (multi mode) sets only the low bit,
+// so it still points one byte INTO the heap allocation it represents. ASAN's
+// leak scanner uses interior-pointer detection and recognizes such pointers
+// as references to the surrounding allocation, so the owning pointer is not
+// hidden from the leak checker.
+//
+// This class works exclusively through the public InternedStringPtr API. It
+// is not a friend of InternedStringPtr or its underlying string type. All
+// ref-count traffic flows through InternedStringPtr's public copy/move
+// constructors and destructor, invoked via placement new and explicit
+// destruction on the storage slot.
+//
+// The bag is intentionally non-copyable and non-equality-comparable; only
+// move construction and move assignment are provided.
+//
+class BagOfInternedStringPtrs {
+ public:
+  using value_type = InternedStringPtr;
+  using key_type = InternedStringPtr;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+
+  class const_iterator {
+   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = InternedStringPtr;
+    using reference = const InternedStringPtr &;
+    using pointer = const InternedStringPtr *;
+    using difference_type = std::ptrdiff_t;
+
+    const_iterator() = default;
+
+    reference operator*() const {
+      if (tag_ == Tag::kSingle) {
+        // bag_->storage_ in single mode IS a clean InternedStringPtr;
+        // SingleRef() exposes it as a stable reference into the bag's slot.
+        return bag_->SingleRef();
+      }
+      return *multi_;
+    }
+    pointer operator->() const {
+      if (tag_ == Tag::kSingle) {
+        return &bag_->SingleRef();
+      }
+      return multi_.operator->();
+    }
+    const_iterator &operator++() {
+      if (tag_ == Tag::kSingle) {
+        tag_ = Tag::kEnd;
+      } else if (tag_ == Tag::kMulti) {
+        ++multi_;
+      }
+      return *this;
+    }
+    const_iterator operator++(int) {
+      const_iterator tmp(*this);
+      ++(*this);
+      return tmp;
+    }
+    bool operator==(const const_iterator &other) const {
+      if (tag_ != other.tag_) {
+        return false;
+      }
+      switch (tag_) {
+        case Tag::kEnd:
+          return true;
+        case Tag::kSingle:
+          return bag_ == other.bag_;
+        case Tag::kMulti:
+          return multi_ == other.multi_;
+      }
+      return false;
+    }
+    bool operator!=(const const_iterator &other) const {
+      return !(*this == other);
+    }
+
+   private:
+    friend class BagOfInternedStringPtrs;
+    enum class Tag { kEnd, kSingle, kMulti };
+
+    const_iterator(Tag tag, const BagOfInternedStringPtrs *bag,
+                   InternedStringSet::const_iterator multi = {})
+        : tag_(tag), bag_(bag), multi_(multi) {}
+
+    Tag tag_ = Tag::kEnd;
+    const BagOfInternedStringPtrs *bag_ = nullptr;
+    InternedStringSet::const_iterator multi_;
+  };
+  using iterator = const_iterator;
+  using pointer = const InternedStringPtr *;
+  using const_pointer = const InternedStringPtr *;
+  using reference = const InternedStringPtr &;
+  using const_reference = const InternedStringPtr &;
+
+  BagOfInternedStringPtrs() = default;
+  BagOfInternedStringPtrs(const BagOfInternedStringPtrs &) = delete;
+  BagOfInternedStringPtrs &operator=(const BagOfInternedStringPtrs &) = delete;
+  BagOfInternedStringPtrs(BagOfInternedStringPtrs &&other) noexcept
+      : storage_(other.storage_) {
+    other.storage_ = 0;
+  }
+  BagOfInternedStringPtrs &operator=(BagOfInternedStringPtrs &&other) noexcept {
+    if (this != &other) {
+      clear();
+      storage_ = other.storage_;
+      other.storage_ = 0;
+    }
+    return *this;
+  }
+  ~BagOfInternedStringPtrs() { clear(); }
+
+  size_type size() const {
+    if (IsEmpty()) {
+      return 0;
+    }
+    if (IsSingle()) {
+      return 1;
+    }
+    return AsMulti()->size();
+  }
+  bool empty() const { return storage_ == 0; }
+
+  void clear() {
+    if (IsSingle()) {
+      // storage_ in single mode IS a clean InternedStringPtr; in-place
+      // destruct it to drop the ref count, then zero out the slot.
+      reinterpret_cast<InternedStringPtr *>(&storage_)->~InternedStringPtr();
+    } else if (IsMulti()) {
+      delete AsMulti();
+    }
+    storage_ = 0;
+  }
+
+  bool contains(const InternedStringPtr &key) const {
+    if (IsEmpty()) {
+      return false;
+    }
+    if (IsSingle()) {
+      // SingleRef() exposes storage_ as an InternedStringPtr; default
+      // operator== is a bit-exact compare of the underlying impl_ values.
+      return SingleRef() == key;
+    }
+    return AsMulti()->contains(key);
+  }
+
+  const_iterator find(const InternedStringPtr &key) const {
+    if (IsEmpty()) {
+      return end();
+    }
+    if (IsSingle()) {
+      if (SingleRef() == key) {
+        return const_iterator(const_iterator::Tag::kSingle, this);
+      }
+      return end();
+    }
+    auto it = AsMulti()->find(key);
+    if (it == AsMulti()->end()) {
+      return end();
+    }
+    return const_iterator(const_iterator::Tag::kMulti, this, it);
+  }
+
+  std::pair<const_iterator, bool> insert(const InternedStringPtr &key) {
+    if (IsEmpty()) {
+      // Public copy ctor bumps the ref count and writes a clean
+      // InternedStringPtr directly into storage_. No tagging needed.
+      new (&storage_) InternedStringPtr(key);
+      return {const_iterator(const_iterator::Tag::kSingle, this), true};
+    }
+    if (IsSingle()) {
+      if (SingleRef() == key) {
+        return {const_iterator(const_iterator::Tag::kSingle, this), false};
+      }
+      // Promote: move the lone clean InternedStringPtr into a new set, then
+      // insert the new key.
+      auto *set = new InternedStringSet();
+      set->insert(
+          std::move(*reinterpret_cast<InternedStringPtr *>(&storage_)));
+      // The move ctor nulled impl_, so storage_ is now 0.
+      auto [it, inserted] = set->insert(key);
+      SetMulti(set);
+      return {const_iterator(const_iterator::Tag::kMulti, this, it), inserted};
+    }
+    auto [it, inserted] = AsMulti()->insert(key);
+    return {const_iterator(const_iterator::Tag::kMulti, this, it), inserted};
+  }
+  std::pair<const_iterator, bool> insert(InternedStringPtr &&key) {
+    if (IsEmpty()) {
+      // Public move ctor adopts the ref count without bump/drop.
+      new (&storage_) InternedStringPtr(std::move(key));
+      return {const_iterator(const_iterator::Tag::kSingle, this), true};
+    }
+    if (IsSingle()) {
+      if (SingleRef() == key) {
+        return {const_iterator(const_iterator::Tag::kSingle, this), false};
+      }
+      auto *set = new InternedStringSet();
+      set->insert(
+          std::move(*reinterpret_cast<InternedStringPtr *>(&storage_)));
+      auto [it, inserted] = set->insert(std::move(key));
+      SetMulti(set);
+      return {const_iterator(const_iterator::Tag::kMulti, this, it), inserted};
+    }
+    auto [it, inserted] = AsMulti()->insert(std::move(key));
+    return {const_iterator(const_iterator::Tag::kMulti, this, it), inserted};
+  }
+
+  size_type erase(const InternedStringPtr &key) {
+    if (IsEmpty()) {
+      return 0;
+    }
+    if (IsSingle()) {
+      if (SingleRef() == key) {
+        reinterpret_cast<InternedStringPtr *>(&storage_)->~InternedStringPtr();
+        storage_ = 0;
+        return 1;
+      }
+      return 0;
+    }
+    size_type n = AsMulti()->erase(key);
+    if (n > 0) {
+      DemoteIfPossible();
+    }
+    return n;
+  }
+
+  // erase(iterator) follows flat_hash_set semantics: any outstanding iterator
+  // (including pos) is invalidated. absl::flat_hash_set::erase(it) returns
+  // void (it does not provide a "next" iterator like std::unordered_set), so
+  // we mirror that here and always return end(). Callers that need to
+  // continue iterating after an erase must restart from begin().
+  const_iterator erase(const_iterator pos) {
+    if (pos.tag_ == const_iterator::Tag::kSingle) {
+      reinterpret_cast<InternedStringPtr *>(&storage_)->~InternedStringPtr();
+      storage_ = 0;
+      return end();
+    }
+    AsMulti()->erase(pos.multi_);
+    DemoteIfPossible();
+    return end();
+  }
+
+  const_iterator begin() const {
+    if (IsEmpty()) {
+      return end();
+    }
+    if (IsSingle()) {
+      return const_iterator(const_iterator::Tag::kSingle, this);
+    }
+    return const_iterator(const_iterator::Tag::kMulti, this,
+                          AsMulti()->begin());
+  }
+  const_iterator end() const {
+    if (IsMulti()) {
+      return const_iterator(const_iterator::Tag::kMulti, this,
+                            AsMulti()->end());
+    }
+    return const_iterator();
+  }
+  const_iterator cbegin() const { return begin(); }
+  const_iterator cend() const { return end(); }
+
+  void swap(BagOfInternedStringPtrs &other) noexcept {
+    std::swap(storage_, other.storage_);
+  }
+
+ private:
+  // Bit 0 marks the multi-element mode. The single mode stores a clean
+  // InternedStringPtr directly with no tag bits.
+  static constexpr uintptr_t kMultiTag = uintptr_t(1);
+
+  uintptr_t storage_ = 0;
+
+  bool IsEmpty() const { return storage_ == 0; }
+  bool IsMulti() const { return (storage_ & kMultiTag) != 0; }
+  bool IsSingle() const {
+    return storage_ != 0 && (storage_ & kMultiTag) == 0;
+  }
+
+  // Stable reference to the bag's single-mode slot, viewed as an
+  // InternedStringPtr. Precondition: IsSingle().
+  const InternedStringPtr &SingleRef() const {
+    return *reinterpret_cast<const InternedStringPtr *>(&storage_);
+  }
+  InternedStringSet *AsMulti() const {
+    return reinterpret_cast<InternedStringSet *>(storage_ & ~kMultiTag);
+  }
+  void SetMulti(InternedStringSet *p) {
+    storage_ = reinterpret_cast<uintptr_t>(p) | kMultiTag;
+  }
+
+  void DemoteIfPossible() {
+    if (!IsMulti()) {
+      return;
+    }
+    auto *set = AsMulti();
+    if (set->size() == 0) {
+      delete set;
+      storage_ = 0;
+    } else if (set->size() == 1) {
+      // Move-construct the lone InternedStringPtr into our slot. The public
+      // move ctor adopts the ref count without bump/drop, leaving storage_ as
+      // a clean InternedStringPtr (single mode is identified by an untagged
+      // non-zero storage_).
+      InternedStringPtr lone = std::move(*set->begin());
+      delete set;
+      new (&storage_) InternedStringPtr(std::move(lone));
+    }
+  }
+};
+static_assert(sizeof(BagOfInternedStringPtrs) == 8,
+              "BagOfInternedStringPtrs must fit in 8 bytes");
 
 class StringInternStore {
  public:
@@ -246,16 +598,5 @@ class StringInternStore {
 };
 
 }  // namespace valkey_search
-
-//
-// Helper classes to allow using InternedStringPtr as keys in hash maps and
-// sets.
-//
-template <>
-struct std::hash<valkey_search::InternedStringPtr> {
-  std::size_t operator()(const valkey_search::InternedStringPtr &sp) const {
-    return sp.Hash();
-  }
-};
 
 #endif  // VALKEYSEARCH_SRC_UTILS_STRING_INTERNING_H_

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -134,9 +134,9 @@ class MockTag : public indexes::Tag {
 class TestedTagEntriesFetcher : public indexes::Tag::EntriesFetcher {
  public:
   TestedTagEntriesFetcher(
-      size_t size, PatriciaTree<InternedStringPtr> &tree,
-      absl::flat_hash_set<PatriciaNode<InternedStringPtr> *> &entries,
-      bool negate, InternedStringSet &untracked_keys)
+      size_t size, indexes::Tag::PatriciaTreeIndex &tree,
+      absl::flat_hash_set<indexes::Tag::PatriciaNodeIndex *> &entries,
+      bool negate, indexes::Tag::KeySet &untracked_keys)
       : indexes::Tag::EntriesFetcher(tree, entries, size, negate,
                                      untracked_keys),
         size_(size) {}
@@ -215,9 +215,9 @@ void InitIndexSchema(MockIndexSchema *index_schema) {
 
   VMSDK_EXPECT_OK(index_schema->AddIndex("tag_index_100_15", "tag_index_100_15",
                                          tag_index_100_15));
-  static PatriciaTree<InternedStringPtr> tree(false);
-  static absl::flat_hash_set<PatriciaNode<InternedStringPtr> *> entries;
-  static InternedStringSet untracked_keys;
+  static indexes::Tag::PatriciaTreeIndex tree(false);
+  static absl::flat_hash_set<indexes::Tag::PatriciaNodeIndex *> entries;
+  static indexes::Tag::KeySet untracked_keys;
   EXPECT_CALL(*tag_index_100_15, Search(_, false)).WillRepeatedly([]() {
     return std::make_unique<TestedTagEntriesFetcher>(15, tree, entries, false,
                                                      untracked_keys);

--- a/testing/utils/string_interning_test.cc
+++ b/testing/utils/string_interning_test.cc
@@ -7,11 +7,17 @@
 
 #include "src/utils/string_interning.h"
 
+#include <algorithm>
 #include <cstring>
+#include <iterator>
 #include <memory>
 #include <string>
 #include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
 
+#include "absl/container/flat_hash_set.h"
 #include "gtest/gtest.h"
 #include "src/utils/allocator.h"
 #include "src/utils/intrusive_ref_count.h"
@@ -178,6 +184,348 @@ TEST_F(StringInterningMultithreadTest, ConcurrentInterning) {
 
   EXPECT_EQ(StringInternStore::Instance().UniqueStrings(), 0);
 }
+// ---------------------------------------------------------------------------
+// BagOfInternedStringPtrs tests
+// ---------------------------------------------------------------------------
+
+class BagOfInternedStringPtrsTest : public vmsdk::ValkeyTest {};
+
+TEST_F(BagOfInternedStringPtrsTest, FitsIn8Bytes) {
+  static_assert(sizeof(BagOfInternedStringPtrs) == 8);
+  EXPECT_EQ(sizeof(BagOfInternedStringPtrs), 8u);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, DefaultEmpty) {
+  BagOfInternedStringPtrs bag;
+  EXPECT_TRUE(bag.empty());
+  EXPECT_EQ(bag.size(), 0u);
+  EXPECT_EQ(bag.begin(), bag.end());
+  EXPECT_FALSE(bag.contains(StringInternStore::Intern("nope")));
+  EXPECT_EQ(bag.find(StringInternStore::Intern("nope")), bag.end());
+}
+
+TEST_F(BagOfInternedStringPtrsTest, SingleElementLifecycle) {
+  auto k = StringInternStore::Intern("k");
+  EXPECT_EQ(k.RefCount(), 1);
+  {
+    BagOfInternedStringPtrs bag;
+    auto [it, inserted] = bag.insert(k);
+    EXPECT_TRUE(inserted);
+    EXPECT_EQ(k.RefCount(), 2);
+    EXPECT_FALSE(bag.empty());
+    EXPECT_EQ(bag.size(), 1u);
+    EXPECT_TRUE(bag.contains(k));
+    EXPECT_NE(bag.find(k), bag.end());
+    EXPECT_EQ(it->Hash(), k.Hash());
+    EXPECT_EQ((*it)->Str(), "k");
+  }
+  EXPECT_EQ(k.RefCount(), 1);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, InsertDuplicateInSingleMode) {
+  auto k = StringInternStore::Intern("dup");
+  BagOfInternedStringPtrs bag;
+  bag.insert(k);
+  EXPECT_EQ(k.RefCount(), 2);
+  auto [it, inserted] = bag.insert(k);
+  EXPECT_FALSE(inserted);
+  EXPECT_EQ(bag.size(), 1u);
+  EXPECT_EQ(k.RefCount(), 2);
+  EXPECT_NE(it, bag.end());
+}
+
+TEST_F(BagOfInternedStringPtrsTest, PromoteSingleToMulti) {
+  auto a = StringInternStore::Intern("a");
+  auto b = StringInternStore::Intern("b");
+  BagOfInternedStringPtrs bag;
+  bag.insert(a);
+  bag.insert(b);
+  EXPECT_EQ(bag.size(), 2u);
+  EXPECT_TRUE(bag.contains(a));
+  EXPECT_TRUE(bag.contains(b));
+  EXPECT_EQ(a.RefCount(), 2);
+  EXPECT_EQ(b.RefCount(), 2);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, MultiInsertEraseFindContains) {
+  std::vector<InternedStringPtr> keys;
+  for (int i = 0; i < 8; ++i) {
+    keys.push_back(StringInternStore::Intern("multi_" + std::to_string(i)));
+  }
+  BagOfInternedStringPtrs bag;
+  for (const auto& k : keys) {
+    auto [it, inserted] = bag.insert(k);
+    EXPECT_TRUE(inserted);
+    EXPECT_NE(it, bag.end());
+  }
+  EXPECT_EQ(bag.size(), keys.size());
+  for (const auto& k : keys) {
+    EXPECT_TRUE(bag.contains(k));
+    EXPECT_NE(bag.find(k), bag.end());
+    EXPECT_EQ(k.RefCount(), 2);
+  }
+  // erase a missing key
+  auto missing = StringInternStore::Intern("missing");
+  EXPECT_EQ(bag.erase(missing), 0u);
+  // erase real keys (down to 2 so we stay in multi mode)
+  for (size_t i = 0; i < keys.size() - 2; ++i) {
+    EXPECT_EQ(bag.erase(keys[i]), 1u);
+    EXPECT_EQ(keys[i].RefCount(), 1);
+  }
+  EXPECT_EQ(bag.size(), 2u);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, DemoteMultiToSingleOnErase) {
+  auto a = StringInternStore::Intern("demoteA");
+  auto b = StringInternStore::Intern("demoteB");
+  auto c = StringInternStore::Intern("demoteC");
+  BagOfInternedStringPtrs bag;
+  bag.insert(a);
+  bag.insert(b);
+  bag.insert(c);
+  EXPECT_EQ(bag.size(), 3u);
+  EXPECT_EQ(bag.erase(b), 1u);
+  EXPECT_EQ(bag.erase(c), 1u);
+  EXPECT_EQ(bag.size(), 1u);
+  EXPECT_TRUE(bag.contains(a));
+  EXPECT_FALSE(bag.contains(b));
+  EXPECT_FALSE(bag.contains(c));
+  EXPECT_EQ(a.RefCount(), 2);
+  EXPECT_EQ(b.RefCount(), 1);
+  EXPECT_EQ(c.RefCount(), 1);
+  // After demotion the surviving element is reachable through normal
+  // single-mode iteration.
+  EXPECT_EQ(std::distance(bag.begin(), bag.end()), 1);
+  EXPECT_EQ((*bag.begin())->Str(), "demoteA");
+  // Removing the lone element returns to empty.
+  EXPECT_EQ(bag.erase(a), 1u);
+  EXPECT_TRUE(bag.empty());
+  EXPECT_EQ(a.RefCount(), 1);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, EraseByIterator) {
+  // Single mode.
+  {
+    auto k = StringInternStore::Intern("eraseit_single");
+    BagOfInternedStringPtrs bag;
+    bag.insert(k);
+    auto next = bag.erase(bag.begin());
+    EXPECT_EQ(next, bag.end());
+    EXPECT_TRUE(bag.empty());
+    EXPECT_EQ(k.RefCount(), 1);
+  }
+  // Multi mode (erase one of three; demotion happens at size==1, not here).
+  {
+    auto a = StringInternStore::Intern("eit_a");
+    auto b = StringInternStore::Intern("eit_b");
+    auto c = StringInternStore::Intern("eit_c");
+    BagOfInternedStringPtrs bag;
+    bag.insert(a);
+    bag.insert(b);
+    bag.insert(c);
+    auto it = bag.find(b);
+    ASSERT_NE(it, bag.end());
+    auto next = bag.erase(it);
+    EXPECT_EQ(next, bag.end());  // matches absl::flat_hash_set::erase semantics
+    EXPECT_FALSE(bag.contains(b));
+    EXPECT_EQ(bag.size(), 2u);
+    EXPECT_EQ(b.RefCount(), 1);
+  }
+}
+
+TEST_F(BagOfInternedStringPtrsTest, ClearAllStates) {
+  auto a = StringInternStore::Intern("clear_a");
+  auto b = StringInternStore::Intern("clear_b");
+  // Empty -> empty.
+  {
+    BagOfInternedStringPtrs bag;
+    bag.clear();
+    EXPECT_TRUE(bag.empty());
+  }
+  // Single -> empty.
+  {
+    BagOfInternedStringPtrs bag;
+    bag.insert(a);
+    EXPECT_EQ(a.RefCount(), 2);
+    bag.clear();
+    EXPECT_TRUE(bag.empty());
+    EXPECT_EQ(a.RefCount(), 1);
+  }
+  // Multi -> empty.
+  {
+    BagOfInternedStringPtrs bag;
+    bag.insert(a);
+    bag.insert(b);
+    EXPECT_EQ(a.RefCount(), 2);
+    EXPECT_EQ(b.RefCount(), 2);
+    bag.clear();
+    EXPECT_TRUE(bag.empty());
+    EXPECT_EQ(a.RefCount(), 1);
+    EXPECT_EQ(b.RefCount(), 1);
+  }
+}
+
+TEST_F(BagOfInternedStringPtrsTest, NonCopyable) {
+  static_assert(!std::is_copy_constructible_v<BagOfInternedStringPtrs>);
+  static_assert(!std::is_copy_assignable_v<BagOfInternedStringPtrs>);
+  static_assert(std::is_move_constructible_v<BagOfInternedStringPtrs>);
+  static_assert(std::is_move_assignable_v<BagOfInternedStringPtrs>);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, MoveCtorAndAssign) {
+  auto a = StringInternStore::Intern("mv_a");
+  auto b = StringInternStore::Intern("mv_b");
+  // Single.
+  {
+    BagOfInternedStringPtrs src;
+    src.insert(a);
+    EXPECT_EQ(a.RefCount(), 2);
+    BagOfInternedStringPtrs dst(std::move(src));
+    EXPECT_TRUE(src.empty());
+    EXPECT_EQ(dst.size(), 1u);
+    EXPECT_EQ(a.RefCount(), 2);  // no churn
+  }
+  // Multi via move-assign over an existing single.
+  {
+    BagOfInternedStringPtrs src;
+    src.insert(a);
+    src.insert(b);
+    BagOfInternedStringPtrs dst;
+    dst.insert(a);
+    EXPECT_EQ(a.RefCount(), 3);
+    dst = std::move(src);
+    EXPECT_TRUE(src.empty());
+    EXPECT_EQ(dst.size(), 2u);
+    EXPECT_EQ(a.RefCount(), 2);  // dst dropped its own ref before adopting
+    EXPECT_EQ(b.RefCount(), 2);
+  }
+  EXPECT_EQ(a.RefCount(), 1);
+  EXPECT_EQ(b.RefCount(), 1);
+  // Self-move is a no-op (does not crash, contents preserved).
+  {
+    BagOfInternedStringPtrs bag;
+    bag.insert(a);
+    auto& bag_ref = bag;
+    bag = std::move(bag_ref);
+    EXPECT_EQ(bag.size(), 1u);
+    EXPECT_TRUE(bag.contains(a));
+  }
+}
+
+TEST_F(BagOfInternedStringPtrsTest, IterationVisitsEverythingExactlyOnce) {
+  auto check_iteration = [](const std::vector<std::string>& strings) {
+    std::vector<InternedStringPtr> keys;
+    for (const auto& s : strings) {
+      keys.push_back(StringInternStore::Intern(s));
+    }
+    BagOfInternedStringPtrs bag;
+    for (const auto& k : keys) {
+      bag.insert(k);
+    }
+    absl::flat_hash_set<std::string> seen;
+    for (const auto& v : bag) {
+      seen.insert(std::string(v->Str()));
+    }
+    EXPECT_EQ(seen.size(), strings.size());
+    for (const auto& s : strings) {
+      EXPECT_TRUE(seen.contains(s)) << s;
+    }
+    EXPECT_EQ(static_cast<size_t>(std::distance(bag.begin(), bag.end())),
+              strings.size());
+  };
+  check_iteration({});
+  check_iteration({"only"});
+  check_iteration({"two_a", "two_b"});
+  check_iteration({"many_1", "many_2", "many_3", "many_4", "many_5"});
+}
+
+TEST_F(BagOfInternedStringPtrsTest, IteratorIsStlForwardIterator) {
+  using It = BagOfInternedStringPtrs::const_iterator;
+  static_assert(
+      std::is_same_v<std::iterator_traits<It>::iterator_category,
+                     std::forward_iterator_tag>);
+  static_assert(std::is_same_v<std::iterator_traits<It>::value_type,
+                               InternedStringPtr>);
+  // Usable with STL algorithms.
+  auto a = StringInternStore::Intern("stl_a");
+  auto b = StringInternStore::Intern("stl_b");
+  BagOfInternedStringPtrs bag;
+  bag.insert(a);
+  bag.insert(b);
+  auto found = std::find_if(bag.begin(), bag.end(),
+                            [&](const InternedStringPtr& p) {
+                              return p->Str() == "stl_b";
+                            });
+  ASSERT_NE(found, bag.end());
+  EXPECT_EQ((*found)->Str(), "stl_b");
+  std::vector<InternedStringPtr> copied(bag.begin(), bag.end());
+  EXPECT_EQ(copied.size(), 2u);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, SwapAcrossAllModeCombinations) {
+  auto a = StringInternStore::Intern("sw_a");
+  auto b = StringInternStore::Intern("sw_b");
+  auto c = StringInternStore::Intern("sw_c");
+  auto make = [&](int mode) {
+    BagOfInternedStringPtrs bag;
+    if (mode == 1) {
+      bag.insert(a);
+    } else if (mode == 2) {
+      bag.insert(b);
+      bag.insert(c);
+    }
+    return bag;
+  };
+  for (int lhs_mode = 0; lhs_mode <= 2; ++lhs_mode) {
+    for (int rhs_mode = 0; rhs_mode <= 2; ++rhs_mode) {
+      auto lhs = make(lhs_mode);
+      auto rhs = make(rhs_mode);
+      auto lhs_size = lhs.size();
+      auto rhs_size = rhs.size();
+      lhs.swap(rhs);
+      EXPECT_EQ(lhs.size(), rhs_size);
+      EXPECT_EQ(rhs.size(), lhs_size);
+    }
+  }
+}
+
+TEST_F(BagOfInternedStringPtrsTest, RvalueInsertAdoptsRefCount) {
+  auto k = StringInternStore::Intern("rv_k");
+  EXPECT_EQ(k.RefCount(), 1);
+  BagOfInternedStringPtrs bag;
+  {
+    InternedStringPtr local = k;
+    EXPECT_EQ(k.RefCount(), 2);
+    bag.insert(std::move(local));
+    // local was emptied; the ref count moved into the bag.
+    EXPECT_EQ(k.RefCount(), 2);
+  }
+  EXPECT_EQ(k.RefCount(), 2);
+  bag.clear();
+  EXPECT_EQ(k.RefCount(), 1);
+}
+
+TEST_F(BagOfInternedStringPtrsTest, NoLeaksUnderRepeatedChurn) {
+  // Repeatedly insert and erase to exercise promote/demote transitions and
+  // confirm we always settle back to baseline ref counts.
+  auto a = StringInternStore::Intern("churn_a");
+  auto b = StringInternStore::Intern("churn_b");
+  auto c = StringInternStore::Intern("churn_c");
+  BagOfInternedStringPtrs bag;
+  for (int i = 0; i < 100; ++i) {
+    bag.insert(a);
+    bag.insert(b);
+    bag.insert(c);
+    bag.erase(c);
+    bag.erase(b);
+    bag.erase(a);
+    EXPECT_TRUE(bag.empty());
+  }
+  EXPECT_EQ(a.RefCount(), 1);
+  EXPECT_EQ(b.RefCount(), 1);
+  EXPECT_EQ(c.RefCount(), 1);
+}
+
 }  // namespace
 
 }  // namespace valkey_search


### PR DESCRIPTION
Numeric and Tag indexes contain a flat_hash_map<InternedStringPtr>. This consumes 40-60 bytes regardless of occupancy. Yet, in many instances, there is only 1 entry, resulting in substantial wasted space.

A new class BagOfInternedStringPtrs is created which occupies 8 bytes and is either a single InternedStringPtr or a pointer to an owned flat_hash_map<InternedStringPtr> (it uses the low order bit of the pointer to differentiate). Optimizing the case of 1 entry. for more than one entry, there will be an extra 8 bytes and extra level of indirection. As the # of keys / entry climbs the 8 byte overhead diminishes. 

Below is a table of measured memory savings. Savings are modest, but this is the first step in optimizing these two indexes.

  Numeric Index (10,000 keys)
```
  ┌────────────┬──────────────────────────┬──────────────────────────┬─────────────┬─────────┐
  │ keys/value │ Baseline (flat_hash_set) │           Bag            │ Δ bytes/key │   Δ %   │
  ├────────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │          1 │ 1,746,336 (174.63 B/key) │ 1,468,256 (146.83 B/key) │      −27.81 │ −15.92% │
  ├────────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │          2 │ 1,467,840 (146.78 B/key) │ 1,568,000 (156.80 B/key) │      +10.02 │  +6.83% │
  ├────────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │          3 │ 1,070,336 (107.03 B/key) │ 1,136,544 (113.65 B/key) │       +6.62 │  +6.19% │
  ├────────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │        100 │    411,984 (41.20 B/key) │    414,400 (41.44 B/key) │       +0.24 │  +0.59% │
  └────────────┴──────────────────────────┴──────────────────────────┴─────────────┴─────────┘

  Tag Index (10,000 keys)

  ┌──────────┬──────────────────────────┬──────────────────────────┬─────────────┬─────────┐
  │ keys/tag │ Baseline (flat_hash_set) │           Bag            │ Δ bytes/key │   Δ %   │
  ├──────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │        1 │ 2,231,184 (223.12 B/key) │ 1,911,248 (191.13 B/key) │      −31.99 │ −14.34% │
  ├──────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │        2 │ 2,085,520 (208.55 B/key) │ 2,165,952 (216.60 B/key) │       +8.04 │  +3.86% │
  ├──────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │        3 │ 1,655,984 (165.60 B/key) │ 1,709,680 (170.97 B/key) │       +5.37 │  +3.24% │
  ├──────────┼──────────────────────────┼──────────────────────────┼─────────────┼─────────┤
  │      100 │    935,712 (93.57 B/key) │    937,680 (93.77 B/key) │       +0.20 │  +0.21% │
  └──────────┴──────────────────────────┴──────────────────────────┴─────────────┴─────────┘
```