### PR TITLE
RemoveSubscription improper destruction handling fix

### DIFF
--- a/integration/test_rdb_load_error_cleanup.py
+++ b/integration/test_rdb_load_error_cleanup.py
@@ -128,7 +128,7 @@ class TestRdbLoadErrorCleanup(ValkeySearchTestCaseDebugMode):
                 n = replica.client.execute_command(
                     "FT._DEBUG", "PAUSEPOINT", "TEST", self.PAUSEPOINT_NAME)
                 return int(n) >= 1
-            except Exception:
+            except (TypeError, ValueError):
                 return False
 
         try:
@@ -136,6 +136,17 @@ class TestRdbLoadErrorCleanup(ValkeySearchTestCaseDebugMode):
                 lambda: error_logged() and workers_paused(),
                 timeout=60)
         except Exception:
+            # If the replica died during the waiter loop, that IS the crash
+            # we're testing for. Detect it here so we fail loudly instead of
+            # falling through to pytest.skip below.
+            try:
+                replica.client.ping()
+            except Exception as exc:
+                pytest.fail(
+                    "Replica died before the bug window could be verified. "
+                    "This is the crash the test is designed to catch, but it "
+                    f"happened during setup instead of at the release point: "
+                    f"{exc!r}")
             err = error_logged()
             paused = workers_paused()
             load_ran = replica.does_logfile_contains("Loading Index Extension")

--- a/integration/test_rdb_load_error_cleanup.py
+++ b/integration/test_rdb_load_error_cleanup.py
@@ -1,0 +1,203 @@
+"""
+Regression test for a replica crash in
+KeyspaceEventManager::RemoveSubscription when LoadFromRDB fails mid-load.
+
+Without the fix, workers parked in ScheduleMutation can hold the last strong
+ref to the staged IndexSchema. When the load fails and the main thread drops
+its ref, the destructor runs on a worker thread, calls MarkAsDestructing,
+hits the main-thread CHECK in subscriptions_.Get(), and aborts.
+
+The fix (absl::Cleanup in LoadFromRDB) ensures MarkAsDestructing runs on the
+main thread on every error path, so the worker-thread destructor sees
+is_destructing_ == true and skips the main-thread-only cleanup.
+
+The test reproduces the bug window deterministically by:
+  - parking workers at the mutation_processing pause point (they hold strong
+    refs while parked),
+  - tripping the ForceRDBLoadFailure controlled variable mid-load,
+  - using diskless replica load (the only path where the engine survives an
+    aux_load failure - on disk-based load the engine exits before we can
+    observe the worker-thread crash).
+"""
+import struct
+import time
+
+import pytest
+
+from valkey_search_test_case import ValkeySearchTestCaseDebugMode
+from valkeytestframework.util import waiters
+from valkeytestframework.conftest import resource_port_tracker  # noqa: F401
+from ft_info_parser import FTInfoParser
+
+
+class TestRdbLoadErrorCleanup(ValkeySearchTestCaseDebugMode):
+    """Regression test for the worker-thread-destruction crash."""
+
+    INDEX_NAME = "idx"
+    PAUSEPOINT_NAME = "mutation_processing"
+    CONTROLLED_VAR = "ForceRDBLoadFailure"
+    NUM_VECTORS = 50
+    SIM_ERROR_LOG = "Simulated IO error during RDB load"
+
+    def get_config_file_lines(self, testdir, port):
+        # Diskless sync on both ends - required for the engine to survive
+        # an aux_load failure (cancelReplicationHandshake instead of exit(1)).
+        # `flush-before-load` (not `on-empty-db` or `swapdb`) is required so
+        # that the second sync also uses diskless: `on-empty-db` falls back
+        # to disk once the replica is populated, and `swapdb` requires every
+        # loaded module to opt into VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD
+        # (the JSON module doesn't).
+        return super().get_config_file_lines(testdir, port) + [
+            "repl-diskless-sync yes",
+            "repl-diskless-sync-delay 0",
+            "repl-diskless-load flush-before-load",
+            "repl-timeout 10",
+        ]
+
+    def append_startup_args(self, args: dict[str, str]) -> dict[str, str]:
+        args = super().append_startup_args(args)
+        # LoadIndexExtension only runs when both ends use V2; otherwise the
+        # supplemental section is skipped during load.
+        args["search.rdb-write-v2"] = "yes"
+        args["search.rdb-read-v2"] = "yes"
+        return args
+
+    def _populate_primary_with_index(self, primary):
+        """Create an HNSW index with NUM_VECTORS vectors on the primary."""
+        primary.client.execute_command(
+            "FT.CREATE", self.INDEX_NAME,
+            "PREFIX", "1", "vec:",
+            "SCHEMA", "vector", "VECTOR", "HNSW", "8",
+            "TYPE", "FLOAT32", "DIM", "3",
+            "DISTANCE_METRIC", "L2", "INITIAL_CAP", str(self.NUM_VECTORS))
+
+        for i in range(self.NUM_VECTORS):
+            v = struct.pack('<3f', float(i), float(i + 1), float(i + 2))
+            primary.client.hset(f"vec:{i}", mapping={"vector": v})
+
+    def _trigger_full_sync(self, primary, replica):
+        """Force a full sync by changing the primary's replication id.
+
+        change-repl-id forces the next handshake to be a full sync rather
+        than a partial resync.
+        """
+        primary.client.execute_command("DEBUG", "change-repl-id")
+        replica.client.execute_command("REPLICAOF", "NO", "ONE")
+        time.sleep(0.5)
+        replica.client.execute_command(
+            "REPLICAOF", primary.server.bind_ip, str(primary.server.port))
+
+    @pytest.mark.parametrize(
+        "setup_test", [{"replica_count": 1}], indirect=True
+    )
+    def test_rdb_load_error_with_inflight_mutations_does_not_crash(self):
+        primary = self.rg.primary
+        replica = self.rg.replicas[0]
+
+        self._populate_primary_with_index(primary)
+
+        # Wait for initial sync to settle so the index is on the replica.
+        waiters.wait_for_true(
+            lambda: self.INDEX_NAME.encode() in replica.client.execute_command(
+                "FT._LIST"),
+            timeout=30)
+        waiters.wait_for_equal(
+            lambda: FTInfoParser(replica.client.execute_command(
+                "FT.INFO", self.INDEX_NAME)).num_docs,
+            self.NUM_VECTORS,
+            timeout=30)
+
+        # Arm the trap: park workers at mutation_processing, then trip
+        # ForceRDBLoadFailure mid-load.
+        replica.client.execute_command(
+            "FT._DEBUG", "PAUSEPOINT", "SET", self.PAUSEPOINT_NAME)
+        replica.client.execute_command(
+            "FT._DEBUG", "CONTROLLED_VARIABLE", "SET",
+            self.CONTROLLED_VAR, "yes")
+
+        self._trigger_full_sync(primary, replica)
+
+        # The bug window requires both: workers holding strong refs (parked)
+        # AND the main thread having unwound from LoadFromRDB (error logged).
+        # Either alone can pass without exercising the bug.
+        def error_logged():
+            return replica.does_logfile_contains(self.SIM_ERROR_LOG)
+
+        def workers_paused():
+            try:
+                n = replica.client.execute_command(
+                    "FT._DEBUG", "PAUSEPOINT", "TEST", self.PAUSEPOINT_NAME)
+                return int(n) >= 1
+            except Exception:
+                return False
+
+        try:
+            waiters.wait_for_true(
+                lambda: error_logged() and workers_paused(),
+                timeout=60)
+        except Exception:
+            err = error_logged()
+            paused = workers_paused()
+            load_ran = replica.does_logfile_contains("Loading Index Extension")
+            # Reset the trap before exiting.
+            try:
+                replica.client.execute_command(
+                    "FT._DEBUG", "PAUSEPOINT", "RESET", self.PAUSEPOINT_NAME)
+            except Exception:
+                pass
+            try:
+                replica.client.execute_command(
+                    "FT._DEBUG", "CONTROLLED_VARIABLE", "SET",
+                    self.CONTROLLED_VAR, "no")
+            except Exception:
+                pass
+            if load_ran and not err:
+                pytest.fail(
+                    "LoadIndexExtension ran but ForceRDBLoadFailure never "
+                    "tripped - test infrastructure is broken (likely "
+                    "--debug-mode missing on the replica).")
+            pytest.skip(
+                f"Bug window not engaged (err={err}, paused={paused}, "
+                f"load_ran={load_ran}). The replica likely did a partial "
+                "resync, or workers drained before parking.")
+
+        # Release the workers. The last one to drop its shared_ptr runs
+        # ~IndexSchema(). With the fix is_destructing_ is already true, so
+        # the destructor skips MarkAsDestructing and the replica survives.
+        # Without the fix the destructor calls MarkAsDestructing on the
+        # worker thread, hits the main-thread CHECK, and aborts with SIGABRT.
+        replica.client.execute_command(
+            "FT._DEBUG", "PAUSEPOINT", "RESET", self.PAUSEPOINT_NAME)
+        time.sleep(2)  # let workers drain and run destructors
+
+        crash_msg = (
+            "Replica process died after RDB load error. IndexSchema "
+            "destructor ran on a worker thread without MarkAsDestructing "
+            "being called on the main thread - the fix is missing.")
+
+        # Liveness check with retry over a window.
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                replica.client.ping()
+            except Exception as exc:
+                pytest.fail(f"{crash_msg} ({exc!r})")
+            time.sleep(0.25)
+
+        # Disarm the failure injection so the engine's automatic post-failure
+        # resync can succeed, then verify sync recovers and the index is
+        # repopulated. This proves the replica is not just alive but
+        # functional after the crash window.
+        replica.client.execute_command(
+            "FT._DEBUG", "CONTROLLED_VARIABLE", "SET",
+            self.CONTROLLED_VAR, "no")
+
+        # Wait for the post-failure resync to succeed.
+        self.rg._wait_for_replication()
+
+        # And verify the index is fully repopulated.
+        waiters.wait_for_equal(
+            lambda: FTInfoParser(replica.client.execute_command(
+                "FT.INFO", self.INDEX_NAME)).num_docs,
+            self.NUM_VECTORS,
+            timeout=60)

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "absl/base/optimization.h"
+#include "absl/cleanup/cleanup.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
@@ -967,6 +968,7 @@ void IndexSchema::BackfillScanCallback(ValkeyModuleCtx *ctx,
 }
 
 CONTROLLED_BOOLEAN(StopBackfill, false);
+CONTROLLED_BOOLEAN(ForceRDBLoadFailure, false);
 
 uint32_t IndexSchema::PerformBackfill(ValkeyModuleCtx *ctx,
                                       uint32_t batch_size) {
@@ -1550,6 +1552,11 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
     Metrics::GetStats().rdb_restore_current_index_keys_loaded = i + 1;
   }
 
+  if (ForceRDBLoadFailure.GetValue()) {
+    return absl::InternalError(
+        "Simulated IO error during RDB load (ForceRDBLoadFailure)");
+  }
+
   if (Metrics::GetStats().rdb_restore_backpressure_wait_cycles > 0) {
     VMSDK_LOG(NOTICE, ctx)
         << "RDB restore completed with backpressure. Total wait cycles: "
@@ -1627,6 +1634,12 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
       auto index_schema,
       IndexSchema::Create(ctx, *index_schema_proto, mutations_thread_pool,
                           !load_attributes_on_create, true));
+
+  // If we exit early after creating a new schema, workers may already hold
+  // strong references via ValkeyModule_Yield. Ensure MarkAsDestructing is
+  // called so the destructor won't attempt main-thread-only cleanup.
+  auto mark_destructing_on_error =
+      absl::MakeCleanup([&]() { index_schema->MarkAsDestructing(); });
 
   // Supplemental content will include indices and any content for them
   while (supplemental_iter.HasNext()) {
@@ -1707,6 +1720,8 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
   }
   VMSDK_LOG(NOTICE, ctx) << "Loaded index schema with "
                          << index_schema->GetAttributeCount() << " attributes";
+  std::move(mark_destructing_on_error)
+      .Cancel();  // Don't mark for destruction since no error has been returned
   return index_schema;
 }
 


### PR DESCRIPTION
# Summary
Fix replica crash in `KeyspaceEventManager::RemoveSubscription` when `IndexSchema::LoadFromRDB` fails partway through populating a new schema. Adds a deterministic regression test.

## Root cause
When `LoadFromRDB` errors out, the staged IndexSchema is dropped on the failure path on the main thread. Worker threads parked inside ScheduleMutation can hold the last strong refs via `weak_index_schema.lock()`. The last worker to exit ProcessSingleMutationAsync drops its ref, runs ~IndexSchema() on a worker thread, sees is_destructing_ == false, and calls MarkAsDestructing — which tries to access subscriptions_ (a main-thread-only resource) and aborts.

## Fix
Add an `absl::Cleanup` in LoadFromRDB that calls MarkAsDestructing on the main thread on every error path. The cleanup is cancelled at the success point so it only fires when the load aborts.

When LoadFromRDB errors out:

1. The cleanup runs on the main thread before LoadFromRDB returns. It removes the keyspace subscription (the only main-thread-only resource), notifies waiting queries, clears tracked_mutated_records_, and sets is_destructing_ = true.
2. The main thread's local shared_ptr<IndexSchema> drops as LoadFromRDB returns.
3. Multiple workers may still hold strong refs to the staged schema. Each one eventually finishes its ProcessSingleMutationAsync task and drops its ref. Workers that wake from the `mutation_processing` pause point (or backpressure) call ConsumeTrackedMutatedAttribute, find the now-empty tracked_mutated_records map, and exit cleanly.
4. The worker that happens to drop the last strong ref runs ~IndexSchema() on its thread. With the fix, `is_destructing_ == true`, so the destructor skips the call to MarkAsDestructing and never touches the main-thread-only subscriptions_. The rest of the destructor body is thread-safe on a worker: the log line, Collector::IndexDropped (which enqueues the main-thread-only metering cleanup via RunByMain and returns), and C++ member destructors.

**Net effect:** the main-thread-only work happens on the main thread proactively; whichever worker eventually runs the destructor only does thread-safe work.

## Test

`test_rdb_load_error_cleanup.py` reproduces the bug deterministically. If the bug window cannot be engaged (partial resync, workers drained too fast), the test reports diagnostics and skips rather than passing silently. A real test infrastructure failure is reported as a fail rather than a skip.

### Regression Testing

**Without the code fix, this is what the test returns:**

```
assert replica.is_alive(), (
            "Replica process died after RDB load error. IndexSchema "
            "destructor ran on a worker thread without MarkAsDestructing "
            "being called on the main thread - the bug in ELMO-119562 is "
            "unfixed.")
E       AssertionError: Replica process died after RDB load error. IndexSchema destructor ran on a worker thread without MarkAsDestructing being called on the main thread - the bug in ELMO-119562 is unfixed.
E       assert False
E        +  where False = <bound method RedisServerHandle.is_alive of RedisServerHandle(port=7617, bind_ip=0.0.0.0, server_id=3, multi_ip_mode=False, client_connect_ip=127.0.0.1)>()
E        +    where <bound method RedisServerHandle.is_alive of RedisServerHandle(port=7617, bind_ip=0.0.0.0, server_id=3, multi_ip_mode=False, client_connect_ip=127.0.0.1)> = RedisServerHandle(port=7617, bind_ip=0.0.0.0, server_id=3, multi_ip_mode=False, client_connect_ip=127.0.0.1).is_alive

test_rdb_load_error_cleanup.py:209: AssertionError
```

**[Local Stack Trace](https://paste.amazon.com/show/branylin/1779404208): (identical to [QA crash stack trace](https://sim.amazon.com/issues/ELMO-119562))**
```
25348 write-worker-12 *
/lib64/libpthread.so.0(+0x118e0)[0x7f75b6a6a8e0]
/lib64/libc.so.6(gsignal+0x110)[0x7f75b5d44ca0]
/lib64/libc.so.6(abort+0x148)[0x7f75b5d46148]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0xced352)[0x7f75ac9ef352]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0xced8b5)[0x7f75ac9ef8b5]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0xcede29)[0x7f75ac9efe29]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0x1a0926)[0x7f75abea2926]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0x1a0949)[0x7f75abea2949]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(_ZN13valkey_search11IndexSchema17MarkAsDestructingEv+0x39)[0x7f75ac73a0a3]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(_ZN13valkey_search11IndexSchemaD1Ev+0x7f8)[0x7f75ac73ad80]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(_ZNSt15_Sp_counted_ptrIPN13valkey_search11IndexSchemaELN9__gnu_cxx12_Lock_policyE2EE10_M_disposeEv+0x25)[0x7f75ac7561b5]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0x2d3a1a)[0x7f75abfd5a1a]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(_ZN5vmsdk10ThreadPool12WorkerThreadESt10shared_ptrINS0_6ThreadEE+0x669)[0x7f75ac090779]
/home/branylin/workplace/ECRedis/src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so(+0x390663)[0x7f75ac092663]
/lib64/libpthread.so.0(+0x744b)[0x7f75b6a6044b]
/lib64/libc.so.6(clone+0x3f)[0x7f75b5e0052f]

------------

/.../libsearch.so(+0x1a0926)[0x7f75abea2926]   ← this is RemoveSubscription
/.../libsearch.so(+0x1a0949)[0x7f75abea2949]   ← inside RemoveSubscription
```

```
addr2line -f -C -e src/ElastiCacheValkeySearch/build/private/.build-release/libsearch.so 0x1a0926 0x1a0949
valkey_search::KeyspaceEventManager::RemoveSubscription(valkey_search::KeyspaceEventSubscription*) [clone .cold]
keyspace_event_manager.cc:?
valkey_search::KeyspaceEventManager::RemoveSubscription(valkey_search::KeyspaceEventSubscription*) [clone .cold]
keyspace_event_manager.cc:?
```