### PR TITLE
Delete stale project VERSION on 1.1 branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   ValkeySearch
-  VERSION 1.0.0
+  VERSION 1.1.0
   LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ cmake_minimum_required(VERSION 3.16)
 
 project(
   ValkeySearch
-  VERSION 1.1.0
   LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 


### PR DESCRIPTION
## Summary

The `1.1` release branch has `project(... VERSION 1.0.0)` in `CMakeLists.txt` — left over from 1.0 and never updated.

The CMake `VERSION` field is **not consumed anywhere** in the build on this branch (no `PROJECT_VERSION` use, no CPACK/SOVERSION, `debs/` is a placeholder), so rather than correcting the number, this PR **removes it entirely** — consistent with the same cleanup on `main` and `1.2`.

- **`CMakeLists.txt`**: remove `VERSION 1.0.0` from `project()`.

The authoritative module version already reports correctly on this branch: `src/version.h` has `kModuleVersion = 1.1.0` and `MODULE_RELEASE_STAGE "ga"`, and `module_loader.cc` passes `kModuleVersion` to `ValkeyModule_Init`. No functional/runtime behavior changes.