### PR TITLE
[backport 1.2] Add check for cluster_slots_complete check in test_fanout_low_utilization_fanout (#951)

### DIFF
--- a/integration/test_fanout_base.py
+++ b/integration/test_fanout_base.py
@@ -161,6 +161,9 @@ class TestFanout(ValkeySearchClusterTestCase):
         rg = self.get_replication_group(0)
         primary = rg.get_primary_connection()
         assert(primary.info("replication")["role"] == "master")
+
+        # Wait for cluster topology to propagate to all nodes
+        self.wait_for_cluster_setup()
         
         # Set the fanout low utilization threshold
         primary.execute_command("CONFIG", "SET", "search.local-fanout-queue-wait-threshold", threshold)

--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -534,6 +534,26 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
     def replication_lag(self) -> int:
         return max([rg.replication_lag() for rg in self.replication_groups])
 
+    def _cluster_slots_complete(self, client, expected_nodes_per_shard: int) -> bool:
+        """Check if CLUSTER SLOTS returns complete topology with all replicas."""
+        slots = client.execute_command("CLUSTER", "SLOTS")
+        for slot_range in slots:
+            # slot_range format: [start, end, [primary_ip, port, id, ...], [replica1...], ...]
+            # Length should be 2 (start, end) + expected_nodes_per_shard (1 primary + N replicas)
+            if len(slot_range) < 2 + expected_nodes_per_shard:
+                return False
+        return True
+
+    def wait_for_cluster_setup(self):
+        """Wait for cluster topology to propagate to all nodes."""
+        replica_count = len(self.replication_groups[0].replicas)
+        expected_nodes_per_shard = 1 + replica_count
+        for node in self.get_nodes():
+            waiters.wait_for_true(
+                lambda n=node: self._cluster_slots_complete(n.client, expected_nodes_per_shard),
+                timeout=30
+            )
+
 class ValkeySearchClusterTestCaseDebugMode(ValkeySearchClusterTestCase):
     '''
     Same as ValkeySearchClusterTestCase, except that "debug-mode" is enabled.


### PR DESCRIPTION
Backport of #951 to the 1.2 release branch.

Cherry-picks the cluster_slots_complete topology check: `test_fanout` now waits for `CLUSTER SLOTS` to report the full set of nodes per shard (1 primary + N replicas) on every node before configuring the fanout threshold, fixing flakiness from incomplete topology propagation.

Clean cherry-pick; no conflicts.