### PR TITLE
Minor fix : Fix _cluster_slots_complete to treat empty CLUSTER SLOTS as incomplete

### DIFF
--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -540,6 +540,8 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
     def _cluster_slots_complete(self, client, expected_nodes_per_shard: int) -> bool:
         """Check if CLUSTER SLOTS returns complete topology with all replicas."""
         slots = client.execute_command("CLUSTER", "SLOTS")
+        if not slots:
+            return False
         for slot_range in slots:
             # slot_range format: [start, end, [primary_ip, port, id, ...], [replica1...], ...]
             # Length should be 2 (start, end) + expected_nodes_per_shard (1 primary + N replicas)


### PR DESCRIPTION
Follow-up to #951.

`_cluster_slots_complete()` iterates over the `CLUSTER SLOTS` reply to validate each shard's node count. When a node has not yet received any topology gossip, `CLUSTER SLOTS` returns an **empty list** — the loop body never runs and the helper returns `True`. `wait_for_cluster_setup()` then exits immediately on the exact not-ready node it is meant to wait for, which is the early-pass race #951 was added to prevent.

Fix: treat an empty reply as incomplete (`if not slots: return False`) so the wait keeps polling until topology has actually propagated.

Caught by Greptile on the 1.2 backport (#1180). https://github.com/valkey-io/valkey-search/pull/1180#discussion_r3471199165