### PR TITLE
Fix SIGSEGV on FT.SEARCH query with empty OR right-hand side

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -975,6 +975,9 @@ absl::StatusOr<FilterParser::ParseResult> FilterParser::ParseExpression(
       }
       VMSDK_ASSIGN_OR_RETURN(auto sub_result, ParseExpression(level));
       predicate = std::move(sub_result.prev_predicate);
+      if (!predicate) {
+        return absl::InvalidArgumentError("Missing OR term");
+      }
       if (result.prev_predicate) {
         node_count_++;
       } else {

--- a/testing/filter_test.cc
+++ b/testing/filter_test.cc
@@ -1627,6 +1627,25 @@ INSTANTIATE_TEST_SUITE_P(
             .create_success = false,
             .create_expected_error_message = "Missing OR term",
         },
+        {
+            .test_name = "or_with_missing_right_operand_trailing_pipe",
+            .filter = "@num_field_1.5:[1.0 2.0]|",
+            .create_success = false,
+            .create_expected_error_message = "Missing OR term",
+        },
+        {
+            .test_name = "or_with_missing_right_operand_trailing_pipe_space",
+            .filter = "@num_field_1.5:[1.0 2.0] |",
+            .create_success = false,
+            .create_expected_error_message = "Missing OR term",
+        },
+        {
+            .test_name =
+                "or_with_missing_right_operand_trailing_pipe_in_parens",
+            .filter = "(@num_field_1.5:[1.0 2.0]|)",
+            .create_success = false,
+            .create_expected_error_message = "Missing OR term",
+        },
         // =================================================================
         // Tests for escaped pipe separator in tag values
         // =================================================================


### PR DESCRIPTION
The ParseExpression function's '|' branch validated the left operand but never checked that the right operand (from the recursive call) was non-null. A trailing '|' or stopword-only RHS caused a null pointer to flow into WrapPredicate → MayNegatePredicate → GetType() dereference → SIGSEGV.

Add null-check for the right-hand predicate after the recursive ParseExpression call, returning "Missing OR term" error.

Add unit tests for trailing pipe variants:
- @field:[range]|       (end of input)
- @field:[range] |      (trailing with space)
- (@field:[range]|)     (inside parentheses)

Fixes #1105