### PR TITLE
[backport 1.0] Fix concurrency group for integration asan tests (#676)

### DIFF
--- a/.github/workflows/integration_tests-asan.yml
+++ b/.github/workflows/integration_tests-asan.yml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: integration-tests-${{ github.head_ref || github.ref }}
+  group: integration-tests-asan-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Backports **#676** to `1.0` (cherry-pick `7e28676`).

Fixes the integration-asan concurrency group, which incorrectly shared `integration-tests-…` with the non-asan workflow (causing runs to cancel each other). Now uses `integration-tests-asan-…`.

`macos.yml` doesn't exist on `1.0`, so only the asan file is changed.
