### PR TITLE
[backport 1.2] Deflake test_saverestore_backfill_only (#933)

### DIFF
--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -307,7 +307,7 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         # Fill the mutation queue with only backfills on an index that's not done backfilling and assert that no keys get saved.
         #
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
-        self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
+        self.client.execute_command("FT._DEBUG CONTROLLED_VARIABLE SET StopBackfill yes")
         load_data(self.client)
         index.create(self.client, False)
         self.client.execute_command("save")
@@ -317,7 +317,6 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         assert i["search_rdb_save_mutation_entries"] == 0
         assert i["search_rdb_save_backfilling_indexes"] == 1
         os.environ["SKIPLOGCLEAN"] = "1"
-        self.client.execute_command("ft._debug pausepoint reset block_mutation_queue")
         self.server.restart(remove_rdb=False)
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         i = self.client.info("search")


### PR DESCRIPTION
Backport of #933 to the 1.2 branch.

Cherry-picked from f85c179b3ee2cd9048db2780c4f00085bdbe3a3e (clean, no conflicts).

Test-only change: swaps the `block_mutation_queue` pausepoint for `FT._DEBUG CONTROLLED_VARIABLE SET StopBackfill yes`, which reliably stops backfill on both worker and main (cron) threads. The `StopBackfill` controlled variable already exists on 1.2 (src/index_schema.cc) and is used by another test in the same file.

Original description:
> The test verifies that when an index is still backfilling with zero progress, RDB save writes 0 keys and 0 mutation entries. The `block_mutation_queue` pausepoint only blocks worker threads (ProcessSingleMutationAsync), not the main thread where the cron callback performs backfill and populates `search_rdb_save_keys`, causing intermittent failures. Switching to the `StopBackfill` debug variable ensures the save happens on an index that's not done backfilling.