### PR TITLE
Fix reclaimable memory overcounting #500

### DIFF
--- a/integration/test_reclaimable_memory.py
+++ b/integration/test_reclaimable_memory.py
@@ -121,11 +121,12 @@ class TestReclaimableMemory(ValkeySearchTestCaseBase):
         initial_reclaimable = int(info_data["search_index_reclaimable_memory"])
         assert initial_reclaimable == 0
         
-        # Add vectors to both indexes
-        for idx_name in indexes:
+        # Add unique vectors to each index (different values so interning
+        # doesn't deduplicate across indexes)
+        for idx_num, idx_name in enumerate(indexes):
             for i in range(5):
                 key = f"{idx_name}:{i}"
-                vector = [float(i), float(i*2)]
+                vector = [float(i + idx_num * 100), float(i * 2 + idx_num * 100)]
                 # Convert vector to proper binary format (little-endian float32)
                 vector_bytes = struct.pack('<2f', *vector)
                 client.hset(key, "embedding", vector_bytes)

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -79,6 +79,11 @@ std::optional<hnswlib::tableint> GetInternalIdDuringSearch(
 namespace valkey_search::indexes {
 
 template <typename T>
+VectorHNSW<T>::~VectorHNSW() {
+  Metrics::GetStats().reclaimable_memory -= reclaimable_memory_contribution_;
+}
+
+template <typename T>
 absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> VectorHNSW<T>::Create(
     const data_model::VectorIndex &vector_index_proto,
     absl::string_view attribute_identifier,
@@ -155,6 +160,17 @@ absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> VectorHNSW<T>::LoadFromRDB(
                                 vector_index_proto.initial_cap(), index.get()));
     // ef_runtime is not persisted in the index contents
     index->algo_->setEf(vector_index_proto.hnsw_algorithm().ef_runtime());
+    auto vector_size = vector_index_proto.dimension_count() * sizeof(T);
+    for (size_t i = 0; i < index->algo_->cur_element_count_; i++) {
+      if (index->algo_->isMarkedDeleted(i)) {
+        auto label = index->algo_->getExternalLabel(i);
+        auto it = index->tracked_vectors_.find(label);
+        if (it != index->tracked_vectors_.end() && it->second.RefCount() == 1) {
+          Metrics::GetStats().reclaimable_memory += vector_size;
+          index->reclaimable_memory_contribution_ += vector_size;
+        }
+      }
+    }
     return index;
   } catch (const std::exception &e) {
     ++Metrics::GetStats().hnsw_create_exceptions_cnt;
@@ -295,6 +311,15 @@ absl::Status VectorHNSW<T>::RemoveRecordImpl(uint64_t internal_id) {
     ++Metrics::GetStats().hnsw_remove_exceptions_cnt;
     return absl::InternalError(
         absl::StrCat("Error while removing a record: ", e.what()));
+  }
+  {
+    absl::MutexLock lock(&tracked_vectors_mutex_);
+    auto it = tracked_vectors_.find(internal_id);
+    if (it != tracked_vectors_.end() && it->second.RefCount() == 1) {
+      auto vector_size = dimensions_ * sizeof(T);
+      Metrics::GetStats().reclaimable_memory += vector_size;
+      reclaimable_memory_contribution_ += vector_size;
+    }
   }
   return absl::OkStatus();
 }

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -43,7 +43,7 @@ class VectorHNSW : public VectorBase {
       const data_model::VectorIndex& vector_index_proto,
       absl::string_view attribute_identifier,
       SupplementalContentChunkIter&& iter) ABSL_NO_THREAD_SAFETY_ANALYSIS;
-  ~VectorHNSW() override = default;
+  ~VectorHNSW() override;
   size_t GetDataTypeSize() const override { return sizeof(T); }
 
   const hnswlib::SpaceInterface<float>* GetSpace() const {
@@ -114,6 +114,7 @@ class VectorHNSW : public VectorBase {
   mutable absl::Mutex tracked_vectors_mutex_;
   absl::flat_hash_map<uint64_t, InternedStringPtr> tracked_vectors_
       ABSL_GUARDED_BY(tracked_vectors_mutex_);
+  uint64_t reclaimable_memory_contribution_{0};
 };
 
 }  // namespace valkey_search::indexes

--- a/testing/search_test.cc
+++ b/testing/search_test.cc
@@ -37,6 +37,7 @@
 #include "src/indexes/vector_base.h"
 #include "src/indexes/vector_flat.h"
 #include "src/indexes/vector_hnsw.h"
+#include "src/metrics.h"
 #include "src/query/predicate.h"
 #include "src/utils/patricia_tree.h"
 #include "src/utils/string_interning.h"

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -30,6 +30,7 @@
 #include "src/indexes/vector_base.h"
 #include "src/indexes/vector_flat.h"
 #include "src/indexes/vector_hnsw.h"
+#include "src/metrics.h"
 #include "src/utils/cancel.h"
 #include "src/utils/string_interning.h"
 #include "src/valkey_search_options.h"

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -21,7 +21,6 @@
 #include "absl/strings/str_cat.h"
 #include "hnswlib.h"
 #include "iostream.h"
-#include "src/metrics.h"
 #include "third_party/hnswlib/index.pb.h"
 #include "visited_list_pool.h"
 #include "vmsdk/src/status/status_macros.h"
@@ -187,8 +186,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       }
       linkLists_->clear();
     }
-    valkey_search::Metrics::GetStats().reclaimable_memory -=
-        num_deleted_ * vector_size_;
     cur_element_count_ = 0;
     visited_list_pool_.reset(nullptr);
   }
@@ -906,7 +903,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     for (size_t i = 0; i < cur_element_count_; i++) {
       if (isMarkedDeleted(i)) {
         num_deleted_ += 1;
-        valkey_search::Metrics::GetStats().reclaimable_memory += vector_size_;
         if (allow_replace_deleted_) {
           deleted_elements.insert(i);
         }
@@ -973,7 +969,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       unsigned char *ll_cur = ((unsigned char *)get_linklist0(internalId)) + 2;
       *ll_cur |= DELETE_MARK;
       num_deleted_ += 1;
-      valkey_search::Metrics::GetStats().reclaimable_memory += vector_size_;
       if (allow_replace_deleted_) {
         std::unique_lock<std::mutex> lock_deleted_elements(
             deleted_elements_lock);
@@ -1017,7 +1012,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       unsigned char *ll_cur = ((unsigned char *)get_linklist0(internalId)) + 2;
       *ll_cur &= ~DELETE_MARK;
       num_deleted_ -= 1;
-      valkey_search::Metrics::GetStats().reclaimable_memory -= vector_size_;
       if (allow_replace_deleted_) {
         std::unique_lock<std::mutex> lock_deleted_elements(
             deleted_elements_lock);


### PR DESCRIPTION
Based on analysis from #500

The index_reclaimable_memory metric tells users how much memory they'd recover by rebuilding their HNSW indexes. The old code lived inside hnswlib's markDeletedInternal every time a node was marked deleted, it added vector_size_ to the counter. The issue with this is when two documents have the same vector, StringInternStore stores the data once and ref-counts it. So if 10 documents share a vector and you delete all 10, the old code reports 10 * vector_size_ as reclaimable. In reality the interned string is stored once only 1 * vector_size_ could ever be freed. The metric over-reports by 9x.

This matters because users rely on this metric to decide whether to trigger an expensive index rebuild. Over-reporting makes them rebuild unnecessarily.


Option 1 : Maintain unique deleted vector with deleted nodes referencing it and only update reclaimable memory if all instances of that unique vector have been deleted. (Most accurate, adds few bytes more each unique vector, overkill)

Option B: Compute on demand at FT.INFO time. Remove the counter entirely. When FT.INFO is called, iterate all tracked_vectors, check which internal_ids are marked deleted, collect unique pointers in a temp set, count them. Zero persistent memory, perfectly accurate. complexity O(N)  where N is the number of tracked vectors. For a 10M vector index that's tens of milliseconds on every info call. Monitoring systems call FT.INFO frequently. (Accurate , expensive FT.INFO calls)

Option C: RefCount check at delete time (chosen)

When a node is deleted, look up its vector in tracked_vectors_ and check InternedStringPtr::RefCount(). If RefCount == 1, this is the only holder the memory would be freed on rebuild, so count it. If RefCount > 1, someone else holds this vector too, so the memory won't be freed regardless don't count it.

Cost: zero memory, one atomic load per deletion (the InternedString header is already in cache since we just looked up the entry).

Drawbacks : We still don't return accurate reclaimable memory. Instead of overcounting as we did earlier we are now undercounting the memory that can be reclaimed on index rebuild. Because when deleting a vector , if we see if its InternedStringPtr::RefCount() > 1, We don't increment the vector size to the reclaimable memory because there might be other vectors referenced which might or might not be deleted. 

Old behaviour (Over-counting). User sees "you'd gain X" where reality is much less.
New behaviour (Under-counting). User sees "you'd gain X" where reality is more.

This also includes changes from  https://github.com/valkey-io/valkey-search/pull/1015 . Once that is merged will rebase and update this PR . 





