### PR TITLE
Open next development cycle on main (release stage "dev", drop stale CMake VERSION)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   ValkeySearch
-  VERSION 1.0.0
   LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 2, 0);
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
-#define MODULE_RELEASE_STAGE "rc2"
+#define MODULE_RELEASE_STAGE "dev"
 
 //
 // Set the minimum acceptable server version


### PR DESCRIPTION
Fixing based on https://github.com/valkey-io/valkey/blob/unstable/src/version.h

## Summary

`main` currently reports itself as the shipped **1.2.0 GA** release: `src/version.h` still has `MODULE_RELEASE_STAGE "rc2"` from the 1.2 release, and its version bytes are identical to the `1.2.0` tag. This makes a build from `main` indistinguishable from the released artifact.

This PR opens the development cycle on `main`:

- **`src/version.h`**: `MODULE_RELEASE_STAGE` `rc2` → `dev`, matching the documented convention ("In unstable branch the status is always dev").
- **`CMakeLists.txt`**: remove the stale `VERSION 1.0.0` from `project()`.

`kModuleVersion` is intentionally **left at 1.2.0**. Unlike Valkey core's `VALKEY_VERSION` (a display-only string that can be a `255.255.255` sentinel), `kModuleVersion` is functionally load-bearing — it is the ceiling for RDB load (`rdb_serialization.cc`), the default `encoding_version` stamped into persisted/replicated metadata (`metadata_manager`), and a config-validation bound. A sentinel here would corrupt those paths. The dev marker therefore lives in the release stage, not the version integer. It will be bumped to the next target when 1.3 development begins.

### Why drop the CMake VERSION
`project(... VERSION 1.0.0)` is never propagated anywhere in the build (no `PROJECT_VERSION` use, no CPACK/SOVERSION, not consumed by packaging). It has been stuck at 1.0.0 on every branch and only serves to mislead. The authoritative module version is `src/version.h`.

No functional/runtime behavior changes.