### PR TITLE
Fix FT.INTERNAL_UPDATE crashes during AOF/RDB load (#1108, #1109)

### DIFF
--- a/src/commands/ft_internal_update.cc
+++ b/src/commands/ft_internal_update.cc
@@ -16,14 +16,10 @@ namespace valkey_search {
 
 constexpr int kFTInternalUpdateArgCount = 4;
 
-// Handles a parse/processing failure for an FT.INTERNAL_UPDATE entry. Returns a
-// status that the caller propagates by returning immediately (it never falls
-// through to applying a half-parsed entry).
-//
-// During AOF/RDB loading a failure is either skipped (when the operator opts in
-// via search.skip-corrupted-internal-update-entries) or surfaced as a
-// recoverable error. Corrupt persisted data must not abort the process, so this
-// never uses a fatal CHECK.
+// Handles an FT.INTERNAL_UPDATE failure. The caller must return its result
+// immediately (never fall through to applying a half-parsed entry). During
+// loading, a failure is either skipped (if the skip-corrupted config is set) or
+// returned as a recoverable error -- corrupt persisted data must not abort.
 absl::Status HandleInternalUpdateFailure(ValkeyModuleCtx *ctx,
                                          const std::string &operation_type,
                                          const std::string &id,
@@ -48,9 +44,8 @@ absl::Status HandleInternalUpdateFailure(ValkeyModuleCtx *ctx,
       return absl::OkStatus();
     }
     return absl::DataLossError(
-        "Corrupt FT.INTERNAL_UPDATE entry encountered during loading. Set "
-        "search.skip-corrupted-internal-update-entries=yes to skip such "
-        "entries, or repair/remove the offending AOF entry.");
+        "Corrupt FT.INTERNAL_UPDATE entry during loading; set "
+        "search.skip-corrupted-internal-update-entries=yes to skip it");
   }
 
   return error_status;
@@ -82,11 +77,10 @@ absl::Status FTInternalUpdateCmd(ValkeyModuleCtx *ctx,
             "Failed to parse GlobalMetadataVersionHeader"));
   }
 
-  // FT.INTERNAL_UPDATE only carries coordinator metadata. The MetadataManager
-  // is only initialized when the coordinator is enabled (cluster mode). If a
-  // node persisted these entries to its AOF and is later loaded without the
-  // coordinator (e.g. standalone), there is no MetadataManager to apply them
-  // to, so skip rather than dereference an uninitialized instance.
+  // The MetadataManager only exists when the coordinator is enabled (cluster
+  // mode). If these entries were persisted to the AOF and later loaded without
+  // the coordinator (e.g. standalone), skip rather than dereference the
+  // uninitialized instance.
   if (!coordinator::MetadataManager::IsInitialized()) {
     ValkeyModule_ReplyWithSimpleString(ctx, "OK");
     return absl::OkStatus();

--- a/src/commands/ft_internal_update.cc
+++ b/src/commands/ft_internal_update.cc
@@ -16,15 +16,18 @@ namespace valkey_search {
 
 constexpr int kFTInternalUpdateArgCount = 4;
 
-// Helper function to handle parse failures with poison pill recovery
-absl::Status HandleInternalUpdateFailure(
-    ValkeyModuleCtx *ctx, const std::string &operation_type,
-    const std::string &id,
-    const absl::Status &error_status = absl::OkStatus()) {
-  if (error_status.ok()) {
-    return absl::OkStatus();
-  }
-
+// Handles a parse/processing failure for an FT.INTERNAL_UPDATE entry. Returns a
+// status that the caller propagates by returning immediately (it never falls
+// through to applying a half-parsed entry).
+//
+// During AOF/RDB loading a failure is either skipped (when the operator opts in
+// via search.skip-corrupted-internal-update-entries) or surfaced as a
+// recoverable error. Corrupt persisted data must not abort the process, so this
+// never uses a fatal CHECK.
+absl::Status HandleInternalUpdateFailure(ValkeyModuleCtx *ctx,
+                                         const std::string &operation_type,
+                                         const std::string &id,
+                                         const absl::Status &error_status) {
   VMSDK_LOG(WARNING, ctx) << "CRITICAL: " << operation_type
                           << " failed in FT.INTERNAL_UPDATE. "
                           << "Index ID: " << vmsdk::config::RedactIfNeeded(id);
@@ -38,19 +41,19 @@ absl::Status HandleInternalUpdateFailure(
   if (ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING) {
     if (options::GetSkipCorruptedInternalUpdateEntries().GetValue()) {
       VMSDK_LOG(WARNING, ctx)
-          << "SKIPPING corrupted AOF entry due to configuration";
+          << "SKIPPING corrupted FT.INTERNAL_UPDATE AOF entry due to "
+             "configuration";
       Metrics::GetStats().ft_internal_update_skipped_entries_cnt++;
       ValkeyModule_ReplyWithSimpleString(ctx, "OK");
       return absl::OkStatus();
-    } else {
-      CHECK(false)
-          << "Internal update failure during AOF loading - cannot continue";
     }
+    return absl::DataLossError(
+        "Corrupt FT.INTERNAL_UPDATE entry encountered during loading. Set "
+        "search.skip-corrupted-internal-update-entries=yes to skip such "
+        "entries, or repair/remove the offending AOF entry.");
   }
 
-  return error_status.ok()
-             ? absl::InternalError("ERR " + operation_type + " failed")
-             : error_status;
+  return error_status;
 }
 
 absl::Status FTInternalUpdateCmd(ValkeyModuleCtx *ctx,
@@ -65,27 +68,40 @@ absl::Status FTInternalUpdateCmd(ValkeyModuleCtx *ctx,
   coordinator::GlobalMetadataEntry metadata_entry;
   if (!metadata_entry.ParseFromArray(metadata_view.data(),
                                      metadata_view.size())) {
-    VMSDK_RETURN_IF_ERROR(HandleInternalUpdateFailure(
+    return HandleInternalUpdateFailure(
         ctx, "GlobalMetadataEntry parse", id,
-        absl::InvalidArgumentError("Failed to parse GlobalMetadataEntry")));
+        absl::InvalidArgumentError("Failed to parse GlobalMetadataEntry"));
   }
 
   auto header_view = vmsdk::ToStringView(argv[3]);
   coordinator::GlobalMetadataVersionHeader version_header;
   if (!version_header.ParseFromArray(header_view.data(), header_view.size())) {
-    VMSDK_RETURN_IF_ERROR(HandleInternalUpdateFailure(
+    return HandleInternalUpdateFailure(
         ctx, "GlobalMetadataVersionHeader parse", id,
         absl::InvalidArgumentError(
-            "Failed to parse GlobalMetadataVersionHeader")));
+            "Failed to parse GlobalMetadataVersionHeader"));
   }
+
+  // FT.INTERNAL_UPDATE only carries coordinator metadata. The MetadataManager
+  // is only initialized when the coordinator is enabled (cluster mode). If a
+  // node persisted these entries to its AOF and is later loaded without the
+  // coordinator (e.g. standalone), there is no MetadataManager to apply them
+  // to, so skip rather than dereference an uninitialized instance.
+  if (!coordinator::MetadataManager::IsInitialized()) {
+    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
+    return absl::OkStatus();
+  }
+
   int flags = ValkeyModule_GetContextFlags(ctx);
   if ((flags & VALKEYMODULE_CTX_FLAGS_SLAVE) ||
       (flags & VALKEYMODULE_CTX_FLAGS_LOADING)) {
     auto status = coordinator::MetadataManager::Instance().CreateEntryOnReplica(
         ctx, kSchemaManagerMetadataTypeName, id, &metadata_entry,
         &version_header);
-    VMSDK_RETURN_IF_ERROR(
-        HandleInternalUpdateFailure(ctx, "CreateEntryOnReplica", id, status));
+    if (!status.ok()) {
+      return HandleInternalUpdateFailure(ctx, "CreateEntryOnReplica", id,
+                                         status);
+    }
   }
 
   ValkeyModule_ReplicateVerbatim(ctx);

--- a/src/commands/ft_internal_update.cc
+++ b/src/commands/ft_internal_update.cc
@@ -78,12 +78,16 @@ absl::Status FTInternalUpdateCmd(ValkeyModuleCtx *ctx,
   }
 
   // The MetadataManager only exists when the coordinator is enabled (cluster
-  // mode). If these entries were persisted to the AOF and later loaded without
-  // the coordinator (e.g. standalone), skip rather than dereference the
-  // uninitialized instance.
+  // mode). Receiving an FT.INTERNAL_UPDATE without it (e.g. a coordinator-mode
+  // AOF replayed on a standalone node) is a misconfiguration: there is nowhere
+  // to apply the entry. Surface it as an error rather than dereferencing the
+  // uninitialized instance; during loading it is skippable like any other
+  // corrupt/unexpected entry.
   if (!coordinator::MetadataManager::IsInitialized()) {
-    ValkeyModule_ReplyWithSimpleString(ctx, "OK");
-    return absl::OkStatus();
+    return HandleInternalUpdateFailure(
+        ctx, "MetadataManager not initialized", id,
+        absl::FailedPreconditionError(
+            "FT.INTERNAL_UPDATE received without the coordinator enabled"));
   }
 
   int flags = ValkeyModule_GetContextFlags(ctx);

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -915,23 +915,25 @@ absl::Status MetadataManager::CreateEntryOnReplica(
     ValkeyModuleCtx *ctx, absl::string_view type_name, absl::string_view id,
     const coordinator::GlobalMetadataEntry *metadata_entry,
     const coordinator::GlobalMetadataVersionHeader *global_version_header) {
-  // Verify this is only called on replica nodes or during loading
-  CHECK((ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_SLAVE) ||
-        (ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING))
-      << "CreateEntryOnReplica should only be called on replica nodes or "
-         "during loading";
-
   auto obj_name = ObjName::Decode(id);
 
-  // Skip the callback during loading: the SchemaManager is not ready during
-  // early AOF/RDB replay and would crash. The entry is still stored below, and
-  // OnLoadingEnded re-applies fingerprints/versions to the schemas after load.
-  if (!(ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING)) {
+  if (ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_SLAVE) {
+    // On a live replica, apply the entry to the SchemaManager immediately.
     auto callback_result =
         TriggerCallbacks(type_name, obj_name, *metadata_entry);
     if (!callback_result.ok()) {
       return callback_result;
     }
+  } else {
+    // The only other valid caller is AOF/RDB loading. The SchemaManager is not
+    // ready during early replay, so the callback is skipped here; the entry is
+    // still stored below. Schemas themselves are recreated from their own AOF
+    // commands (FT.CREATE/FT.DROP/...), and OnLoadingEnded then re-applies the
+    // coordinator fingerprint/version onto them via
+    // PopulateFingerprintVersionFromMetadata.
+    CHECK(ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING)
+        << "CreateEntryOnReplica should only be called on a replica or during "
+           "loading";
   }
 
   auto result = metadata_.Get();

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -923,11 +923,9 @@ absl::Status MetadataManager::CreateEntryOnReplica(
 
   auto obj_name = ObjName::Decode(id);
 
-  // Skip the registered update callback during loading. The callback applies
-  // the entry to the SchemaManager, whose state is not yet ready during early
-  // AOF/RDB replay (and would otherwise crash). Fingerprints/versions for the
-  // stored entries are re-applied to the schemas in OnLoadingEnded once loading
-  // completes, mirroring the staged-reconcile path used for RDB replication.
+  // Skip the callback during loading: the SchemaManager is not ready during
+  // early AOF/RDB replay and would crash. The entry is still stored below, and
+  // OnLoadingEnded re-applies fingerprints/versions to the schemas after load.
   if (!(ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING)) {
     auto callback_result =
         TriggerCallbacks(type_name, obj_name, *metadata_entry);

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -922,9 +922,18 @@ absl::Status MetadataManager::CreateEntryOnReplica(
          "during loading";
 
   auto obj_name = ObjName::Decode(id);
-  auto callback_result = TriggerCallbacks(type_name, obj_name, *metadata_entry);
-  if (!callback_result.ok()) {
-    return callback_result;
+
+  // Skip the registered update callback during loading. The callback applies
+  // the entry to the SchemaManager, whose state is not yet ready during early
+  // AOF/RDB replay (and would otherwise crash). Fingerprints/versions for the
+  // stored entries are re-applied to the schemas in OnLoadingEnded once loading
+  // completes, mirroring the staged-reconcile path used for RDB replication.
+  if (!(ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING)) {
+    auto callback_result =
+        TriggerCallbacks(type_name, obj_name, *metadata_entry);
+    if (!callback_result.ok()) {
+      return callback_result;
+    }
   }
 
   auto result = metadata_.Get();

--- a/testing/commands/ft_internal_update_test.cc
+++ b/testing/commands/ft_internal_update_test.cc
@@ -20,17 +20,15 @@ class FTInternalUpdateTest : public ValkeySearchTest {
   void SetUp() override {
     ValkeySearchTest::SetUp();
     // Ensure each test starts with the skip flag disabled (the default).
-    VMSDK_EXPECT_OK(
-        const_cast<vmsdk::config::Boolean&>(
-            options::GetSkipCorruptedInternalUpdateEntries())
-            .SetValue(false));
+    VMSDK_EXPECT_OK(const_cast<vmsdk::config::Boolean&>(
+                        options::GetSkipCorruptedInternalUpdateEntries())
+                        .SetValue(false));
   }
 
   void TearDown() override {
-    VMSDK_EXPECT_OK(
-        const_cast<vmsdk::config::Boolean&>(
-            options::GetSkipCorruptedInternalUpdateEntries())
-            .SetValue(false));
+    VMSDK_EXPECT_OK(const_cast<vmsdk::config::Boolean&>(
+                        options::GetSkipCorruptedInternalUpdateEntries())
+                        .SetValue(false));
     ValkeySearchTest::TearDown();
   }
 };
@@ -86,9 +84,8 @@ TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingReturnsErrorNoCrash) {
 
   auto status = FTInternalUpdateCmd(&fake_ctx_, argv, 4);
   EXPECT_EQ(status.code(), absl::StatusCode::kDataLoss);
-  EXPECT_THAT(
-      status.message(),
-      testing::HasSubstr("skip-corrupted-internal-update-entries"));
+  EXPECT_THAT(status.message(),
+              testing::HasSubstr("skip-corrupted-internal-update-entries"));
 
   for (int i = 0; i < 4; i++) {
     TestValkeyModule_FreeString(&fake_ctx_, argv[i]);
@@ -99,10 +96,9 @@ TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingReturnsErrorNoCrash) {
 // command returns OK, increments the skipped metric, and does not crash.
 // Regression test for #1109 (the flag used to log "SKIPPING" then SIGSEGV).
 TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingSkippedWhenConfigured) {
-  VMSDK_EXPECT_OK(
-      const_cast<vmsdk::config::Boolean&>(
-          options::GetSkipCorruptedInternalUpdateEntries())
-          .SetValue(true));
+  VMSDK_EXPECT_OK(const_cast<vmsdk::config::Boolean&>(
+                      options::GetSkipCorruptedInternalUpdateEntries())
+                      .SetValue(true));
   EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
       .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
 

--- a/testing/commands/ft_internal_update_test.cc
+++ b/testing/commands/ft_internal_update_test.cc
@@ -121,15 +121,40 @@ TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingSkippedWhenConfigured) {
   }
 }
 
-// A valid entry replayed while loading, with no coordinator (MetadataManager
-// uninitialized — the standalone default), must not crash. It replies OK and
-// returns without touching the uninitialized singleton.
+// A valid entry replayed while loading with no coordinator (MetadataManager
+// uninitialized -- the standalone default) is a misconfiguration. It must not
+// crash on the uninitialized singleton; it returns a recoverable error.
 TEST_F(FTInternalUpdateTest, ValidEntryWhileLoadingWithoutCoordinatorNoCrash) {
   ASSERT_FALSE(coordinator::MetadataManager::IsInitialized());
   EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
       .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
 
   // Empty strings parse as valid (empty) protobufs.
+  ValkeyModuleString* argv[4];
+  argv[0] =
+      TestValkeyModule_CreateStringPrintf(&fake_ctx_, "FT.INTERNAL_UPDATE");
+  argv[1] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "test_id");
+  argv[2] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "");
+  argv[3] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "");
+
+  auto status = FTInternalUpdateCmd(&fake_ctx_, argv, 4);
+  EXPECT_FALSE(status.ok());
+
+  for (int i = 0; i < 4; i++) {
+    TestValkeyModule_FreeString(&fake_ctx_, argv[i]);
+  }
+}
+
+// The same misconfiguration is skippable: with the skip flag set, a loading
+// node without a coordinator returns OK instead of erroring.
+TEST_F(FTInternalUpdateTest, WithoutCoordinatorWhileLoadingSkippable) {
+  ASSERT_FALSE(coordinator::MetadataManager::IsInitialized());
+  VMSDK_EXPECT_OK(const_cast<vmsdk::config::Boolean&>(
+                      options::GetSkipCorruptedInternalUpdateEntries())
+                      .SetValue(true));
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
+
   ValkeyModuleString* argv[4];
   argv[0] =
       TestValkeyModule_CreateStringPrintf(&fake_ctx_, "FT.INTERNAL_UPDATE");

--- a/testing/commands/ft_internal_update_test.cc
+++ b/testing/commands/ft_internal_update_test.cc
@@ -6,12 +6,34 @@
 
 #include <gtest/gtest.h>
 
+#include "absl/status/status.h"
 #include "src/commands/commands.h"
+#include "src/metrics.h"
+#include "src/valkey_search_options.h"
 #include "testing/common.h"
+#include "vmsdk/src/module_config.h"
 
 namespace valkey_search {
 
-class FTInternalUpdateTest : public ValkeySearchTest {};
+class FTInternalUpdateTest : public ValkeySearchTest {
+ protected:
+  void SetUp() override {
+    ValkeySearchTest::SetUp();
+    // Ensure each test starts with the skip flag disabled (the default).
+    VMSDK_EXPECT_OK(
+        const_cast<vmsdk::config::Boolean&>(
+            options::GetSkipCorruptedInternalUpdateEntries())
+            .SetValue(false));
+  }
+
+  void TearDown() override {
+    VMSDK_EXPECT_OK(
+        const_cast<vmsdk::config::Boolean&>(
+            options::GetSkipCorruptedInternalUpdateEntries())
+            .SetValue(false));
+    ValkeySearchTest::TearDown();
+  }
+};
 
 TEST_F(FTInternalUpdateTest, WrongArguments) {
   ValkeyModuleString* argv[2];
@@ -48,7 +70,10 @@ TEST_F(FTInternalUpdateTest, ParseErrorMetadata) {
   }
 }
 
-TEST_F(FTInternalUpdateTest, ParseErrorWithLoadingFlagCrashes) {
+// A corrupt entry during loading with the skip flag disabled (the default)
+// must NOT abort the process. It returns a recoverable DataLossError that
+// points at the skip flag. Regression test for #1109 (was a fatal CHECK).
+TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingReturnsErrorNoCrash) {
   EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
       .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
 
@@ -59,10 +84,66 @@ TEST_F(FTInternalUpdateTest, ParseErrorWithLoadingFlagCrashes) {
   argv[2] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "invalid");
   argv[3] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "invalid");
 
-  // With LOADING flag but skip disabled by default, should crash
-  EXPECT_DEATH(
-      [[maybe_unused]] auto res = FTInternalUpdateCmd(&fake_ctx_, argv, 4),
-      "Internal update failure during AOF loading");
+  auto status = FTInternalUpdateCmd(&fake_ctx_, argv, 4);
+  EXPECT_EQ(status.code(), absl::StatusCode::kDataLoss);
+  EXPECT_THAT(
+      status.message(),
+      testing::HasSubstr("skip-corrupted-internal-update-entries"));
+
+  for (int i = 0; i < 4; i++) {
+    TestValkeyModule_FreeString(&fake_ctx_, argv[i]);
+  }
+}
+
+// With the skip flag enabled, a corrupt entry during loading is skipped: the
+// command returns OK, increments the skipped metric, and does not crash.
+// Regression test for #1109 (the flag used to log "SKIPPING" then SIGSEGV).
+TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingSkippedWhenConfigured) {
+  VMSDK_EXPECT_OK(
+      const_cast<vmsdk::config::Boolean&>(
+          options::GetSkipCorruptedInternalUpdateEntries())
+          .SetValue(true));
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
+
+  auto skipped_before =
+      Metrics::GetStats().ft_internal_update_skipped_entries_cnt.load();
+
+  ValkeyModuleString* argv[4];
+  argv[0] =
+      TestValkeyModule_CreateStringPrintf(&fake_ctx_, "FT.INTERNAL_UPDATE");
+  argv[1] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "test_id");
+  argv[2] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "invalid");
+  argv[3] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "invalid");
+
+  auto status = FTInternalUpdateCmd(&fake_ctx_, argv, 4);
+  EXPECT_TRUE(status.ok());
+  EXPECT_EQ(Metrics::GetStats().ft_internal_update_skipped_entries_cnt.load(),
+            skipped_before + 1);
+
+  for (int i = 0; i < 4; i++) {
+    TestValkeyModule_FreeString(&fake_ctx_, argv[i]);
+  }
+}
+
+// A valid entry replayed while loading, with no coordinator (MetadataManager
+// uninitialized — the standalone default), must not crash. It replies OK and
+// returns without touching the uninitialized singleton. Regression for #1108.
+TEST_F(FTInternalUpdateTest, ValidEntryWhileLoadingWithoutCoordinatorNoCrash) {
+  ASSERT_FALSE(coordinator::MetadataManager::IsInitialized());
+  EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
+      .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
+
+  // Empty strings parse as valid (empty) protobufs.
+  ValkeyModuleString* argv[4];
+  argv[0] =
+      TestValkeyModule_CreateStringPrintf(&fake_ctx_, "FT.INTERNAL_UPDATE");
+  argv[1] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "test_id");
+  argv[2] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "");
+  argv[3] = TestValkeyModule_CreateStringPrintf(&fake_ctx_, "");
+
+  auto status = FTInternalUpdateCmd(&fake_ctx_, argv, 4);
+  EXPECT_TRUE(status.ok());
 
   for (int i = 0; i < 4; i++) {
     TestValkeyModule_FreeString(&fake_ctx_, argv[i]);

--- a/testing/commands/ft_internal_update_test.cc
+++ b/testing/commands/ft_internal_update_test.cc
@@ -70,7 +70,7 @@ TEST_F(FTInternalUpdateTest, ParseErrorMetadata) {
 
 // A corrupt entry during loading with the skip flag disabled (the default)
 // must NOT abort the process. It returns a recoverable DataLossError that
-// points at the skip flag. Regression test for #1109 (was a fatal CHECK).
+// points at the skip flag.
 TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingReturnsErrorNoCrash) {
   EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))
       .WillRepeatedly(testing::Return(VALKEYMODULE_CTX_FLAGS_LOADING));
@@ -94,7 +94,6 @@ TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingReturnsErrorNoCrash) {
 
 // With the skip flag enabled, a corrupt entry during loading is skipped: the
 // command returns OK, increments the skipped metric, and does not crash.
-// Regression test for #1109 (the flag used to log "SKIPPING" then SIGSEGV).
 TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingSkippedWhenConfigured) {
   VMSDK_EXPECT_OK(const_cast<vmsdk::config::Boolean&>(
                       options::GetSkipCorruptedInternalUpdateEntries())
@@ -124,7 +123,7 @@ TEST_F(FTInternalUpdateTest, ParseErrorWhileLoadingSkippedWhenConfigured) {
 
 // A valid entry replayed while loading, with no coordinator (MetadataManager
 // uninitialized — the standalone default), must not crash. It replies OK and
-// returns without touching the uninitialized singleton. Regression for #1108.
+// returns without touching the uninitialized singleton.
 TEST_F(FTInternalUpdateTest, ValidEntryWhileLoadingWithoutCoordinatorNoCrash) {
   ASSERT_FALSE(coordinator::MetadataManager::IsInitialized());
   EXPECT_CALL(*kMockValkeyModule, GetContextFlags(&fake_ctx_))


### PR DESCRIPTION
FT.INTERNAL_UPDATE is registered unconditionally, but MetadataManager is only initialized when the coordinator is enabled (cluster mode). A node that persisted FT.INTERNAL_UPDATE entries to its AOF and is later loaded without the coordinator (e.g. standalone) ran FTInternalUpdateCmd, which called MetadataManager::Instance() on an uninitialized (null) instance and dereferenced it via CreateEntryOnReplica -> TriggerCallbacks -> SIGSEGV. This happened even for a valid (empty) entry (#1108).

Corrupt entries (#1109) had two more problems:
- Default config hit CHECK(false) -> SIGABRT. A corrupt persisted entry must not be a fatal assertion.
- The skip-corrupted flag returned OkStatus from a helper wrapped in VMSDK_RETURN_IF_ERROR, which does not short-circuit on OK, so execution fell through into CreateEntryOnReplica with a default-constructed entry and hit the same SIGSEGV. The flag never actually skipped the command.

Fixes:
- Guard FTInternalUpdateCmd with MetadataManager::IsInitialized() (matching the existing pattern in server_events.cc); reply OK and return when there is no coordinator to apply the entry to.
- Make parse failures return immediately instead of falling through; replace CHECK(false) with a recoverable DataLossError that names the skip flag.
- Skip TriggerCallbacks in CreateEntryOnReplica during loading; the schema manager is not ready during early replay, and OnLoadingEnded already re-applies fingerprints/versions afterward (matching the staged-reconcile path used for RDB replication).

Verified by reproducing all three crashes on a standalone server with a crafted AOF, then confirming the fixed build survives each: valid entry loads, corrupt entry with skip=yes logs SKIPPING and starts, corrupt entry with default config returns a recoverable error instead of aborting.

Fixes #1108
Fixes #1109