### PR TITLE
Validate HNSW index data when loading from an external file

### DIFF
--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -150,9 +150,10 @@ absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> VectorHNSW<T>::LoadFromRDB(
     index->algo_->allow_replace_deleted_ =
         options::GetHNSWAllowReplaceDeleted().GetValue();
     RDBChunkInputStream input(std::move(iter));
-    VMSDK_RETURN_IF_ERROR(
-        index->algo_->LoadIndex(input, index->space_.get(),
-                                vector_index_proto.initial_cap(), index.get()));
+    VMSDK_RETURN_IF_ERROR(index->algo_->LoadIndex(
+        input, index->space_.get(), vector_index_proto.initial_cap(),
+        index.get(), vector_index_proto.hnsw_algorithm().m(),
+        options::GetHNSWValidationEnable().GetValue()));
     // ef_runtime is not persisted in the index contents
     index->algo_->setEf(vector_index_proto.hnsw_algorithm().ef_runtime());
     return index;

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -153,6 +153,15 @@ static auto hnsw_allow_replace_deleted =
         .Dev()
         .Build();
 
+// Kill switch for HNSW index load-time validation (corruption hardening).
+// Default true; can be disabled in the field if a bug in the validation logic
+// were to reject otherwise-valid indexes.
+constexpr absl::string_view kHNSWValidationEnable{"hnsw-validation-enable"};
+static auto hnsw_validation_enable =
+    config::BooleanBuilder(kHNSWValidationEnable, true)  // default true
+        .Dev()
+        .Build();
+
 // Register an enumerator for the log level
 static const std::vector<std::string_view> kLogLevelNames = {
     VALKEYMODULE_LOGLEVEL_WARNING,
@@ -554,6 +563,14 @@ const config::Boolean& GetHNSWAllowReplaceDeleted() {
 
 config::Boolean& GetHNSWAllowReplaceDeletedMutable() {
   return dynamic_cast<config::Boolean&>(*hnsw_allow_replace_deleted);
+}
+
+const config::Boolean& GetHNSWValidationEnable() {
+  return dynamic_cast<const config::Boolean&>(*hnsw_validation_enable);
+}
+
+config::Boolean& GetHNSWValidationEnableMutable() {
+  return dynamic_cast<config::Boolean&>(*hnsw_validation_enable);
 }
 
 absl::Status Reset() {

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -64,6 +64,12 @@ const config::Boolean& GetHNSWAllowReplaceDeleted();
 /// Return a mutable reference for testing
 config::Boolean& GetHNSWAllowReplaceDeletedMutable();
 
+/// Return the configuration entry for the HNSW load-time validation kill switch
+const config::Boolean& GetHNSWValidationEnable();
+
+/// Return a mutable reference for testing
+config::Boolean& GetHNSWValidationEnableMutable();
+
 /// Reset the state of the options (mainly needed for testing)
 absl::Status Reset();
 

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -713,7 +713,8 @@ TEST_F(VectorIndexTest, LoadRecomputesAlignedOffsetForOldSnapshot) {
   hnswlib::HierarchicalNSW<float> algo(&l2_space);
   SingleChunkInputStream input(serialized);
   VMSDK_EXPECT_OK(algo.LoadIndex(input, &l2_space, /*max_elements_i=*/16,
-                                 nullptr, /*expected_m=*/kM, /*validate=*/true));
+                                 nullptr, /*expected_m=*/kM,
+                                 /*validate=*/true));
   EXPECT_EQ(algo.offsetData_ % alignof(char*), 0u);
   EXPECT_EQ(algo.size_data_per_element_ % alignof(char*), 0u);
 }
@@ -769,10 +770,10 @@ class BufTracker : public hnswlib::VectorTracker {
 
 // On-disk geometry for kM / kDimensions, used to locate bytes for mutation.
 constexpr size_t kU32 = sizeof(uint32_t);
-constexpr size_t kStride = kM * kU32 + kU32;                   // 68
-constexpr size_t kLinks0 = 2 * kM * kU32 + kU32;               // 132
-constexpr size_t kVecBytes = kDimensions * sizeof(float);      // 400
-constexpr size_t kLabelOff = kLinks0 + kVecBytes;              // 532
+constexpr size_t kStride = kM * kU32 + kU32;               // 68
+constexpr size_t kLinks0 = 2 * kM * kU32 + kU32;           // 132
+constexpr size_t kVecBytes = kDimensions * sizeof(float);  // 400
+constexpr size_t kLabelOff = kLinks0 + kVecBytes;          // 532
 constexpr size_t kElemChunkBytes = kLabelOff + sizeof(hnswlib::labeltype);
 
 template <typename T>
@@ -794,13 +795,23 @@ void PokeAt(std::string* c, size_t off, T v) {
 ChunkStream BuildGoldenChunks(const std::vector<int>& force_levels,
                               size_t max_elements) {
   hnswlib::L2Space space{kDimensions};
-  hnswlib::HierarchicalNSW<float> algo(&space, max_elements, kM, kEFConstruction,
+  hnswlib::HierarchicalNSW<float> algo(&space, max_elements, kM,
+                                       kEFConstruction,
                                        /*random_seed=*/100,
                                        /*allow_replace_deleted=*/false);
+  // HNSW stores a POINTER to each vector (it does not copy). Both addPoint
+  // (distance computations against earlier elements) and SaveIndex dereference
+  // those pointers, so the source vectors must outlive SaveIndex. Own them all
+  // here until the index is serialized; reserve() keeps the backing buffers
+  // stable as the container grows. After SaveIndex the golden ChunkStream owns
+  // its bytes by value, so this storage can safely be destroyed.
+  std::vector<std::vector<float>> vectors;
+  vectors.reserve(force_levels.size());
   for (size_t i = 0; i < force_levels.size(); i++) {
     std::vector<float> v(kDimensions, 0.1f);
     v[i % kDimensions] = static_cast<float>(i + 1);
-    algo.addPoint(v.data(), /*label=*/i, force_levels[i]);
+    vectors.push_back(std::move(v));
+    algo.addPoint(vectors.back().data(), /*label=*/i, force_levels[i]);
   }
   ChunkStream golden;
   EXPECT_TRUE(algo.SaveIndex(golden).ok());
@@ -950,8 +961,8 @@ TEST_F(VectorIndexTest, RejectHeaderMaxLevelTooLarge) {
 TEST_F(VectorIndexTest, RejectHeaderSerializeSizeMismatch) {
   auto golden = MultiLayerGolden();
   auto h = GetHeader(golden);
-  h.set_serialize_size_data_per_element(
-      h.serialize_size_data_per_element() + 1);
+  h.set_serialize_size_data_per_element(h.serialize_size_data_per_element() +
+                                        1);
   SetHeader(&golden, h);
   ExpectReject(std::move(golden), "serialized element size is inconsistent");
 }
@@ -988,15 +999,16 @@ TEST_F(VectorIndexTest, RejectLevel0CountTooLarge) {
 
 TEST_F(VectorIndexTest, RejectLevel0NeighborOutOfRange) {
   auto golden = MultiLayerGolden();
-  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);          // element 1: count = 1
-  PokeAt<uint32_t>(&golden.chunks[2], kU32, 9999);    // neighbor[0] out of range
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);        // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32, 9999);  // neighbor[0] out of range
   ExpectReject(std::move(golden), "level-0 neighbor id out of range");
 }
 
 TEST_F(VectorIndexTest, RejectDuplicateLabel) {
   auto golden = MultiLayerGolden();
   auto label0 = PeekAt<hnswlib::labeltype>(golden.chunks[1], kLabelOff);
-  PokeAt<hnswlib::labeltype>(&golden.chunks[3], kLabelOff, label0);  // element 2 dup
+  PokeAt<hnswlib::labeltype>(&golden.chunks[3], kLabelOff,
+                             label0);  // element 2 dup
   ExpectReject(std::move(golden), "duplicate label in index");
 }
 
@@ -1012,7 +1024,8 @@ TEST_F(VectorIndexTest, RejectSizeChunkWrongSize) {
 TEST_F(VectorIndexTest, RejectLinkListSizeNotMultiple) {
   auto golden = MultiLayerGolden();
   auto g = AnalyzeGolden(golden);
-  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, 2 * kStride + 1);
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0,
+                   2 * kStride + 1);
   ExpectReject(std::move(golden), "not a multiple of the stride");
 }
 
@@ -1027,14 +1040,16 @@ TEST_F(VectorIndexTest, RejectElementLevelExceedsMaxLevel) {
 TEST_F(VectorIndexTest, RejectUpperChunkWrongSize) {
   auto golden = MultiLayerGolden();
   auto g = AnalyzeGolden(golden);
-  golden.chunks[g.data_chunk[g.enterpoint]].resize(kStride);  // declared 2 levels
+  golden.chunks[g.data_chunk[g.enterpoint]].resize(
+      kStride);  // declared 2 levels
   ExpectReject(std::move(golden), "upper-level link-list chunk has the wrong");
 }
 
 TEST_F(VectorIndexTest, RejectUpperCountTooLarge) {
   auto golden = MultiLayerGolden();
   auto g = AnalyzeGolden(golden);
-  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0, kM + 1);  // level 1
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0,
+                   kM + 1);  // level 1
   ExpectReject(std::move(golden), "upper-level neighbor count exceeds M");
 }
 
@@ -1051,7 +1066,8 @@ TEST_F(VectorIndexTest, RejectUpperNeighborAbsentAtLevel) {
   auto g = AnalyzeGolden(golden);
   // Entry point's level-2 list -> element 1, which exists only at level 1.
   PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride, 1);
-  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride + kU32, 1);
+  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride + kU32,
+                   1);
   ExpectReject(std::move(golden), "neighbor is absent at that level");
 }
 
@@ -1068,8 +1084,9 @@ TEST_F(VectorIndexTest, RejectEntrypointNotMaxLevel) {
 
 TEST_F(VectorIndexTest, ValidationDisabledBypassesChecks) {
   auto golden = MultiLayerGolden();
-  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);        // element 1: count = 1
-  PokeAt<uint32_t>(&golden.chunks[2], kU32, 1);     // neighbor[0] == self (a self-loop)
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);  // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32,
+                   1);  // neighbor[0] == self (a self-loop)
   // Enabled: rejected. Disabled: loads (the self-loop is not memory-unsafe).
   EXPECT_FALSE(LoadGolden(golden, kGoldenMax, /*validate=*/true).ok());
   VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/false));

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -7,6 +7,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
@@ -776,7 +777,7 @@ TEST_F(VectorIndexTest, LoadRecomputesAlignedOffsetForOldSnapshot) {
   header.set_max_m(kM);
   header.set_max_m_0(kM * 2);
   header.set_m(kM);
-  header.set_mult(1.0);
+  header.set_mult(1.0 / std::log(static_cast<double>(kM)));  // == 1/log(M)
   header.set_ef_construction(kEFConstruction);
   std::string serialized;
   ASSERT_TRUE(header.SerializeToString(&serialized));
@@ -1046,12 +1047,14 @@ TEST_F(VectorIndexTest, RejectHeaderOffsetLevel0Nonzero) {
   ExpectReject(std::move(golden), "offset_level_0 must be 0");
 }
 
-TEST_F(VectorIndexTest, RejectHeaderMultOutOfRange) {
+TEST_F(VectorIndexTest, RejectHeaderMultInconsistentWithM) {
   auto golden = MultiLayerGolden();
   auto h = GetHeader(golden);
-  h.set_mult(0.0);
+  // 0.5 is well-formed (0 < 0.5 <= 2) but != 1/log(kM); the tightened check
+  // recomputes 1/log(M) and rejects it, where the old range check would not.
+  h.set_mult(0.5);
   SetHeader(&golden, h);
-  ExpectReject(std::move(golden), "mult is out of range");
+  ExpectReject(std::move(golden), "mult is inconsistent with M");
 }
 
 // ---- Level-0 record corruption -------------------------------------------

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -7,8 +7,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <deque>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -18,6 +18,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -711,10 +712,367 @@ TEST_F(VectorIndexTest, LoadRecomputesAlignedOffsetForOldSnapshot) {
 
   hnswlib::HierarchicalNSW<float> algo(&l2_space);
   SingleChunkInputStream input(serialized);
-  VMSDK_EXPECT_OK(
-      algo.LoadIndex(input, &l2_space, /*max_elements_i=*/16, nullptr));
+  VMSDK_EXPECT_OK(algo.LoadIndex(input, &l2_space, /*max_elements_i=*/16,
+                                 nullptr, /*expected_m=*/kM, /*validate=*/true));
   EXPECT_EQ(algo.offsetData_ % alignof(char*), 0u);
   EXPECT_EQ(algo.size_data_per_element_ % alignof(char*), 0u);
+}
+
+// ---------------------------------------------------------------------------
+// HNSW load-validation tests (corruption hardening).
+//
+// These exercise HierarchicalNSW::LoadIndex directly via in-memory chunk
+// streams, so a golden serialization can be built deterministically and then
+// surgically corrupted. A valid index must load; a corrupt one must be
+// rejected (status error) without crashing.
+// ---------------------------------------------------------------------------
+namespace {
+
+// A chunk store that is both an InputStream and an OutputStream. SaveIndex
+// writes into `chunks`, tests mutate `chunks` in place, and LoadIndex replays
+// it from the front -- so there is no copying between separate stream objects.
+// LoadChunk mirrors the real stream's exhaustion behavior (NotFound) so a
+// truncated input is realistic.
+class ChunkStream : public hnswlib::InputStream, public hnswlib::OutputStream {
+ public:
+  std::vector<std::string> chunks;
+
+  absl::Status SaveChunk(const char* data, size_t len) override {
+    chunks.emplace_back(data, len);
+    return absl::OkStatus();
+  }
+  absl::StatusOr<std::unique_ptr<std::string>> LoadChunk() override {
+    if (read_idx_ >= chunks.size()) {
+      return absl::NotFoundError("No more elements remaining");
+    }
+    return std::make_unique<std::string>(chunks[read_idx_++]);
+  }
+  // Reset the read cursor so the same store can be replayed again.
+  void Rewind() { read_idx_ = 0; }
+
+ private:
+  size_t read_idx_ = 0;
+};
+
+// VectorTracker that copies each vector into stable storage and hands back a
+// pointer to it (LoadIndex stores that pointer in the level-0 record).
+class BufTracker : public hnswlib::VectorTracker {
+ public:
+  char* TrackVector(uint64_t /*id*/, char* vector, size_t len) override {
+    storage_.emplace_back(vector, len);
+    return storage_.back().data();
+  }
+
+ private:
+  std::deque<std::string> storage_;
+};
+
+// On-disk geometry for kM / kDimensions, used to locate bytes for mutation.
+constexpr size_t kU32 = sizeof(uint32_t);
+constexpr size_t kStride = kM * kU32 + kU32;                   // 68
+constexpr size_t kLinks0 = 2 * kM * kU32 + kU32;               // 132
+constexpr size_t kVecBytes = kDimensions * sizeof(float);      // 400
+constexpr size_t kLabelOff = kLinks0 + kVecBytes;              // 532
+constexpr size_t kElemChunkBytes = kLabelOff + sizeof(hnswlib::labeltype);
+
+template <typename T>
+T PeekAt(const std::string& c, size_t off) {
+  CHECK_LE(off + sizeof(T), c.size()) << "PeekAt out of bounds";
+  T v;
+  std::memcpy(&v, c.data() + off, sizeof(T));
+  return v;
+}
+template <typename T>
+void PokeAt(std::string* c, size_t off, T v) {
+  CHECK_LE(off + sizeof(T), c->size()) << "PokeAt out of bounds";
+  std::memcpy(c->data() + off, &v, sizeof(T));
+}
+
+// Build a deterministic HNSW index with explicit per-element levels (a level of
+// 0 falls back to the seeded RNG, since addPoint only forces level > 0) and
+// serialize it into a golden ChunkStream.
+ChunkStream BuildGoldenChunks(const std::vector<int>& force_levels,
+                              size_t max_elements) {
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space, max_elements, kM, kEFConstruction,
+                                       /*random_seed=*/100,
+                                       /*allow_replace_deleted=*/false);
+  for (size_t i = 0; i < force_levels.size(); i++) {
+    std::vector<float> v(kDimensions, 0.1f);
+    v[i % kDimensions] = static_cast<float>(i + 1);
+    algo.addPoint(v.data(), /*label=*/i, force_levels[i]);
+  }
+  ChunkStream golden;
+  EXPECT_TRUE(algo.SaveIndex(golden).ok());
+  return golden;
+}
+
+// Load a golden ChunkStream, returning a Status (validation throws; mirror the
+// real LoadFromRDB by converting the exception into an error status).
+absl::Status LoadGolden(ChunkStream& golden, size_t max_elements,
+                        bool validate) {
+  golden.Rewind();
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space);
+  BufTracker tracker;
+  try {
+    return algo.LoadIndex(golden, &space, max_elements, &tracker, kM, validate);
+  } catch (const std::exception& e) {
+    return absl::InternalError(e.what());
+  }
+}
+
+// Walk the golden stream and record, per element, the index of its link-list
+// size chunk and (if present) its upper-level data chunk. Robust to whatever
+// levels the RNG assigned to the un-forced elements.
+struct GoldenLayout {
+  uint32_t enterpoint = 0;
+  int32_t maxlevel = 0;
+  size_t num_elements = 0;
+  std::vector<size_t> size_chunk;
+  std::vector<int> data_chunk;  // -1 if the element has no upper levels
+};
+GoldenLayout AnalyzeGolden(const ChunkStream& golden) {
+  const std::vector<std::string>& chunks = golden.chunks;
+  GoldenLayout g;
+  hnswlib::data_model::HNSWIndexHeader h;
+  EXPECT_TRUE(h.ParseFromString(chunks[0]));
+  g.enterpoint = h.enterpoint_node();
+  g.maxlevel = h.max_level();
+  g.num_elements = h.curr_element_count();
+  size_t idx = 1 + g.num_elements;  // first link-list size chunk
+  for (size_t i = 0; i < g.num_elements; i++) {
+    g.size_chunk.push_back(idx);
+    // The size chunk holds the link-list BYTE size as a size_t (8 bytes); the
+    // layer count is derived from it, not stored directly.
+    uint64_t lls = PeekAt<uint64_t>(chunks[idx], 0);  // LE host == on-disk LE
+    idx++;
+    if (lls != 0) {
+      g.data_chunk.push_back(static_cast<int>(idx));
+      idx++;
+    } else {
+      g.data_chunk.push_back(-1);
+    }
+  }
+  return g;
+}
+
+hnswlib::data_model::HNSWIndexHeader GetHeader(const ChunkStream& golden) {
+  hnswlib::data_model::HNSWIndexHeader h;
+  EXPECT_TRUE(h.ParseFromString(golden.chunks[0]));
+  return h;
+}
+void SetHeader(ChunkStream* golden,
+               const hnswlib::data_model::HNSWIndexHeader& h) {
+  std::string s;
+  EXPECT_TRUE(h.SerializeToString(&s));
+  golden->chunks[0] = s;
+}
+
+// Multi-layer golden index reused across corruption tests: element 0 is forced
+// to level 2 (the entry point), element 1 to level 1, the rest level 0.
+constexpr size_t kGoldenMax = 32;
+ChunkStream MultiLayerGolden() {
+  return BuildGoldenChunks({2, 1, 0, 0, 0, 0, 0, 0}, kGoldenMax);
+}
+
+void ExpectReject(ChunkStream golden, absl::string_view substr) {
+  auto status = LoadGolden(golden, kGoldenMax, /*validate=*/true);
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), ::testing::HasSubstr(substr));
+}
+
+}  // namespace
+
+// ---- Happy path ----------------------------------------------------------
+
+TEST_F(VectorIndexTest, LoadValidatesEmptyIndex) {
+  auto golden = BuildGoldenChunks({}, kGoldenMax);
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/true));
+}
+
+TEST_F(VectorIndexTest, LoadValidatesSingleVector) {
+  auto golden = BuildGoldenChunks({0}, kGoldenMax);
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/true));
+}
+
+TEST_F(VectorIndexTest, LoadValidatesMultiLayerRoundTripIdentity) {
+  auto golden = MultiLayerGolden();
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space);
+  BufTracker tracker;
+  golden.Rewind();
+  VMSDK_EXPECT_OK(algo.LoadIndex(golden, &space, kGoldenMax, &tracker, kM,
+                                 /*validate=*/true));
+  EXPECT_EQ(algo.cur_element_count_, 8u);
+  EXPECT_EQ(algo.maxlevel_, 2);
+  EXPECT_EQ(algo.element_levels_[algo.enterpoint_node_], 2);
+  // save -> load -> save must be byte-identical for a valid index.
+  ChunkStream resaved;
+  VMSDK_EXPECT_OK(algo.SaveIndex(resaved));
+  EXPECT_EQ(resaved.chunks, golden.chunks);
+}
+
+// ---- Header corruption ---------------------------------------------------
+
+TEST_F(VectorIndexTest, RejectHeaderMMismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_m(kM + 1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "header M does not match");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMaxM0Mismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_max_m_0(2 * kM + 1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "maxM0 does not equal 2*M");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderEnterpointOutOfRange) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_enterpoint_node(h.curr_element_count());  // == cur, out of range
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "enterpoint_node is out of range");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMaxLevelTooLarge) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_max_level(1000);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "max_level exceeds the element count");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderSerializeSizeMismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_serialize_size_data_per_element(
+      h.serialize_size_data_per_element() + 1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "serialized element size is inconsistent");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderOffsetLevel0Nonzero) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_offset_level_0(8);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "offset_level_0 must be 0");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMultOutOfRange) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_mult(0.0);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "mult is out of range");
+}
+
+// ---- Level-0 record corruption -------------------------------------------
+
+TEST_F(VectorIndexTest, RejectLevel0ChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  golden.chunks[1].resize(kElemChunkBytes - 1);  // truncate element 0's chunk
+  ExpectReject(std::move(golden), "level-0 element chunk has the wrong size");
+}
+
+TEST_F(VectorIndexTest, RejectLevel0CountTooLarge) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[1], 0, 2 * kM + 1);  // count > maxM0_
+  ExpectReject(std::move(golden), "level-0 neighbor count exceeds 2*M");
+}
+
+TEST_F(VectorIndexTest, RejectLevel0NeighborOutOfRange) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);          // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32, 9999);    // neighbor[0] out of range
+  ExpectReject(std::move(golden), "level-0 neighbor id out of range");
+}
+
+TEST_F(VectorIndexTest, RejectDuplicateLabel) {
+  auto golden = MultiLayerGolden();
+  auto label0 = PeekAt<hnswlib::labeltype>(golden.chunks[1], kLabelOff);
+  PokeAt<hnswlib::labeltype>(&golden.chunks[3], kLabelOff, label0);  // element 2 dup
+  ExpectReject(std::move(golden), "duplicate label in index");
+}
+
+// ---- Upper-level record corruption ---------------------------------------
+
+TEST_F(VectorIndexTest, RejectSizeChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  golden.chunks[g.size_chunk[g.enterpoint]].resize(4);  // not sizeof(size_t)
+  ExpectReject(std::move(golden), "link-list size chunk has the wrong size");
+}
+
+TEST_F(VectorIndexTest, RejectLinkListSizeNotMultiple) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, 2 * kStride + 1);
+  ExpectReject(std::move(golden), "not a multiple of the stride");
+}
+
+TEST_F(VectorIndexTest, RejectElementLevelExceedsMaxLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Declare level 3 (> maxlevel 2) for the entry point.
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, 3 * kStride);
+  ExpectReject(std::move(golden), "element level exceeds max_level");
+}
+
+TEST_F(VectorIndexTest, RejectUpperChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  golden.chunks[g.data_chunk[g.enterpoint]].resize(kStride);  // declared 2 levels
+  ExpectReject(std::move(golden), "upper-level link-list chunk has the wrong");
+}
+
+TEST_F(VectorIndexTest, RejectUpperCountTooLarge) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0, kM + 1);  // level 1
+  ExpectReject(std::move(golden), "upper-level neighbor count exceeds M");
+}
+
+TEST_F(VectorIndexTest, RejectUpperNeighborOutOfRange) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0, 1);
+  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kU32, 9999);
+  ExpectReject(std::move(golden), "upper-level neighbor id out of range");
+}
+
+TEST_F(VectorIndexTest, RejectUpperNeighborAbsentAtLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Entry point's level-2 list -> element 1, which exists only at level 1.
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride, 1);
+  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride + kU32, 1);
+  ExpectReject(std::move(golden), "neighbor is absent at that level");
+}
+
+TEST_F(VectorIndexTest, RejectEntrypointNotMaxLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Demote the entry point to level 1 while the header still claims maxlevel 2.
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, kStride);
+  golden.chunks[g.data_chunk[g.enterpoint]].resize(kStride);
+  ExpectReject(std::move(golden), "enterpoint node is not at max_level");
+}
+
+// ---- Kill switch ---------------------------------------------------------
+
+TEST_F(VectorIndexTest, ValidationDisabledBypassesChecks) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);        // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32, 1);     // neighbor[0] == self (a self-loop)
+  // Enabled: rejected. Disabled: loads (the self-loop is not memory-unsafe).
+  EXPECT_FALSE(LoadGolden(golden, kGoldenMax, /*validate=*/true).ok());
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/false));
 }
 
 }  // namespace

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -25,6 +25,7 @@
 #include "src/metrics.h"
 #include "third_party/hnswlib/index.pb.h"
 #include "visited_list_pool.h"
+#include "vmsdk/src/log.h"
 #include "vmsdk/src/status/status_macros.h"
 
 #ifdef VMSDK_ENABLE_MEMORY_ALLOCATION_OVERRIDES
@@ -867,10 +868,18 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
   // disabled. On failure it throws; VectorHNSW::LoadFromRDB converts the
   // exception into a failed (rejected) RDB load.
   inline void loadCheck(bool ok, absl::string_view msg) const {
-    if (load_validation_enabled_ && !ok) {
+    if (ok) {
+      return;
+    }
+    if (load_validation_enabled_) {
       throw std::runtime_error(
           absl::StrCat("HNSW index load validation failed: ", msg));
     }
+    // Validation disabled: don't fail the load, but log (throttled) the defect.
+    VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+        << "HNSW load validation is disabled; ignoring detected index "
+           "corruption: "
+        << msg;
   }
 
   absl::Status LoadIndex(InputStream &input, SpaceInterface<dist_t> *s,
@@ -939,11 +948,14 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
                     size_links_level0_ + vector_size_ + sizeof(labeltype),
                 "serialized element size is inconsistent with the geometry");
       loadCheck(offsetLevel0_ == 0, "offset_level_0 must be 0");
-      // mult_ = 1/log(M_) is always in (0, ~1.45] for M_ >= 2. A range check
-      // (rather than std::isfinite, which is unreliable under finite-math
-      // build flags) rejects inf / out-of-range garbage. mult_ only affects
-      // future-insert level assignment, so this is a soft, non-safety check.
-      loadCheck(mult_ > 0.0 && mult_ <= 2.0, "mult is out of range");
+      // Recompute mult=1/log(M) and match within a guardband (cross-arch libm);
+      // skip M<2 where 1/log(M) is not finite. Soft, non-safety check.
+      if (M_ >= 2) {
+        const double expected_mult = 1.0 / std::log(static_cast<double>(M_));
+        loadCheck(mult_ > 0.0 &&
+                      std::fabs(mult_ - expected_mult) <= 1e-6 * expected_mult,
+                  "mult is inconsistent with M");
+      }
 
       // Element-count / level / entry-point consistency.
       loadCheck(cur_element_count_ <= max_elements_,

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include <atomic>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -97,6 +98,10 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
   bool allow_replace_deleted_ = false;  // flag to replace deleted elements
                                         // (marked as deleted) during insertions
+
+  // Gate for load-time corruption validation, wired from the
+  // hnsw-validation-enable config via LoadIndex. Consulted only in loadCheck().
+  bool load_validation_enabled_ = false;
 
   std::mutex deleted_elements_lock;  // lock for deleted_elements
   std::unordered_set<tableint>
@@ -812,9 +817,23 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     return absl::OkStatus();
   }
 
+  // Single choke-point for load-time validation. The kill switch
+  // (load_validation_enabled_, wired from the hnsw-validation-enable config) is
+  // consulted here and nowhere else, so a defective check can be globally
+  // disabled. On failure it throws; VectorHNSW::LoadFromRDB converts the
+  // exception into a failed (rejected) RDB load.
+  inline void loadCheck(bool ok, absl::string_view msg) const {
+    if (load_validation_enabled_ && !ok) {
+      throw std::runtime_error(
+          absl::StrCat("HNSW index load validation failed: ", msg));
+    }
+  }
+
   absl::Status LoadIndex(InputStream &input, SpaceInterface<dist_t> *s,
-                         size_t max_elements_i, VectorTracker *vector_tracker) {
+                         size_t max_elements_i, VectorTracker *vector_tracker,
+                         size_t expected_m, bool validate) {
     clear();
+    load_validation_enabled_ = validate;
 
     VMSDK_ASSIGN_OR_RETURN(auto serialized_header, input.LoadChunk());
     auto header = std::make_unique<data_model::HNSWIndexHeader>();
@@ -822,6 +841,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       return absl::InternalError("Could not deserialize HNSW header");
     }
 
+    // --- Read raw header fields (untrusted) ---
     offsetLevel0_ = header->offset_level_0();
     max_elements_ = header->max_elements();
     cur_element_count_ = header->curr_element_count();
@@ -836,29 +856,84 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     mult_ = header->mult();
     ef_construction_ = header->ef_construction();
 
-    size_t max_elements = max_elements_i;
-    if (max_elements < cur_element_count_) {
-      max_elements = max_elements_;
-    }
-    max_elements_ = max_elements;
+    // Authoritative parameters come from the index definition (the space and
+    // expected_m), never from the untrusted header.
+    vector_size_ = s->get_data_size();
+    fstdistfunc_ = s->get_dist_func();
+    dist_func_param_ = s->get_dist_func_param();
 
+    // Recompute the geometry that governs memory layout. When validation is
+    // enabled these are cross-checked against the header below; the header's
+    // own copies are only ever used as values to validate against.
     size_links_level0_ = maxM0_ * sizeof(tableint) + sizeof(linklistsizeint);
     offsetData_ =
         (size_links_level0_ + alignof(char *) - 1) & ~(alignof(char *) - 1);
-
-    vector_size_ = s->get_data_size();
-    size_data_per_element_ =
-        offsetData_ + sizeof(char *) + sizeof(labeltype);
+    size_data_per_element_ = offsetData_ + sizeof(char *) + sizeof(labeltype);
     label_offset_ = offsetData_ + sizeof(char *);
+    size_links_per_element_ =
+        maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
 
-    fstdistfunc_ = s->get_dist_func();
-    dist_func_param_ = s->get_dist_func_param();
+    // Resolve capacity: at least the live element count, honoring the larger of
+    // the caller-requested cap and the file's recorded capacity.
+    size_t cur_count = cur_element_count_;
+    size_t max_elements =
+        std::max(cur_count, std::max(max_elements_i, max_elements_));
+    max_elements_ = max_elements;
+
+    // --- Header validation (the kill switch lives inside loadCheck) ---
+    {
+      const size_t exp_m = expected_m > 10000 ? 10000 : expected_m;
+      // Layout parameters must match the index definition exactly.
+      loadCheck(exp_m >= 1, "M must be >= 1");
+      loadCheck(M_ == exp_m, "header M does not match index definition");
+      loadCheck(maxM_ == M_, "header maxM does not equal M");
+      loadCheck(maxM0_ == 2 * M_, "header maxM0 does not equal 2*M");
+      loadCheck(maxM0_ <= 0xFFFF,
+                "maxM0 exceeds the 16-bit neighbor-count field");
+      loadCheck(vector_size_ > 0, "vector size must be > 0");
+      loadCheck(serialize_size_data_per_element_ ==
+                    size_links_level0_ + vector_size_ + sizeof(labeltype),
+                "serialized element size is inconsistent with the geometry");
+      loadCheck(offsetLevel0_ == 0, "offset_level_0 must be 0");
+      // mult_ = 1/log(M_) is always in (0, ~1.45] for M_ >= 2. A range check
+      // (rather than std::isfinite, which is unreliable under finite-math
+      // build flags) rejects inf / out-of-range garbage. mult_ only affects
+      // future-insert level assignment, so this is a soft, non-safety check.
+      loadCheck(mult_ > 0.0 && mult_ <= 2.0, "mult is out of range");
+
+      // Element-count / level / entry-point consistency.
+      loadCheck(cur_element_count_ <= max_elements_,
+                "curr_element_count exceeds max_elements");
+      if (cur_element_count_ == 0) {
+        loadCheck(maxlevel_ == -1 || maxlevel_ == 0,
+                  "empty index has a non-trivial max_level");
+      } else {
+        loadCheck(maxlevel_ >= 0, "non-empty index has a negative max_level");
+        loadCheck(maxlevel_ <= static_cast<int>(cur_element_count_),
+                  "max_level exceeds the element count");
+        loadCheck(enterpoint_node_ < cur_element_count_,
+                  "enterpoint_node is out of range");
+      }
+
+      // Guard every load allocation against size_t overflow / address-space
+      // wraparound, which also bounds an absurd element count.
+      loadCheck(size_data_per_element_ > 0, "size_data_per_element is 0");
+      loadCheck(max_elements_ <= SIZE_MAX / size_data_per_element_,
+                "level-0 allocation size overflows");
+      loadCheck(max_elements_ <= SIZE_MAX / sizeof(void *),
+                "linkLists allocation size overflows");
+      loadCheck(max_elements_ <= SIZE_MAX / sizeof(int),
+                "element_levels allocation size overflows");
+    }
 
     data_level0_memory_ = std::make_unique<ChunkedArray>(
         size_data_per_element_, k_elements_per_chunk, max_elements);
 
     for (size_t i = 0; i < cur_element_count_; i++) {
       VMSDK_ASSIGN_OR_RETURN(auto chunk, input.LoadChunk());
+      loadCheck(chunk->size() ==
+                    size_links_level0_ + vector_size_ + sizeof(labeltype),
+                "level-0 element chunk has the wrong size");
       memcpy((*data_level0_memory_)[i], chunk->data(), size_links_level0_);
       labeltype id;
       memcpy((char *)&id, chunk->data() + size_links_level0_ + vector_size_,
@@ -868,10 +943,21 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
                                       vector_size_);
       memcpy((*data_level0_memory_)[i] + label_offset_, (char *)&id,
              sizeof(labeltype));
-    }
 
-    size_links_per_element_ =
-        maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
+      // Validate the level-0 link list now that it is in place. The neighbor
+      // scan is clamped to maxM0_ so it stays within the record even when the
+      // (corrupt) count is larger and validation is disabled.
+      linklistsizeint *ll0 = get_linklist0(i);
+      size_t l0_count = getListCount(ll0);
+      loadCheck(l0_count <= maxM0_, "level-0 neighbor count exceeds 2*M");
+      tableint *l0_neighbors = (tableint *)(ll0 + 1);
+      size_t l0_scan = std::min(l0_count, maxM0_);
+      for (size_t j = 0; j < l0_scan; j++) {
+        loadCheck(l0_neighbors[j] < cur_element_count_,
+                  "level-0 neighbor id out of range");
+        loadCheck(l0_neighbors[j] != i, "level-0 self-loop");
+      }
+    }
 
     std::vector<std::mutex>(max_elements).swap(link_list_locks_);
     std::vector<std::mutex>(MAX_LABEL_OPERATION_LOCKS).swap(label_op_locks_);
@@ -885,21 +971,85 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     revSize_ = 1.0 / mult_;
     ef_ = 10;
     for (size_t i = 0; i < cur_element_count_; i++) {
-      label_lookup_[getExternalLabel(i)] = i;
+      // Establish safe defaults first: element_levels_[i] stays 0 and the
+      // link-list pointer stays null until a valid allocation is stored, so an
+      // early return / thrown validation cannot leave clear() freeing an
+      // uninitialized pointer (ChunkedArray memory is not zeroed).
+      element_levels_[i] = 0;
+      *reinterpret_cast<char **>((*linkLists_)[i]) = nullptr;
+
+      labeltype ext_label = getExternalLabel(i);
+      loadCheck(label_lookup_.find(ext_label) == label_lookup_.end(),
+                "duplicate label in index");
+      label_lookup_[ext_label] = i;
       size_t linkListSize;
       VMSDK_ASSIGN_OR_RETURN(auto size_chunk, input.LoadChunk());
+      loadCheck(size_chunk->size() == sizeof(size_t),
+                "link-list size chunk has the wrong size");
       memcpy(&linkListSize, size_chunk->data(), sizeof(size_t));
       linkListSize = le64toh(linkListSize);
-      if (linkListSize == 0) {
-        element_levels_[i] = 0;
-        *reinterpret_cast<char **>((*linkLists_)[i]) = nullptr;
-      } else {
-        element_levels_[i] = linkListSize / size_links_per_element_;
+      if (linkListSize != 0) {
+        loadCheck(linkListSize % size_links_per_element_ == 0,
+                  "upper-level link-list size is not a multiple of the stride");
+        int level = linkListSize / size_links_per_element_;
+        loadCheck(level <= maxlevel_, "element level exceeds max_level");
         VMSDK_ASSIGN_OR_RETURN(auto link_list_chunk, input.LoadChunk());
-        *reinterpret_cast<char **>((*linkLists_)[i]) =
-            new char[link_list_chunk->size()];
-        memcpy(*reinterpret_cast<char **>((*linkLists_)[i]),
-               link_list_chunk->data(), link_list_chunk->size());
+        loadCheck(link_list_chunk->size() == linkListSize,
+                  "upper-level link-list chunk has the wrong size");
+        // Allocate from the derived level count (== linkListSize for valid
+        // data) so get_linklist() stays in-bounds for levels 1..level
+        // regardless of whether validation is enabled.
+        size_t alloc_size =
+            static_cast<size_t>(level) * size_links_per_element_;
+        char *links = new char[alloc_size];
+        memset(links, 0, alloc_size);
+        memcpy(links, link_list_chunk->data(),
+               std::min(alloc_size, link_list_chunk->size()));
+        // Store the pointer, then publish the level, so the two stay in sync
+        // for clear() even if a later check throws.
+        *reinterpret_cast<char **>((*linkLists_)[i]) = links;
+        element_levels_[i] = level;
+        // Validate per-level neighbor counts. Neighbor ids are validated in the
+        // global pass, since their target slots may not be loaded yet.
+        for (int l = 1; l <= level; l++) {
+          loadCheck(getListCount(get_linklist(i, l)) <= maxM_,
+                    "upper-level neighbor count exceeds M");
+        }
+      }
+    }
+
+    // --- Global graph-invariant pass (requires all element_levels_ loaded) ---
+    // The entry point must be one of the tallest nodes (proven invariant:
+    // maxlevel_ is only ever raised together with enterpoint_node_). The
+    // short-circuit also guards the array access if validation is disabled and
+    // enterpoint_node_ is out of range.
+    if (cur_element_count_ > 0) {
+      loadCheck(enterpoint_node_ < cur_element_count_ &&
+                    element_levels_[enterpoint_node_] == maxlevel_,
+                "enterpoint node is not at max_level");
+    }
+    // Every upper-level link must target a slot that actually exists at that
+    // level; otherwise a graph descent would over-read the target's smaller
+    // link-list allocation. This needs the full element_levels_, so it cannot
+    // be done in the streaming load loop above.
+    for (size_t i = 0; i < cur_element_count_; i++) {
+      for (int level = 1; level <= element_levels_[i]; level++) {
+        linklistsizeint *ll = get_linklist(i, level);
+        size_t count = getListCount(ll);
+        // count was bounded to maxM_ per-record; clamp the scan so a corrupt
+        // count cannot over-read the per-level region when validation is off.
+        size_t scan = std::min(count, maxM_);
+        tableint *neighbors = (tableint *)(ll + 1);
+        for (size_t j = 0; j < scan; j++) {
+          tableint e = neighbors[j];
+          loadCheck(e < cur_element_count_,
+                    "upper-level neighbor id out of range");
+          loadCheck(e != i, "upper-level self-loop");
+          // Short-circuit guards element_levels_[e] when validation is off and
+          // e is out of range (the first check above did not throw).
+          loadCheck(e >= cur_element_count_ || element_levels_[e] >= level,
+                    "upper-level neighbor is absent at that level");
+        }
       }
     }
 


### PR DESCRIPTION
Loading an HNSW index from RDB previously trusted the serialized data completely; a corrupt or malicious snapshot could drive out-of-bounds reads/writes and crash the server during load or on the next search.

Add defensive validation to HierarchicalNSW::LoadIndex, gated by a single choke-point (loadCheck) that throws on failure (converted to a rejected RDB load by VectorHNSW::LoadFromRDB):

- Header: cross-check M/maxM/maxM0/serialize-size/offsets against the authoritative index definition (expected_m, the space's vector size), bound enterpoint/max_level, guard every allocation against size_t overflow, and fix the capacity resolution so max_elements is always
  >= curr_element_count.
- Per record: level-0 chunk size, neighbor count <= 2M, neighbor ids < curr_element_count; upper-level size-chunk/multiple/chunk-size, level <= max_level, per-level count <= M, and duplicate-label detection.
- Global pass: enterpoint is at max_level, and every upper-level link targets a slot that exists at that level (closing the descent over-read that an id-range check alone cannot).

Validation scans are clamped to safe bounds so disabling the kill switch never introduces a new load-time OOB. Add the hnsw-validation-enable (Dev, default true) config as the kill switch.

Also fix a latent double-free: if the upper-level load loop returned/threw after setting element_levels_[i] nonzero but before storing the link-list pointer, clear() would free uninitialized ChunkedArray memory. Now the pointer is nulled first and the level published only after a valid alloc.

Tests (testing/vector_test.cc): a combined in-memory ChunkStream double, deterministic forced-level golden builder, empty/single/multi-layer happy-path round-trips (including save->load->save byte identity), and one corruption test per validation rule plus a kill-switch bypass test.