### PR TITLE
Implement `JPARAMS`

### DIFF
--- a/src/commands/ft.search.json
+++ b/src/commands/ft.search.json
@@ -7,7 +7,7 @@
     ],
     "history": [
       [
-        "1.2.0", 
+        "1.2.0",
         "Added Text Indexing and Search support"
       ]
     ],
@@ -113,6 +113,37 @@
             "name": "params_token",
             "type": "pure-token",
             "token": "PARAMS"
+          },
+          {
+            "name": "count",
+            "type": "integer"
+          },
+          {
+            "name": "parameters",
+            "type": "block",
+            "multiple": true,
+            "arguments": [
+              {
+                "name": "name",
+                "type": "string"
+              },
+              {
+                "name": "value",
+                "type": "string"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "JPARAMS",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "jparams_token",
+            "type": "pure-token",
+            "token": "JPARAMS"
           },
           {
             "name": "count",
@@ -260,6 +291,7 @@
     "complexity": "O(log N)",
     "group": "search",
     "module_since": "1.0.0",
-    "summary": "Performs a search of the specified index. The keys which match the query expression are returned"
+    "summary":
+        "Performs a search of the specified index. The keys which match the query expression are returned"
   }
 }

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -54,6 +54,38 @@ vmsdk::config::Number &GetMaxKnn() {
 
 namespace {
 
+using ParamMap = query::SearchParameters::ParseTimeVariables::ParamValue;
+
+absl::Status VerifyAllParametersUsed(
+    absl::flat_hash_map<absl::string_view, ParamMap> &params) {
+  while (!params.empty()) {
+    auto begin = params.begin();
+    if (begin->second.first == 0) {
+      return absl::NotFoundError(
+          absl::StrCat("Parameter `", begin->first, "` not used."));
+    }
+    params.erase(begin);
+  }
+  return absl::OkStatus();
+}
+
+absl::Status InsertParam(
+    absl::flat_hash_map<absl::string_view, ParamMap> &target_params,
+    const absl::flat_hash_map<absl::string_view, ParamMap> &other_params,
+    absl::string_view key, absl::string_view value) {
+  if (other_params.contains(key)) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Parameter ", key, " is already defined."));
+  }
+  auto [_, inserted] = target_params.insert(std::make_pair(
+      key, query::SearchParameters::ParseTimeVariables::ParamValue{0, value}));
+  if (!inserted) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Parameter ", key, " is already defined."));
+  }
+  return absl::OkStatus();
+}
+
 absl::Status Verify(query::SearchParameters &parameters) {
   // Only verify the vector KNN parameters for vector based queries.
   if (!parameters.IsNonVectorQuery()) {
@@ -88,14 +120,8 @@ absl::Status Verify(query::SearchParameters &parameters) {
   }
 
   // Validate all parameters used, nuke the map to avoid dangling pointers
-  while (!parameters.parse_vars.params.empty()) {
-    auto begin = parameters.parse_vars.params.begin();
-    if (begin->second.first == 0) {
-      return absl::NotFoundError(
-          absl::StrCat("Parameter `", begin->first, "` not used."));
-    }
-    parameters.parse_vars.params.erase(begin);
-  }
+  VMSDK_RETURN_IF_ERROR(VerifyAllParametersUsed(parameters.parse_vars.params));
+  VMSDK_RETURN_IF_ERROR(VerifyAllParametersUsed(parameters.parse_vars.jparams));
   return absl::OkStatus();
 }
 
@@ -126,12 +152,34 @@ std::unique_ptr<vmsdk::ParamParser<SearchCommand>> ConstructParamsParser() {
           itr.Next();
           absl::string_view key = vmsdk::ToStringView(key_str);
           absl::string_view value = vmsdk::ToStringView(value_str);
-          auto [_, inserted] = parameters.parse_vars.params.insert(
-              std::make_pair(key, std::make_pair(0, value)));
-          if (!inserted) {
-            return absl::InvalidArgumentError(
-                absl::StrCat("Parameter ", key, " is already defined."));
-          }
+          VMSDK_RETURN_IF_ERROR(InsertParam(parameters.parse_vars.params,
+                                            parameters.parse_vars.jparams, key,
+                                            value));
+          count -= 2;
+        }
+        return absl::OkStatus();
+      });
+}
+
+std::unique_ptr<vmsdk::ParamParser<SearchCommand>> ConstructJParamsParser() {
+  return std::make_unique<vmsdk::ParamParser<SearchCommand>>(
+      [](SearchCommand &parameters, vmsdk::ArgsIterator &itr) -> absl::Status {
+        unsigned count{0};
+        VMSDK_RETURN_IF_ERROR(vmsdk::ParseParamValue(itr, count));
+        if (count & 1) {
+          return absl::InvalidArgumentError(
+              "Parameter count must be an even number.");
+        }
+        while (count > 0) {
+          VMSDK_ASSIGN_OR_RETURN(auto key_str, itr.Get());
+          itr.Next();
+          VMSDK_ASSIGN_OR_RETURN(auto value_str, itr.Get());
+          itr.Next();
+          absl::string_view key = vmsdk::ToStringView(key_str);
+          absl::string_view value = vmsdk::ToStringView(value_str);
+          VMSDK_RETURN_IF_ERROR(InsertParam(parameters.parse_vars.jparams,
+                                            parameters.parse_vars.params, key,
+                                            value));
           count -= 2;
         }
         return absl::OkStatus();
@@ -229,6 +277,7 @@ vmsdk::KeyValueParser<SearchCommand> CreateSearchParser() {
   parser.AddParamParser(query::kReturnParam, ConstructReturnParser());
   parser.AddParamParser(query::kSortByParam, ConstructSortByParser());
   parser.AddParamParser(query::kParamsParam, ConstructParamsParser());
+  parser.AddParamParser(query::kJParamsParam, ConstructJParamsParser());
   parser.AddParamParser(query::kInorder,
                         GENERATE_FLAG_PARSER(SearchCommand, inorder));
   parser.AddParamParser(query::kVerbatim,
@@ -256,48 +305,7 @@ absl::Status SearchCommand::PostParseQueryString() {
 }
 
 absl::Status VerifyQueryString(query::SearchParameters &parameters) {
-  // Only verify the vector KNN parameters for vector based queries.
-  if (!parameters.IsNonVectorQuery()) {
-    if (parameters.query.empty()) {
-      return absl::InvalidArgumentError("Invalid Query Syntax");
-    }
-    if (parameters.ef.has_value()) {
-      auto max_ef_runtime_value = options::GetMaxEfRuntime().GetValue();
-      VMSDK_RETURN_IF_ERROR(
-          vmsdk::VerifyRange(parameters.ef.value(), 1, max_ef_runtime_value))
-          << "`EF_RUNTIME` must be a positive integer greater than 0 and "
-             "cannot "
-             "exceed "
-          << max_ef_runtime_value << ".";
-    }
-    auto max_knn_value = options::GetMaxKnn().GetValue();
-    VMSDK_RETURN_IF_ERROR(vmsdk::VerifyRange(parameters.k, 1, max_knn_value))
-        << "KNN parameter must be a positive integer greater than 0 and cannot "
-           "exceed "
-        << max_knn_value << ".";
-  }
-  if (parameters.timeout_ms > query::kMaxTimeoutMs) {
-    return absl::InvalidArgumentError(
-        absl::StrCat(query::kTimeoutParam,
-                     " must be a positive integer greater than 0 and "
-                     "cannot exceed ",
-                     query::kMaxTimeoutMs, "."));
-  }
-  if (parameters.dialect < 2 || parameters.dialect > 4) {
-    return absl::InvalidArgumentError(
-        "DIALECT requires a non negative integer >=2 and <= 4");
-  }
-
-  // Validate all parameters used, nuke the map to avoid dangling pointers
-  while (!parameters.parse_vars.params.empty()) {
-    auto begin = parameters.parse_vars.params.begin();
-    if (begin->second.first == 0) {
-      return absl::NotFoundError(
-          absl::StrCat("Parameter `", begin->first, "` not used."));
-    }
-    parameters.parse_vars.params.erase(begin);
-  }
-  return absl::OkStatus();
+  return Verify(parameters);
 }
 
 absl::Status SearchCommand::ParseCommand(vmsdk::ArgsIterator &itr) {

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -57,6 +57,15 @@
 
 namespace valkey_search::query {
 
+namespace {
+
+struct ParamSubstitution {
+  absl::string_view value;
+  bool is_json;
+};
+
+}  // namespace
+
 // Query operation counters
 DEV_INTEGER_COUNTER(query_stats, query_text_term_count);
 DEV_INTEGER_COUNTER(query_stats, query_text_prefix_count);
@@ -874,20 +883,24 @@ void IncrementQueryOperationMetrics(QueryOperations query_operations) {
   }
 }
 
-absl::StatusOr<absl::string_view> SubstituteParam(
+absl::StatusOr<ParamSubstitution> SubstituteParam(
     query::SearchParameters &parameters, absl::string_view source) {
   if (source.empty() || source[0] != '$') {
-    return source;
+    return ParamSubstitution{source, false};
   } else {
     source.remove_prefix(1);
     auto itr = parameters.parse_vars.params.find(source);
-    if (itr == parameters.parse_vars.params.end()) {
-      return absl::NotFoundError(
-          absl::StrCat("Parameter ", source, " not found."));
-    } else {
+    if (itr != parameters.parse_vars.params.end()) {
       itr->second.first++;
-      return itr->second.second;
+      return ParamSubstitution{itr->second.second, false};
     }
+    auto jitr = parameters.parse_vars.jparams.find(source);
+    if (jitr != parameters.parse_vars.jparams.end()) {
+      jitr->second.first++;
+      return ParamSubstitution{jitr->second.second, true};
+    }
+    return absl::NotFoundError(
+        absl::StrCat("Parameter ", source, " not found."));
   }
 }
 
@@ -1081,23 +1094,38 @@ absl::Status PostParseVectorParameters(query::SearchParameters &parameters) {
   VMSDK_ASSIGN_OR_RETURN(
       auto k_string,
       SubstituteParam(parameters, parameters.parse_vars.k_string));
-  VMSDK_ASSIGN_OR_RETURN(parameters.k, vmsdk::To<unsigned>(k_string));
+  VMSDK_ASSIGN_OR_RETURN(parameters.k, vmsdk::To<unsigned>(k_string.value));
 
   VMSDK_ASSIGN_OR_RETURN(
-      parameters.query,
+      auto query_vector,
       SubstituteParam(parameters, parameters.parse_vars.query_vector_string));
+  if (query_vector.is_json) {
+    VMSDK_ASSIGN_OR_RETURN(auto index, parameters.index_schema->GetIndex(
+                                           parameters.attribute_alias));
+    auto normalized_query = index->NormalizeStringRecord(
+        vmsdk::MakeUniqueValkeyString(std::string(query_vector.value)));
+    if (!normalized_query) {
+      return absl::InvalidArgumentError(absl::StrCat(
+          "JPARAMS `", parameters.parse_vars.query_vector_string.substr(1),
+          "` is not a valid vector value."));
+    }
+    parameters.query = std::string(vmsdk::ToStringView(normalized_query.get()));
+  } else {
+    parameters.query = std::string(query_vector.value);
+  }
 
   if (!parameters.parse_vars.ef_string.empty()) {
     VMSDK_ASSIGN_OR_RETURN(
         auto ef_string,
         SubstituteParam(parameters, parameters.parse_vars.ef_string));
-    VMSDK_ASSIGN_OR_RETURN(parameters.ef, vmsdk::To<unsigned>(ef_string));
+    VMSDK_ASSIGN_OR_RETURN(parameters.ef, vmsdk::To<unsigned>(ef_string.value));
   }
 
   if (!parameters.parse_vars.score_as_string.empty()) {
     VMSDK_ASSIGN_OR_RETURN(
-        parameters.parse_vars.score_as_string,
+        auto score_as_string,
         SubstituteParam(parameters, parameters.parse_vars.score_as_string));
+    parameters.parse_vars.score_as_string = score_as_string.value;
   }
   return absl::OkStatus();
 }

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -56,6 +56,7 @@ constexpr uint32_t kDialect{2};
 
 // Parser keywords
 constexpr absl::string_view kParamsParam{"PARAMS"};
+constexpr absl::string_view kJParamsParam{"JPARAMS"};
 constexpr absl::string_view kDialectParam{"DIALECT"};
 constexpr absl::string_view kLimitParam{"LIMIT"};
 constexpr absl::string_view kNoContentParam{"NOCONTENT"};
@@ -182,6 +183,7 @@ struct SearchParameters {
   uint64_t slot_fingerprint;
   SearchResult search_result;
   struct ParseTimeVariables {
+    using ParamValue = std::pair<int, absl::string_view>;
     // Members of this struct are only valid during the parsing of
     // VectorSearchParameters on the mainthread. They get cleared
     // at the end of the parse to ensure no dangling pointers.
@@ -195,9 +197,8 @@ struct SearchParameters {
     // that is the string of the value AND a reference count so that we can
     // detect unused parameters.
     // Marked mutable so that const parsing functions can bump the ref-count
-    mutable absl::flat_hash_map<absl::string_view,
-                                std::pair<int, absl::string_view>>
-        params;
+    mutable absl::flat_hash_map<absl::string_view, ParamValue> params;
+    mutable absl::flat_hash_map<absl::string_view, ParamValue> jparams;
     void ClearAtEndOfParse() {
       query_string = absl::string_view();
       score_as_string = absl::string_view();
@@ -205,6 +206,7 @@ struct SearchParameters {
       k_string = absl::string_view();
       ef_string = absl::string_view();
       params.clear();
+      jparams.clear();
     }
   } parse_vars;
   bool IsNonVectorQuery() const { return attribute_alias.empty(); }

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -68,6 +68,8 @@ struct FTSearchParserTestCase {
   std::unordered_map<std::string, std::string> return_attributes;
   bool no_content{false};
   std::string search_parameters_str;
+  absl::string_view jparams_str;
+  std::optional<std::string> jparam_blob_value;
   uint64_t timeout_ms{query::kTimeoutMS};
   bool vector_query{true};
   bool verbatim{false};
@@ -189,8 +191,26 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   args.insert(args.end(), params_vec.begin(), params_vec.end());
   bool dialect_expected_success = true;
   if (test_case.vector_query) {
-    auto floats_vec = FloatToValkeyStringVector(floats);
-    args.insert(args.end(), floats_vec.begin(), floats_vec.end());
+    if (!test_case.params_str.empty()) {
+      auto floats_vec = FloatToValkeyStringVector(floats);
+      args.insert(args.end(), floats_vec.begin(), floats_vec.end());
+    }
+    if (test_case.jparam_blob_value.has_value()) {
+      auto jparams_vec = vmsdk::ToValkeyStringVector(test_case.jparams_str);
+      args.insert(args.end(), jparams_vec.begin(), jparams_vec.end());
+      const absl::string_view blob_str = "BLOB";
+      args.push_back(
+          ValkeyModule_CreateString(nullptr, blob_str.data(), blob_str.size()));
+      args.push_back(ValkeyModule_CreateString(
+          nullptr, test_case.jparam_blob_value->data(),
+          test_case.jparam_blob_value->size()));
+    } else if (!test_case.jparams_str.empty()) {
+      auto jparams_vec = vmsdk::ToValkeyStringVector(test_case.jparams_str);
+      args.insert(args.end(), jparams_vec.begin(), jparams_vec.end());
+    } else if (test_case.params_str.empty()) {
+      auto floats_vec = FloatToValkeyStringVector(floats);
+      args.insert(args.end(), floats_vec.begin(), floats_vec.end());
+    }
   }
   // Add search parameters for both vector and non-vector queries
   if (!test_case.search_parameters_str.empty()) {
@@ -839,6 +859,60 @@ INSTANTIATE_TEST_SUITE_P(
             .k = 5,
             .search_parameters_str = "SLOP 0",
             .slop = 0,
+        },
+        {
+            .test_name = "jparam_vector_happy_path",
+            .success = true,
+            .filter_str = "*=>[KNN 5 @vec $BLOB]",
+            .k = 5,
+            .jparams_str = " JPARAMS 2",
+            .jparam_blob_value = "[0.1, 0.2, 0.3]",
+        },
+        {
+            .test_name = "jparam_numeric_and_vector_happy_path",
+            .success = true,
+            .filter_str = "*=>[KNN $K @vec $BLOB]",
+            .k = 5,
+            .jparams_str = " JPARAMS 4 K 5",
+            .jparam_blob_value = "[0.1, 0.2, 0.3]",
+        },
+        {
+            .test_name = "jparams_numeric_only_with_params_blob_happy_path",
+            .success = true,
+            .params_str = " PARAMS 2",
+            .filter_str = "*=>[KNN $K @vec $BLOB]",
+            .k = 5,
+            .jparams_str = " JPARAMS 2 K 5",
+        },
+        {
+            .test_name = "jparam_duplicate_across_params",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = "*=>[KNN 5 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing value for the parameter `JPARAMS` - Parameter "
+                "BLOB is already defined.",
+            .jparams_str = " JPARAMS 2",
+            .jparam_blob_value = "[0.1, 0.2, 0.3]",
+        },
+        {
+            .test_name = "unused_jparams",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = "*=>[KNN 5 @vec $BLOB]",
+            .k = 5,
+            .expected_error_message = "Parameter `UNUSED` not used.",
+            .jparams_str = " JPARAMS 2 UNUSED 123",
+        },
+        {
+            .test_name = "jparam_invalid_vector_value",
+            .success = false,
+            .filter_str = "*=>[KNN 5 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing vector similarity parameters: JPARAMS `BLOB` is "
+                "not a valid vector value.",
+            .jparams_str = " JPARAMS 2",
+            .jparam_blob_value = "[0.1, nope, 0.3]",
         },
         // Combined parameter tests
         {


### PR DESCRIPTION
Add JPARAMS support to FT.SEARCH for vector queries so callers can pass JSON-style vector values instead of pre-encoded binary blobs.

ex
```
FT.SEARCH idx "*=>[KNN 10 @vec $query]" JPARAMS 2 query "[0.1, 0.2, 0.3]"
```
issue : #1078
