### PR TITLE
[Backport 1.2] ASAN build and test fixes

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -500,7 +500,7 @@ elif [[ "${INTEGRATION_TEST}" == "yes" ]]; then
     export TEST_PATTERN=${TEST_PATTERN}
     export INTEG_RETRIES=${INTEG_RETRIES}
     # Run will run ASan or normal tests based on the environment variable SAN_BUILD
-    ./run.sh
+    ./run.sh || EXIT_CODE=1
     popd >/dev/null
 fi
 

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -147,6 +147,8 @@ print_environment_var "LOGS_DIR" "${LOGS_DIR}"
 rm -fr ${LOGS_DIR}
 mkdir -p ${LOGS_DIR}
 
+PYTEST_OUTPUT_LOG=${LOGS_DIR}/pytest_output.log
+
 function run_pytest() {
   zap valkey-server
   
@@ -158,7 +160,8 @@ function run_pytest() {
   fi
   
   LOG_INFO "Running: ${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/"
-  ${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/
+  # Capture pytest output to check for sanitizer errors
+  script -q -e -c "${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/" ${PYTEST_OUTPUT_LOG}
   RUN_SUCCESS=$?
 }
 
@@ -197,4 +200,6 @@ if [[ "${SAN_BUILD}" != "no" ]]; then
   # And now we can check the logs
   logfiles=$(find ${LOGS_DIR} -name "*.log")
   check_for_san_errors "${logfiles}"
+  # Check pytest output for sanitizer errors
+  check_for_san_errors "${PYTEST_OUTPUT_LOG}"
 fi

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -13,6 +13,7 @@
 #include "src/schema_manager.h"
 #include "src/valkey_search.h"
 #include "vmsdk/src/debug.h"
+#include "vmsdk/src/utils.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::server_events {
@@ -53,9 +54,19 @@ void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
 
 void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                         uint64_t subevent, void *data) {
-  // Clear all PausePoints first so any waiting worker threads wake up and
-  // exit their spin loops before global destructors destroy the map.
+  // Mark the module as shutting down so that RunByMain() stops
+  // scheduling new tasks.
+  vmsdk::MarkAsShuttingDown();
+  // Clear all PausePoints so any waiting worker threads wake up and exit
+  // their spin loops, then join all thread pools so every in-flight task
+  // completes before we tear down index schemas.  This ordering matters:
+  //   1. ClearAllPausePoints  – unblocks workers stuck in PausePoint().
+  //   2. JoinAllThreadPools   – drains task queues and waits for every
+  //      worker thread to exit.
+  //   3. OnShutdownCallback   – removes all index schemas on the main
+  //      thread.
   vmsdk::debug::ClearAllPausePoints();
+  ValkeySearch::Instance().JoinAllThreadPools();
   SchemaManager::Instance().OnShutdownCallback(ctx, eid, subevent, data);
 }
 

--- a/src/server_events.cc
+++ b/src/server_events.cc
@@ -12,6 +12,7 @@
 #include "src/coordinator/metadata_manager.h"
 #include "src/schema_manager.h"
 #include "src/valkey_search.h"
+#include "vmsdk/src/debug.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
 namespace valkey_search::server_events {
@@ -52,6 +53,9 @@ void OnServerCronCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
 
 void OnShutdownCallback(ValkeyModuleCtx *ctx, ValkeyModuleEvent eid,
                         uint64_t subevent, void *data) {
+  // Clear all PausePoints first so any waiting worker threads wake up and
+  // exit their spin loops before global destructors destroy the map.
+  vmsdk::debug::ClearAllPausePoints();
   SchemaManager::Instance().OnShutdownCallback(ctx, eid, subevent, data);
 }
 

--- a/src/valkey_search.h
+++ b/src/valkey_search.h
@@ -54,6 +54,16 @@ class ValkeySearch {
   vmsdk::ThreadPool *GetUtilityThreadPool() const {
     return utility_thread_pool_.get();
   }
+
+  // Stop and join all owned thread pools so no worker threads remain alive.
+  // Intended for use during module shutdown before global destructors run,
+  // to avoid worker threads racing with destruction of global state.
+  void JoinAllThreadPools() {
+    if (reader_thread_pool_) reader_thread_pool_->JoinWorkers();
+    if (writer_thread_pool_) writer_thread_pool_->JoinWorkers();
+    if (utility_thread_pool_) utility_thread_pool_->JoinWorkers();
+  }
+
   std::shared_ptr<vmsdk::ThreadGroupCPUMonitor> GetCoordinatorThreadsMonitor()
       const {
     return coordinator_thread_monitor_;

--- a/vmsdk/src/debug.cc
+++ b/vmsdk/src/debug.cc
@@ -132,6 +132,16 @@ void PausePointList(ValkeyModuleCtx* ctx) {
 }
 
 //
+// Release all PausePoint waiters by clearing the map. Waiting threads will
+// see that their point no longer exists and return from PausePoint().
+// Must be called during shutdown before global destructors run.
+//
+void ClearAllPausePoints() {
+  absl::MutexLock lock(&pause_point_lock);
+  pause_point_waiters.clear();
+}
+
+//
 // Controlled Variable Machinery
 //
 absl::Mutex ControlledVariableLock;

--- a/vmsdk/src/debug.h
+++ b/vmsdk/src/debug.h
@@ -56,6 +56,13 @@ absl::StatusOr<size_t> PausePointWaiters(absl::string_view point);
 void PausePointList(ValkeyModuleCtx* ctx);
 
 //
+// Release all PausePoint waiters and clear the map.
+// Must be called during shutdown before global destructors run.
+//
+void ClearAllPausePoints();
+
+//
+//
 // Controlled variables are similar to Configurables in that they are
 // variables that code can use to control their behavior. Controlled Variables
 // are not part of the stable API as they are specifically targeted at internal

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -70,9 +70,21 @@ void TrackCurrentAsMainThread() {
 
 bool IsMainThread() { return is_main_thread; }
 
+static std::atomic<bool> shutting_down{false};
+
+void MarkAsShuttingDown() { shutting_down.store(true); }
+
+bool IsShuttingDown() { return shutting_down.load(); }
+
 int RunByMain(absl::AnyInvocable<void()> fn, bool force_async) {
   if (IsMainThread() && !force_async) {
     fn();
+    return VALKEYMODULE_OK;
+  }
+  // During shutdown the event loop is no longer processing one-shot
+  // callbacks.
+  if (IsShuttingDown()) {
+    VMSDK_LOG(DEBUG, nullptr) << "RunByMain: dropping callback during shutdown";
     return VALKEYMODULE_OK;
   }
   auto call_by_main = new absl::AnyInvocable<void()>(std::move(fn));

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -55,6 +55,9 @@ void TrackCurrentAsMainThread();
 bool IsMainThread();
 inline void VerifyMainThread() { CHECK(IsMainThread()); }
 
+void MarkAsShuttingDown();
+bool IsShuttingDown();
+
 // MainThreadAccessGuard ensures that all access to the underlying data
 // structure is done on the main thread.
 template <typename T>


### PR DESCRIPTION
Backport couple of ASAN fixes

  | Commit | Commit Message | PR |
  |--------|----------------|-----|
  | `84bc31f` | Fix build script for ASAN integration tests | [#777](https://github.com/valkey-io/valkey-search/pull/777) |
  | `0678285` | Fix heap-use-after-free in PausePoint during server shutdown for multirdb test | [#958](https://github.com/valkey-io/valkey-search/pull/958) |
  | `e8bb678` | fix test_dropindex_with_background_queries heap-use-after-free leak | [#961](https://github.com/valkey-io/valkey-search/pull/961) |
  
  
**Note:** Both #958 and #961 touch `server_events.cc`. Took #961's version since it's a superset of #958 — nothing lost.