### PR TITLE
[backport 1.2] Fix crash in unittests introduced in previous PR (#1027)

### DIFF
--- a/testing/expr/expr_test.cc
+++ b/testing/expr/expr_test.cc
@@ -12,6 +12,7 @@
 #include "absl/container/flat_hash_map.h"
 #include "gtest/gtest.h"
 #include "src/expr/value.h"
+#include "vmsdk/src/testing_infra/utils.h"
 
 namespace valkey_search {
 namespace expr {
@@ -20,7 +21,7 @@ struct Record : public Expression::Record {
   std::map<std::string, Value> attrs;
 };
 
-class ExprTest : public testing::Test {
+class ExprTest : public vmsdk::ValkeyTest {
  protected:
   struct Ref : public Expression::AttributeReference {
     Ref(const absl::string_view s) : name_(s) {}
@@ -65,11 +66,11 @@ class ExprTest : public testing::Test {
   std::unique_ptr<Record> record_;
 
   void SetUp() override {
+    vmsdk::ValkeyTest::SetUp();
     record_ = std::make_unique<Record>();
     record_->attrs["one"] = Value(1.0);
     record_->attrs["two"] = Value(2.0);
   }
-  void TearDown() override {}
 };
 
 TEST_F(ExprTest, TypesTest) {

--- a/testing/expr/value_test.cc
+++ b/testing/expr/value_test.cc
@@ -9,13 +9,12 @@
 #include <cmath>
 
 #include "gtest/gtest.h"
+#include "vmsdk/src/testing_infra/utils.h"
 
 namespace valkey_search::expr {
 
-class ValueTest : public testing::Test {
+class ValueTest : public vmsdk::ValkeyTest {
  protected:
-  void SetUp() override {}
-  void TearDown() override {}
   Value pos_inf = Value(std::numeric_limits<double>::infinity());
   Value neg_inf = Value(-std::numeric_limits<double>::infinity());
   Value pos_zero = Value(0.0);


### PR DESCRIPTION
Fixing https://github.com/valkey-io/valkey-search/pull/1145

(cherry picked from commit 1c30dd5b3bc95d15742d699b2dd7a8565501feda)