### PR TITLE
Fix data race on index_key_info_ in search fanout

### DIFF
--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -39,6 +39,7 @@
 #include "vmsdk/src/managed_pointers.h"
 #include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/thread_pool.h"
+#include "vmsdk/src/time_sliced_mrmw_mutex.h"
 #include "vmsdk/src/type_conversions.h"
 #include "vmsdk/src/utils.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
@@ -317,7 +318,12 @@ absl::Status PerformSearchFanoutAsync(
     std::unique_ptr<SearchParameters> parameters,
     vmsdk::ThreadPool *thread_pool) {
   auto request = coordinator::ParametersToGRPCSearchRequest(*parameters);
-  uint64_t index_size = parameters->index_schema->GetIndexKeyInfoSize();
+  uint64_t index_size;
+  {
+    auto &time_sliced_mutex = parameters->index_schema->GetTimeSlicedMutex();
+    vmsdk::ReaderMutexLock lock(&time_sliced_mutex);
+    index_size = parameters->index_schema->GetIndexKeyInfoSize();
+  }
   uint32_t min_index_size =
       options::GetFanoutUniformityMinIndexSize().GetValue();
   if (parameters->IsNonVectorQuery()) {


### PR DESCRIPTION
PerformSearchFanoutAsync read IndexSchema::GetIndexKeyInfoSize() without holding the time-sliced mutex, racing concurrent mutation inserts/erases that rehash index_key_info_ (ABSL_GUARDED_BY(time_sliced_mutex_)). This could crash the server (SIGSEGV) under HSET/DEL concurrent with FT.SEARCH in cluster mode. GetIndexKeyInfoSize() is ABSL_SHARED_LOCKS_REQUIRED, so take the read lock, mirroring Search() in search.cc.

Resolves #1178