### PR TITLE
Update CME error message for MULTI/EXEC and Lua

### DIFF
--- a/integration/test_multi_lua.py
+++ b/integration/test_multi_lua.py
@@ -17,7 +17,7 @@ from indexes import *
 INDEX = "idx"
 OK = b"OK"
 QUEUED = b"QUEUED"
-FANOUT_NOT_SUPPORTED_ERR = "MULTI/EXEC or Lua script are not supported in CME mode"
+FANOUT_NOT_SUPPORTED_ERR = "MULTI/EXEC or Lua script are not supported in CME mode unless the query targets a single-slot index on the local node."
 
 
 def _lua_call(cmd: str, *args: str) -> str:

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -161,7 +161,8 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
     if (ABSL_PREDICT_FALSE(inside_multi_exec && do_fanout) &&
         !IsSingleSlotQueryRoutedToLocalNode(ctx, *parameters)) {
       return absl::InvalidArgumentError(
-          "MULTI/EXEC or Lua script are not supported in CME mode.");
+          "MULTI/EXEC or Lua script are not supported in CME mode unless the "
+          "query targets a single-slot index on the local node.");
     }
 
     if (ABSL_PREDICT_FALSE(!ValkeySearch::Instance().SupportParallelQueries() ||


### PR DESCRIPTION
Clarify the CME error message for FT.SEARCH/FT.AGGREGATE in MULTI/EXEC and Lua.
It now reflects the single-slot local-node exception added in #866