### PR TITLE
Mark 1.2 branch as GA and drop stale CMake VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   ValkeySearch
-  VERSION 1.0.0
   LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 

--- a/src/version.h
+++ b/src/version.h
@@ -19,7 +19,7 @@ constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 2, 0);
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
-#define MODULE_RELEASE_STAGE "rc2"
+#define MODULE_RELEASE_STAGE "ga"
 
 //
 // Set the minimum acceptable server version


### PR DESCRIPTION
## Summary

The `1.2` release branch still carries `MODULE_RELEASE_STAGE "rc2"` even though **1.2.0 has shipped GA** (see [releases](https://github.com/valkey-io/valkey-search/releases)). The GA-ness currently exists only in the git tag, never on the branch.

- **`src/version.h`**: `MODULE_RELEASE_STAGE` `rc2` → `ga`, per the documented convention ("When the version is released the status will be ga").
- **`CMakeLists.txt`**: remove the stale `VERSION 1.0.0` from `project()` (never propagated into the build; module version lives in `src/version.h`).

`kModuleVersion` is already `1.2.0` and is unchanged. No functional/runtime behavior changes.