### PR TITLE
Fix memory reporting when reader/writer threads change at runtime

### DIFF
--- a/vmsdk/src/sharded_atomic.h
+++ b/vmsdk/src/sharded_atomic.h
@@ -77,6 +77,8 @@ class ShardedAtomic {
 
     void Unregister(ThreadLocalNode* node) {
       absl::MutexLock lock(&mutex_);
+      retired_total_.fetch_add(node->value.load(std::memory_order_relaxed),
+                               std::memory_order_relaxed);
       auto it = std::find(nodes_.begin(), nodes_.end(), node);
       if (it != nodes_.end()) {
         *it = nodes_.back();
@@ -85,7 +87,7 @@ class ShardedAtomic {
     }
 
     T GetTotal(std::memory_order order) const {
-      T total = 0;
+      T total = retired_total_.load(order);
       // We lock purely to ensure the vector doesn't change size (iterators
       // validity)
       absl::ReaderMutexLock lock(&mutex_);
@@ -100,6 +102,7 @@ class ShardedAtomic {
       // We lock purely to ensure the vector doesn't change size (iterators
       // validity)
       absl::ReaderMutexLock lock(&mutex_);
+      retired_total_.store(0, std::memory_order_seq_cst);
       for (auto* node : nodes_) {
         // Forcibly set value to 0.
         node->value.store(0, std::memory_order_seq_cst);
@@ -112,6 +115,12 @@ class ShardedAtomic {
                 RawSystemAllocator<ThreadLocalNode*,
                                    DisableRawSystemAllocatorReporting>>
         nodes_ ABSL_GUARDED_BY(mutex_);
+    // Carries over the value of threads that have exited. A ThreadLocalNode can
+    // hold a non-zero value at exit when an increment and its matching decrement
+    // happen on different threads (e.g. memory allocated on a worker thread and
+    // freed on the main thread); discarding it would make the reported total
+    // memory inaccurate.
+    std::atomic<T> retired_total_{0};
   };
 
   // ThreadLocalNode is the TLS container

--- a/vmsdk/src/sharded_atomic.h
+++ b/vmsdk/src/sharded_atomic.h
@@ -116,10 +116,10 @@ class ShardedAtomic {
                                    DisableRawSystemAllocatorReporting>>
         nodes_ ABSL_GUARDED_BY(mutex_);
     // Carries over the value of threads that have exited. A ThreadLocalNode can
-    // hold a non-zero value at exit when an increment and its matching decrement
-    // happen on different threads (e.g. memory allocated on a worker thread and
-    // freed on the main thread); discarding it would make the reported total
-    // memory inaccurate.
+    // hold a non-zero value at exit when an increment and its matching
+    // decrement happen on different threads (e.g. memory allocated on a worker
+    // thread and freed on the main thread); discarding it would make the
+    // reported total memory inaccurate.
     std::atomic<T> retired_total_{0};
   };
 


### PR DESCRIPTION
 Fix `search_used_memory_bytes` metric going negative when worker threads are resized at runtime.

The used-memory counter is a `ShardedAtomic<uint64_t>` that keeps one thread-local value per live thread and reports their sum. An allocation and its matching freed can happen on different threads — e.g. FT.SEARCH allocates its result buffers on a reader worker thread and frees them on the main thread. The per-thread values are individually unbalanced but sum to the correct total while both threads are alive.
When a worker thread exits, its node is removed and its value discarded — leaving the matching opposite value stranded on a surviving thread. That skews the global sum, and because the counter is unsigned  it can wrap below zero and be reported as a large negative number. Worker pools resize at runtime, so this happens routinely and worsens with each resize.
 
 ### Fix
 Carry an exiting thread's value into a `retired_total_` accumulator instead of discarding it.

 ### Repro
 #### Step 1
 ```
cd ~/workplace/valkey-search
  BIN=$PWD/.build-release/valkey-server/.build-release/bin
  JSON=$PWD/.build-release/valkey-json/build/src/libjson.so
  MOD=$PWD/.build-release/libsearch.so

  $BIN/valkey-server --port 7711 --daemonize yes --logfile /tmp/repro.log \
    --loadmodule "$JSON" --loadmodule "$MOD" --enable-debug-command yes

  cli() { "$BIN/valkey-cli" -p 7711 "$@"; }
  cli ping
   ```
#### Step 2
```
BODY="alpha bravo charlie delta echo foxtrot golf hotel india juliet \
  kilo lima mike november oscar papa quebec romeo sierra tango"

  cli CONFIG SET search.reader-threads 8
  cli FT.CREATE rt ON HASH PREFIX 1 d: SCHEMA body TEXT
  for i in $(seq 1 1000); do cli HSET d:$i body "$BODY" >/dev/null; done
  echo "baseline: $(cli INFO SEARCH | tr -d '\r' | grep search_used_memory_bytes)"

  for r in $(seq 1 12); do
    for i in $(seq 1 200); do cli FT.SEARCH rt '@body:alpha' LIMIT 0 5000 >/dev/null; done
    cli CONFIG SET search.reader-threads 1 >/dev/null; sleep 0.3
    cli CONFIG SET search.reader-threads 8 >/dev/null; sleep 0.3
    echo "round $r: $(cli INFO SEARCH | tr -d '\r' | grep search_used_memory_bytes)"
  done
  ```
  #### Step3
  ```
  cli SHUTDOWN NOSAVE 2>/dev/null
  ```
#### Without fix
  ```
  baseline: search_used_memory_bytes:36713904
round 1: search_used_memory_bytes:25250864
round 2: search_used_memory_bytes:13786592
round 3: search_used_memory_bytes:2322320
round 4: search_used_memory_bytes:-9141952
round 5: search_used_memory_bytes:-20606224
round 6: search_used_memory_bytes:-32070496
round 7: search_used_memory_bytes:-43534768
```
#### With the fix
```
baseline: search_used_memory_bytes:2701792
round 1: search_used_memory_bytes:2703424
round 2: search_used_memory_bytes:2703424
round 3: search_used_memory_bytes:2703424
round 4: search_used_memory_bytes:2703424
round 5: search_used_memory_bytes:2703424
```


  