### PR TITLE
Fix 1.0 build

### DIFF
--- a/src/indexes/tag.cc
+++ b/src/indexes/tag.cc
@@ -48,6 +48,7 @@
 #include "src/query/predicate.h"
 #include "src/utils/patricia_tree.h"
 #include "src/utils/string_interning.h"
+#include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::indexes {

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -31,6 +31,7 @@
 #include "valkey_search.h"
 #include "vmsdk/src/concurrency.h"
 #include "vmsdk/src/module_config.h"
+#include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/thread_pool.h"
 
 namespace valkey_search {


### PR DESCRIPTION
tag.cc and valkey_search_options.cc use VMSDK_RETURN_IF_ERROR but don't include status_macros.h directly. On main this works via a transitive include through rdb_serialization.h, but on 1.0 that transitive path doesn't exist, causing a build failure.