### PR TITLE
Fix flaky test_fulltext_inflight_blocking: actually wait for backfill

### DIFF
--- a/integration/test_fulltext_inflight_blocking.py
+++ b/integration/test_fulltext_inflight_blocking.py
@@ -31,7 +31,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
         )
         client.execute_command("HSET", "doc:1", "content", "hello world")
         client.execute_command("HSET", "doc:2", "content", "hello there")
-        IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        waiters.wait_for_true(
+            lambda: IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        )
         assert client.execute_command("FT.SEARCH", "idx", "@content:hello")[0] == 2
 
         # Pause mutation processing to keep key in-flight
@@ -105,7 +107,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
         vec1 = struct.pack('<4f', 0.0, 0.0, 0.0, 0.0)
         vec2 = struct.pack('<4f', 1.0, 1.0, 1.0, 1.0)
         client.execute_command("HSET", "doc:1", "content", "hello world", "vec", vec1)
-        IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        waiters.wait_for_true(
+            lambda: IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        )
 
         client.execute_command("FT._DEBUG PAUSEPOINT SET mutation_processing")
 
@@ -151,7 +155,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
             "SCHEMA", "content", "TEXT", "category", "TAG"
         )
         client.execute_command("HSET", "doc:1", "content", "hello world", "category", "news")
-        IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        waiters.wait_for_true(
+            lambda: IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        )
 
         client.execute_command("FT._DEBUG PAUSEPOINT SET mutation_processing")
 
@@ -186,7 +192,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
             "SCHEMA", "content", "TEXT"
         )
         client.execute_command("HSET", "doc:1", "content", "hello world")
-        IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        waiters.wait_for_true(
+            lambda: IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        )
 
         # Plug the mutation queue
         client.execute_command("FT._DEBUG PAUSEPOINT SET mutation_processing")
@@ -236,7 +244,9 @@ class TestFullTextInFlightBlockingCMD(ValkeySearchTestCaseDebugMode):
             "SCHEMA", "content", "TEXT"
         )
         client.execute_command("HSET", "doc:1", "content", "hello world")
-        IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        waiters.wait_for_true(
+            lambda: IndexingTestHelper.is_indexing_complete_on_node(client, "idx")
+        )
 
         # Plug the mutation queue
         client.execute_command("FT._DEBUG PAUSEPOINT SET mutation_processing")


### PR DESCRIPTION
TestFullTextInFlightBlockingCMD called
IndexingTestHelper.is_indexing_complete_on_node() as a bare statement. That function is a predicate returning bool, not a waiter, so its result was discarded and the tests never waited for the initial backfill.

These tests run with search.writer-threads=2 and depend on exactly one writer thread being parked at the mutation_processing pausepoint. When the FT.CREATE backfill scan was still in flight, its low-priority mutation tasks occupied both writer threads and parked at mutation_processing. The tests' own HSET tasks then never got a worker, so they never reached the block_mutation_queue pausepoint at the top of ScheduleMutation, and the test timed out waiting for it.

Wrap the five call sites in waiters.wait_for_true(). FT.INFO's backfill_in_progress is driven by IsBackfillInProgress(), which stays true while backfill_inqueue_tasks > 0, so waiting on it guarantees the backfill mutation tasks have drained and not merely that the scan finished. Every other caller in the repo, including the cluster test in this same file, already wraps the predicate in a waiter.