### PR TITLE
Fix GetTargetsForSlot to resolve slots in the middle/end of a range

### DIFF
--- a/vmsdk/src/cluster_map.cc
+++ b/vmsdk/src/cluster_map.cc
@@ -140,15 +140,21 @@ std::vector<NodeInfo> ClusterMap::GetTargetsForSlot(FanoutTargetMode mode,
   if (slot_to_shard_map_.empty()) {
     return {};
   }
-  auto iter = slot_to_shard_map_.lower_bound(slot);
-  if (iter == slot_to_shard_map_.end()) {
-    iter--;
+  // Find the range [start_slot, end_slot] that contains `slot`. The map is
+  // keyed by start_slot, so the candidate range is the last one whose start is
+  // <= slot, i.e. the entry just before the first start > slot.
+  auto iter = slot_to_shard_map_.upper_bound(slot);
+  if (iter == slot_to_shard_map_.begin()) {
+    return {};  // slot is before the first range.
+  }
+  --iter;
+  uint16_t start_slot = iter->first;
+  uint16_t end_slot = iter->second.first;  // end_slot is inclusive.
+  if (slot < start_slot || slot > end_slot) {
+    return {};  // Slot is in a gap; no shard owns it.
   }
   const ShardInfo* shard = iter->second.second;
   CHECK(shard);
-  if (slot < iter->first || slot >= iter->second.first) {
-    return {};  // Slot not in range means no shard has this slot.
-  }
 
   //
   // We have the right shard, pick from it.

--- a/vmsdk/testing/cluster_map_test.cc
+++ b/vmsdk/testing/cluster_map_test.cc
@@ -490,6 +490,72 @@ TEST_F(ClusterMapTest, GetShardBySlotTest) {
   EXPECT_EQ(cluster_map->GetShardBySlot(16384), nullptr);  // Invalid slot
 }
 
+TEST_F(ClusterMapTest, GetTargetsForSlotTest) {
+  // Standard 3-shard config: [0-5460], [5461-10922], [10923-16383].
+  auto ranges = CreateStandard3ShardConfig();
+  auto cluster_map = CreateClusterMapWithConfig(ranges, primary_ids.at(0));
+  ASSERT_NE(cluster_map, nullptr);
+
+  // For every range, the start, middle, and (inclusive) end slot must all
+  // resolve to that range's primary. A lower_bound based lookup only works
+  // for the start slot, so the middle/end cases guard the regression.
+  struct Case {
+    uint16_t slot;
+    int shard;  // index into primary_ids
+  };
+  const std::vector<Case> cases = {
+      {0, 0},      {2730, 0},   {5460, 0},   // first range: start/middle/end
+      {5461, 1},   {8191, 1},   {10922, 1},  // middle range: start/middle/end
+      {10923, 2},  {13653, 2},  {16383, 2},  // last range: start/middle/end
+  };
+  for (const auto& c : cases) {
+    auto targets = cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary,
+                                                  false, c.slot);
+    ASSERT_EQ(targets.size(), 1u) << "no target for slot " << c.slot;
+    EXPECT_EQ(targets[0].node_id, primary_ids.at(c.shard))
+        << "wrong shard for slot " << c.slot;
+  }
+
+  // A slot beyond the covered range resolves to no target.
+  EXPECT_TRUE(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 16384)
+          .empty());
+}
+
+TEST_F(ClusterMapTest, GetTargetsForSlotGapTest) {
+  // Two ranges with a gap [5001-9999] between them.
+  std::vector<SlotRangeConfig> ranges = {
+      {.start_slot = 0,
+       .end_slot = 5000,
+       .primary = NodeConfig{"127.0.0.1", 30001, primary_ids.at(0), {}},
+       .replicas = {}},
+      {.start_slot = 10000,
+       .end_slot = 16383,
+       .primary = NodeConfig{"127.0.0.1", 30002, primary_ids.at(1), {}},
+       .replicas = {}}};
+  auto cluster_map = CreateClusterMapWithConfig(ranges, primary_ids.at(0));
+  ASSERT_NE(cluster_map, nullptr);
+
+  // Slots inside a covered range resolve; slots in the gap do not.
+  EXPECT_EQ(cluster_map
+                ->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 5000)
+                .size(),
+            1u);
+  EXPECT_TRUE(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 5001)
+          .empty());
+  EXPECT_TRUE(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 7500)
+          .empty());
+  EXPECT_TRUE(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 9999)
+          .empty());
+  EXPECT_EQ(cluster_map
+                ->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 10000)
+                .size(),
+            1u);
+}
+
 TEST_F(ClusterMapTest, GetShardByIdTest) {
   std::vector<SlotRangeConfig> ranges = {
       {.start_slot = 0,

--- a/vmsdk/testing/cluster_map_test.cc
+++ b/vmsdk/testing/cluster_map_test.cc
@@ -504,9 +504,9 @@ TEST_F(ClusterMapTest, GetTargetsForSlotTest) {
     int shard;  // index into primary_ids
   };
   const std::vector<Case> cases = {
-      {0, 0},      {2730, 0},   {5460, 0},   // first range: start/middle/end
-      {5461, 1},   {8191, 1},   {10922, 1},  // middle range: start/middle/end
-      {10923, 2},  {13653, 2},  {16383, 2},  // last range: start/middle/end
+      {0, 0},     {2730, 0},  {5460, 0},   // first range: start/middle/end
+      {5461, 1},  {8191, 1},  {10922, 1},  // middle range: start/middle/end
+      {10923, 2}, {13653, 2}, {16383, 2},  // last range: start/middle/end
   };
   for (const auto& c : cases) {
     auto targets = cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary,
@@ -537,10 +537,10 @@ TEST_F(ClusterMapTest, GetTargetsForSlotGapTest) {
   ASSERT_NE(cluster_map, nullptr);
 
   // Slots inside a covered range resolve; slots in the gap do not.
-  EXPECT_EQ(cluster_map
-                ->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 5000)
-                .size(),
-            1u);
+  EXPECT_EQ(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 5000)
+          .size(),
+      1u);
   EXPECT_TRUE(
       cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 5001)
           .empty());
@@ -550,10 +550,10 @@ TEST_F(ClusterMapTest, GetTargetsForSlotGapTest) {
   EXPECT_TRUE(
       cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 9999)
           .empty());
-  EXPECT_EQ(cluster_map
-                ->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 10000)
-                .size(),
-            1u);
+  EXPECT_EQ(
+      cluster_map->GetTargetsForSlot(FanoutTargetMode::kPrimary, false, 10000)
+          .size(),
+      1u);
 }
 
 TEST_F(ClusterMapTest, GetShardByIdTest) {


### PR DESCRIPTION
GetTargetsForSlot used a lower_bound() lookup against a map keyed by each range's start slot, so it only landed on the correct range when the slot equaled a range start. For any other slot it jumped to the next range and returned an empty target list, and it also used an exclusive end-slot check. As a result, single-slot queries for hash tags whose slot fell in the middle or end of a range failed with "No available nodes to execute the query" from every node, including the owner.

Replace the lookup with the same correct upper_bound()/decrement and inclusive [start, end] range check already used by GetShardBySlot. Add unit tests covering the start, middle, and end of the first, middle, and last ranges, plus gap handling; these fail on the old logic and pass now.