### PR TITLE
Fix reclaimable_memory underflow issue

### DIFF
--- a/src/metrics.h
+++ b/src/metrics.h
@@ -27,11 +27,11 @@ class Metrics {
   ~Metrics() = default;
 
   struct Stats {
-    uint64_t reclaimable_memory{0};
     uint64_t query_successful_requests_cnt{0};
     uint64_t query_failed_requests_cnt{0};
     uint64_t query_result_record_dropped_cnt{0};
     uint64_t query_hybrid_requests_cnt{0};
+    std::atomic<uint64_t> reclaimable_memory{0};
     std::atomic<uint64_t> query_nonvector_requests_cnt{0};
     std::atomic<uint64_t> query_vector_requests_cnt{0};
     std::atomic<uint64_t> query_text_requests_cnt{0};

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <thread>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -616,7 +616,7 @@ TEST_F(VectorIndexTest, SaveAndLoadFlat) {
 
 // verify reclaimable_memory is correctly synchronized and writes are not lost
 // lost writes can lead to negative integer underflow issue
-TEST_F(VectorIndexTest, ReclaimableMemoryRaceDoesNotReturnToBaseline)
+TEST_F(VectorIndexTest, ReclaimableMemoryRaceReturnsToBaseline)
 ABSL_NO_THREAD_SAFETY_ANALYSIS {
   constexpr int kThreads = 8;
   constexpr int kIters = 50000;
@@ -629,8 +629,9 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
     algo.addPoint(v.data(), t);  // one element owned per thread
   }
 
-  const int64_t baseline =
-      static_cast<int64_t>(Metrics::GetStats().reclaimable_memory);
+  // baseline is unsigned 64-bit integer, if goes to negative it underflows to a
+  // large positive integer
+  const uint64_t baseline = Metrics::GetStats().reclaimable_memory;
 
   std::vector<std::thread> threads;
   threads.reserve(kThreads);
@@ -646,10 +647,9 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
     th.join();
   }
 
-  // Correct behavior: perfectly balanced ops return to baseline. Current code
-  // loses updates under contention, so the counter drifts off baseline.
-  EXPECT_EQ(static_cast<int64_t>(Metrics::GetStats().reclaimable_memory),
-            baseline);
+  // With atomic RMW ops, perfectly balanced mark/unmark cycles must net to
+  // zero, so the counter must return to its pre-test baseline.
+  EXPECT_EQ(Metrics::GetStats().reclaimable_memory, baseline);
 }
 
 }  // namespace

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -12,9 +12,9 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
-#include <thread>
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -613,6 +613,45 @@ TEST_F(VectorIndexTest, SaveAndLoadFlat) {
     }
   }
 }
+
+// verify reclaimable_memory is correctly synchronized and writes are not lost
+// lost writes can lead to negative integer underflow issue
+TEST_F(VectorIndexTest, ReclaimableMemoryRaceDoesNotReturnToBaseline)
+ABSL_NO_THREAD_SAFETY_ANALYSIS {
+  constexpr int kThreads = 8;
+  constexpr int kIters = 50000;
+  hnswlib::L2Space l2_space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&l2_space, /*max_elements=*/kThreads, kM,
+                                       kEFConstruction, /*random_seed=*/100,
+                                       /*allow_replace_deleted=*/false);
+  std::vector<float> v(kDimensions, 1.0f);
+  for (int t = 0; t < kThreads; ++t) {
+    algo.addPoint(v.data(), t);  // one element owned per thread
+  }
+
+  const int64_t baseline =
+      static_cast<int64_t>(Metrics::GetStats().reclaimable_memory);
+
+  std::vector<std::thread> threads;
+  threads.reserve(kThreads);
+  for (int t = 0; t < kThreads; ++t) {
+    threads.emplace_back([&algo, t]() {
+      for (int i = 0; i < kIters; ++i) {
+        algo.markDelete(t);    // += vector_size_
+        algo.unmarkDelete(t);  // -= vector_size_  (net per cycle: 0)
+      }
+    });
+  }
+  for (auto& th : threads) {
+    th.join();
+  }
+
+  // Correct behavior: perfectly balanced ops return to baseline. Current code
+  // loses updates under contention, so the counter drifts off baseline.
+  EXPECT_EQ(static_cast<int64_t>(Metrics::GetStats().reclaimable_memory),
+            baseline);
+}
+
 }  // namespace
 
 }  // namespace valkey_search::indexes


### PR DESCRIPTION
## Fix Summary — reclaimable_memory Underflow

  ### Root Cause

  Metrics::Stats::reclaimable_memory was declared as a plain uint64_t but updated concurrently from multiple threads (vector index deletes/reclaims). Racing read-modify-write on subtraction caused the counter to wrap around past zero, surfacing as a huge bogus value in the reported memory stats.

  ### Fix

  src/metrics.h — Changed the field type from uint64_t to std::atomic<uint64_t>:
  This ensures all increments and decrements are atomic and can no longer interleave into an underflow.

  ### Test

testing/vector_test.cc — Added a multi-threaded test that performs concurrent updates to reclaimable_memory to verify the counter stays consistent under load.

### Note
If not setting reclaimable_memory to atomic, the test fails with an underflow, exactly reproducing the production scenario
```
[ RUN      ] VectorIndexTest.ReclaimableMemoryRaceReturnsToBaseline
/testing/vector_test.cc:652: Failure
Expected equality of these values:
  Metrics::GetStats().reclaimable_memory
    Which is: 18446744073709539216
  baseline
    Which is: 0
```