### PR TITLE
Add pre-compute for text scoring

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -641,14 +641,8 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
                                       MutatedAttributes &mutated_attributes,
                                       const Key &key) {
   if (text_index_schema_) {
-    // Decrement total_doc_len by the old document length before deleting
-    auto old_info_itr = index_key_info_.find(key);
-    if (old_info_itr != index_key_info_.end()) {
-      text_index_schema_->GetMetadata().total_doc_len -=
-          old_info_itr->second.doc_len;
-    }
     // Always clean up indexed words from all text attributes of the key up
-    // front
+    // front. DeleteKeyData also decrements total_doc_len internally.
     text_index_schema_->DeleteKeyData(key);
   }
   bool all_deletes = true;
@@ -673,15 +667,9 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
   }
   if (text_index_schema_) {
     // Text index structures operate at the schema-level so we commit the
-    // updates to all Text attributes in one operation for efficiency
-    auto result = text_index_schema_->CommitKeyData(key);
-    if (!all_deletes) {
-      auto info_itr = index_key_info_.find(key);
-      if (info_itr != index_key_info_.end()) {
-        info_itr->second.doc_len = result.doc_len;
-        info_itr->second.norm = result.norm;
-      }
-    }
+    // updates to all Text attributes in one operation for efficiency.
+    // CommitKeyData stores doc_len/norm in TextIndexSchema internally.
+    text_index_schema_->CommitKeyData(key);
   }
 }
 

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -641,6 +641,12 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
                                       MutatedAttributes &mutated_attributes,
                                       const Key &key) {
   if (text_index_schema_) {
+    // Decrement total_doc_len by the old document length before deleting
+    auto old_info_itr = index_key_info_.find(key);
+    if (old_info_itr != index_key_info_.end()) {
+      text_index_schema_->GetMetadata().total_doc_len -=
+          old_info_itr->second.doc_len;
+    }
     // Always clean up indexed words from all text attributes of the key up
     // front
     text_index_schema_->DeleteKeyData(key);
@@ -668,7 +674,11 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
   if (text_index_schema_) {
     // Text index structures operate at the schema-level so we commit the
     // updates to all Text attributes in one operation for efficiency
-    text_index_schema_->CommitKeyData(key);
+    auto result = text_index_schema_->CommitKeyData(key);
+    if (!all_deletes) {
+      index_key_info_[key].doc_len = result.doc_len;
+      index_key_info_[key].norm = result.norm;
+    }
   }
 }
 

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -676,8 +676,11 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
     // updates to all Text attributes in one operation for efficiency
     auto result = text_index_schema_->CommitKeyData(key);
     if (!all_deletes) {
-      index_key_info_[key].doc_len = result.doc_len;
-      index_key_info_[key].norm = result.norm;
+      auto info_itr = index_key_info_.find(key);
+      if (info_itr != index_key_info_.end()) {
+        info_itr->second.doc_len = result.doc_len;
+        info_itr->second.norm = result.norm;
+      }
     }
   }
 }

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -91,6 +91,8 @@ class IndexSchema : public KeyspaceEventSubscription,
   struct IndexKeyInfo {
     MutationSequenceNumber mutation_sequence_number_{0};
     float document_score{kDefaultDocumentScore};
+    uint32_t doc_len{0};  // Total indexed terms in this document
+    uint32_t norm{0};     // Max term frequency of any word in this document
   };
 
   using IndexKeyInfoMap = absl::flat_hash_map<Key, IndexKeyInfo>;
@@ -192,6 +194,32 @@ class IndexSchema : public KeyspaceEventSubscription,
       return score_;
     }
     return itr->second.document_score;
+  }
+
+  uint32_t GetDocumentLength(const Key &key) const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    auto itr = index_key_info_.find(key);
+    if (itr == index_key_info_.end()) {
+      return 0;
+    }
+    return itr->second.doc_len;
+  }
+
+  uint32_t GetDocumentNorm(const Key &key) const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    auto itr = index_key_info_.find(key);
+    if (itr == index_key_info_.end()) {
+      return 0;
+    }
+    return itr->second.norm;
+  }
+
+  uint64_t GetTotalDocumentLength() const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    if (!text_index_schema_) {
+      return 0;
+    }
+    return text_index_schema_->GetMetadata().total_doc_len.load();
   }
 
   void CreateTextIndexSchema() {

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -91,8 +91,6 @@ class IndexSchema : public KeyspaceEventSubscription,
   struct IndexKeyInfo {
     MutationSequenceNumber mutation_sequence_number_{0};
     float document_score{kDefaultDocumentScore};
-    uint32_t doc_len{0};  // Total indexed terms in this document
-    uint32_t norm{0};     // Max term frequency of any word in this document
   };
 
   using IndexKeyInfoMap = absl::flat_hash_map<Key, IndexKeyInfo>;
@@ -198,20 +196,18 @@ class IndexSchema : public KeyspaceEventSubscription,
 
   uint32_t GetDocumentLength(const Key &key) const
       ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
-    auto itr = index_key_info_.find(key);
-    if (itr == index_key_info_.end()) {
+    if (!text_index_schema_) {
       return 0;
     }
-    return itr->second.doc_len;
+    return text_index_schema_->GetKeyDocLen(key);
   }
 
   uint32_t GetDocumentNorm(const Key &key) const
       ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
-    auto itr = index_key_info_.find(key);
-    if (itr == index_key_info_.end()) {
+    if (!text_index_schema_) {
       return 0;
     }
-    return itr->second.norm;
+    return text_index_schema_->GetKeyNorm(key);
   }
 
   uint64_t GetTotalDocumentLength() const

--- a/src/indexes/text/flat_position_map.cc
+++ b/src/indexes/text/flat_position_map.cc
@@ -18,7 +18,7 @@
 namespace {
 
 // Read fixed-length unsigned int (little-endian) helper
-inline uint32_t ReadVarUint(const char *ptr, uint8_t num_bytes) {
+inline uint32_t ReadVarUint(const char* ptr, uint8_t num_bytes) {
   uint32_t value = 0;
   for (uint8_t i = 0; i < num_bytes; ++i) {
     value |= (static_cast<uint32_t>(static_cast<uint8_t>(ptr[i])) << (i * 8));
@@ -60,7 +60,7 @@ inline char C(uint8_t v) { return static_cast<char>(v); }
 // Encoding scheme: bit 7 = 1 (continue), bit 7 = 0 (end/last byte)
 template <typename T>
 static inline void EncodeValue(
-    absl::InlinedVector<char, kPartitionSize> &buffer, T value,
+    absl::InlinedVector<char, kPartitionSize>& buffer, T value,
     bool is_position) {
   __uint128_t v = (U128(value) << 1) | __uint128_t(is_position);
 
@@ -79,7 +79,7 @@ static inline void EncodeValue(
 // Decode: big-endian, continuation bytes bit 7=1, last byte bit 7=0
 // Returns pair of (decoded_value, is_position)
 template <typename T>
-static inline std::pair<T, bool> DecodeValue(const char *&ptr) {
+static inline std::pair<T, bool> DecodeValue(const char*& ptr) {
   // Read first byte (should not be terminator)
   CHECK(U8(*ptr) != kTerminatorByte) << "Attempted to decode terminator byte";
 
@@ -104,8 +104,8 @@ static inline std::pair<T, bool> DecodeValue(const char *&ptr) {
 //=============================================================================
 
 // Static factory and destroyer
-FlatPositionMap *FlatPositionMap::Create(
-    const absl::btree_map<Position, FieldMask> &position_map,
+FlatPositionMap* FlatPositionMap::Create(
+    const absl::btree_map<Position, FieldMask>& position_map,
     size_t num_text_fields) {
   CHECK(!position_map.empty())
       << "Cannot create FlatPositionMap from empty position_map";
@@ -129,7 +129,7 @@ FlatPositionMap *FlatPositionMap::Create(
   bool is_partition_start = true;
 
   // Encode: [field_mask (if changed)][position]...
-  for (const auto &[pos, field_mask] : position_map) {
+  for (const auto& [pos, field_mask] : position_map) {
     // Check for new partition boundary
     if (position_data.size() >=
             (partition_byte_offsets.size() + 1) * kPartitionSize &&
@@ -174,8 +174,8 @@ FlatPositionMap *FlatPositionMap::Create(
   size_t total_size = sizeof(FlatPositionMap) + data_size;
 
   // Allocate single block: [FlatPositionMap | data...]
-  void *mem = operator new(total_size);
-  auto *map = new (mem) FlatPositionMap();
+  void* mem = operator new(total_size);
+  auto* map = new (mem) FlatPositionMap();
 
   // Initialize header fields
   map->header_scheme_ = 0;
@@ -185,7 +185,7 @@ FlatPositionMap *FlatPositionMap::Create(
   map->unused_ = 0;
 
   // Write data immediately after struct
-  char *p = map->data();
+  char* p = map->data();
 
   // Write pre-computed term frequency first (4 bytes, little-endian)
   std::memcpy(p, &term_frequency, kTermFrequencyBytes);
@@ -208,7 +208,7 @@ FlatPositionMap *FlatPositionMap::Create(
   return map;
 }
 
-void FlatPositionMap::Destroy(FlatPositionMap *map) {
+void FlatPositionMap::Destroy(FlatPositionMap* map) {
   if (!map) return;
   map->~FlatPositionMap();
   operator delete(map);
@@ -226,7 +226,7 @@ uint8_t FlatPositionMap::BytesNeeded(uint32_t value) {
 }
 
 std::pair<uint32_t, uint32_t> FlatPositionMap::ReadCounts(
-    const char *&p) const {
+    const char*& p) const {
   uint32_t num_positions = ReadVarUint(p, pos_bytes_ + 1);
   p += pos_bytes_ + 1;
   uint32_t num_partitions = ReadVarUint(p, part_bytes_ + 1);
@@ -234,7 +234,7 @@ std::pair<uint32_t, uint32_t> FlatPositionMap::ReadCounts(
   return {num_positions, num_partitions};
 }
 
-void FlatPositionMap::WriteCounts(char *&p, uint32_t num_positions,
+void FlatPositionMap::WriteCounts(char*& p, uint32_t num_positions,
                                   uint32_t num_partitions) const {
   std::memcpy(p, &num_positions, pos_bytes_ + 1);
   p += pos_bytes_ + 1;
@@ -246,7 +246,7 @@ void FlatPositionMap::WriteCounts(char *&p, uint32_t num_positions,
 // Iterator Implementation
 //=============================================================================
 
-PositionIterator::PositionIterator(const FlatPositionMap &flat_map)
+PositionIterator::PositionIterator(const FlatPositionMap& flat_map)
     : flat_map_(flat_map.data() + kTermFrequencyBytes),
       current_ptr_(nullptr),
       data_start_(nullptr),
@@ -259,7 +259,7 @@ PositionIterator::PositionIterator(const FlatPositionMap &flat_map)
   CHECK(flat_map_)
       << "Cannot create PositionIterator from null FlatPositionMap";
 
-  const char *p = flat_map_;
+  const char* p = flat_map_;
   auto [num_positions, num_partitions] = flat_map.ReadCounts(p);
   CHECK(num_positions > 0)
       << "Cannot create PositionIterator from FlatPositionMap with 0 positions";
@@ -296,7 +296,7 @@ void PositionIterator::NextPosition() {
 
     // Load next partition offset (or UINT32_MAX if no more partitions)
     if (current_partition_idx_ < num_partitions_) {
-      const char *partition_map = flat_map_ + header_size_;
+      const char* partition_map = flat_map_ + header_size_;
       next_partition_offset_ = ReadVarUint(
           partition_map + (current_partition_idx_ * kPartitionDeltaBytes * 2),
           kPartitionDeltaBytes);
@@ -321,7 +321,7 @@ void PositionIterator::NextPosition() {
 }
 
 // Binary search to find partition index before target position
-uint32_t PositionIterator::FindPartitionForTarget(const char *partition_map,
+uint32_t PositionIterator::FindPartitionForTarget(const char* partition_map,
                                                   uint32_t num_partitions,
                                                   Position target) {
   uint32_t left = 0, right = num_partitions;
@@ -359,7 +359,7 @@ bool PositionIterator::SkipForwardPosition(Position target) {
 
   // Jump to partition if beneficial
   if (IsValid() && num_partitions_) {
-    const char *partition_map = flat_map_ + header_size_;
+    const char* partition_map = flat_map_ + header_size_;
     uint32_t partition_idx =
         FindPartitionForTarget(partition_map, num_partitions_, target);
 
@@ -400,13 +400,13 @@ uint64_t PositionIterator::GetFieldMask() const { return current_field_mask_; }
 //=============================================================================
 
 uint32_t FlatPositionMap::CountPositions() const {
-  const char *p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
+  const char* p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [num_positions, _] = ReadCounts(p);
   return num_positions;
 }
 
 uint32_t FlatPositionMap::GetNumPartitions() const {
-  const char *p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
+  const char* p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [_, num_partitions] = ReadCounts(p);
   return num_partitions;
 }
@@ -418,9 +418,9 @@ size_t FlatPositionMap::GetTermFrequency() const {
 }
 
 size_t FlatPositionMap::ComputeTermFrequency(
-    const absl::btree_map<Position, FieldMask> &position_map) {
+    const absl::btree_map<Position, FieldMask>& position_map) {
   size_t total_frequency = 0;
-  for (const auto &[pos, field_mask] : position_map) {
+  for (const auto& [pos, field_mask] : position_map) {
     total_frequency += __builtin_popcountll(field_mask.GetMask());
   }
   return total_frequency;

--- a/src/indexes/text/flat_position_map.cc
+++ b/src/indexes/text/flat_position_map.cc
@@ -18,7 +18,7 @@
 namespace {
 
 // Read fixed-length unsigned int (little-endian) helper
-inline uint32_t ReadVarUint(const char* ptr, uint8_t num_bytes) {
+inline uint32_t ReadVarUint(const char *ptr, uint8_t num_bytes) {
   uint32_t value = 0;
   for (uint8_t i = 0; i < num_bytes; ++i) {
     value |= (static_cast<uint32_t>(static_cast<uint8_t>(ptr[i])) << (i * 8));
@@ -37,6 +37,7 @@ constexpr uint8_t kSevenBitMask = 0x7F;    // Bits 0-6: data
 constexpr uint8_t kBitsPerByte = 7;        // 7 bits of data per byte
 constexpr uint8_t kTerminatorByte = 0x00;  // Terminator byte
 constexpr uint8_t kPartitionDeltaBytes = 4;
+constexpr size_t kTermFrequencyBytes = 4;  // Pre-computed TF stored at start
 
 // Type conversion helpers
 inline uint8_t U8(char c) { return static_cast<uint8_t>(c); }
@@ -59,7 +60,7 @@ inline char C(uint8_t v) { return static_cast<char>(v); }
 // Encoding scheme: bit 7 = 1 (continue), bit 7 = 0 (end/last byte)
 template <typename T>
 static inline void EncodeValue(
-    absl::InlinedVector<char, kPartitionSize>& buffer, T value,
+    absl::InlinedVector<char, kPartitionSize> &buffer, T value,
     bool is_position) {
   __uint128_t v = (U128(value) << 1) | __uint128_t(is_position);
 
@@ -78,7 +79,7 @@ static inline void EncodeValue(
 // Decode: big-endian, continuation bytes bit 7=1, last byte bit 7=0
 // Returns pair of (decoded_value, is_position)
 template <typename T>
-static inline std::pair<T, bool> DecodeValue(const char*& ptr) {
+static inline std::pair<T, bool> DecodeValue(const char *&ptr) {
   // Read first byte (should not be terminator)
   CHECK(U8(*ptr) != kTerminatorByte) << "Attempted to decode terminator byte";
 
@@ -103,11 +104,17 @@ static inline std::pair<T, bool> DecodeValue(const char*& ptr) {
 //=============================================================================
 
 // Static factory and destroyer
-FlatPositionMap* FlatPositionMap::Create(
-    const absl::btree_map<Position, FieldMask>& position_map,
+FlatPositionMap *FlatPositionMap::Create(
+    const absl::btree_map<Position, FieldMask> &position_map,
     size_t num_text_fields) {
   CHECK(!position_map.empty())
       << "Cannot create FlatPositionMap from empty position_map";
+
+  // Pre-compute term frequency from the position map
+  size_t tf = ComputeTermFrequency(position_map);
+  CHECK_LE(tf, static_cast<size_t>(UINT32_MAX))
+      << "Term frequency exceeds FlatPositionMap storage";
+  uint32_t term_frequency = static_cast<uint32_t>(tf);
 
   // First pass: compute data size (same logic as old constructor)
   uint32_t num_positions = position_map.size();
@@ -122,7 +129,7 @@ FlatPositionMap* FlatPositionMap::Create(
   bool is_partition_start = true;
 
   // Encode: [field_mask (if changed)][position]...
-  for (const auto& [pos, field_mask] : position_map) {
+  for (const auto &[pos, field_mask] : position_map) {
     // Check for new partition boundary
     if (position_data.size() >=
             (partition_byte_offsets.size() + 1) * kPartitionSize &&
@@ -162,12 +169,13 @@ FlatPositionMap* FlatPositionMap::Create(
   uint8_t part_bytes = BytesNeeded(num_partitions) - 1;
   size_t partition_map_size = num_partitions * kPartitionDeltaBytes * 2;
   size_t counts_size = (pos_bytes + 1) + (part_bytes + 1);
-  size_t data_size = counts_size + partition_map_size + position_data.size();
+  size_t data_size = kTermFrequencyBytes + counts_size + partition_map_size +
+                     position_data.size();
   size_t total_size = sizeof(FlatPositionMap) + data_size;
 
   // Allocate single block: [FlatPositionMap | data...]
-  void* mem = operator new(total_size);
-  auto* map = new (mem) FlatPositionMap();
+  void *mem = operator new(total_size);
+  auto *map = new (mem) FlatPositionMap();
 
   // Initialize header fields
   map->header_scheme_ = 0;
@@ -177,7 +185,11 @@ FlatPositionMap* FlatPositionMap::Create(
   map->unused_ = 0;
 
   // Write data immediately after struct
-  char* p = map->data();
+  char *p = map->data();
+
+  // Write pre-computed term frequency first (4 bytes, little-endian)
+  std::memcpy(p, &term_frequency, kTermFrequencyBytes);
+  p += kTermFrequencyBytes;
 
   // Write counts
   map->WriteCounts(p, num_positions, num_partitions);
@@ -196,7 +208,7 @@ FlatPositionMap* FlatPositionMap::Create(
   return map;
 }
 
-void FlatPositionMap::Destroy(FlatPositionMap* map) {
+void FlatPositionMap::Destroy(FlatPositionMap *map) {
   if (!map) return;
   map->~FlatPositionMap();
   operator delete(map);
@@ -214,7 +226,7 @@ uint8_t FlatPositionMap::BytesNeeded(uint32_t value) {
 }
 
 std::pair<uint32_t, uint32_t> FlatPositionMap::ReadCounts(
-    const char*& p) const {
+    const char *&p) const {
   uint32_t num_positions = ReadVarUint(p, pos_bytes_ + 1);
   p += pos_bytes_ + 1;
   uint32_t num_partitions = ReadVarUint(p, part_bytes_ + 1);
@@ -222,7 +234,7 @@ std::pair<uint32_t, uint32_t> FlatPositionMap::ReadCounts(
   return {num_positions, num_partitions};
 }
 
-void FlatPositionMap::WriteCounts(char*& p, uint32_t num_positions,
+void FlatPositionMap::WriteCounts(char *&p, uint32_t num_positions,
                                   uint32_t num_partitions) const {
   std::memcpy(p, &num_positions, pos_bytes_ + 1);
   p += pos_bytes_ + 1;
@@ -234,8 +246,8 @@ void FlatPositionMap::WriteCounts(char*& p, uint32_t num_positions,
 // Iterator Implementation
 //=============================================================================
 
-PositionIterator::PositionIterator(const FlatPositionMap& flat_map)
-    : flat_map_(flat_map.data()),
+PositionIterator::PositionIterator(const FlatPositionMap &flat_map)
+    : flat_map_(flat_map.data() + kTermFrequencyBytes),
       current_ptr_(nullptr),
       data_start_(nullptr),
       cumulative_position_(0),
@@ -247,7 +259,7 @@ PositionIterator::PositionIterator(const FlatPositionMap& flat_map)
   CHECK(flat_map_)
       << "Cannot create PositionIterator from null FlatPositionMap";
 
-  const char* p = flat_map_;
+  const char *p = flat_map_;
   auto [num_positions, num_partitions] = flat_map.ReadCounts(p);
   CHECK(num_positions > 0)
       << "Cannot create PositionIterator from FlatPositionMap with 0 positions";
@@ -284,7 +296,7 @@ void PositionIterator::NextPosition() {
 
     // Load next partition offset (or UINT32_MAX if no more partitions)
     if (current_partition_idx_ < num_partitions_) {
-      const char* partition_map = flat_map_ + header_size_;
+      const char *partition_map = flat_map_ + header_size_;
       next_partition_offset_ = ReadVarUint(
           partition_map + (current_partition_idx_ * kPartitionDeltaBytes * 2),
           kPartitionDeltaBytes);
@@ -309,7 +321,7 @@ void PositionIterator::NextPosition() {
 }
 
 // Binary search to find partition index before target position
-uint32_t PositionIterator::FindPartitionForTarget(const char* partition_map,
+uint32_t PositionIterator::FindPartitionForTarget(const char *partition_map,
                                                   uint32_t num_partitions,
                                                   Position target) {
   uint32_t left = 0, right = num_partitions;
@@ -347,7 +359,7 @@ bool PositionIterator::SkipForwardPosition(Position target) {
 
   // Jump to partition if beneficial
   if (IsValid() && num_partitions_) {
-    const char* partition_map = flat_map_ + header_size_;
+    const char *partition_map = flat_map_ + header_size_;
     uint32_t partition_idx =
         FindPartitionForTarget(partition_map, num_partitions_, target);
 
@@ -388,21 +400,28 @@ uint64_t PositionIterator::GetFieldMask() const { return current_field_mask_; }
 //=============================================================================
 
 uint32_t FlatPositionMap::CountPositions() const {
-  const char* p = data();
+  const char *p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [num_positions, _] = ReadCounts(p);
   return num_positions;
 }
 
 uint32_t FlatPositionMap::GetNumPartitions() const {
-  const char* p = data();
+  const char *p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [_, num_partitions] = ReadCounts(p);
   return num_partitions;
 }
 
-size_t FlatPositionMap::CountTermFrequency() const {
+size_t FlatPositionMap::GetTermFrequency() const {
+  uint32_t tf = 0;
+  std::memcpy(&tf, data(), kTermFrequencyBytes);
+  return static_cast<size_t>(tf);
+}
+
+size_t FlatPositionMap::ComputeTermFrequency(
+    const absl::btree_map<Position, FieldMask> &position_map) {
   size_t total_frequency = 0;
-  for (PositionIterator iter(*this); iter.IsValid(); iter.NextPosition()) {
-    total_frequency += __builtin_popcountll(iter.GetFieldMask());
+  for (const auto &[pos, field_mask] : position_map) {
+    total_frequency += __builtin_popcountll(field_mask.GetMask());
   }
   return total_frequency;
 }

--- a/src/indexes/text/flat_position_map.h
+++ b/src/indexes/text/flat_position_map.h
@@ -85,10 +85,16 @@ class FlatPositionMap {
   // Get partition count
   uint32_t GetNumPartitions() const;
 
-  // Get total term frequency
-  size_t CountTermFrequency() const;
+  // Get total term frequency (pre-computed during Create, O(1) lookup)
+  size_t GetTermFrequency() const;
+
+  // Compute term frequency by iterating (used internally during Create)
+  static size_t ComputeTermFrequency(
+      const absl::btree_map<Position, FieldMask>& position_map);
 
   // Access to raw data pointer (stored immediately after this object)
+  // Layout: [term_frequency (4 bytes)] [header counts] [partition map]
+  // [position data]
   inline char* data() { return reinterpret_cast<char*>(this + 1); }
 
   inline const char* data() const {

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -69,7 +69,7 @@ void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
 
   // Use member functions to get counts
   size_t position_count = flat_map->CountPositions();
-  size_t term_frequency = flat_map->CountTermFrequency();
+  size_t term_frequency = flat_map->GetTermFrequency();
 
   metadata->total_positions -= position_count;
   metadata->total_term_frequency -= term_frequency;
@@ -94,7 +94,7 @@ size_t Postings::GetPositionCount() const {
 size_t Postings::GetTotalTermFrequency() const {
   size_t total_frequency = 0;
   for (const auto& [key, flat_map] : key_to_positions_) {
-    total_frequency += flat_map->CountTermFrequency();
+    total_frequency += flat_map->GetTermFrequency();
   }
   return total_frequency;
 }

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -289,25 +289,29 @@ TextIndexSchema::CommitResult TextIndexSchema::CommitKeyData(
     }
   }
 
-  // Map the key to the newly created per-key index
+  // Map the key to the newly created per-key index and scoring info
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
+    per_key_scoring_info_[key] = {doc_len, norm};
+    metadata_.total_doc_len += doc_len;
   }
 
-  // Update total document length for avg_doc_len computation
-  metadata_.total_doc_len += doc_len;
   return {doc_len, norm};
 }
 
 void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
-  // Extract the per-key index
+  // Extract the per-key index and scoring info
   absl::node_hash_map<Key, TextIndex>::node_type node;
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     node = per_key_text_indexes_.extract(key);
     if (node.empty()) {
       return;
+    }
+    auto scoring_node = per_key_scoring_info_.extract(key);
+    if (!scoring_node.empty()) {
+      metadata_.total_doc_len -= scoring_node.mapped().doc_len;
     }
   }
   TextIndex &key_index = node.mapped();

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -188,7 +188,8 @@ absl::StatusOr<bool> TextIndexSchema::StageAttributeData(
   return true;
 }
 
-void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
+TextIndexSchema::CommitResult TextIndexSchema::CommitKeyData(
+    const InternedStringPtr &key) {
   // Retrieve the key's staged data
   TokenPositions token_positions;
   {
@@ -196,7 +197,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     auto node = in_progress_key_updates_.extract(key);
     // Exit early if the key contains no new text updates
     if (node.empty()) {
-      return;
+      return {};
     }
     token_positions = std::move(node.mapped());
   }
@@ -213,6 +214,10 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
   TextIndex key_index{with_suffix_trie_};
 
+  // Accumulate document length (total term frequency for this key)
+  uint32_t doc_len = 0;
+  uint32_t norm = 0;
+
   // Index the key's tokens
   for (auto &entry : token_positions) {
     const std::string &token = entry.first;
@@ -225,9 +230,14 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
     // Update metadata from PositionMap
     metadata_.total_positions += pos_map.size();
+    uint32_t token_freq = 0;
     for (const auto &[_, field_mask] : pos_map) {
-      metadata_.total_term_frequency += field_mask.CountSetFields();
+      uint32_t fields_count = field_mask.CountSetFields();
+      metadata_.total_term_frequency += fields_count;
+      token_freq += fields_count;
+      doc_len += fields_count;
     }
+    norm = std::max(norm, token_freq);
 
     // Create FlatPositionMap from PositionMap
     FlatPositionMap *flat_map =
@@ -284,6 +294,10 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
   }
+
+  // Update total document length for avg_doc_len computation
+  metadata_.total_doc_len += doc_len;
+  return {doc_len, norm};
 }
 
 void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -47,6 +47,8 @@ struct TextIndexMetadata {
   std::atomic<uint64_t> total_positions{0};
   std::atomic<uint64_t> num_unique_terms{0};
   std::atomic<uint64_t> total_term_frequency{0};
+  std::atomic<uint64_t> total_doc_len{
+      0};  // Sum of all doc_lens for avg_doc_len
 
   // Memory pools for text index components
   MemoryPool posting_memory_pool_{0};
@@ -96,7 +98,13 @@ class TextIndexSchema {
                                           absl::string_view data,
                                           size_t text_field_number, bool stem,
                                           bool suffix);
-  void CommitKeyData(const InternedStringPtr &key);
+  // Commits staged key data into the text index structures.
+  // Returns the document length and norm (max term frequency).
+  struct CommitResult {
+    uint32_t doc_len{0};
+    uint32_t norm{0};
+  };
+  CommitResult CommitKeyData(const InternedStringPtr &key);
   void DeleteKeyData(const InternedStringPtr &key);
 
   uint8_t AllocateTextFieldNumber() { return num_text_fields_++; }

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -116,6 +116,17 @@ class TextIndexSchema {
   // Access to metadata for memory pool usage
   TextIndexMetadata &GetMetadata() { return metadata_; }
 
+  uint32_t GetKeyDocLen(const InternedStringPtr &key) const {
+    std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
+    auto itr = per_key_scoring_info_.find(key);
+    return itr != per_key_scoring_info_.end() ? itr->second.doc_len : 0;
+  }
+  uint32_t GetKeyNorm(const InternedStringPtr &key) const {
+    std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
+    auto itr = per_key_scoring_info_.find(key);
+    return itr != per_key_scoring_info_.end() ? itr->second.norm : 0;
+  }
+
   // Access stem tree for word expansion during search
   const Rax &GetStemTree() const { return stem_tree_; }
 
@@ -177,8 +188,16 @@ class TextIndexSchema {
   //
   absl::node_hash_map<Key, TextIndex> per_key_text_indexes_;
 
-  // Prevent concurrent mutations to per-key text index map
-  std::mutex per_key_text_indexes_mutex_;
+  // Per-key scoring metadata (doc_len and norm), populated alongside
+  // per_key_text_indexes_ during CommitKeyData/DeleteKeyData.
+  struct KeyScoringInfo {
+    uint32_t doc_len{0};
+    uint32_t norm{0};
+  };
+  absl::node_hash_map<Key, KeyScoringInfo> per_key_scoring_info_;
+
+  // Prevent concurrent mutations to per-key text index map and scoring info
+  mutable std::mutex per_key_text_indexes_mutex_;
 
   Lexer lexer_;
 

--- a/testing/flat_position_map_test.cc
+++ b/testing/flat_position_map_test.cc
@@ -116,7 +116,7 @@ TEST_F(FlatPositionMapTest, SinglePositionSingleField) {
   EXPECT_FALSE(iter.IsValid());
 
   EXPECT_EQ(flat_map->CountPositions(), 1);
-  EXPECT_EQ(flat_map->CountTermFrequency(), 1);
+  EXPECT_EQ(flat_map->GetTermFrequency(), 1);
 }
 
 TEST_F(FlatPositionMapTest, MultiplePositionsIteration) {
@@ -197,7 +197,7 @@ TEST_F(FlatPositionMapTest, TermFrequencyCalculation) {
       CreatePositionMap({{10, 0b001}, {20, 0b011}, {30, 0b111}}, 3);
   FlatPositionMapPtr flat_map(position_map, 3);
 
-  EXPECT_EQ(flat_map->CountTermFrequency(), 6);  // 1+2+3
+  EXPECT_EQ(flat_map->GetTermFrequency(), 6);  // 1+2+3
 }
 
 //=============================================================================
@@ -768,7 +768,7 @@ TEST_F(FlatPositionMapTest, RandomMapWithTermFrequencyVerification) {
       expected_freq += __builtin_popcountll(mask);
     }
 
-    EXPECT_EQ(flat_map->CountTermFrequency(), expected_freq)
+    EXPECT_EQ(flat_map->GetTermFrequency(), expected_freq)
         << "Test " << test << " failed: term frequency mismatch";
   }
 }
@@ -796,7 +796,7 @@ TEST_F(FlatPositionMapTest, VeryLargeMapScenarios) {
       FlatPositionMapPtr flat_map(position_map, 1);
 
       ASSERT_EQ(flat_map->CountPositions(), target_size);
-      EXPECT_EQ(flat_map->CountTermFrequency(), target_size);
+      EXPECT_EQ(flat_map->GetTermFrequency(), target_size);
 
       // Test skip to various positions
       PositionIterator iter1(*flat_map);

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -63,6 +63,119 @@ TEST_F(TextIndexSchemaTest, ConcurrentCommitKeyData) {
   EXPECT_EQ(schema->GetNumUniqueTerms(), 7);
 }
 
+TEST_F(TextIndexSchemaTest, CommitKeyDataReturnsDocLen) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // With with_offsets=false, all tokens get position 0.
+  // "hello world hello" has 2 unique tokens -> doc_len = 2
+  // (duplicate "hello" merges into same position entry)
+  auto key = StringInternStore::Intern("doc1");
+  auto result =
+      schema->StageAttributeData(key, "hello world hello", 0, false, false);
+  ASSERT_TRUE(result.ok());
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 2);
+  EXPECT_EQ(commit.norm, 1);  // Each unique token appears once (position 0)
+}
+
+TEST_F(TextIndexSchemaTest, CommitKeyDataReturnsZeroForEmptyStage) {
+  auto schema = CreateSchema();
+
+  // CommitKeyData without staging returns 0
+  auto key = StringInternStore::Intern("no_data");
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 0);
+  EXPECT_EQ(commit.norm, 0);
+}
+
+TEST_F(TextIndexSchemaTest, TotalDocLenAccumulatesAcrossDocuments) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // doc1: "hello world" -> 2 terms
+  auto key1 = StringInternStore::Intern("doc1");
+  auto r1 = schema->StageAttributeData(key1, "hello world", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+  schema->CommitKeyData(key1);
+
+  // doc2: "foo bar baz" -> 3 terms
+  auto key2 = StringInternStore::Intern("doc2");
+  auto r2 = schema->StageAttributeData(key2, "foo bar baz", 0, false, false);
+  ASSERT_TRUE(r2.ok());
+  schema->CommitKeyData(key2);
+
+  // total_doc_len should be 2 + 3 = 5
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 5);
+}
+
+TEST_F(TextIndexSchemaTest, TotalDocLenDecrementsOnDelete) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // doc1: "hello world foo" -> 3 terms
+  auto key1 = StringInternStore::Intern("doc1");
+  auto r1 =
+      schema->StageAttributeData(key1, "hello world foo", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+  uint32_t doc_len = schema->CommitKeyData(key1).doc_len;
+  EXPECT_EQ(doc_len, 3);
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 3);
+
+  // Simulate what SyncProcessMutation does: decrement then delete
+  schema->GetMetadata().total_doc_len -= doc_len;
+  schema->DeleteKeyData(key1);
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 0);
+}
+
+TEST_F(TextIndexSchemaTest, DocLenWithMultipleFields) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+
+  // Create two Text instances to allocate field numbers 0 and 1
+  auto text1 = std::make_shared<Text>(proto, schema);
+  auto text2 = std::make_shared<Text>(proto, schema);
+
+  auto key = StringInternStore::Intern("doc1");
+
+  // Field 0: "hello world" -> 2 terms
+  auto r1 = schema->StageAttributeData(key, "hello world", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+
+  // Field 1: "foo bar baz" -> 3 terms
+  auto r2 = schema->StageAttributeData(key, "foo bar baz", 1, false, false);
+  ASSERT_TRUE(r2.ok());
+
+  // doc_len should be total across both fields = 5
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 5);
+  // norm = max token freq; each token appears once per field = 1
+  EXPECT_EQ(commit.norm, 1);
+}
+
+TEST_F(TextIndexSchemaTest, NormReflectsMaxTermFrequency) {
+  // with_offsets=true so duplicate tokens get distinct positions
+  std::vector<std::string> empty_stop_words;
+  auto schema = std::make_shared<TextIndexSchema>(
+      data_model::LANGUAGE_ENGLISH, " \t\n\r!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+      true, empty_stop_words, 4);
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // "hello hello hello world" -> "hello" appears 3 times, "world" 1 time
+  auto key = StringInternStore::Intern("doc1");
+  auto r = schema->StageAttributeData(key, "hello hello hello world", 0, false,
+                                      false);
+  ASSERT_TRUE(r.ok());
+  auto commit = schema->CommitKeyData(key);
+  // doc_len = 4 (total tokens), norm = 3 (max freq is "hello" with 3)
+  EXPECT_EQ(commit.doc_len, 4);
+  EXPECT_EQ(commit.norm, 3);
+}
+
 TEST_F(TextIndexSchemaTest, FieldAllocationAcrossMultipleTexts) {
   // Test that TextIndexSchema properly manages field number allocation
   // across multiple Text instances - this is the key schema responsibility

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -125,8 +125,7 @@ TEST_F(TextIndexSchemaTest, TotalDocLenDecrementsOnDelete) {
   EXPECT_EQ(doc_len, 3);
   EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 3);
 
-  // Simulate what SyncProcessMutation does: decrement then delete
-  schema->GetMetadata().total_doc_len -= doc_len;
+  // DeleteKeyData decrements total_doc_len internally
   schema->DeleteKeyData(key1);
   EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 0);
 }


### PR DESCRIPTION
## Pre-compute scoring values during text ingestion

Pre-computes per-document and per-(term, document) values needed for BM25/TFIDF scoring, so the scorer can read them in O(1) at query time instead of recomputing on every call.

### Pre-computed values

| Value | Scope | Where stored | Getter |
|---|---|---|---|
| `TF` | per (term, doc) | 4-byte prefix in `FlatPositionMap` | `FlatPositionMap::GetTermFrequency()` |
| `doc_len` | per doc | `TextIndexSchema::per_key_scoring_info_` | `IndexSchema::GetDocumentLength(key)` |
| `norm` | per doc | `TextIndexSchema::per_key_scoring_info_` | `IndexSchema::GetDocumentNorm(key)` |
| `total_doc_len` | index-wide | `TextIndexMetadata::total_doc_len` | `IndexSchema::GetTotalDocumentLength()` |
| `document_score` | per doc | `IndexKeyInfo::document_score` | `IndexSchema::GetDocumentScore(key)` |
| `weight` | per text field | `Text::weight_` | `Text::Weight()` |
| `N` (doc count) | index-wide | `Stats::document_cnt` | `IndexSchema::GetIndexKeyInfoSize()` |
| `dt` (docs with term) | per term | `Postings::key_to_positions_` | `Postings::GetKeyCount()` |

With these, the scorer has everything it needs at query time without any further ingestion-time changes.

### Implementation

- `FlatPositionMap::Create` computes TF once and stores it as a 4-byte prefix; `GetTermFrequency()` reads it via `memcpy` (replaces the old `CountTermFrequency()` which iterated the serialized data).
- `TextIndexSchema::CommitKeyData` returns `{doc_len, norm}` computed in the existing token loop. `total_doc_len` is incremented inside `CommitKeyData` and decremented in `SyncProcessMutation` before `DeleteKeyData` runs.
- `k1` and `b` are not stored — they belong in the BM25 scorer.

### Tests

Added unit tests in `text_index_schema_test.cc` covering `doc_len`, `norm`, `total_doc_len` accumulation, and decrement-on-delete. Existing `flat_position_map_test.cc` tests updated for the rename.
