### PR TITLE
Add BM25STD scorer + ScoringSession for full-text scoring

### DIFF
--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -1,6 +1,19 @@
 valkey_search_create_proto_library("src/index_schema.proto"
                                    "index_schema_cc_proto")
 
+set(SRCS_SCORING
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_stats.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scorer.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scorer.cc
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer.cc
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_session.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_session.cc)
+
+valkey_search_add_static_library(scoring "${SRCS_SCORING}")
+target_include_directories(scoring PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(scoring PUBLIC vmsdklib)
+
 add_library(index_base INTERFACE ${SRCS_INDEX_BASE})
 target_include_directories(index_base INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(index_base INTERFACE index_schema_cc_proto)

--- a/src/indexes/scoring/bm25std_scorer.cc
+++ b/src/indexes/scoring/bm25std_scorer.cc
@@ -26,8 +26,16 @@ bool IsInf(double d) {
   static constexpr uint64_t kMantissaMask = 0x000FFFFFFFFFFFFFULL;
   uint64_t bits;
   std::memcpy(&bits, &d, sizeof(bits));
-  return (bits & kExponentMask) == kExponentMask &&
-         (bits & kMantissaMask) == 0;
+  return (bits & kExponentMask) == kExponentMask && (bits & kMantissaMask) == 0;
+}
+
+// std::isnan is unreliable under -ffadt-math
+bool IsNan(double d) {
+  static constexpr uint64_t kExponentMask = 0x7FF0000000000000ULL;
+  static constexpr uint64_t kMantissaMask = 0x000FFFFFFFFFFFFFULL;
+  uint64_t bits;
+  std::memcpy(&bits, &d, sizeof(bits));
+  return (bits & kExponentMask) == kExponentMask && (bits & kMantissaMask) != 0;
 }
 
 // IDF = ln(1 + (N - dt + 0.5) / (dt + 0.5)).
@@ -49,9 +57,8 @@ double Bm25StdScorer::ScoreLeaf(const ScoringStats& stats,
   // Empty / pathological index — nothing meaningful to score.
   if (bm25_stats->avg_doc_len <= 0.0) return 0.0;
 
-  const double idf = Idf(bm25_stats->total_docs,
-                         bm25_stats->num_doc_contain_term);
-  if (idf == 0.0) return 0.0;
+  const double idf =
+      Idf(bm25_stats->total_docs, bm25_stats->num_doc_contain_term);
 
   const double f = static_cast<double>(bm25_stats->term_frequency);
   const double dl = static_cast<double>(bm25_stats->doc_len);
@@ -60,13 +67,16 @@ double Bm25StdScorer::ScoreLeaf(const ScoringStats& stats,
   // bm25_leaf = leaf_weight * IDF * F*(k1+1) /
   //             (F + k1*(1 - b + b * dl/avgdl))
   const double numerator = f * (kK1 + 1.0);
-  const double denominator =
-      f + kK1 * (1.0 - kB + kB * dl / avgdl);
+  const double denominator = f + kK1 * (1.0 - kB + kB * dl / avgdl);
   return leaf_weight * idf * (numerator / denominator);
 }
 
-double Bm25StdScorer::ComposeDocumentScore(
-    double sum_of_terms, const ScoringStats& stats) const {
+double Bm25StdScorer::ComposeDocumentScore(double sum_of_terms,
+                                           const ScoringStats& stats) const {
+  // safe guard for nan values
+  if (IsNan(stats.document_score) || IsNan(sum_of_terms)) {
+    return 0.0;
+  }
   // Short-circuit on infinite document_score: the final score is
   // predetermined regardless of the per-leaf math, and
   // sum_of_terms * ±inf would otherwise yield NaN when sum_of_terms is

--- a/src/indexes/scoring/bm25std_scorer.cc
+++ b/src/indexes/scoring/bm25std_scorer.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/bm25std_scorer.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+#include "absl/log/check.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+namespace {
+
+// std::isinf is unreliable under -ffast-math (the build enables it for
+// performance — see cmake/Modules/valkey_search.cmake). Detect by IEEE
+// 754 bit pattern: exponent bits all 1, mantissa all 0.
+bool IsInf(double d) {
+  static constexpr uint64_t kExponentMask = 0x7FF0000000000000ULL;
+  static constexpr uint64_t kMantissaMask = 0x000FFFFFFFFFFFFFULL;
+  uint64_t bits;
+  std::memcpy(&bits, &d, sizeof(bits));
+  return (bits & kExponentMask) == kExponentMask &&
+         (bits & kMantissaMask) == 0;
+}
+
+// IDF = ln(1 + (N - dt + 0.5) / (dt + 0.5)).
+// Invariant enforced by caller: dt <= N (counter consistency).
+double Idf(uint64_t total_docs, uint64_t num_doc_contain_term) {
+  CHECK_LE(num_doc_contain_term, total_docs);
+  const double n = static_cast<double>(total_docs);
+  const double dt = static_cast<double>(num_doc_contain_term);
+  return std::log1p((n - dt + 0.5) / (dt + 0.5));
+}
+
+}  // namespace
+
+double Bm25StdScorer::ScoreLeaf(const ScoringStats& stats,
+                                double leaf_weight) const {
+  const auto* bm25_stats = dynamic_cast<const Bm25StdStats*>(&stats);
+  CHECK(bm25_stats != nullptr);
+
+  // Empty / pathological index — nothing meaningful to score.
+  if (bm25_stats->avg_doc_len <= 0.0) return 0.0;
+
+  const double idf = Idf(bm25_stats->total_docs,
+                         bm25_stats->num_doc_contain_term);
+  if (idf == 0.0) return 0.0;
+
+  const double f = static_cast<double>(bm25_stats->term_frequency);
+  const double dl = static_cast<double>(bm25_stats->doc_len);
+  const double avgdl = bm25_stats->avg_doc_len;
+
+  // bm25_leaf = leaf_weight * IDF * F*(k1+1) /
+  //             (F + k1*(1 - b + b * dl/avgdl))
+  const double numerator = f * (kK1 + 1.0);
+  const double denominator =
+      f + kK1 * (1.0 - kB + kB * dl / avgdl);
+  return leaf_weight * idf * (numerator / denominator);
+}
+
+double Bm25StdScorer::ComposeDocumentScore(
+    double sum_of_terms, const ScoringStats& stats) const {
+  // Short-circuit on infinite document_score: the final score is
+  // predetermined regardless of the per-leaf math, and
+  // sum_of_terms * ±inf would otherwise yield NaN when sum_of_terms is
+  // zero. Both +inf and -inf are propagated as the final score; this
+  // implementation does not filter -inf documents out of results.
+  if (IsInf(stats.document_score)) {
+    return stats.document_score;
+  }
+
+  // BM25STD does not clamp negative document_score.
+  return sum_of_terms * stats.document_score;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/bm25std_scorer.h
+++ b/src/indexes/scoring/bm25std_scorer.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_BM25STD_SCORER_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_BM25STD_SCORER_H_
+
+#include <string_view>
+
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Standard Okapi BM25 scorer ("BM25STD"). Per-leaf and per-document
+// math:
+//
+//   IDF       = ln(1 + (N - dt + 0.5) / (dt + 0.5))
+//   bm25_leaf = leaf_weight * IDF *
+//               F * (k1 + 1) /
+//               (F + k1 * (1 - b + b * doc_len / avg_doc_len))
+//   final     = sum_of_leaves * document_score
+//
+// k1 = 1.2, b = 0.75 — aligned with Redis 8.6 / OpenSearch / Wikipedia
+// standard.
+//
+// Expects Bm25StdStats as the ScoringStats subtype. Mismatched subtypes
+// trigger a DCHECK in debug builds.
+class Bm25StdScorer : public Scorer {
+ public:
+  static constexpr std::string_view kName = "BM25STD";
+  static constexpr double kK1 = 1.2;
+  static constexpr double kB = 0.75;
+
+  std::string_view Name() const override { return kName; }
+  ScorerType Type() const override { return ScorerType::kBm25Std; }
+
+  double ScoreLeaf(const ScoringStats& stats,
+                   double leaf_weight) const override;
+
+  double ComposeDocumentScore(double sum_of_terms,
+                              const ScoringStats& stats) const override;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scorer.cc
+++ b/src/indexes/scoring/scorer.cc
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/scorer.h"
+
+#include "absl/types/span.h"
+
+namespace valkey_search::indexes::scoring {
+
+double Scorer::CombineGroup(absl::Span<const double> child_scores,
+                            double group_weight) const {
+  double sum = 0.0;
+  for (double s : child_scores) sum += s;
+  return group_weight * sum;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/scorer.h
+++ b/src/indexes/scoring/scorer.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORER_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORER_H_
+
+#include <string_view>
+
+#include "absl/types/span.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Enumerates the concrete scoring algorithms. Returned by Scorer::Type()
+// for cheap dispatch in switch statements (factory, EXPLAINSCORE
+// formatting, telemetry) without string compares against Name().
+//
+// Add a new entry here when introducing a new concrete scorer.
+enum class ScorerType {
+  kBm25Std,
+  kTfidf,
+};
+
+// Polymorphic base for query-result scoring algorithms. Initial concrete
+// scorers cover full-text (BM25STD, TFIDF); tag and numeric scorers may
+// be added as peers in the future without changing this interface.
+//
+// A Scorer is stateless and pure: the same instance can be safely shared
+// across concurrent queries. Per-query state (accumulated per-doc partial
+// scores, group weight stack, ranking) lives in ScoringSession.
+//
+// Three call sites during query evaluation:
+//   - ScoreLeaf: contribution of one (query leaf, candidate document)
+//     match. The "leaf" is whatever the query tree's terminal node
+//     represents for a given index type (a term for text; later: a tag
+//     value, a numeric range hit).
+//   - CombineGroup: combine children of an AND/OR/group node, applying
+//     the node's group weight. Same logic for every algorithm; the base
+//     class provides a non-virtual default implementation.
+//   - ComposeDocumentScore: produce one document's final score from its
+//     accumulated leaf + group contributions.
+//
+// Concrete scorers expect a specific ScoringStats subtype (e.g. BM25STD
+// expects Bm25StdStats). The caller must pass the matching subtype;
+// scorers DCHECK this contract.
+class Scorer {
+ public:
+  virtual ~Scorer() = default;
+
+  // Identity string surfaced by FT.SEARCH SCORER and EXPLAINSCORE.
+  virtual std::string_view Name() const = 0;
+
+  // Concrete-class identity for dispatch.
+  virtual ScorerType Type() const = 0;
+
+  // Per-leaf contribution for one (query leaf, candidate document) match.
+  // `leaf_weight` comes from the leaf's =>{$weight:N}; default 1.0.
+  virtual double ScoreLeaf(const ScoringStats& stats,
+                           double leaf_weight) const = 0;
+
+  // Final composition: takes the accumulated sum of leaf + group
+  // contributions for one document and applies algorithm-specific
+  // post-processing (e.g. document_score multiplier; norm / slop
+  // divisors for TFIDF).
+  virtual double ComposeDocumentScore(double sum_of_terms,
+                                      const ScoringStats& stats) const = 0;
+
+  // Combine an internal node's children:
+  //   group_weight * sum(child_scores)
+  // Identical for every algorithm, so the base class implements this
+  // non-virtually.
+  double CombineGroup(absl::Span<const double> child_scores,
+                      double group_weight) const;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scoring_session.cc
+++ b/src/indexes/scoring/scoring_session.cc
@@ -33,8 +33,12 @@ void ScoringSession::RecordLeaf(const ScoringStats& stats, double leaf_weight) {
 
   // Remember the stats for ComposeDocumentScore. First write wins;
   // subsequent records for the same doc must agree on doc-level fields
-  // (document_score, etc.), which is the caller's contract.
-  doc_stats_.try_emplace(stats.doc_id, &stats);
+  // (document_score, etc.), which is the caller's contract. The
+  // session owns the stored copy via Clone() so its lifetime is
+  // independent of the caller-supplied `stats`.
+  if (!doc_stats_.contains(stats.doc_id)) {
+    doc_stats_.emplace(stats.doc_id, stats.Clone());
+  }
 }
 
 // Push a fresh scope onto the group stack. Subsequent RecordLeaf

--- a/src/indexes/scoring/scoring_session.cc
+++ b/src/indexes/scoring/scoring_session.cc
@@ -25,8 +25,7 @@ ScoringSession::ScoringSession(const Scorer* scorer) : scorer_(scorer) {
 // Record one (query leaf, candidate document) match into the
 // innermost group scope. Computes the leaf's contribution via the
 // Scorer and adds it to that doc's running sum within the scope.
-void ScoringSession::RecordLeaf(const ScoringStats& stats,
-                                double leaf_weight) {
+void ScoringSession::RecordLeaf(const ScoringStats& stats, double leaf_weight) {
   CHECK(!group_stack_.empty());
 
   const double leaf_score = scorer_->ScoreLeaf(stats, leaf_weight);

--- a/src/indexes/scoring/scoring_session.cc
+++ b/src/indexes/scoring/scoring_session.cc
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/scoring_session.h"
+
+#include <algorithm>
+
+#include "absl/log/check.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Initialize the session with a single root scope on the group stack.
+// Leaves recorded outside any EnterGroup/ExitGroup pair land here, and
+// after a balanced sequence of group calls only this scope remains —
+// it holds the per-doc sums fed into ComposeDocumentScore at Rank().
+ScoringSession::ScoringSession(const Scorer* scorer) : scorer_(scorer) {
+  CHECK(scorer_ != nullptr);
+  group_stack_.emplace_back();
+}
+
+// Record one (query leaf, candidate document) match into the
+// innermost group scope. Computes the leaf's contribution via the
+// Scorer and adds it to that doc's running sum within the scope.
+void ScoringSession::RecordLeaf(const ScoringStats& stats,
+                                double leaf_weight) {
+  CHECK(!group_stack_.empty());
+
+  const double leaf_score = scorer_->ScoreLeaf(stats, leaf_weight);
+  group_stack_.back()[stats.doc_id] += leaf_score;
+
+  // Remember the stats for ComposeDocumentScore. First write wins;
+  // subsequent records for the same doc must agree on doc-level fields
+  // (document_score, etc.), which is the caller's contract.
+  doc_stats_.try_emplace(stats.doc_id, &stats);
+}
+
+// Push a fresh scope onto the group stack. Subsequent RecordLeaf
+// calls accumulate into the new scope until the matching ExitGroup
+// folds it back into the parent.
+void ScoringSession::EnterGroup() {
+  CHECK(!group_stack_.empty());
+  group_stack_.emplace_back();
+}
+
+// Close the innermost group scope and merge it into its parent,
+// scaling each per-doc partial by group_weight first. This is what
+// makes layered weights compose multiplicatively across nested
+// groups.
+void ScoringSession::ExitGroup(double group_weight) {
+  CHECK_GE(group_stack_.size(), 2u);
+
+  auto inner = std::move(group_stack_.back());
+  group_stack_.pop_back();
+
+  auto& outer = group_stack_.back();
+  for (const auto& [doc_id, partial] : inner) {
+    outer[doc_id] += group_weight * partial;
+  }
+}
+
+// Finalize the session: take every doc's accumulated sum from the
+// root scope, apply ComposeDocumentScore, and return the docs sorted
+// by score descending (doc_id ascending breaks ties). The session is
+// consumed by this call — subsequent RecordLeaf/EnterGroup/ExitGroup
+// will fail.
+std::vector<RankedDoc> ScoringSession::Rank() {
+  CHECK_EQ(group_stack_.size(), 1u);
+
+  auto root = std::move(group_stack_.back());
+  group_stack_.clear();
+
+  std::vector<RankedDoc> results;
+  results.reserve(root.size());
+  for (const auto& [doc_id, sum] : root) {
+    auto stats_it = doc_stats_.find(doc_id);
+    CHECK(stats_it != doc_stats_.end());
+    const double final_score =
+        scorer_->ComposeDocumentScore(sum, *stats_it->second);
+    results.push_back({doc_id, final_score});
+  }
+  doc_stats_.clear();
+
+  // Sort by score descending; tie-break by doc_id ascending for
+  // deterministic ordering.
+  std::sort(results.begin(), results.end(),
+            [](const RankedDoc& a, const RankedDoc& b) {
+              if (a.score != b.score) return a.score > b.score;
+              return a.doc_id < b.doc_id;
+            });
+  return results;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/scoring_session.h
+++ b/src/indexes/scoring/scoring_session.h
@@ -9,6 +9,7 @@
 #define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_SESSION_H_
 
 #include <cstdint>
+#include <memory>
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
@@ -53,10 +54,11 @@ class ScoringSession {
 
   // Record one (query leaf, candidate document) match.
   //
-  // `stats` must remain alive until Rank() returns; the session stores
-  // a pointer to it for the eventual ComposeDocumentScore call. The
-  // doc-level fields in `stats` (e.g. document_score) must be invariant
-  // across all leaves recorded for the same `stats.doc_id`.
+  // The session takes its own copy of `stats` (via ScoringStats::Clone)
+  // for the eventual ComposeDocumentScore call, so the caller's
+  // instance need not outlive this call. The doc-level fields in
+  // `stats` (e.g. document_score) must be invariant across all leaves
+  // recorded for the same `stats.doc_id`.
   void RecordLeaf(const ScoringStats& stats, double leaf_weight);
 
   // Open a new group scope. RecordLeaf calls between EnterGroup() and
@@ -84,8 +86,9 @@ class ScoringSession {
   std::vector<absl::flat_hash_map<DocId, double>> group_stack_;
 
   // Per-doc ScoringStats remembered for the ComposeDocumentScore call
-  // at Rank() time. Pointer storage; lifetime managed by caller.
-  absl::flat_hash_map<DocId, const ScoringStats*> doc_stats_;
+  // at Rank() time. The session owns these copies so its lifetime is
+  // independent of the caller-supplied stats passed to RecordLeaf.
+  absl::flat_hash_map<DocId, std::unique_ptr<ScoringStats>> doc_stats_;
 };
 
 }  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/scoring_session.h
+++ b/src/indexes/scoring/scoring_session.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_SESSION_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_SESSION_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Opaque per-query document identifier. The integration boundary
+// (e.g. TermIterator wiring) is responsible for mapping the index's
+// native key type (InternedStringPtr) to and from DocId.
+using DocId = uint64_t;
+
+struct RankedDoc {
+  DocId doc_id;
+  double score;
+};
+
+// Per-query collector and ranker. One ScoringSession is created per
+// FT.SEARCH invocation, driven by a depth-first walk of the predicate
+// tree, and discarded once Rank() has produced the sorted output.
+//
+// Lifecycle:
+//   ScoringSession session(scorer);
+//   for each predicate-tree node (depth-first):
+//     if leaf:           session.RecordLeaf(stats, leaf_weight);
+//     if group enter:    session.EnterGroup();
+//     if group exit:     session.ExitGroup(group_weight);
+//   auto results = session.Rank();
+//
+// Group-weight semantics:
+//   final = ... w_outer * (... + w_inner * (sum_of_leaves) ...)
+//
+// The session does not apply LIMIT offset/count slicing. Rank() returns
+// every candidate document sorted by score descending; the result-
+// collection path applies LIMIT on the returned vector.
+class ScoringSession {
+ public:
+  // The Scorer is borrowed and must outlive this session. Typically a
+  // single Scorer instance is shared across all queries in a process.
+  explicit ScoringSession(const Scorer* scorer);
+
+  // Record one (query leaf, candidate document) match.
+  //
+  // `stats` must remain alive until Rank() returns; the session stores
+  // a pointer to it for the eventual ComposeDocumentScore call. The
+  // doc-level fields in `stats` (e.g. document_score) must be invariant
+  // across all leaves recorded for the same `stats.doc_id`.
+  void RecordLeaf(const ScoringStats& stats, double leaf_weight);
+
+  // Open a new group scope. RecordLeaf calls between EnterGroup() and
+  // its matching ExitGroup(w) are accumulated independently; on
+  // ExitGroup the per-doc sums are multiplied by w and merged into
+  // the enclosing scope. Calls must be balanced.
+  void EnterGroup();
+  void ExitGroup(double group_weight);
+
+  // Compute final scores via Scorer::ComposeDocumentScore and return
+  // every candidate document sorted by score descending. Tied scores
+  // are broken by doc_id ascending for deterministic ordering.
+  //
+  // Must be called exactly once, after all groups have been exited.
+  std::vector<RankedDoc> Rank();
+
+ private:
+  const Scorer* scorer_;
+
+  // Stack of per-group accumulators (DocId -> running sum). Initialized
+  // with a single root scope; EnterGroup pushes, ExitGroup pops after
+  // applying the group weight and merging into the parent scope. After
+  // a balanced sequence of calls, only the root scope remains and
+  // holds the final per-doc sums passed to ComposeDocumentScore.
+  std::vector<absl::flat_hash_map<DocId, double>> group_stack_;
+
+  // Per-doc ScoringStats remembered for the ComposeDocumentScore call
+  // at Rank() time. Pointer storage; lifetime managed by caller.
+  absl::flat_hash_map<DocId, const ScoringStats*> doc_stats_;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scoring_stats.h
+++ b/src/indexes/scoring/scoring_stats.h
@@ -27,7 +27,7 @@ namespace valkey_search::indexes::scoring {
 //   document_score        - SCORE_FIELD | SCORE | 1.0
 //   term                  - surface term from the query leaf
 //   num_doc_contain_term  - dt, docs containing this term (index-wide)
-//   term_frequency        - doc-wide term frequency (§5.2)
+//   term_frequency        - doc-wide term frequency
 struct ScoringStats {
   virtual ~ScoringStats() = default;
 
@@ -51,16 +51,16 @@ struct Bm25StdStats : ScoringStats {
 };
 
 // TFIDF-specific inputs. Adds the fields TFIDF needs on top of the common
-// stats: the per-document `norm` divisor (§3.4) and the term's positional
-// offsets within the document (used for the SLOP penalty, §3.5).
+// stats: the per-document `norm` divisor and the term's positional
+// offsets within the document (used for the SLOP penalty).
 //
 // `positions` is a non-owning view; the underlying storage must outlive
 // the ScoringStats. Empty when SLOP is not being computed.
 //
 // Field semantics:
-//   norm       - max term frequency within the document (§3.4); 0 means
-//                the document has no TEXT fields, which forces the final
-//                score to 0 (§6 row 1)
+//   norm       - max term frequency within the document; 0 means the
+//                document has no TEXT fields, which forces the final
+//                score to 0
 //   positions  - positional offsets of `term` within the document, sorted
 //                ascending; empty when SLOP is not used
 struct TfidfStats : ScoringStats {

--- a/src/indexes/scoring/scoring_stats.h
+++ b/src/indexes/scoring/scoring_stats.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_STATS_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_STATS_H_
+
+#include <cstdint>
+
+#include "absl/strings/string_view.h"
+#include "absl/types/span.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Inputs common to every scoring algorithm. Populated for one
+// (query term, candidate document) pair during result collection.
+//
+// Concrete algorithms derive from this and add their algorithm-specific
+// fields (e.g. Bm25StdStats adds doc_len / avg_doc_len).
+//
+// Field semantics:
+//   total_docs            - N, total documents in the index
+//   doc_id                - candidate document id
+//   document_score        - SCORE_FIELD | SCORE | 1.0
+//   term                  - surface term from the query leaf
+//   num_doc_contain_term  - dt, docs containing this term (index-wide)
+//   term_frequency        - doc-wide term frequency (§5.2)
+struct ScoringStats {
+  virtual ~ScoringStats() = default;
+
+  uint64_t total_docs = 0;
+  uint64_t doc_id = 0;
+  double document_score = 1.0;
+  absl::string_view term;
+  uint64_t num_doc_contain_term = 0;
+  uint32_t term_frequency = 0;
+};
+
+// BM25STD-specific inputs. Adds only the fields BM25STD needs on top of
+// the common stats.
+//
+// Field semantics:
+//   avg_doc_len  - index-wide average indexed-terms per document
+//   doc_len      - total indexed terms in this document
+struct Bm25StdStats : ScoringStats {
+  double avg_doc_len = 0.0;
+  uint32_t doc_len = 0;
+};
+
+// TFIDF-specific inputs. Adds the fields TFIDF needs on top of the common
+// stats: the per-document `norm` divisor (§3.4) and the term's positional
+// offsets within the document (used for the SLOP penalty, §3.5).
+//
+// `positions` is a non-owning view; the underlying storage must outlive
+// the ScoringStats. Empty when SLOP is not being computed.
+//
+// Field semantics:
+//   norm       - max term frequency within the document (§3.4); 0 means
+//                the document has no TEXT fields, which forces the final
+//                score to 0 (§6 row 1)
+//   positions  - positional offsets of `term` within the document, sorted
+//                ascending; empty when SLOP is not used
+struct TfidfStats : ScoringStats {
+  uint32_t norm = 0;
+  absl::Span<const uint32_t> positions;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scoring_stats.h
+++ b/src/indexes/scoring/scoring_stats.h
@@ -10,8 +10,8 @@
 
 #include <cstdint>
 #include <memory>
+#include <string>
 
-#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 
 namespace valkey_search::indexes::scoring {
@@ -42,7 +42,7 @@ struct ScoringStats {
   uint64_t total_docs = 0;
   uint64_t doc_id = 0;
   double document_score = 1.0;
-  absl::string_view term;
+  std::string term;
   uint64_t num_doc_contain_term = 0;
   uint32_t term_frequency = 0;
 };

--- a/src/indexes/scoring/scoring_stats.h
+++ b/src/indexes/scoring/scoring_stats.h
@@ -9,6 +9,7 @@
 #define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_STATS_H_
 
 #include <cstdint>
+#include <memory>
 
 #include "absl/strings/string_view.h"
 #include "absl/types/span.h"
@@ -31,6 +32,13 @@ namespace valkey_search::indexes::scoring {
 struct ScoringStats {
   virtual ~ScoringStats() = default;
 
+  // Polymorphic deep copy. ScoringSession uses this to take an owned
+  // copy of caller-supplied stats so its lifetime is independent of
+  // the original.
+  virtual std::unique_ptr<ScoringStats> Clone() const {
+    return std::make_unique<ScoringStats>(*this);
+  }
+
   uint64_t total_docs = 0;
   uint64_t doc_id = 0;
   double document_score = 1.0;
@@ -46,6 +54,10 @@ struct ScoringStats {
 //   avg_doc_len  - index-wide average indexed-terms per document
 //   doc_len      - total indexed terms in this document
 struct Bm25StdStats : ScoringStats {
+  std::unique_ptr<ScoringStats> Clone() const override {
+    return std::make_unique<Bm25StdStats>(*this);
+  }
+
   double avg_doc_len = 0.0;
   uint32_t doc_len = 0;
 };
@@ -64,6 +76,10 @@ struct Bm25StdStats : ScoringStats {
 //   positions  - positional offsets of `term` within the document, sorted
 //                ascending; empty when SLOP is not used
 struct TfidfStats : ScoringStats {
+  std::unique_ptr<ScoringStats> Clone() const override {
+    return std::make_unique<TfidfStats>(*this);
+  }
+
   uint32_t norm = 0;
   absl::Span<const uint32_t> positions;
 };

--- a/src/indexes/text/rax/rax.h
+++ b/src/indexes/text/rax/rax.h
@@ -162,46 +162,46 @@ extern "C" {
 
 #define RAX_NODE_MAX_SIZE ((1 << 29) - 1)
 typedef struct raxNode {
-    uint32_t iskey : 1;   /* Does this node contain a key? */
-    uint32_t isnull : 1;  /* Associated value is NULL (don't store it). */
-    uint32_t iscompr : 1; /* Node is compressed. */
-    uint32_t size : 29;   /* Number of children, or compressed string len. */
-    uint64_t subtree_items; // SEARCH
-    /* Data layout is as follows:
-     *
-     * If node is not compressed we have 'size' bytes, one for each children
-     * character, and 'size' raxNode pointers, point to each child node.
-     * Note how the character is not stored in the children but in the
-     * edge of the parents:
-     *
-     * [header iscompr=0][abc][a-ptr][b-ptr][c-ptr](value-ptr?)
-     *
-     * if node is compressed (iscompr bit is 1) the node has 1 children.
-     * In that case the 'size' bytes of the string stored immediately at
-     * the start of the data section, represent a sequence of successive
-     * nodes linked one after the other, for which only the last one in
-     * the sequence is actually represented as a node, and pointed to by
-     * the current compressed node.
-     *
-     * [header iscompr=1][xyz][z-ptr](value-ptr?)
-     *
-     * Both compressed and not compressed nodes can represent a key
-     * with associated data in the radix tree at any level (not just terminal
-     * nodes).
-     *
-     * If the node has an associated key (iskey=1) and is not NULL
-     * (isnull=0), then after the raxNode pointers pointing to the
-     * children, an additional value pointer is present (as you can see
-     * in the representation above as "value-ptr" field).
-     */
-    unsigned char data[];
+  uint32_t iskey : 1;      /* Does this node contain a key? */
+  uint32_t isnull : 1;     /* Associated value is NULL (don't store it). */
+  uint32_t iscompr : 1;    /* Node is compressed. */
+  uint32_t size : 29;      /* Number of children, or compressed string len. */
+  uint64_t subtree_items;  // SEARCH
+  /* Data layout is as follows:
+   *
+   * If node is not compressed we have 'size' bytes, one for each children
+   * character, and 'size' raxNode pointers, point to each child node.
+   * Note how the character is not stored in the children but in the
+   * edge of the parents:
+   *
+   * [header iscompr=0][abc][a-ptr][b-ptr][c-ptr](value-ptr?)
+   *
+   * if node is compressed (iscompr bit is 1) the node has 1 children.
+   * In that case the 'size' bytes of the string stored immediately at
+   * the start of the data section, represent a sequence of successive
+   * nodes linked one after the other, for which only the last one in
+   * the sequence is actually represented as a node, and pointed to by
+   * the current compressed node.
+   *
+   * [header iscompr=1][xyz][z-ptr](value-ptr?)
+   *
+   * Both compressed and not compressed nodes can represent a key
+   * with associated data in the radix tree at any level (not just terminal
+   * nodes).
+   *
+   * If the node has an associated key (iskey=1) and is not NULL
+   * (isnull=0), then after the raxNode pointers pointing to the
+   * children, an additional value pointer is present (as you can see
+   * in the representation above as "value-ptr" field).
+   */
+  unsigned char data[];
 } raxNode;
 
 typedef struct rax {
-    raxNode *head;     /* Pointer to root node of tree */
-    uint64_t numele;   /* Number of keys in the tree */
-    uint64_t numnodes; /* Number of rax nodes in the tree */
-    size_t alloc_size; /* Total allocation size of the tree in bytes */
+  raxNode *head;     /* Pointer to root node of tree */
+  uint64_t numele;   /* Number of keys in the tree */
+  uint64_t numnodes; /* Number of rax nodes in the tree */
+  size_t alloc_size; /* Total allocation size of the tree in bytes */
 } rax;
 
 /* Stack data structure used by raxLowWalk() in order to, optionally, return
@@ -209,12 +209,12 @@ typedef struct rax {
  * field for space concerns, so we use the auxiliary stack when needed. */
 #define RAX_STACK_STATIC_ITEMS 32
 typedef struct raxStack {
-    void **stack;           /* Points to static_items or an heap allocated array. */
-    size_t items, maxitems; /* Number of items contained and total space. */
-    /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
-     * and use this static array of pointers instead. */
-    void *static_items[RAX_STACK_STATIC_ITEMS];
-    int oom; /* True if pushing into this stack failed for OOM at some point. */
+  void **stack; /* Points to static_items or an heap allocated array. */
+  size_t items, maxitems; /* Number of items contained and total space. */
+  /* Up to RAXSTACK_STACK_ITEMS items we avoid to allocate on the heap
+   * and use this static array of pointers instead. */
+  void *static_items[RAX_STACK_STATIC_ITEMS];
+  int oom; /* True if pushing into this stack failed for OOM at some point. */
 } raxStack;
 
 /* Optional callback used for iterators and be notified on each rax node,
@@ -234,35 +234,34 @@ typedef int (*raxNodeCallback)(raxNode **noderef);
 
 /* Radix tree iterator state is encapsulated into this data structure. */
 #define RAX_ITER_STATIC_LEN 128
-#define RAX_ITER_JUST_SEEKED (1 << 0) /* Iterator was just seeked. Return current \
-                                         element for the first iteration and      \
-                                         clear the flag. */
-#define RAX_ITER_EOF (1 << 1)         /* End of iteration reached. */
-#define RAX_ITER_SAFE (1 << 2)        /* Safe iterator, allows operations while \
-                                         iterating. But it is slower. */
-#define RAX_ITER_SUB_TREE (1 << 3)    /* SEARCH - restrict iteration to sub-tree. */
+#define RAX_ITER_JUST_SEEKED                                              \
+  (1 << 0)                    /* Iterator was just seeked. Return current \
+                                 element for the first iteration and      \
+                                 clear the flag. */
+#define RAX_ITER_EOF (1 << 1) /* End of iteration reached. */
+#define RAX_ITER_SAFE                                \
+  (1 << 2) /* Safe iterator, allows operations while \
+              iterating. But it is slower. */
+#define RAX_ITER_SUB_TREE \
+  (1 << 3) /* SEARCH - restrict iteration to sub-tree. */
 
 typedef struct raxIterator {
-    int flags;
-    rax *rt;            /* Radix tree we are iterating. */
-    unsigned char *key; /* The current string. */
-    void *data;         /* Data associated to this key. */
-    size_t key_len;     /* Current key length. */
-    size_t key_max;     /* Max key len the current key buffer can hold. */
-    unsigned char key_static_string[RAX_ITER_STATIC_LEN];
-    raxNode *node;           /* Current node. Only for unsafe iteration. */
-    raxStack stack;          /* Stack used for unsafe iteration. */
-    raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
-    raxNode *head;           /* SEARCH - Used to limit iteration to a subtree */
+  int flags;
+  rax *rt;            /* Radix tree we are iterating. */
+  unsigned char *key; /* The current string. */
+  void *data;         /* Data associated to this key. */
+  size_t key_len;     /* Current key length. */
+  size_t key_max;     /* Max key len the current key buffer can hold. */
+  unsigned char key_static_string[RAX_ITER_STATIC_LEN];
+  raxNode *node;           /* Current node. Only for unsafe iteration. */
+  raxStack stack;          /* Stack used for unsafe iteration. */
+  raxNodeCallback node_cb; /* Optional node callback. Normally set to NULL. */
+  raxNode *head;           /* SEARCH - Used to limit iteration to a subtree */
 } raxIterator;
 
 /* BEGIN SEARCH */
 /* Used to modify the subtree_items count */
-typedef enum {
-    NONE,
-    ADD,
-    SUBTRACT
-} item_count_op;
+typedef enum { NONE, ADD, SUBTRACT } item_count_op;
 
 /* Callback type for raxMutate. Receives current value (NULL if key doesn't
  * exist) and the passed through caller context. Returns new value (NULL to
@@ -271,13 +270,16 @@ typedef void *(*raxMutateCallback)(void *current_value, void *caller_context);
 
 uint32_t raxGetSubtreeItemCount(rax *rax, unsigned char *s, size_t len);
 int raxSeekSubTree(raxIterator *it, unsigned char *ele, size_t len);
-int raxMutate(rax *rax, unsigned char *s, size_t len, raxMutateCallback callback, void *caller_context, item_count_op op);
+int raxMutate(rax *rax, unsigned char *s, size_t len,
+              raxMutateCallback callback, void *caller_context,
+              item_count_op op);
 /* END SEARCH */
 
 /* Exported API. */
 rax *raxNew(void);
 int raxInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
-int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data, void **old);
+int raxTryInsert(rax *rax, unsigned char *s, size_t len, void *data,
+                 void **old);
 int raxRemove(rax *rax, unsigned char *s, size_t len, void **old);
 int raxFind(rax *rax, unsigned char *s, size_t len, void **value);
 void raxFree(rax *rax);
@@ -287,7 +289,8 @@ int raxSeek(raxIterator *it, const char *op, unsigned char *ele, size_t len);
 int raxNext(raxIterator *it);
 int raxPrev(raxIterator *it);
 int raxRandomWalk(raxIterator *it, size_t steps);
-int raxCompare(raxIterator *iter, const char *op, unsigned char *key, size_t key_len);
+int raxCompare(raxIterator *iter, const char *op, unsigned char *key,
+               size_t key_len);
 void raxStop(raxIterator *it);
 int raxEOF(raxIterator *it);
 void raxShow(rax *rax);

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -168,7 +168,7 @@ target_link_libraries(valkey_utils_test PRIVATE segment_tree)
 finalize_test_flags(valkey_utils_test)
 
 # 7. Text Index Test Suite
-add_executable(text_index_test 
+add_executable(text_index_test
     ${CMAKE_CURRENT_LIST_DIR}/flat_position_map_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/radix_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/rax_wrapper_test.cc
@@ -177,6 +177,15 @@ target_include_directories(text_index_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(text_index_test PRIVATE testing_common_base)
 target_link_libraries(text_index_test PRIVATE text)
 finalize_test_flags(text_index_test)
+
+# 8. Scoring Test Suite
+add_executable(scoring_test
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_session_test.cc)
+target_include_directories(scoring_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(scoring_test PRIVATE testing_common_base)
+target_link_libraries(scoring_test PRIVATE scoring)
+finalize_test_flags(scoring_test)
 
 # 8. Expr Test Suite
 add_subdirectory(expr)

--- a/testing/scoring/bm25std_scorer_test.cc
+++ b/testing/scoring/bm25std_scorer_test.cc
@@ -42,9 +42,7 @@ TEST(Bm25StdScorerTest, IdentityNameAndType) {
 }
 
 // One absolute-score reference against the corpus (doc:5 hello, F=4,
-// dl=4). Verified against Redis 7.4.7-oss. Failures here pinpoint the
-// scorer math; full per-doc score coverage lives in
-// scoring_session_test.cc.
+// dl=4).
 TEST(Bm25StdScorerTest, ScoreLeafCorpusReference) {
   Bm25StdScorer scorer;
   Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[4]);
@@ -94,10 +92,10 @@ TEST(Bm25StdScorerTest, IdfDifferentiatesByDt) {
 // hello despite doc:4 having a higher F.
 TEST(Bm25StdScorerTest, LengthNormalizationFavorsShorterDoc) {
   Bm25StdScorer scorer;
-  const double doc4 = scorer.ScoreLeaf(
-      test_data::StatsForHello(test_data::kDocs[3]), 1.0);
-  const double doc5 = scorer.ScoreLeaf(
-      test_data::StatsForHello(test_data::kDocs[4]), 1.0);
+  const double doc4 =
+      scorer.ScoreLeaf(test_data::StatsForHello(test_data::kDocs[3]), 1.0);
+  const double doc5 =
+      scorer.ScoreLeaf(test_data::StatsForHello(test_data::kDocs[4]), 1.0);
   EXPECT_GT(doc5, doc4);
 }
 

--- a/testing/scoring/bm25std_scorer_test.cc
+++ b/testing/scoring/bm25std_scorer_test.cc
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/bm25std_scorer.h"
+
+#include <limits>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+#include "testing/scoring/scoring_test_data.h"
+
+namespace valkey_search::indexes::scoring {
+namespace {
+
+constexpr double kFloatTolerance = 1e-4;
+
+// Ad-hoc Bm25StdStats builder for edge-case inputs that the shared
+// corpus in scoring_test_data.h cannot express (N=0, dt>N).
+Bm25StdStats MakeStats(uint64_t total_docs, double avg_doc_len,
+                       uint64_t num_doc_contain_term, uint32_t term_frequency,
+                       uint32_t doc_len, double document_score = 1.0) {
+  Bm25StdStats s;
+  s.total_docs = total_docs;
+  s.avg_doc_len = avg_doc_len;
+  s.num_doc_contain_term = num_doc_contain_term;
+  s.term_frequency = term_frequency;
+  s.doc_len = doc_len;
+  s.document_score = document_score;
+  return s;
+}
+
+TEST(Bm25StdScorerTest, IdentityNameAndType) {
+  Bm25StdScorer scorer;
+  EXPECT_EQ(scorer.Name(), "BM25STD");
+  EXPECT_EQ(scorer.Type(), ScorerType::kBm25Std);
+}
+
+// One absolute-score reference against the corpus (doc:5 hello, F=4,
+// dl=4). Verified against Redis 7.4.7-oss. Failures here pinpoint the
+// scorer math; full per-doc score coverage lives in
+// scoring_session_test.cc.
+TEST(Bm25StdScorerTest, ScoreLeafCorpusReference) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[4]);
+  EXPECT_NEAR(scorer.ScoreLeaf(stats, 1.0), 0.574385, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerTest, ScoreLeafLeafWeightScalesLinearly) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  const double base = scorer.ScoreLeaf(stats, 1.0);
+  EXPECT_NEAR(scorer.ScoreLeaf(stats, 5.0), 5.0 * base, kFloatTolerance);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 0.0), 0.0);
+}
+
+// Term absent from this doc (F=0): contributes 0.
+TEST(Bm25StdScorerTest, ScoreLeafZeroFrequencyReturnsZero) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForWorld(test_data::kDocs[4]);
+  ASSERT_EQ(stats.term_frequency, 0u);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 1.0), 0.0);
+}
+
+// Empty index (N=0, avg_doc_len=0): ScoreLeaf returns 0 instead of
+// dividing by zero.
+TEST(Bm25StdScorerTest, ScoreLeafEmptyIndexReturnsZero) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = MakeStats(/*N=*/0, /*avg_doc_len=*/0.0,
+                                 /*dt=*/0, /*F=*/0, /*doc_len=*/0);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 1.0), 0.0);
+}
+
+// IDF axis: rarer terms (lower dt) score higher than common ones at
+// matched-once-per-doc inputs.
+TEST(Bm25StdScorerTest, IdfDifferentiatesByDt) {
+  Bm25StdScorer scorer;
+  const double hello = scorer.ScoreLeaf(
+      test_data::StatsForHello(test_data::kDocs[0]), 1.0);  // dt=6
+  const double rare = scorer.ScoreLeaf(
+      test_data::StatsForRare(test_data::kDocs[5]), 1.0);  // dt=2
+  const double unique = scorer.ScoreLeaf(
+      test_data::StatsForUnique(test_data::kDocs[5]), 1.0);  // dt=1
+  EXPECT_GT(rare, hello);
+  EXPECT_GT(unique, rare);
+}
+
+// Length-norm axis: doc:5 (F=4, dl=4) outranks doc:4 (F=5, dl=9) on
+// hello despite doc:4 having a higher F.
+TEST(Bm25StdScorerTest, LengthNormalizationFavorsShorterDoc) {
+  Bm25StdScorer scorer;
+  const double doc4 = scorer.ScoreLeaf(
+      test_data::StatsForHello(test_data::kDocs[3]), 1.0);
+  const double doc5 = scorer.ScoreLeaf(
+      test_data::StatsForHello(test_data::kDocs[4]), 1.0);
+  EXPECT_GT(doc5, doc4);
+}
+
+TEST(Bm25StdScorerDeathTest, DtGreaterThanNCrashes) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = MakeStats(/*N=*/2, /*avg_doc_len=*/10.0,
+                                 /*dt=*/3, /*F=*/1, /*doc_len=*/10);
+  EXPECT_DEATH(scorer.ScoreLeaf(stats, 1.0), "");
+}
+
+TEST(Bm25StdScorerDeathTest, WrongStatsSubtypeCrashes) {
+  Bm25StdScorer scorer;
+  ScoringStats base_stats;
+  base_stats.total_docs = 10;
+  base_stats.num_doc_contain_term = 1;
+  base_stats.term_frequency = 1;
+  EXPECT_DEATH(scorer.ScoreLeaf(base_stats, 1.0), "");
+}
+
+TEST(Bm25StdScorerTest, ComposeMultipliesByDocumentScore) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  stats.document_score = 0.7;
+  EXPECT_NEAR(scorer.ComposeDocumentScore(0.5, stats), 0.5 * 0.7,
+              kFloatTolerance);
+}
+
+// Infinite document_score short-circuits to itself. std::isinf is
+// unreliable under -ffast-math, so the scorer uses a bit-pattern
+// check; this test guards both signs of the IsInf path.
+TEST(Bm25StdScorerTest, ComposeInfinityShortCircuits) {
+  Bm25StdScorer scorer;
+  const double kInf = std::numeric_limits<double>::infinity();
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  stats.document_score = kInf;
+  EXPECT_EQ(scorer.ComposeDocumentScore(0.5, stats), kInf);
+  stats.document_score = -kInf;
+  EXPECT_EQ(scorer.ComposeDocumentScore(0.5, stats), -kInf);
+}
+
+TEST(Bm25StdScorerTest, CombineGroupAppliesWeight) {
+  Bm25StdScorer scorer;
+  std::vector<double> children = {1.0, 2.0, 3.0};
+  EXPECT_NEAR(scorer.CombineGroup(children, /*group_weight=*/2.0), 12.0,
+              kFloatTolerance);
+}
+
+TEST(Bm25StdScorerTest, CombineGroupEmptyChildrenIsZero) {
+  Bm25StdScorer scorer;
+  EXPECT_EQ(scorer.CombineGroup({}, 5.0), 0.0);
+}
+
+}  // namespace
+}  // namespace valkey_search::indexes::scoring

--- a/testing/scoring/scoring_session_test.cc
+++ b/testing/scoring/scoring_session_test.cc
@@ -1,0 +1,336 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/scoring_session.h"
+
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/indexes/scoring/bm25std_scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+#include "testing/scoring/scoring_test_data.h"
+
+// Tests for ScoringSession driven against the shared 8-doc corpus in
+// testing/scoring/scoring_test_data.h.
+namespace valkey_search::indexes::scoring {
+namespace {
+
+using ::testing::ElementsAre;
+
+constexpr double kFloatTolerance = 1e-4;
+
+// Extract the doc_id sequence from a Rank() result for ranking
+// assertions that don't care about absolute scores.
+std::vector<DocId> RankOrder(const std::vector<RankedDoc>& ranked) {
+  std::vector<DocId> ids;
+  ids.reserve(ranked.size());
+  for (const auto& r : ranked) ids.push_back(r.doc_id);
+  return ids;
+}
+
+// Find the score for a specific doc_id in a Rank() result. Asserts the
+// doc is present.
+double ScoreFor(const std::vector<RankedDoc>& ranked, DocId id) {
+  for (const auto& r : ranked) {
+    if (r.doc_id == id) return r.score;
+  }
+  ADD_FAILURE() << "doc_id " << id << " not in ranked results";
+  return 0.0;
+}
+
+// Build a vector of Bm25StdStats for every doc in kDocs that has a
+// non-zero frequency for the named term. The vector is reserved up
+// front so pointers handed to RecordLeaf remain valid.
+template <typename Builder>
+std::vector<Bm25StdStats> BuildStatsForTerm(Builder builder) {
+  std::vector<Bm25StdStats> out;
+  out.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    Bm25StdStats s = builder(doc);
+    if (s.term_frequency > 0) out.push_back(s);
+  }
+  return out;
+}
+
+// ---- Normal-path tests ----
+
+// Single-leaf "hello" query: rank by length-normalized TF across
+// docs that contain "hello" at least once. Verifies rank order AND
+// absolute scores (Redis-verified).
+TEST(ScoringSessionTest, SingleLeafHelloRankOrder) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 1.0);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 5), 0.574385, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.523122, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.477286, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.430172, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.430172, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.331888, kFloatTolerance);
+}
+
+// Implicit AND `hello world`: only docs that contain both terms are
+// admitted. Each admitted doc is scored on both leaves; the session
+// accumulates per-doc.
+TEST(ScoringSessionTest, MultiLeafHelloWorld) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  // Admission filter: docs that have BOTH hello and world present.
+  std::vector<Bm25StdStats> hello_stats, world_stats;
+  hello_stats.reserve(std::size(test_data::kDocs));
+  world_stats.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello > 0 && doc.f_world > 0) {
+      hello_stats.push_back(test_data::StatsForHello(doc));
+      world_stats.push_back(test_data::StatsForWorld(doc));
+    }
+  }
+  for (size_t i = 0; i < hello_stats.size(); ++i) {
+    session.RecordLeaf(hello_stats[i], 1.0);
+    session.RecordLeaf(world_stats[i], 1.0);
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776, kFloatTolerance);
+}
+
+// Leaf weight scales every contribution linearly. `(hello)=>{$weight:5}`
+// must produce exactly 5x the single-leaf hello score, same ranking.
+TEST(ScoringSessionTest, LeafWeightScalesScore) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 5.0);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 5), 2.871923, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 2.615608, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 2.386431, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 2.150861, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 2.150861, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 1.659439, kFloatTolerance);
+}
+
+// `((hello)=>{$weight:4} (world)=>{$weight:3})=>{$weight:2}` — outer
+// group weight composes multiplicatively over per-leaf weights:
+//   final = 2 * (4*hello + 3*world)
+// Drives EnterGroup / ExitGroup once around two weighted leaves.
+TEST(ScoringSessionTest, NestedGroupsLayeredWeights) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> hello_stats, world_stats;
+  hello_stats.reserve(std::size(test_data::kDocs));
+  world_stats.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello > 0 && doc.f_world > 0) {
+      hello_stats.push_back(test_data::StatsForHello(doc));
+      world_stats.push_back(test_data::StatsForWorld(doc));
+    }
+  }
+
+  session.EnterGroup();
+  for (size_t i = 0; i < hello_stats.size(); ++i) {
+    session.RecordLeaf(hello_stats[i], 4.0);
+    session.RecordLeaf(world_stats[i], 3.0);
+  }
+  session.ExitGroup(2.0);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 5.695980, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 5.536520, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 5.286103, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 5.286103, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 4.646429, kFloatTolerance);
+}
+
+// `(hello world) | rare` — OR at the top, two distinct admission paths.
+// Each doc is scored only on the leaves matched on the path that
+// admitted it. doc:6 has `world` but enters via `rare`, so its `world`
+// token contributes nothing.
+TEST(ScoringSessionTest, OrAtTopMixedAdmissionPaths) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  // Persistent storage for the stats. Reserve up front so RecordLeaf's
+  // pointer stays valid across pushes.
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    const bool rare_branch = doc.f_rare > 0;
+    const bool and_branch = doc.f_hello > 0 && doc.f_world > 0;
+    if (rare_branch) {
+      all_stats.push_back(test_data::StatsForRare(doc));
+      session.RecordLeaf(all_stats.back(), 1.0);
+    } else if (and_branch) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 1.0);
+      all_stats.push_back(test_data::StatsForWorld(doc));
+      session.RecordLeaf(all_stats.back(), 1.0);
+    }
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(8, 6, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 8), 1.915183, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 6), 1.419164, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776, kFloatTolerance);
+}
+
+// `hello (world | rare)` — AND of leaf + OR group. None of the
+// admitted docs (1-4, 7) contain `rare`, so the OR group contributes
+// only `world`. Final scores match plain `hello world`.
+TEST(ScoringSessionTest, AndOfLeafAndOrGroup) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    const bool or_match = doc.f_world > 0 || doc.f_rare > 0;
+    if (doc.f_hello > 0 && or_match) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 1.0);
+      session.EnterGroup();
+      if (doc.f_world > 0) {
+        all_stats.push_back(test_data::StatsForWorld(doc));
+        session.RecordLeaf(all_stats.back(), 1.0);
+      }
+      if (doc.f_rare > 0) {
+        all_stats.push_back(test_data::StatsForRare(doc));
+        session.RecordLeaf(all_stats.back(), 1.0);
+      }
+      session.ExitGroup(1.0);
+    }
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776, kFloatTolerance);
+}
+
+// `((hello)=>{$weight:4} | (rare)=>{$weight:2})=>{$weight:3}` — the
+// only test that exercises both per-leaf weights and an outer group
+// weight in composition. Each admitted doc is scored on whichever
+// leaves matched, weighted accordingly:
+//   final = 3 * (4*hello if matched + 2*rare if matched)
+// doc:6 has `world` but `world` is not in the query, so it isn't
+// scored. doc:8 (rare-only) ranks highest because rare's IDF dominates.
+TEST(ScoringSessionTest, PerLeafWeightInsideOrWithGroupWeight) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello == 0 && doc.f_rare == 0) continue;
+    session.EnterGroup();
+    if (doc.f_hello > 0) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 4.0);
+    }
+    if (doc.f_rare > 0) {
+      all_stats.push_back(test_data::StatsForRare(doc));
+      session.RecordLeaf(all_stats.back(), 2.0);
+    }
+    session.ExitGroup(3.0);
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(8, 6, 5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 8), 11.491096, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 6), 8.514985, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 5), 6.892615, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 6.277460, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 5.727435, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 5.162066, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 5.162066, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 3.982653, kFloatTolerance);
+}
+
+// Empty result: no leaves recorded, Rank() returns an empty vector.
+TEST(ScoringSessionTest, NonExistentTermEmpty) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto ranked = session.Rank();
+  EXPECT_TRUE(ranked.empty());
+}
+
+// Docs with byte-identical scoring inputs (doc:2 vs doc:7 on `hello`)
+// must be tie-broken by doc_id ascending.
+TEST(ScoringSessionTest, TiesBrokenByDocIdAscending) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 1.0);
+
+  auto ranked = session.Rank();
+  // Find the positions of doc:2 and doc:7 in the ranking.
+  int pos2 = -1, pos7 = -1;
+  for (size_t i = 0; i < ranked.size(); ++i) {
+    if (ranked[i].doc_id == 2) pos2 = static_cast<int>(i);
+    if (ranked[i].doc_id == 7) pos7 = static_cast<int>(i);
+  }
+  ASSERT_NE(pos2, -1);
+  ASSERT_NE(pos7, -1);
+  EXPECT_LT(pos2, pos7);
+  EXPECT_DOUBLE_EQ(ranked[pos2].score, ranked[pos7].score);
+}
+
+// ---- Death tests: contract violations ----
+
+TEST(ScoringSessionDeathTest, RecordLeafAfterRankCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  (void)session.Rank();
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  EXPECT_DEATH(session.RecordLeaf(stats, 1.0), "");
+}
+
+TEST(ScoringSessionDeathTest, ExitGroupWithoutEnterCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  EXPECT_DEATH(session.ExitGroup(1.0), "");
+}
+
+TEST(ScoringSessionDeathTest, RankWithUnbalancedStackCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  session.EnterGroup();
+  EXPECT_DEATH((void)session.Rank(), "");
+}
+
+TEST(ScoringSessionDeathTest, NullScorerCrashes) {
+  EXPECT_DEATH({ ScoringSession session(nullptr); }, "");
+}
+
+}  // namespace
+}  // namespace valkey_search::indexes::scoring

--- a/testing/scoring/scoring_test_data.h
+++ b/testing/scoring/scoring_test_data.h
@@ -53,14 +53,9 @@ struct DocInfo {
 //   doc:8    Only "rare" with doc_len=1; extreme-short-doc shape for
 //            length norm at dt=2.
 inline constexpr DocInfo kDocs[] = {
-    {1, 5, 1, 1, 0, 0},
-    {2, 6, 2, 1, 0, 0},
-    {3, 7, 3, 1, 0, 0},
-    {4, 9, 5, 1, 0, 0},
-    {5, 4, 4, 0, 0, 0},
-    {6, 4, 0, 1, 1, 1},
-    {7, 6, 2, 1, 0, 0},
-    {8, 1, 0, 0, 1, 0},
+    {1, 5, 1, 1, 0, 0}, {2, 6, 2, 1, 0, 0}, {3, 7, 3, 1, 0, 0},
+    {4, 9, 5, 1, 0, 0}, {5, 4, 4, 0, 0, 0}, {6, 4, 0, 1, 1, 1},
+    {7, 6, 2, 1, 0, 0}, {8, 1, 0, 0, 1, 0},
 };
 
 // Per-term Bm25StdStats builders. Each fills the index-wide constants

--- a/testing/scoring/scoring_test_data.h
+++ b/testing/scoring/scoring_test_data.h
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_
+#define VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_
+
+#include <cstdint>
+
+#include "src/indexes/scoring/scoring_stats.h"
+
+// Shared test data for Bm25StdScorer and ScoringSession unit tests.
+namespace valkey_search::indexes::scoring::test_data {
+
+// Index-wide constants for the corpus below.
+inline constexpr uint64_t kTotalDocs = 8;
+// total_doc_len = 5+6+7+9+4+4+6+1 = 42; avg = 42 / 8 = 5.25.
+inline constexpr double kAvgDocLen = 5.25;
+inline constexpr uint64_t kDtHello = 6;
+inline constexpr uint64_t kDtWorld = 6;
+inline constexpr uint64_t kDtRare = 2;
+inline constexpr uint64_t kDtUnique = 1;
+
+// Per-document fixed inputs. f_<term> is the doc-wide term frequency
+// for that term in this doc; 0 means the term is absent.
+struct DocInfo {
+  uint64_t doc_id;
+  uint32_t doc_len;
+  uint32_t f_hello;
+  uint32_t f_world;
+  uint32_t f_rare;
+  uint32_t f_unique;
+};
+
+// 8-doc corpus. Each row is one document; columns match DocInfo above:
+//   {doc_id, doc_len, f_hello, f_world, f_rare, f_unique}
+// where f_<term> is the doc-wide term frequency (0 = term absent).
+//
+// Each doc earns its slot by isolating one scoring axis:
+//   doc:1-4  F sweep at growing doc_len for "hello"; tests TF saturation
+//            and length normalization together.
+//   doc:4 vs doc:5
+//            Different F (5 vs 4) and very different doc_len (9 vs 4);
+//            doc:5 must outrank doc:4 on "hello" (length norm dominates).
+//   doc:5    Missing "world"; supports OR-partial-match queries.
+//   doc:6    Missing "hello"; introduces low-dt terms ("rare" dt=2,
+//            "unique" dt=1) to exercise high IDF.
+//   doc:7    Byte-identical scoring inputs to doc:2; tests tie-break
+//            by doc_id ascending.
+//   doc:8    Only "rare" with doc_len=1; extreme-short-doc shape for
+//            length norm at dt=2.
+inline constexpr DocInfo kDocs[] = {
+    {1, 5, 1, 1, 0, 0},
+    {2, 6, 2, 1, 0, 0},
+    {3, 7, 3, 1, 0, 0},
+    {4, 9, 5, 1, 0, 0},
+    {5, 4, 4, 0, 0, 0},
+    {6, 4, 0, 1, 1, 1},
+    {7, 6, 2, 1, 0, 0},
+    {8, 1, 0, 0, 1, 0},
+};
+
+// Per-term Bm25StdStats builders. Each fills the index-wide constants
+// above plus the per-doc fields from `doc`. Callers may overwrite
+// individual fields after construction (e.g. document_score).
+inline Bm25StdStats StatsForHello(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "hello";
+  s.num_doc_contain_term = kDtHello;
+  s.term_frequency = doc.f_hello;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForWorld(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "world";
+  s.num_doc_contain_term = kDtWorld;
+  s.term_frequency = doc.f_world;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForRare(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "rare";
+  s.num_doc_contain_term = kDtRare;
+  s.term_frequency = doc.f_rare;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForUnique(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "unique";
+  s.num_doc_contain_term = kDtUnique;
+  s.term_frequency = doc.f_unique;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+}  // namespace valkey_search::indexes::scoring::test_data
+
+#endif  // VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_


### PR DESCRIPTION
  ## Summary

  Adds the math + per-query collection layer for BM25STD scoring.
  Algorithm-agnostic `Scorer` / `ScoringStats` interfaces so TFIDF
  (and later tag / numeric scorers) can plug in without changes.
  Driving the session from the predicate tree is a follow-up.

  ## Changes

  - `src/indexes/scoring/scoring_stats.h` — `ScoringStats` base +
    `Bm25StdStats` / `TfidfStats` subclasses
  - `src/indexes/scoring/scorer.{h,cc}` — `Scorer` interface,
    default `CombineGroup`
  - `src/indexes/scoring/bm25std_scorer.{h,cc}` — Okapi BM25
    (k1=1.2, b=0.75). Uses a bit-pattern `IsInf` because
    `-ffast-math` makes `std::isinf` unreliable.
  - `src/indexes/scoring/scoring_session.{h,cc}` — per-query
    collector. `RecordLeaf` / `EnterGroup` / `ExitGroup` / `Rank`.
  - Wired as `scoring` static lib in `src/indexes/CMakeLists.txt`.

  ## Tests

  New `scoring_test` binary (26 tests, all pass):

  - `testing/scoring/scoring_test_data.h` — shared 8-doc, 4-term
    corpus designed to isolate TF saturation, length norm, IDF
    differentiation, tie-break, partial-match admission.
  - `testing/scoring/bm25std_scorer_test.cc` — scorer math,
    edge cases, death tests for invariant violations.
  - `testing/scoring/scoring_session_test.cc` — all query shapes
    the corpus unlocks (single leaf, AND, OR, weighted/nested
    groups, mixed admission, ties). Absolute scores verified
    against Redis 8.6 docker.