### PR TITLE
Startup validation for numeric config ranges

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -48,12 +48,10 @@ static auto query_terms_count =
                           kDefaultQueryTermsCount,       // default size
                           1,                             // min size
                           kMaxQueryTermsCount)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxQueryTermsCount, kQueryStringTermsCountConfig))
         .Build();
 
-vmsdk::config::Number& GetQueryStringTermsCount() {
-  return dynamic_cast<vmsdk::config::Number&>(*query_terms_count);
+vmsdk::config::Number &GetQueryStringTermsCount() {
+  return dynamic_cast<vmsdk::config::Number &>(*query_terms_count);
 }
 
 /// Register the "fuzzy-max-distance" flag. Controls the maximum edit distance
@@ -65,13 +63,10 @@ constexpr uint32_t kMaximumFuzzyMaxDistance{50};
 static auto fuzzy_max_distance =
     config::NumberBuilder(kFuzzyMaxDistanceConfig, kDefaultFuzzyMaxDistance,
                           kMinimumFuzzyMaxDistance, kMaximumFuzzyMaxDistance)
-        .WithValidationCallback(CHECK_RANGE(kMinimumFuzzyMaxDistance,
-                                            kMaximumFuzzyMaxDistance,
-                                            kFuzzyMaxDistanceConfig))
         .Build();
 
-vmsdk::config::Number& GetFuzzyMaxDistance() {
-  return dynamic_cast<vmsdk::config::Number&>(*fuzzy_max_distance);
+vmsdk::config::Number &GetFuzzyMaxDistance() {
+  return dynamic_cast<vmsdk::config::Number &>(*fuzzy_max_distance);
 }
 }  // namespace options
 
@@ -88,7 +83,7 @@ constexpr double kNegativeInf = -std::numeric_limits<double>::infinity();
 }  // namespace
 
 // Helper function to print predicate tree structure using DFS
-std::string PrintPredicateTree(const query::Predicate* predicate, int indent) {
+std::string PrintPredicateTree(const query::Predicate *predicate, int indent) {
   std::string result;
   std::string indent_str(indent * 2, ' ');
 
@@ -98,8 +93,8 @@ std::string PrintPredicateTree(const query::Predicate* predicate, int indent) {
 
   switch (predicate->GetType()) {
     case query::PredicateType::kComposedAnd: {
-      const auto* composed =
-          static_cast<const query::ComposedPredicate*>(predicate);
+      const auto *composed =
+          static_cast<const query::ComposedPredicate *>(predicate);
       auto slop = composed->GetSlop();
       if (composed->GetInorder() == false && !slop.has_value()) {
         result += indent_str + "AND{\n";
@@ -109,68 +104,68 @@ std::string PrintPredicateTree(const query::Predicate* predicate, int indent) {
                   ", inorder=" + (composed->GetInorder() ? "true" : "false") +
                   "){\n";
       }
-      for (const auto& child : composed->GetChildren()) {
+      for (const auto &child : composed->GetChildren()) {
         result += PrintPredicateTree(child.get(), indent + 1);
       }
       result += indent_str + "}\n";
       break;
     }
     case query::PredicateType::kComposedOr: {
-      const auto* composed =
-          static_cast<const query::ComposedPredicate*>(predicate);
+      const auto *composed =
+          static_cast<const query::ComposedPredicate *>(predicate);
       result += indent_str + "OR{\n";
-      for (const auto& child : composed->GetChildren()) {
+      for (const auto &child : composed->GetChildren()) {
         result += PrintPredicateTree(child.get(), indent + 1);
       }
       result += indent_str + "}\n";
       break;
     }
     case query::PredicateType::kNegate: {
-      const auto* negate =
-          static_cast<const query::NegatePredicate*>(predicate);
+      const auto *negate =
+          static_cast<const query::NegatePredicate *>(predicate);
       result += indent_str + "NOT{\n";
       result += PrintPredicateTree(negate->GetPredicate(), indent + 1);
       result += indent_str + "}\n";
       break;
     }
     case query::PredicateType::kNumeric: {
-      const auto* numeric =
-          static_cast<const query::NumericPredicate*>(predicate);
+      const auto *numeric =
+          static_cast<const query::NumericPredicate *>(predicate);
       result +=
           indent_str + "NUMERIC(" + std::string(numeric->GetAlias()) + ")\n";
       break;
     }
     case query::PredicateType::kTag: {
-      const auto* tag = static_cast<const query::TagPredicate*>(predicate);
+      const auto *tag = static_cast<const query::TagPredicate *>(predicate);
       result += indent_str + "TAG(" + std::string(tag->GetAlias()) + ")\n";
       break;
     }
     case query::PredicateType::kText: {
-      const auto* text = static_cast<const query::TextPredicate*>(predicate);
+      const auto *text = static_cast<const query::TextPredicate *>(predicate);
       std::string field_mask_str = std::to_string(text->GetFieldMask());
 
       // Determine specific text predicate type
-      if (auto term = dynamic_cast<const query::TermPredicate*>(predicate)) {
+      if (auto term = dynamic_cast<const query::TermPredicate *>(predicate)) {
         result += indent_str + "TEXT-TERM(\"" +
                   std::string(term->GetTextString()) +
                   "\", field_mask=" + field_mask_str + ")\n";
       } else if (auto prefix =
-                     dynamic_cast<const query::PrefixPredicate*>(predicate)) {
+                     dynamic_cast<const query::PrefixPredicate *>(predicate)) {
         result += indent_str + "TEXT-PREFIX(\"" +
                   std::string(prefix->GetTextString()) +
                   "\", field_mask=" + field_mask_str + ")\n";
       } else if (auto suffix =
-                     dynamic_cast<const query::SuffixPredicate*>(predicate)) {
+                     dynamic_cast<const query::SuffixPredicate *>(predicate)) {
         result += indent_str + "TEXT-SUFFIX(\"" +
                   std::string(suffix->GetTextString()) +
                   "\", field_mask=" + field_mask_str + ")\n";
       } else if (auto infix =
-                     dynamic_cast<const query::InfixPredicate*>(predicate)) {
+                     dynamic_cast<const query::InfixPredicate *>(predicate)) {
         result += indent_str + "TEXT-INFIX(\"" +
                   std::string(infix->GetTextString()) +
                   "\", field_mask=" + field_mask_str + ")\n";
       } else if (auto fuzzy =
-                     dynamic_cast<const query::FuzzyPredicate*>(predicate)) {
+                     dynamic_cast<const query::FuzzyPredicate *>(predicate)) {
         result += indent_str + "TEXT-FUZZY(\"" +
                   std::string(fuzzy->GetTextString()) +
                   "\", distance=" + std::to_string(fuzzy->GetDistance()) +
@@ -187,9 +182,9 @@ std::string PrintPredicateTree(const query::Predicate* predicate, int indent) {
   return result;
 }
 
-FilterParser::FilterParser(const IndexSchema& index_schema,
+FilterParser::FilterParser(const IndexSchema &index_schema,
                            absl::string_view expression,
-                           const TextParsingOptions& options)
+                           const TextParsingOptions &options)
     : index_schema_(index_schema),
       expression_(absl::StripAsciiWhitespace(expression)),
       options_(options),
@@ -206,9 +201,9 @@ bool FilterParser::Match(char expected, bool skip_whitespace) {
   return false;
 }
 
-bool FilterParser::MatchInsensitive(const std::string& expected) {
+bool FilterParser::MatchInsensitive(const std::string &expected) {
   auto old_pos = pos_;
-  for (const auto& itr : expected) {
+  for (const auto &itr : expected) {
     if (!Match(itr, false) && !Match(absl::ascii_tolower(itr), false)) {
       pos_ = old_pos;
       return false;
@@ -281,7 +276,7 @@ absl::StatusOr<double> FilterParser::ParseNumber() {
 }
 
 absl::StatusOr<std::unique_ptr<query::NumericPredicate>>
-FilterParser::ParseNumericPredicate(const std::string& attribute_alias) {
+FilterParser::ParseNumericPredicate(const std::string &attribute_alias) {
   auto index = index_schema_.GetIndex(attribute_alias);
   if (!index.ok() ||
       index.value()->GetIndexerType() != indexes::IndexerType::kNumeric) {
@@ -319,7 +314,7 @@ FilterParser::ParseNumericPredicate(const std::string& attribute_alias) {
                      pos_));
   }
   auto numeric_index =
-      dynamic_cast<const indexes::Numeric*>(index.value().get());
+      dynamic_cast<const indexes::Numeric *>(index.value().get());
   query_operations_ |= QueryOperations::kContainsNumeric;
   return std::make_unique<query::NumericPredicate>(
       numeric_index, attribute_alias, identifier, start, is_inclusive_start,
@@ -347,7 +342,7 @@ FilterParser::ParseQueryTags(absl::string_view tag_string) {
 }
 
 absl::StatusOr<std::unique_ptr<query::TagPredicate>>
-FilterParser::ParseTagPredicate(const std::string& attribute_alias) {
+FilterParser::ParseTagPredicate(const std::string &attribute_alias) {
   auto index = index_schema_.GetIndex(attribute_alias);
   if (!index.ok() ||
       index.value()->GetIndexerType() != indexes::IndexerType::kTag) {
@@ -357,7 +352,7 @@ FilterParser::ParseTagPredicate(const std::string& attribute_alias) {
   auto identifier = index_schema_.GetIdentifier(attribute_alias).value();
   filter_identifiers_.insert(identifier);
 
-  auto tag_index = dynamic_cast<indexes::Tag*>(index.value().get());
+  auto tag_index = dynamic_cast<indexes::Tag *>(index.value().get());
   VMSDK_ASSIGN_OR_RETURN(auto tag_string, ParseTagString());
   VMSDK_ASSIGN_OR_RETURN(auto parsed_tags, ParseQueryTags(tag_string));
   query_operations_ |= QueryOperations::kContainsTag;
@@ -414,10 +409,10 @@ absl::StatusOr<bool> FilterParser::IsMatchAllExpression() {
 }
 
 void FilterParser::FlagNestedComposedPredicate(
-    std::unique_ptr<query::Predicate>& predicate) {
-  auto* composed = dynamic_cast<query::ComposedPredicate*>(predicate.get());
+    std::unique_ptr<query::Predicate> &predicate) {
+  auto *composed = dynamic_cast<query::ComposedPredicate *>(predicate.get());
   if (!composed) return;
-  for (const auto& child : composed->GetChildren()) {
+  for (const auto &child : composed->GetChildren()) {
     if (child->GetType() == query::PredicateType::kComposedAnd ||
         child->GetType() == query::PredicateType::kComposedOr) {
       query_operations_ |= QueryOperations::kContainsNestedComposed;
@@ -459,8 +454,8 @@ absl::StatusOr<FilterParseResults> FilterParser::Parse() {
 }
 
 inline std::unique_ptr<query::Predicate> MayNegatePredicate(
-    std::unique_ptr<query::Predicate> predicate, bool& negate,
-    QueryOperations& query_operations) {
+    std::unique_ptr<query::Predicate> predicate, bool &negate,
+    QueryOperations &query_operations) {
   if (negate) {
     negate = false;
     query_operations |= QueryOperations::kContainsNegate;
@@ -471,7 +466,7 @@ inline std::unique_ptr<query::Predicate> MayNegatePredicate(
 
 absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::WrapPredicate(
     std::unique_ptr<query::Predicate> prev_predicate,
-    std::unique_ptr<query::Predicate> predicate, bool& negate,
+    std::unique_ptr<query::Predicate> predicate, bool &negate,
     query::LogicalOperator logical_operator, bool no_prev_grp,
     bool not_rightmost_bracket) {
   auto new_predicate =
@@ -489,8 +484,8 @@ absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::WrapPredicate(
   // Only extend AND nodes when we're adding with AND operator
   if (prev_predicate->GetType() == query::PredicateType::kComposedAnd &&
       logical_operator == query::LogicalOperator::kAnd && !no_prev_grp) {
-    auto* composed =
-        dynamic_cast<query::ComposedPredicate*>(prev_predicate.get());
+    auto *composed =
+        dynamic_cast<query::ComposedPredicate *>(prev_predicate.get());
     composed->AddChild(std::move(new_predicate));
     query_operations_ |= QueryOperations::kContainsAnd;
     return prev_predicate;
@@ -502,14 +497,14 @@ absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::WrapPredicate(
       not_rightmost_bracket &&
       new_predicate->GetType() == query::PredicateType::kComposedOr) {
     std::vector<std::unique_ptr<query::Predicate>> new_children;
-    auto* new_composed =
-        dynamic_cast<query::ComposedPredicate*>(new_predicate.get());
+    auto *new_composed =
+        dynamic_cast<query::ComposedPredicate *>(new_predicate.get());
     auto children = new_composed->ReleaseChildren();
     new_children.reserve(1 + children.size());
     if (prev_predicate) {
       new_children.push_back(std::move(prev_predicate));
     }
-    for (auto& child : children) {
+    for (auto &child : children) {
       new_children.push_back(std::move(child));
     }
     query_operations_ |= QueryOperations::kContainsOr;
@@ -541,7 +536,7 @@ absl::StatusOr<std::unique_ptr<query::Predicate>> FilterParser::WrapPredicate(
 // \<non-punctuation> -> (break to new token)<non-punctuation>...
 // \<EOL> -> Return error
 absl::StatusOr<bool> FilterParser::HandleBackslashEscape(
-    const indexes::text::Lexer& lexer, std::string& processed_content) {
+    const indexes::text::Lexer &lexer, std::string &processed_content) {
   if (!Match('\\', false)) {
     // No backslash, continue normal processing of the same token.
     return true;
@@ -583,8 +578,8 @@ absl::StatusOr<bool> FilterParser::HandleBackslashEscape(
 // Token boundaries (separated by space): " <punctuation> \<non-punctuation>
 absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseQuotedTextToken(
     std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
-    const std::optional<std::string>& field_or_default) {
-  const auto& lexer = text_index_schema->GetLexer();
+    const std::optional<std::string> &field_or_default) {
+  const auto &lexer = text_index_schema->GetLexer();
   std::string processed_content;
   while (!IsEnd()) {
     VMSDK_ASSIGN_OR_RETURN(bool should_continue,
@@ -628,8 +623,8 @@ absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseQuotedTextToken(
 //   { } [ ] : ; $ -> error
 absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseUnquotedTextToken(
     std::shared_ptr<indexes::text::TextIndexSchema> text_index_schema,
-    const std::optional<std::string>& field_or_default) {
-  const auto& lexer = text_index_schema->GetLexer();
+    const std::optional<std::string> &field_or_default) {
+  const auto &lexer = text_index_schema->GetLexer();
   std::string processed_content;
   bool starts_with_star = false;
   bool ends_with_star = false;
@@ -770,15 +765,15 @@ absl::StatusOr<FilterParser::TokenResult> FilterParser::ParseUnquotedTextToken(
 }
 
 absl::Status FilterParser::SetupTextFieldConfiguration(
-    FieldMaskPredicate& field_mask,
-    const std::optional<std::string>& field_name, bool with_suffix) {
+    FieldMaskPredicate &field_mask,
+    const std::optional<std::string> &field_name, bool with_suffix) {
   if (field_name.has_value()) {
     auto index = index_schema_.GetIndex(*field_name);
     if (!index.ok() ||
         index.value()->GetIndexerType() != indexes::IndexerType::kText) {
       return absl::InvalidArgumentError("Index does not have any text field");
     }
-    auto* text_index = dynamic_cast<const indexes::Text*>(index.value().get());
+    auto *text_index = dynamic_cast<const indexes::Text *>(index.value().get());
     if (with_suffix && !text_index->WithSuffixTrie()) {
       return absl::InvalidArgumentError("Field does not support suffix search");
     }
@@ -814,7 +809,7 @@ absl::Status FilterParser::SetupTextFieldConfiguration(
 // parsing stops after first token.
 absl::StatusOr<std::optional<std::unique_ptr<query::Predicate>>>
 FilterParser::ParseTextTokens(
-    const std::optional<std::string>& field_or_default) {
+    const std::optional<std::string> &field_or_default) {
   auto text_index_schema = index_schema_.GetTextIndexSchema();
   if (!text_index_schema) {
     return absl::InvalidArgumentError("Index does not have any text field");
@@ -868,7 +863,7 @@ FilterParser::ParseTextTokens(
     }
     std::vector<std::unique_ptr<query::Predicate>> children;
     children.reserve(terms.size());
-    for (auto& term : terms) {
+    for (auto &term : terms) {
       children.push_back(std::move(term));
     }
     query_operations_ |= QueryOperations::kContainsProximity;

--- a/src/commands/ft_create_parser.cc
+++ b/src/commands/ft_create_parser.cc
@@ -110,8 +110,6 @@ static auto max_prefixes =
                                  kDefaultPrefixesCountLimit,  // default size
                                  1,                           // min size
                                  kMaxPrefixesCount)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxPrefixesCount, kMaxPrefixesConfig))
         .Build();
 
 /// Register the "--max-tag-field-length" flag. Controls the max length of a tag
@@ -121,8 +119,6 @@ static auto max_tag_field_len =
                                  kDefaultTagFieldLenLimit,  // default size
                                  1,                         // min size
                                  kMaxTagFieldLen)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxTagFieldLen, kMaxTagFieldLenConfig))
         .Build();
 
 /// Register the "--max-numeric-field-length" flag. Controls the max length of a
@@ -132,8 +128,6 @@ static auto max_numeric_field_len =
                                  kDefaultNumericFieldLenLimit,  // default size
                                  1,                             // min size
                                  kMaxNumericFieldLen)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxNumericFieldLen, kMaxNumericFieldLenConfig))
         .Build();
 
 /// Register the "--max-attributes" flag. Controls the max number of attributes
@@ -143,8 +137,6 @@ static auto max_attributes =
                                  kDefaultAttributesCountLimit,  // default size
                                  1,                             // min size
                                  kMaxAttributesCount)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxAttributesCount, kMaxAttributesConfig))
         .Build();
 
 /// Register the "--max-vector-attributes" flag. Controls the max number of
@@ -156,8 +148,6 @@ static auto max_vector_attributes =
                                  kDefaultAttributesCountLimit,  // default size
                                  1,                             // min size
                                  kMaxAttributesCount)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxAttributesCount, kMaxVectorAttributesConfig))
         .Build();
 
 /// Register the "--max-dimensions" flag. Controls the max dimensions for vector
@@ -167,19 +157,15 @@ static auto max_dimensions =
                                  kDefaultDimensionsCountLimit,  // default size
                                  1,                             // min size
                                  kMaxDimensionsCount)           // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxDimensionsCount, kMaxDimensionsConfig))
         .Build();
 
 /// Register the "--max-m" flag. Controls the max M parameter for HNSW
 /// algorithm.
-static auto max_m =
-    vmsdk::config::NumberBuilder(kMaxMConfig,  // name
-                                 kMaxM,        // default size
-                                 2,            // min size
-                                 kMaxM)        // max size
-        .WithValidationCallback(CHECK_RANGE(1, kMaxM, kMaxMConfig))
-        .Build();
+static auto max_m = vmsdk::config::NumberBuilder(kMaxMConfig,  // name
+                                                 kMaxM,        // default size
+                                                 2,            // min size
+                                                 kMaxM)        // max size
+                        .Build();
 
 /// Register the "--max-ef-construction" flag. Controls the max EF construction
 /// parameter for HNSW algorithm.
@@ -188,8 +174,6 @@ static auto max_ef_construction =
                                  kMaxEfConstruction,        // default size
                                  1,                         // min size
                                  kMaxEfConstruction)        // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxEfConstruction, kMaxEfConstructionConfig))
         .Build();
 
 /// Register the "--max-ef-runtime" flag. Controls the max EF runtime parameter
@@ -199,8 +183,6 @@ static auto max_ef_runtime =
                                  kMaxEfRuntime,        // default size
                                  1,                    // min size
                                  kMaxEfRuntime)        // max size
-        .WithValidationCallback(
-            CHECK_RANGE(1, kMaxEfRuntime, kMaxEfRuntimeConfig))
         .Build();
 
 /// Register the "--default-timeout-ms" flag. Controls the default timeout

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -42,7 +42,6 @@ static auto max_knn =
                                  kDefaultKnnLimit,  // default size
                                  1,                 // min size
                                  kMaxKnn)           // max size
-        .WithValidationCallback(CHECK_RANGE(1, kMaxKnn, kMaxKnnConfig))
         .Build();
 
 namespace options {

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -55,9 +55,6 @@ static auto max_search_result_record_size =
         kMaxSearchResultRecordSize / 2,    // default size
         kMinSearchResultRecordSize,        // min size
         kMaxSearchResultRecordSize)        // max size
-        .WithValidationCallback(CHECK_RANGE(kMinSearchResultRecordSize,
-                                            kMaxSearchResultRecordSize,
-                                            kMaxSearchResultRecordSizeConfig))
         .Build();
 
 /// Register the "--max-search-result-fields-count" flag. Controls the max
@@ -68,8 +65,6 @@ static auto max_search_result_fields_count =
         kMaxSearchResultFieldsCount / 2,    // default size
         1,                                  // min size
         kMaxSearchResultFieldsCount)        // max size
-        .WithValidationCallback(CHECK_RANGE(1, kMaxSearchResultFieldsCount,
-                                            kMaxSearchResultFieldsCountConfig))
         .Build();
 
 vmsdk::config::Number &GetMaxSearchResultRecordSize() {

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -64,7 +64,6 @@ static auto max_indexes =
                                  kMaxIndexesDefault,  // default size
                                  1,                   // min size
                                  kMaxIndexes)         // max size
-        .WithValidationCallback(CHECK_RANGE(1, kMaxIndexes, kMaxIndexesConfig))
         .Build();
 
 vmsdk::config::Number &GetMaxIndexes() {
@@ -77,9 +76,6 @@ static auto backfill_batch_size =
     vmsdk::config::NumberBuilder(kIndexSchemaBackfillBatchSizeConfig,
                                  kIndexSchemaBackfillBatchSize, 1,
                                  std::numeric_limits<int32_t>::max())
-        .WithValidationCallback(
-            CHECK_RANGE(1, std::numeric_limits<int32_t>::max(),
-                        kIndexSchemaBackfillBatchSizeConfig))
         .Build();
 
 vmsdk::config::Number &GetBackfillBatchSize() {

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -26,19 +26,8 @@ constexpr uint32_t kMaximumFTInfoRpcTimeoutMs{300000};
 
 namespace {
 
-/// Check that the new value for configuration item `hnsw-block-size` confirms
-/// to the allowed values.
-absl::Status ValidateHNSWBlockSize(long long new_value) {
-  if (new_value < kHNSWMinimumBlockSize || new_value > UINT32_MAX) {
-    return absl::InvalidArgumentError(
-        absl::StrFormat("Block size must be between %u and %u",
-                        kHNSWMinimumBlockSize, UINT32_MAX));
-  }
-  return absl::OkStatus();
-}
-
 /// Resize `pool` to match its new value
-void UpdateThreadPoolCount(vmsdk::ThreadPool* pool, long long new_value) {
+void UpdateThreadPoolCount(vmsdk::ThreadPool *pool, long long new_value) {
   if (!pool) {
     return;
   }
@@ -77,7 +66,6 @@ static auto hnsw_block_size =
                           kHNSWDefaultBlockSize,  // default size
                           kHNSWMinimumBlockSize,  // min size
                           UINT_MAX)               // max size
-        .WithValidationCallback(ValidateHNSWBlockSize)
         .Build();
 
 static const int64_t kDefaultThreadsCount = vmsdk::GetPhysicalCPUCoresCount();
@@ -301,7 +289,7 @@ static auto thread_pool_wait_time_samples =
         kMaximumThreadPoolWaitTimeSamples)  // max size (10k)
         .WithModifyCallback([](uint32_t new_size) {
           // Update thread pools when sample queue size changes
-          auto& instance = ValkeySearch::Instance();
+          auto &instance = ValkeySearch::Instance();
           if (auto reader_pool = instance.GetReaderThreadPool()) {
             reader_pool->ResizeSampleQueue(new_size);
           }
@@ -501,59 +489,57 @@ static auto query_string_depth =
                           kDefaultQueryStringDepth,  // default size
                           kMinimumQueryStringDepth,  // min size
                           UINT_MAX)                  // max size
-        .WithValidationCallback(CHECK_RANGE(kMinimumQueryStringDepth, UINT_MAX,
-                                            kQueryStringDepthConfig))
         .Build();
 
 uint32_t GetQueryStringBytes() { return query_string_bytes->GetValue(); }
 
-vmsdk::config::Number& GetHNSWBlockSize() {
-  return dynamic_cast<vmsdk::config::Number&>(*hnsw_block_size);
+vmsdk::config::Number &GetHNSWBlockSize() {
+  return dynamic_cast<vmsdk::config::Number &>(*hnsw_block_size);
 }
 
-vmsdk::config::Number& GetReaderThreadCount() {
-  return dynamic_cast<vmsdk::config::Number&>(*reader_threads_count);
+vmsdk::config::Number &GetReaderThreadCount() {
+  return dynamic_cast<vmsdk::config::Number &>(*reader_threads_count);
 }
 
-vmsdk::config::Number& GetWriterThreadCount() {
-  return dynamic_cast<vmsdk::config::Number&>(*writer_threads_count);
+vmsdk::config::Number &GetWriterThreadCount() {
+  return dynamic_cast<vmsdk::config::Number &>(*writer_threads_count);
 }
 
-vmsdk::config::Number& GetUtilityThreadCount() {
-  return dynamic_cast<vmsdk::config::Number&>(*utility_threads_count);
+vmsdk::config::Number &GetUtilityThreadCount() {
+  return dynamic_cast<vmsdk::config::Number &>(*utility_threads_count);
 }
 
-vmsdk::config::Number& GetMaxWorkerSuspensionSecs() {
+vmsdk::config::Number &GetMaxWorkerSuspensionSecs() {
   return max_worker_suspension_secs;
 }
 
-const vmsdk::config::Boolean& GetUseCoordinator() {
-  return dynamic_cast<const vmsdk::config::Boolean&>(*use_coordinator);
+const vmsdk::config::Boolean &GetUseCoordinator() {
+  return dynamic_cast<const vmsdk::config::Boolean &>(*use_coordinator);
 }
 
-const vmsdk::config::Boolean& GetSkipIndexLoad() {
-  return dynamic_cast<const vmsdk::config::Boolean&>(*rdb_load_skip_index);
+const vmsdk::config::Boolean &GetSkipIndexLoad() {
+  return dynamic_cast<const vmsdk::config::Boolean &>(*rdb_load_skip_index);
 }
 
-vmsdk::config::Boolean& GetSkipIndexLoadMutable() {
-  return dynamic_cast<vmsdk::config::Boolean&>(*rdb_load_skip_index);
+vmsdk::config::Boolean &GetSkipIndexLoadMutable() {
+  return dynamic_cast<vmsdk::config::Boolean &>(*rdb_load_skip_index);
 }
 
-const vmsdk::config::Boolean& GetSkipCorruptedInternalUpdateEntries() {
-  return dynamic_cast<const vmsdk::config::Boolean&>(
+const vmsdk::config::Boolean &GetSkipCorruptedInternalUpdateEntries() {
+  return dynamic_cast<const vmsdk::config::Boolean &>(
       *skip_corrupted_internal_update_entries);
 }
 
-vmsdk::config::Enum& GetLogLevel() {
-  return dynamic_cast<vmsdk::config::Enum&>(*log_level);
+vmsdk::config::Enum &GetLogLevel() {
+  return dynamic_cast<vmsdk::config::Enum &>(*log_level);
 }
 
-const config::Boolean& GetHNSWAllowReplaceDeleted() {
-  return dynamic_cast<const config::Boolean&>(*hnsw_allow_replace_deleted);
+const config::Boolean &GetHNSWAllowReplaceDeleted() {
+  return dynamic_cast<const config::Boolean &>(*hnsw_allow_replace_deleted);
 }
 
-config::Boolean& GetHNSWAllowReplaceDeletedMutable() {
-  return dynamic_cast<config::Boolean&>(*hnsw_allow_replace_deleted);
+config::Boolean &GetHNSWAllowReplaceDeletedMutable() {
+  return dynamic_cast<config::Boolean &>(*hnsw_allow_replace_deleted);
 }
 
 absl::Status Reset() {
@@ -562,86 +548,87 @@ absl::Status Reset() {
   return absl::OkStatus();
 }
 
-const vmsdk::config::Boolean& GetPreferPartialResults() {
-  return static_cast<vmsdk::config::Boolean&>(prefer_partial_results);
+const vmsdk::config::Boolean &GetPreferPartialResults() {
+  return static_cast<vmsdk::config::Boolean &>(prefer_partial_results);
 }
 
-const vmsdk::config::Boolean& GetPreferConsistentResults() {
-  return static_cast<vmsdk::config::Boolean&>(prefer_consistent_results);
+const vmsdk::config::Boolean &GetPreferConsistentResults() {
+  return static_cast<vmsdk::config::Boolean &>(prefer_consistent_results);
 }
 
-const vmsdk::config::Boolean& GetSearchResultBackgroundCleanup() {
-  return static_cast<vmsdk::config::Boolean&>(search_result_background_cleanup);
+const vmsdk::config::Boolean &GetSearchResultBackgroundCleanup() {
+  return static_cast<vmsdk::config::Boolean &>(
+      search_result_background_cleanup);
 }
 
-vmsdk::config::Number& GetHighPriorityWeight() {
-  return dynamic_cast<vmsdk::config::Number&>(*high_priority_weight);
+vmsdk::config::Number &GetHighPriorityWeight() {
+  return dynamic_cast<vmsdk::config::Number &>(*high_priority_weight);
 }
 
-vmsdk::config::Number& GetFTInfoTimeoutMs() {
-  return dynamic_cast<vmsdk::config::Number&>(*ft_info_timeout_ms);
+vmsdk::config::Number &GetFTInfoTimeoutMs() {
+  return dynamic_cast<vmsdk::config::Number &>(*ft_info_timeout_ms);
 }
 
-vmsdk::config::Number& GetFTInfoRpcTimeoutMs() {
-  return dynamic_cast<vmsdk::config::Number&>(*ft_info_rpc_timeout_ms);
+vmsdk::config::Number &GetFTInfoRpcTimeoutMs() {
+  return dynamic_cast<vmsdk::config::Number &>(*ft_info_rpc_timeout_ms);
 }
 
-vmsdk::config::Number& GetLocalFanoutQueueWaitThreshold() {
-  return dynamic_cast<vmsdk::config::Number&>(
+vmsdk::config::Number &GetLocalFanoutQueueWaitThreshold() {
+  return dynamic_cast<vmsdk::config::Number &>(
       *local_fanout_queue_wait_threshold);
 }
 
-vmsdk::config::Number& GetThreadPoolWaitTimeSamples() {
-  return dynamic_cast<vmsdk::config::Number&>(*thread_pool_wait_time_samples);
+vmsdk::config::Number &GetThreadPoolWaitTimeSamples() {
+  return dynamic_cast<vmsdk::config::Number &>(*thread_pool_wait_time_samples);
 }
 
-vmsdk::config::Number& GetMaxTermExpansions() {
-  return dynamic_cast<vmsdk::config::Number&>(*max_term_expansions);
+vmsdk::config::Number &GetMaxTermExpansions() {
+  return dynamic_cast<vmsdk::config::Number &>(*max_term_expansions);
 }
 
-vmsdk::config::Number& GetTagMinPrefixLength() {
-  return dynamic_cast<vmsdk::config::Number&>(*tag_min_prefix_length);
+vmsdk::config::Number &GetTagMinPrefixLength() {
+  return dynamic_cast<vmsdk::config::Number &>(*tag_min_prefix_length);
 }
 
-const vmsdk::config::Boolean& GetDrainMutationQueueOnSave() {
-  return dynamic_cast<const vmsdk::config::Boolean&>(
+const vmsdk::config::Boolean &GetDrainMutationQueueOnSave() {
+  return dynamic_cast<const vmsdk::config::Boolean &>(
       *drain_mutation_queue_on_save);
 }
 
-const vmsdk::config::Boolean& GetDrainMutationQueueOnLoad() {
-  return dynamic_cast<const vmsdk::config::Boolean&>(
+const vmsdk::config::Boolean &GetDrainMutationQueueOnLoad() {
+  return dynamic_cast<const vmsdk::config::Boolean &>(
       *drain_mutation_queue_on_load);
 }
 
-vmsdk::config::Number& GetFanoutDataUniformity() {
-  return dynamic_cast<vmsdk::config::Number&>(*fanout_data_uniformity);
+vmsdk::config::Number &GetFanoutDataUniformity() {
+  return dynamic_cast<vmsdk::config::Number &>(*fanout_data_uniformity);
 }
 
-vmsdk::config::Number& GetFanoutUniformityMinIndexSize() {
-  return dynamic_cast<vmsdk::config::Number&>(
+vmsdk::config::Number &GetFanoutUniformityMinIndexSize() {
+  return dynamic_cast<vmsdk::config::Number &>(
       *fanout_uniformity_min_index_size);
 }
 
-vmsdk::config::Number& GetMaxMutationQueueSizeOnRestore() {
-  return dynamic_cast<vmsdk::config::Number&>(
+vmsdk::config::Number &GetMaxMutationQueueSizeOnRestore() {
+  return dynamic_cast<vmsdk::config::Number &>(
       *max_mutation_queue_size_on_restore);
 }
 
-vmsdk::config::Number& GetAsyncFanoutThreshold() {
-  return dynamic_cast<vmsdk::config::Number&>(*async_fanout_threshold);
+vmsdk::config::Number &GetAsyncFanoutThreshold() {
+  return dynamic_cast<vmsdk::config::Number &>(*async_fanout_threshold);
 }
 
-config::Number& GetRaxTargetMutexPoolSize() {
-  return dynamic_cast<config::Number&>(*rax_target_mutex_pool_size);
+config::Number &GetRaxTargetMutexPoolSize() {
+  return dynamic_cast<config::Number &>(*rax_target_mutex_pool_size);
 }
 
-vmsdk::config::Number& GetMaxNonVectorSearchResultsFetched() {
-  return dynamic_cast<vmsdk::config::Number&>(
+vmsdk::config::Number &GetMaxNonVectorSearchResultsFetched() {
+  return dynamic_cast<vmsdk::config::Number &>(
       *max_nonvector_search_results_fetched);
 }
 
-vmsdk::config::Number& GetQueryStringDepth() {
-  return dynamic_cast<vmsdk::config::Number&>(*query_string_depth);
+vmsdk::config::Number &GetQueryStringDepth() {
+  return dynamic_cast<vmsdk::config::Number &>(*query_string_depth);
 }
 
 /// Register the "--mutation-weight-vector" flag. Controls the weight multiplier
@@ -691,20 +678,20 @@ static auto mutation_weight_tag =
         .Dev()
         .Build();
 
-config::Number& GetMutationWeightVector() {
-  return dynamic_cast<config::Number&>(*mutation_weight_vector);
+config::Number &GetMutationWeightVector() {
+  return dynamic_cast<config::Number &>(*mutation_weight_vector);
 }
 
-config::Number& GetMutationWeightText() {
-  return dynamic_cast<config::Number&>(*mutation_weight_text);
+config::Number &GetMutationWeightText() {
+  return dynamic_cast<config::Number &>(*mutation_weight_text);
 }
 
-config::Number& GetMutationWeightNumeric() {
-  return dynamic_cast<config::Number&>(*mutation_weight_numeric);
+config::Number &GetMutationWeightNumeric() {
+  return dynamic_cast<config::Number &>(*mutation_weight_numeric);
 }
 
-config::Number& GetMutationWeightTag() {
-  return dynamic_cast<config::Number&>(*mutation_weight_tag);
+config::Number &GetMutationWeightTag() {
+  return dynamic_cast<config::Number &>(*mutation_weight_tag);
 }
 
 /// Register the "emulate-release" flag (see COMPATIBILITY.md).
@@ -735,8 +722,8 @@ static auto emulate_release_config =
         .WithValidationCallback(ValidateEmulateRelease)
         .Build();
 
-config::Version& GetEmulateRelease() {
-  return dynamic_cast<config::Version&>(*emulate_release_config);
+config::Version &GetEmulateRelease() {
+  return dynamic_cast<config::Version &>(*emulate_release_config);
 }
 
 bool EnabledInVersion(vmsdk::ValkeyVersion version) {

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -187,8 +187,8 @@ absl::Status ModuleConfigManager::UpdateConfigFromKeyVal(
   return absl::OkStatus();
 }
 
-Number::Number(std::string_view name, int64_t default_value, int64_t min_value,
-               int64_t max_value)
+Number::Number(std::string_view name, long long default_value,
+               long long min_value, long long max_value)
     : ConfigBase(name),
       default_value_(default_value),
       min_value_(min_value),

--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -248,14 +248,25 @@ class ConfigBase : public Registerable {
 
 class Number : public ConfigBase<long long> {
  public:
-  Number(std::string_view name, int64_t default_value, int64_t min_value,
-         int64_t max_value);
+  Number(std::string_view name, long long default_value, long long min_value,
+         long long max_value);
   ~Number() override = default;
   absl::Status FromString(std::string_view value) override;
 
   // Getters for min/max values
-  int64_t GetMinValue() const { return min_value_; }
-  int64_t GetMaxValue() const { return max_value_; }
+  long long GetMinValue() const { return min_value_; }
+  long long GetMaxValue() const { return max_value_; }
+
+  absl::Status Validate(long long val) const override {
+    VMSDK_RETURN_IF_ERROR(ConfigBase<long long>::Validate(val));
+    // Custom callback overrides the default validation
+    if (!validate_callback_ && (val < min_value_ || val > max_value_)) {
+      return absl::OutOfRangeError(
+          absl::StrFormat("%s must be between %lld and %lld", GetName(),
+                          min_value_, max_value_));
+    }
+    return absl::OkStatus();
+  }
 
  protected:
   // Implementation specific
@@ -270,10 +281,10 @@ class Number : public ConfigBase<long long> {
     current_value_.store(val, std::memory_order_relaxed);
   }
 
-  int64_t default_value_{0};
-  int64_t min_value_{0};
-  int64_t max_value_{0};
-  std::atomic_int64_t current_value_{0};
+  long long default_value_{0};
+  long long min_value_{0};
+  long long max_value_{0};
+  std::atomic<long long> current_value_{0};
   FRIEND_TEST(Builder, ConfigBuilder);
 };
 
@@ -282,7 +293,7 @@ class Enum : public ConfigBase<int> {
  public:
   Enum(std::string_view name, int default_value,
        const std::vector<std::string_view> &names,
-       const std::vector<int> &value);
+       const std::vector<int> &values);
   ~Enum() override = default;
   absl::Status FromString(std::string_view value) override;
 
@@ -634,15 +645,6 @@ template <typename... Args>
 ConfigBuilder<vmsdk::ValkeyVersion> VersionBuilder(Args &&...args) {
   return Builder<vmsdk::ValkeyVersion>(std::forward<Args>(args)...);
 }
-
-#define CHECK_RANGE(MIN, MAX, CONFIG_NAME)                         \
-  [](const int value) {                                            \
-    if (value < MIN || value > MAX) {                              \
-      return absl::OutOfRangeError(absl::StrFormat(                \
-          "%s must be between %u and %u", CONFIG_NAME, MIN, MAX)); \
-    }                                                              \
-    return absl::OkStatus();                                       \
-  }
 
 }  // namespace config
 }  // namespace vmsdk


### PR DESCRIPTION
#1128

`WithValidationCallback` is used to validate the range for `Number` configs repetitively. We can add a `Validate()` function in the `Number` class like we have for the `Double` class.

This becomes a breaking change though because adding a default `Validate()` function to the Number class changes the behaviour of existing numeric configs that do not have a validation callback. For those, they can be set to any value at startup (min and max values aren't enforced) and only at runtime with CONFIG SET do the min and max values start mattering. Arguably this is a bug.