### PR TITLE
Implement text index per-component memory tracking (#655)

### DIFF
--- a/integration/test_fulltext.py
+++ b/integration/test_fulltext.py
@@ -2574,6 +2574,47 @@ class TestFullTextDebugMode(ValkeySearchTestCaseDebugMode):
         
         print("\nCleanup verification passed!")
 
+    def test_text_index_memory_submodule_stats(self):
+        """Verify text index memory sub-component stats return to zero."""
+        client: Valkey = self.server.get_new_client()
+        client.execute_command(
+            "FT.CREATE", "memidx", "ON", "HASH", "PREFIX", "1", "m:",
+            "SCHEMA", "content", "TEXT"
+        )
+        import time
+        time.sleep(2)
+
+        info = IndexingTestHelper.get_ft_info(client, "memidx").parsed_data
+        assert info["text_postings_memory_bytes"] == 0
+        assert info["text_position_memory_bytes"] == 0
+
+        client.execute_command("HSET", "m:1", "content", "hello world foo bar")
+        client.execute_command("HSET", "m:2", "content", "alpha beta gamma delta")
+        client.execute_command("HSET", "m:3", "content", "hello world again today")
+        time.sleep(2)
+
+        info = IndexingTestHelper.get_ft_info(client, "memidx").parsed_data
+        assert info["text_postings_memory_bytes"] > 0
+        assert info["text_position_memory_bytes"] > 0
+        assert info["text_index_total_memory_bytes"] == (
+            info["text_postings_memory_bytes"] +
+            info["text_position_memory_bytes"] +
+            info["text_rax_tree_memory_bytes"]
+        )
+
+        client.execute_command("DEL", "m:1")
+        client.execute_command("DEL", "m:2")
+        client.execute_command("DEL", "m:3")
+        time.sleep(2)
+
+        info = IndexingTestHelper.get_ft_info(client, "memidx").parsed_data
+        assert info["text_postings_memory_bytes"] == 0, \
+            f"Expected 0, got {info['text_postings_memory_bytes']}"
+        assert info["text_position_memory_bytes"] == 0, \
+            f"Expected 0, got {info['text_position_memory_bytes']}"
+
+        client.execute_command("FT.DROPINDEX", "memidx")
+
 class TestFullTextCluster(ValkeySearchClusterTestCaseDebugMode):
 
     @pytest.mark.skip(reason="This test is designed to run for an extended period with high concurrency to detect crashes. It is not suitable for regular test runs and should be run manually when needed.")

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -1127,6 +1127,7 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   if (text_index_schema_) {
     arrSize += 8;  // punctuation, stop_words, with_offsets, min_stem_size (4
                    // key-value pairs = 8 items)
+    arrSize += 8;  // text memory sub-component stats (4 key-value pairs = 8 items)
   }
   ValkeyModule_ReplyWithArray(ctx, arrSize);
   ValkeyModule_ReplyWithSimpleString(ctx, "index_name");
@@ -1170,6 +1171,24 @@ void IndexSchema::RespondWithInfo(ValkeyModuleCtx *ctx) const {
   ValkeyModule_ReplyWithLongLong(
       ctx, text_index_schema_ ? text_index_schema_->GetNumUniqueTerms() : 0);
 
+  if (text_index_schema_) {
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_postings_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx,
+        static_cast<long long>(text_index_schema_->GetPostingsMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_position_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx,
+        static_cast<long long>(text_index_schema_->GetPositionMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_rax_tree_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx,
+        static_cast<long long>(text_index_schema_->GetRadixTreeMemoryUsage()));
+    ValkeyModule_ReplyWithSimpleString(ctx, "text_index_total_memory_bytes");
+    ValkeyModule_ReplyWithLongLong(
+        ctx, static_cast<long long>(
+                 text_index_schema_->GetTotalTextIndexMemoryUsage()));
+  }
   // Text Index info fields end
   ValkeyModule_ReplyWithSimpleString(ctx, "hash_indexing_failures");
   ValkeyModule_ReplyWithCString(

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -14,6 +14,7 @@
 #include "absl/log/check.h"
 #include "src/index_schema.h"
 #include "src/indexes/text/flat_position_map.h"
+#include "vmsdk/src/memory_tracker.h"
 
 namespace valkey_search::indexes::text {
 
@@ -61,7 +62,8 @@ void Postings::InsertKey(const Key& key, FlatPositionMap* flat_map) {
 }
 
 // Remove a document key and all its positions
-void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
+void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata,
+                         MemoryPool* position_pool) {
   auto node = key_to_positions_.extract(key);
   if (node.empty()) return;
 
@@ -75,7 +77,12 @@ void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
   metadata->total_term_frequency -= term_frequency;
 
   // Destroy and remove from map
-  FlatPositionMap::Destroy(flat_map);
+  if (position_pool) {
+    IsolatedMemoryScope pos_scope(*position_pool);
+    FlatPositionMap::Destroy(flat_map);
+  } else {
+    FlatPositionMap::Destroy(flat_map);
+  }
 }
 
 // Get total number of document keys

--- a/src/indexes/text/posting.h
+++ b/src/indexes/text/posting.h
@@ -82,7 +82,8 @@ struct Postings {
   void InsertKey(const Key& key, FlatPositionMap* flat_map);
 
   // Remove a key and all positions for it
-  void RemoveKey(const Key& key, TextIndexMetadata* metadata);
+  void RemoveKey(const Key& key, TextIndexMetadata* metadata,
+                 MemoryPool* position_pool = nullptr);
 
   // Total number of keys
   size_t GetKeyCount() const;

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -16,6 +16,7 @@
 #include "libstemmer.h"
 #include "src/valkey_search_options.h"
 #include "vmsdk/src/memory_allocation.h"
+#include "vmsdk/src/memory_tracker.h"
 namespace valkey_search::indexes::text {
 
 namespace {
@@ -53,10 +54,10 @@ InvasivePtr<Postings> AddKeyToPostings(InvasivePtr<Postings> existing_postings,
 
 InvasivePtr<Postings> RemoveKeyFromPostings(
     InvasivePtr<Postings> existing_postings, const InternedStringPtr &key,
-    TextIndexMetadata *metadata) {
+    TextIndexMetadata *metadata, MemoryPool *position_pool = nullptr) {
   CHECK(existing_postings) << "Per-key tree became unaligned";
 
-  existing_postings->RemoveKey(key, metadata);
+  existing_postings->RemoveKey(key, metadata, position_pool);
 
   if (existing_postings->IsEmpty()) {
     metadata->num_unique_terms--;
@@ -230,8 +231,11 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
 
     // Create FlatPositionMap from PositionMap
-    FlatPositionMap *flat_map =
-        FlatPositionMap::Create(pos_map, num_text_fields_);
+    FlatPositionMap *flat_map;
+    {
+      IsolatedMemoryScope scope(metadata_.position_memory_pool_);
+      flat_map = FlatPositionMap::Create(pos_map, num_text_fields_);
+    }
 
     // The updated target gets set in target_add_fn and later used in
     // target_set_fn, so that all trees point to the same postings object
@@ -247,8 +251,11 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
       }
       bool is_new_word = !existing;
 
-      updated_target =
-          AddKeyToPostings(std::move(existing), key, flat_map, &metadata_);
+      {
+        IsolatedMemoryScope scope(metadata_.postings_memory_pool_);
+        updated_target =
+            AddKeyToPostings(std::move(existing), key, flat_map, &metadata_);
+      }
 
       if (is_new_word) {
         absl::WriterMutexLock tree_lock(&text_index_mutex_);
@@ -281,6 +288,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
   // Map the key to the newly created per-key index
   {
+    IsolatedMemoryScope scope(metadata_.postings_memory_pool_);
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
   }
@@ -318,8 +326,12 @@ void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
       }
 
       InvasivePtr<Postings> updated_target;
-      updated_target =
-          RemoveKeyFromPostings(std::move(existing), key, &metadata_);
+      {
+        IsolatedMemoryScope scope(metadata_.postings_memory_pool_);
+        updated_target = RemoveKeyFromPostings(
+            std::move(existing), key, &metadata_,
+            &metadata_.position_memory_pool_);
+      }
 
       if (!updated_target) {
         absl::WriterMutexLock tree_lock(&text_index_mutex_);
@@ -371,6 +383,39 @@ uint64_t TextIndexSchema::GetNumUniqueTerms() const {
 
 uint64_t TextIndexSchema::GetTotalTermFrequency() const {
   return metadata_.total_term_frequency.load();
+}
+
+uint64_t TextIndexSchema::GetPostingsMemoryUsage() const {
+  return static_cast<uint64_t>(
+      std::max(int64_t{0}, metadata_.postings_memory_pool_.GetUsage()));
+}
+
+uint64_t TextIndexSchema::GetPositionMemoryUsage() const {
+  return static_cast<uint64_t>(
+      std::max(int64_t{0}, metadata_.position_memory_pool_.GetUsage()));
+}
+
+uint64_t TextIndexSchema::GetRadixTreeMemoryUsage() const {
+  // Main shared prefix + suffix tree
+  uint64_t total = text_index_->GetPrefix().GetAllocSize();
+  auto suffix = text_index_->GetSuffix();
+  if (suffix.has_value()) {
+    total += suffix->get().GetAllocSize();
+  }
+  // Per-key rax trees (one per indexed document)
+  for (const auto &[key, key_index] : per_key_text_indexes_) {
+    total += key_index.GetPrefix().GetAllocSize();
+    auto key_suffix = key_index.GetSuffix();
+    if (key_suffix.has_value()) {
+      total += key_suffix->get().GetAllocSize();
+    }
+  }
+  return total;
+}
+
+uint64_t TextIndexSchema::GetTotalTextIndexMemoryUsage() const {
+  return GetPostingsMemoryUsage() + GetPositionMemoryUsage() +
+         GetRadixTreeMemoryUsage();
 }
 
 std::string TextIndexSchema::GetAllStemVariants(

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -48,10 +48,10 @@ struct TextIndexMetadata {
   std::atomic<uint64_t> num_unique_terms{0};
   std::atomic<uint64_t> total_term_frequency{0};
 
-  // Memory pools for text index components
-  MemoryPool posting_memory_pool_{0};
-  MemoryPool radix_memory_pool_{0};
-  MemoryPool text_index_memory_pool_{0};
+  // Postings objects, btree_map nodes, per-key rax nodes, container overhead.
+  MemoryPool postings_memory_pool_{0};
+  // FlatPositionMap allocations (one per document per unique term).
+  MemoryPool position_memory_pool_{0};
 };
 
 class TextIndex {
@@ -212,8 +212,7 @@ class TextIndexSchema {
   uint64_t GetTotalPositions() const;
   uint64_t GetNumUniqueTerms() const;
   uint64_t GetTotalTermFrequency() const;
-  // TODO: Implement the following APIs when we want granular memory metrics for
-  // text index components
+  // Per-component memory usage exposed via FT.INFO.
   uint64_t GetPostingsMemoryUsage() const;
   uint64_t GetRadixTreeMemoryUsage() const;
   uint64_t GetPositionMemoryUsage() const;

--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -397,7 +397,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                      .expect_return_failure = false,
                      .expected_output =
-                         "*36\r\n+index_name\r\n+test_name\r\n+index_"
+                         "*44\r\n+index_name\r\n+test_name\r\n+index_"
                          "definition\r\n*8\r\n+key_type\r\n+HASH\r\n+"
                          "prefixes\r\n*1\r\n+prefix_1\r\n+default_score\r\n"
                          "1\r\n+score_field\r\n+\r\n+attributes\r\n*"
@@ -409,6 +409,10 @@ INSTANTIATE_TEST_SUITE_P(
                          "num_records\r\n:"
                          "0\r\n+total_term_occurrences\r\n:0\r\n+num_terms\r\n:"
                          "0\r\n+"
+                         "text_postings_memory_bytes\r\n:0\r\n+"
+                         "text_position_memory_bytes\r\n:0\r\n+"
+                         "text_rax_tree_memory_bytes\r\n:0\r\n+"
+                         "text_index_total_memory_bytes\r\n:0\r\n+"
                          "hash_indexing_failures\r\n$1\r\n0\r\n+backfill_in_"
                          "progress\r\n$1\r\n0\r\n+backfill_complete_"
                          "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"
@@ -450,7 +454,7 @@ INSTANTIATE_TEST_SUITE_P(
                         )",
                      .expect_return_failure = false,
                      .expected_output =
-                         "*36\r\n+index_name\r\n+test_name\r\n+index_"
+                         "*44\r\n+index_name\r\n+test_name\r\n+index_"
                          "definition\r\n*8\r\n+key_type\r\n+HASH\r\n+"
                          "prefixes\r\n*1\r\n+prefix_1\r\n+default_score\r\n"
                          "1\r\n+score_field\r\n+\r\n+attributes\r\n*"
@@ -462,6 +466,10 @@ INSTANTIATE_TEST_SUITE_P(
                          "num_records\r\n:"
                          "0\r\n+total_term_occurrences\r\n:0\r\n+num_terms\r\n:"
                          "0\r\n+"
+                         "text_postings_memory_bytes\r\n:0\r\n+"
+                         "text_position_memory_bytes\r\n:0\r\n+"
+                         "text_rax_tree_memory_bytes\r\n:0\r\n+"
+                         "text_index_total_memory_bytes\r\n:0\r\n+"
                          "hash_indexing_failures\r\n$1\r\n0\r\n+backfill_in_"
                          "progress\r\n$1\r\n0\r\n+backfill_complete_"
                          "percent\r\n$8\r\n1.000000\r\n+mutation_queue_"

--- a/vmsdk/src/memory_allocation_overrides.h
+++ b/vmsdk/src/memory_allocation_overrides.h
@@ -142,9 +142,9 @@ struct RawSystemAllocator {
     return static_cast<T*>(__real_malloc(n * sizeof(T)));
   }
   // NOLINTNEXTLINE
-  void deallocate(T* p, std::size_t) {
+  void deallocate(T* p, std::size_t n) {
     if constexpr (!std::is_same_v<Tag, DisableRawSystemAllocatorReporting>) {
-      ReportFreeMemorySize(sizeof(T));
+      ReportFreeMemorySize(n * sizeof(T));
     }
     __real_free(p);
   }


### PR DESCRIPTION
#655

Taking another swing at it . We can keep this change in a spearate dev branch for testing purposes, if we decide against adding these. Will do some tests to see if accounting works correctly 

Uses the same IsolatedMemoryScope / MemoryPool pattern as StringInternStore::memory_pool_ to automatically capture net bytes allocated/freed without manual size accounting.

Two pools are added to TextIndexMetadata:
- postings_memory_pool_: Postings objects, btree_map internal nodes, per-key rax tree nodes, and per-key node_hash_map container overhead.
- position_memory_pool_: FlatPositionMap allocations (one per document per unique term).

Also fixes RawSystemAllocator::deallocate reporting sizeof(T) instead of n * sizeof(T), causing monotonically growing memory accounting leak.