### PR TITLE
Reflect 1.0.2 release on 1.0 branch; drop stale CMake VERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Project definition
 
-project(valkey-search VERSION 1.0.0 LANGUAGES C CXX)
+project(valkey-search VERSION 1.0.2 LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # Options

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.16)
 
 # Project definition
 
-project(valkey-search VERSION 1.0.2 LANGUAGES C CXX)
+project(valkey-search LANGUAGES C CXX)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 # Options

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -35,12 +35,12 @@
 #include "vmsdk/src/module.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
-#define MODULE_VERSION 10000
+#define MODULE_VERSION 10002
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.
  * When the version is released the status will be "ga". */
-#define MODULE_RELEASE_STAGE "rc1"
+#define MODULE_RELEASE_STAGE "ga"
 
 namespace {
 


### PR DESCRIPTION
## Summary

The `1.0` branch shipped up to **1.0.2** (see [releases](https://github.com/valkey-io/valkey-search/releases)) but still declares the initial values: `MODULE_VERSION 10000` (= 1.0.0) and `MODULE_RELEASE_STAGE "rc1"`, so the module reports the wrong version and a pre-GA stage.

- **`src/module_loader.cc`** (functional): `MODULE_VERSION` `10000` → `10002` (the decimal M_mm_pp encoding, i.e. 1.0.2); `MODULE_RELEASE_STAGE` `rc1` → `ga`.
- **`CMakeLists.txt`**: **remove** `VERSION 1.0.0` from `project()`. The CMake `VERSION` field is not consumed anywhere in the build (no `PROJECT_VERSION` use, no CPACK/SOVERSION, `debs/` is a placeholder), so it is deleted rather than updated — consistent with `main`, `1.1`, and `1.2`.

Note: this branch predates the `vmsdk::ValkeyVersion` class and `src/version.h` (both introduced after 1.0), so the real module version is defined inline in `module_loader.cc` — there is no `version.h` to update here. No functional/runtime behavior changes beyond the corrected reported version/stage.