### PR TITLE
Fix dropped ostringstream crash workaround in 1.2 backport sweep

### DIFF
--- a/integration/test_non_vector.py
+++ b/integration/test_non_vector.py
@@ -432,6 +432,18 @@ def validate_aggregate_complex_queries(client: Valkey):
         row = dict(zip(result[i][::2], result[i][1::2]))
         assert row[b'distinct_ratings'] == b'50'
 
+    # 10b. COUNT_DISTINCT without AS
+    result = client.execute_command(
+        "FT.AGGREGATE", "products", "@price:[1 1000]",
+        "LOAD", "3", "price", "rating", "category",
+        "GROUPBY", "1", "@category",
+        "REDUCE", "COUNT_DISTINCT", "1", "@rating"
+    )
+    assert result[0] == 2
+    for i in range(1, len(result)):
+        row = dict(zip(result[i][::2], result[i][1::2]))
+        assert row[b'COUNT_DISTINCT(@rating)'] == b'50'
+
     # 11. GROUPBY with STDDEV reducer
     result = client.execute_command(
         "FT.AGGREGATE", "products", "@price:[1 4]",

--- a/src/commands/ft_aggregate_parser.cc
+++ b/src/commands/ft_aggregate_parser.cc
@@ -265,8 +265,8 @@ ConstructGroupByParser() {
               default_name += arg_texts[i];
             }
             default_name += ')';
-            VMSDK_ASSIGN_OR_RETURN(auto output,
-                                   parameters.MakeReference(default_name, true));
+            VMSDK_ASSIGN_OR_RETURN(
+                auto output, parameters.MakeReference(default_name, true));
             r.output_ = std::unique_ptr<Attribute>(
                 dynamic_cast<Attribute *>(output.release()));
           }

--- a/src/commands/ft_aggregate_parser.cc
+++ b/src/commands/ft_aggregate_parser.cc
@@ -232,12 +232,14 @@ ConstructGroupByParser() {
                 absl::StrCat("incorrect number of arguments (", cnt,
                              ") to reducer ", uc_name.AsStringView()));
           }
+          std::vector<std::string> arg_texts;
           for (int i = 0; i < cnt; ++i) {
             VMSDK_ASSIGN_OR_RETURN(auto arg, itr.PopNext(),
                                    _ << "Missing Reducer argument " << i);
+            auto arg_sv = vmsdk::ToStringView(arg);
+            arg_texts.emplace_back(arg_sv);
             VMSDK_ASSIGN_OR_RETURN(
-                auto expr,
-                expr::Expression::Compile(parameters, vmsdk::ToStringView(arg)),
+                auto expr, expr::Expression::Compile(parameters, arg_sv),
                 _ << " in GROUPBY stage");
             r.args_.emplace_back(std::move(expr));
           }
@@ -250,10 +252,21 @@ ConstructGroupByParser() {
             r.output_ = std::unique_ptr<Attribute>(
                 dynamic_cast<Attribute *>(output.release()));
           } else {
-            std::ostringstream os;
-            os << r;
+            // TODO(https://github.com/valkey-io/valkey-search/issues/965):
+            // Workaround for memory allocator issue causing ostringstream to
+            // crash. Build the default reducer name manually instead of
+            // `os << r`.
+            std::string default_name(r.info_->name_);
+            default_name += '(';
+            for (size_t i = 0; i < arg_texts.size(); ++i) {
+              if (i > 0) {
+                default_name += ',';
+              }
+              default_name += arg_texts[i];
+            }
+            default_name += ')';
             VMSDK_ASSIGN_OR_RETURN(auto output,
-                                   parameters.MakeReference(os.str(), true));
+                                   parameters.MakeReference(default_name, true));
             r.output_ = std::unique_ptr<Attribute>(
                 dynamic_cast<Attribute *>(output.release()));
           }

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -1823,6 +1823,14 @@ bool IndexSchema::InTrackedMutationRecords(
   if (ABSL_PREDICT_FALSE(itr == tracked_mutated_records_.end())) {
     return false;
   }
+  // ConsumeTrackedMutatedAttribute moves the attribute map out and sets
+  // attributes = std::nullopt, leaving the entry in the map. After that
+  // sequence, attributes is disengaged and `attributes->find(...)` would
+  // dereference an empty optional (UB; observed crashing under ASAN in the
+  // backfill scan path). No pending mutation == false.
+  if (!itr->second.attributes.has_value()) {
+    return false;
+  }
   if (itr->second.attributes->find(identifier) ==
       itr->second.attributes->end()) {
     return false;

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -535,6 +535,8 @@ class IndexSchema : public KeyspaceEventSubscription,
   FRIEND_TEST(IndexSchemaFriendTest, ConsistencyTest);
   FRIEND_TEST(IndexSchemaFriendTest, MutatedAttributes);
   FRIEND_TEST(IndexSchemaFriendTest, MutatedAttributesSanity);
+  FRIEND_TEST(IndexSchemaFriendTest,
+              InTrackedMutationRecordsAfterConsumeNoCrash);
   FRIEND_TEST(ValkeySearchTest, Info);
   FRIEND_TEST(OnSwapDBCallbackTest, OnSwapDBCallback);
 };

--- a/testing/index_schema_test.cc
+++ b/testing/index_schema_test.cc
@@ -1594,6 +1594,50 @@ TEST_F(IndexSchemaFriendTest, MutatedAttributesSanity) {
   EXPECT_EQ(index_schema->GetMutatedRecordsSize(), 0);
 }
 
+// Regression test for a pre-existing crash in InTrackedMutationRecords.
+//
+// DocumentMutation::attributes is std::optional<flat_hash_map<...>>.
+// ConsumeTrackedMutatedAttribute, after extracting the attribute map, sets
+// `attributes = std::nullopt` but leaves the entry in tracked_mutated_records_
+// (it only erases the entry when there was nothing to consume). A subsequent
+// call to InTrackedMutationRecords(key, identifier) on that same key would
+// then dereference the disengaged optional via `attributes->find(...)`, which
+// is UB. Under ASAN the bad dereference trips absl's SwissTable iterator
+// generation guard and crashes the server (observed in CI as a SIGSEGV from
+// the backfill scan path during a fulltext test).
+//
+// Repro: track a mutation, consume it (disengaging `attributes` while leaving
+// the entry in the map), then call InTrackedMutationRecords. With the fix it
+// returns false cleanly; without the fix it crashes under ASAN.
+TEST_F(IndexSchemaFriendTest, InTrackedMutationRecordsAfterConsumeNoCrash) {
+  absl::string_view data_ptr;
+  auto mutated_attributes =
+      CreateMutatedAttributes(attribute_identifier, data_ptr);
+  EXPECT_TRUE(index_schema->TrackMutatedRecord(
+      nullptr, key, std::move(mutated_attributes), 0, false, false, false));
+  EXPECT_EQ(index_schema->GetMutatedRecordsSize(), 1u);
+
+  // Consume the mutation. Because attributes was engaged, the entry stays in
+  // the map with attributes = std::nullopt (see index_schema.cc:1997-2008).
+  auto consumed = index_schema->ConsumeTrackedMutatedAttribute(key, true);
+  EXPECT_TRUE(consumed.has_value());
+  EXPECT_EQ(index_schema->GetMutatedRecordsSize(), 1u);
+
+  // Verify our reading of the state: entry present, attributes disengaged.
+  {
+    absl::MutexLock lock(&index_schema->mutated_records_mutex_);
+    auto itr = index_schema->tracked_mutated_records_.find(key);
+    ASSERT_NE(itr, index_schema->tracked_mutated_records_.end());
+    EXPECT_FALSE(itr->second.attributes.has_value());
+  }
+
+  // The crash: without the fix this dereferences a disengaged optional.
+  // Expected behavior with the fix: returns false (no pending mutation for
+  // this (key, identifier) pair after the consume drained it).
+  EXPECT_FALSE(
+      index_schema->InTrackedMutationRecords(key, attribute_identifier));
+}
+
 TEST_F(IndexSchemaFriendTest, MutatedAttributes) {
   auto tester = [this](absl::string_view data_ptr,
                        absl::string_view track_before_consumption_data_ptr,


### PR DESCRIPTION
## Problem

The backport sweep PR #1182 cherry-picked #1032 ("Workaround fix for ostringstream crash"), but the AI conflict resolution resolved `src/commands/ft_aggregate_exec.cc` entirely to HEAD, **dropping the actual fix**.

On the 1.2 branch the offending `std::ostringstream` default-reducer-name code does not live in `ft_aggregate_exec.cc` (it was refactored away) — it lives in `src/commands/ft_aggregate_parser.cc` (`os << r`, ~line 253). The conflict resolver noted this file was "out of scope" and left it untouched, so the crash path survived.

Result: `integration-tests` failed — `test_aggregate_complex` and `test_aggregate_complex_cluster` crashed the server (`Connection closed by server` / `Connection refused`), which is exactly the ostringstream allocator crash #1032 set out to fix.

## Fix

Apply the same workaround #1032 used, at the location the code actually lives on 1.2: build the default reducer name manually instead of `os << r`. Produces the identical name (e.g. `COUNT_DISTINCT(@rating)`), matching the test 10b assertion added by #1032.
