### PR TITLE
Validate query vector size against index dimensions at parse time

### DIFF
--- a/integration/test_query_parser.py
+++ b/integration/test_query_parser.py
@@ -1,8 +1,15 @@
+import struct
+
 import pytest
 from valkey import ResponseError
 from valkey.client import Valkey
 from valkey_search_test_case import ValkeySearchTestCaseBase
 from valkeytestframework.conftest import resource_port_tracker
+
+# A correctly sized query vector for the DIM 128 / FLOAT32 indexes used in these
+# tests (128 * 4 = 512 bytes). These tests exercise query-string parsing limits,
+# not vector contents, so any in-range vector blob works.
+VECTOR_BLOB_DIM128 = struct.pack("<128f", *([1.0] * 128))
 
 
 class TestQueryParser(ValkeySearchTestCaseBase):
@@ -19,7 +26,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         command_args = [
             "FT.SEARCH", "my_index",
             query,
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ]
         # Validate the query strings above the limit are rejected.
@@ -45,7 +52,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "@price:[10 20] =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
 
@@ -55,7 +62,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "@price:[10 20] | @category:{electronics|books} =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         # Set depth limit to 1 to test that depth-2 query fails
@@ -66,7 +73,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             client.execute_command(
                 "FT.SEARCH", "my_index",
                 "(@price:[10 20]) =>[KNN 10 @doc_embedding $BLOB]",
-                "PARAMS", 2, "BLOB", "<your_vector_blob>",
+                "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
                 "RETURN", 1, "doc_embedding"
             )
             assert False
@@ -77,13 +84,13 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "(((((((((@price:[10 20]))))))))) =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "((((((((@price:[10 20] | @category:{electronics|books})))))))) =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         # Validate the failure case with a query of depth 11.
@@ -91,7 +98,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             client.execute_command(
                 "FT.SEARCH", "my_index",
                 "((((((((((@price:[10 20])))))))))) =>[KNN 10 @doc_embedding $BLOB]",
-                "PARAMS", 2, "BLOB", "<your_vector_blob>",
+                "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
                 "RETURN", 1, "doc_embedding"
             )
             assert False
@@ -130,7 +137,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "@price:[10 20] @price:[30 40] @price:[50 60] =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         
@@ -142,7 +149,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
             client.execute_command(
                 "FT.SEARCH", "my_index",
                 "@price:[10 20] | @price:[30 40] | @price:[50 60] | @category:{books} | @category:{electronics} | @price:[70 80] =>[KNN 10 @doc_embedding $BLOB]",
-                "PARAMS", 2, "BLOB", "<your_vector_blob>",
+                "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
                 "RETURN", 1, "doc_embedding"
             )
             assert False
@@ -157,7 +164,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "@price:[10 20] @price:[30 40] @price:[50 60] @price:[70 80] =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         
@@ -167,7 +174,7 @@ class TestQueryParser(ValkeySearchTestCaseBase):
         assert client.execute_command(
             "FT.SEARCH", "my_index",
             "@price:[10 20] | @price:[30 40] | @price:[50 60] =>[KNN 10 @doc_embedding $BLOB]",
-            "PARAMS", 2, "BLOB", "<your_vector_blob>",
+            "PARAMS", 2, "BLOB", VECTOR_BLOB_DIM128,
             "RETURN", 1, "doc_embedding"
         ) == [0]
         

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -225,12 +225,6 @@ template <typename T>
 absl::StatusOr<std::vector<Neighbor>> VectorFlat<T>::Search(
     absl::string_view query, uint64_t count, cancel::Token &cancellation_token,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter) {
-  if (!IsValidSizeVector(query)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Error parsing vector similarity query: query vector blob size (",
-        query.size(), ") does not match index's expected size (",
-        dimensions_ * GetDataTypeSize(), ")."));
-  }
   auto perform_search = [this, count, &filter,
                          &cancellation_token](absl::string_view query)
       -> absl::StatusOr<std::priority_queue<std::pair<T, hnswlib::labeltype>>> {

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -315,12 +315,6 @@ absl::StatusOr<std::vector<Neighbor>> VectorHNSW<T>::Search(
     absl::string_view query, uint64_t count, cancel::Token &cancellation_token,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter,
     std::optional<size_t> ef_runtime, bool enable_partial_results) {
-  if (!IsValidSizeVector(query)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Error parsing vector similarity query: query vector blob size (",
-        query.size(), ") does not match index's expected size (",
-        dimensions_ * GetDataTypeSize(), ")."));
-  }
   auto perform_search = [this, count, &filter, enable_partial_results,
                          &ef_runtime,
                          &cancellation_token](absl::string_view query)

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -1140,6 +1140,18 @@ absl::Status PostParseVectorParameters(query::SearchParameters &parameters) {
       parameters.query,
       SubstituteParam(parameters, parameters.parse_vars.query_vector_string));
 
+  VMSDK_ASSIGN_OR_RETURN(auto index, parameters.index_schema->GetIndex(
+                                         parameters.attribute_alias));
+  auto *vector_index = dynamic_cast<indexes::VectorBase *>(index.get());
+  CHECK(vector_index != nullptr);
+  if (parameters.query.size() !=
+      static_cast<size_t>(vector_index->GetVectorDataSize())) {
+    return absl::InvalidArgumentError(
+        absl::StrCat("query vector blob size (", parameters.query.size(),
+                     ") does not match index's expected size (",
+                     vector_index->GetVectorDataSize(), ")."));
+  }
+
   if (!parameters.parse_vars.ef_string.empty()) {
     VMSDK_ASSIGN_OR_RETURN(
         auto ef_string,

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -70,6 +70,7 @@ struct FTSearchParserTestCase {
   std::string search_parameters_str;
   uint64_t timeout_ms{query::kTimeoutMS};
   bool vector_query{true};
+  std::optional<size_t> query_blob_num_floats;
   bool verbatim{false};
   bool inorder{false};
   std::optional<unsigned> slop;
@@ -111,6 +112,9 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   std::cerr << "\n";
 
   std::vector<float> floats = {0.1, 0.2, 0.3};
+  if (test_case.query_blob_num_floats.has_value()) {
+    floats.assign(*test_case.query_blob_num_floats, 0.1f);
+  }
   std::vector<ValkeyModuleString *> args;
   const std::string key_str = "my_schema_name";
   ValkeyModuleCtx fake_ctx;
@@ -528,6 +532,26 @@ INSTANTIATE_TEST_SUITE_P(
             .params_str = " PARAMS 2",
             .filter_str = " * => [KNN 10 @vec $BLOB]",
             .k = 10,
+        },
+        {
+            .test_name = "vector_blob_size_too_small",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = " * => [KNN 10 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing vector similarity parameters: query vector "
+                "blob size",
+            .query_blob_num_floats = 2,
+        },
+        {
+            .test_name = "vector_blob_size_too_large",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = " * => [KNN 10 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing vector similarity parameters: query vector "
+                "blob size",
+            .query_blob_num_floats = 4,
         },
         {
             .test_name = "happy_path_1_with_score_as",

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -180,15 +180,6 @@ void TestIndex(T* index, int dimensions, int vector_size) {
   VerifyModify(index, vectors[vectors.size() - 2], vectors.size() - 1,
                ExpectedResults::kSuccess, true);
 
-  absl::string_view vector = VectorToStr(vectors_small_dim[0]);
-  auto res = index->Search(vector, 10, CancelNever());
-  EXPECT_FALSE(res.ok());
-  EXPECT_EQ(
-      res.status().message(),
-      absl::StrCat(
-          "Error parsing vector similarity query: query vector blob size (",
-          vector.size(), ") does not match index's expected size (",
-          dimensions * sizeof(float), ")."));
   for (size_t i = 1; i < vectors.size() - 1; ++i) {
     absl::string_view vector = VectorToStr(vectors[i]);
     auto res = index->Search(vector, 10, CancelNever());


### PR DESCRIPTION
The query reference vector supplied to FT.SEARCH / FT.AGGREGATE was only length-checked inside the index Search() methods. The pre-filtering path (DoSearchVector -> CalcBestMatchingPrefilteredKeys -> AddPrefilteredKey -> ComputeDistanceFromRecord) bypassed that check and cast the blob directly to the element type, reading dimensions_ elements from it -- an out-of-bounds read when an undersized blob is supplied via PARAMS.

Validate the substituted query vector once in PostParseVectorParameters, the common parse choke point for both commands, so every downstream search path receives a correctly sized blob. Remove the now-redundant IsValidSizeVector checks from VectorFlat::Search and VectorHNSW::Search (IsValidSizeVector is retained for the insert-time guard in InternVector). Add parser regression tests for too-small and too-large blobs.