### PR TITLE
[backport][validation failed] Backport sweep for 1.0

### DIFF
--- a/src/attribute.h
+++ b/src/attribute.h
@@ -68,20 +68,18 @@ class Attribute {
     return 1;
   }
 
+  // Creates a new score-as string for each call.
+  // We intentionally avoid caching because RedisModule_RetainString uses
+  // non-atomic refcount increment (o->refcount++), causing race conditions
+  // when multiple threads call it on the same RedisModuleString.
   inline vmsdk::UniqueRedisString DefaultReplyScoreAs() const {
-    if (!cached_score_as_) {
-      cached_score_as_ =
-          vmsdk::MakeUniqueRedisString(absl::StrCat("__", alias_, "_score"));
-    }
-    return vmsdk::RetainUniqueRedisString(cached_score_as_.get());
+    return vmsdk::MakeUniqueRedisString(absl::StrCat("__", alias_, "_score"));
   }
 
  private:
   std::string alias_;
   std::string identifier_;
   std::shared_ptr<indexes::IndexBase> index_;
-  // Maintaining a cached version
-  mutable vmsdk::UniqueRedisString cached_score_as_;
 };
 
 }  // namespace valkey_search

--- a/vmsdk/src/managed_pointers.h
+++ b/vmsdk/src/managed_pointers.h
@@ -65,6 +65,7 @@ inline UniqueRedisString MakeUniqueRedisString(const char *str) {
 }
 
 inline UniqueRedisString RetainUniqueRedisString(RedisModuleString *redis_str) {
+  VerifyMainThread();
   RedisModule_RetainString(nullptr, redis_str);
   return UniquePtrRedisString(redis_str);
 }


### PR DESCRIPTION
# Backport sweep for 1.0

Automated cherry-picks from PRs marked "To be backported".

## Validation failed

This draft PR preserves the attempted backport branch so maintainers can inspect and fix the validation failure instead of losing the work in scheduled-run logs.

## Applied (validation failed)

These candidates are present on the backport branch, but validation failed.

| Source PR | Title | Validation output |
|---|---|---|
| #565 | Fix use-after-free race in DefaultReplyScoreAs() fix #560 | ~~~~~~~   269 \|           return std::string(attribute_name);       \|           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   270 \|         }));       \|         ~~                              /opt/valkey-search-deps/include/gmock/gmock-actions.h:2059:41: note: declared here  2059 \| typename std::decay<FunctionImpl>::type Invoke(FunctionImpl&& function_impl) {       \|                                         ^~~~~~ /workspace/testing/common.h: In constructor ‘valkey_search::MockThreadPool::MockThreadPool |

---
*Generated by valkey-ci-agent using Claude Code.*