### PR TITLE
[backport 1.0] Security fixes backport #1191 #1192

### DIFF
--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -38,6 +38,7 @@
 #include <vector>
 
 #include "absl/container/inlined_vector.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/ascii.h"
@@ -48,6 +49,7 @@
 #include "src/commands/filter_parser.h"
 #include "src/index_schema.h"
 #include "src/indexes/index_base.h"
+#include "src/indexes/vector_base.h"
 #include "src/metrics.h"
 #include "src/query/search.h"
 #include "src/schema_manager.h"
@@ -367,6 +369,16 @@ absl::Status ParseQueryString(query::VectorSearchParameters &parameters) {
     return absl::InvalidArgumentError(absl::StrCat("Index field `",
                                                    parameters.attribute_alias,
                                                    "` is not a Vector index "));
+  }
+
+  auto *vector_index = dynamic_cast<indexes::VectorBase *>(index.get());
+  CHECK(vector_index != nullptr);
+  if (parameters.query.size() !=
+      static_cast<size_t>(vector_index->GetVectorDataSize())) {
+    return absl::InvalidArgumentError(absl::StrCat(
+        "Error parsing vector similarity parameters: query vector blob size (",
+        parameters.query.size(), ") does not match index's expected size (",
+        vector_index->GetVectorDataSize(), ")."));
   }
 
   if (parameters.parse_vars.score_as_string.empty()) {

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -230,12 +230,6 @@ template <typename T>
 absl::StatusOr<std::deque<Neighbor>> VectorFlat<T>::Search(
     absl::string_view query, uint64_t count,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter) {
-  if (!IsValidSizeVector(query)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Error parsing vector similarity query: query vector blob size (",
-        query.size(), ") does not match index's expected size (",
-        dimensions_ * GetDataTypeSize(), ")."));
-  }
   auto perform_search = [this, count, &filter](absl::string_view query)
       -> absl::StatusOr<std::priority_queue<std::pair<T, hnswlib::labeltype>>> {
     absl::ReaderMutexLock lock(&resize_mutex_);

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -58,6 +58,7 @@
 #include "src/rdb_serialization.h"
 #include "src/utils/string_interning.h"
 #include "src/valkey_search.h"
+#include "src/valkey_search_options.h"
 #include "vmsdk/src/log.h"
 #include "vmsdk/src/status/status_macros.h"
 #include "vmsdk/src/utils.h"
@@ -176,9 +177,10 @@ absl::StatusOr<std::shared_ptr<VectorHNSW<T>>> VectorHNSW<T>::LoadFromRDB(
     // the index being loaded is empty.
 
     RDBChunkInputStream input(std::move(iter));
-    VMSDK_RETURN_IF_ERROR(
-        index->algo_->LoadIndex(input, index->space_.get(),
-                                vector_index_proto.initial_cap(), index.get()));
+    VMSDK_RETURN_IF_ERROR(index->algo_->LoadIndex(
+        input, index->space_.get(), vector_index_proto.initial_cap(),
+        index.get(), vector_index_proto.hnsw_algorithm().m(),
+        options::GetHNSWValidationEnable().GetValue()));
     // ef_runtime is not persisted in the index contents
     index->algo_->setEf(vector_index_proto.hnsw_algorithm().ef_runtime());
     // Notes:

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -332,12 +332,6 @@ absl::StatusOr<std::deque<Neighbor>> VectorHNSW<T>::Search(
     absl::string_view query, uint64_t count,
     std::unique_ptr<hnswlib::BaseFilterFunctor> filter,
     std::optional<size_t> ef_runtime) {
-  if (!IsValidSizeVector(query)) {
-    return absl::InvalidArgumentError(absl::StrCat(
-        "Error parsing vector similarity query: query vector blob size (",
-        query.size(), ") does not match index's expected size (",
-        dimensions_ * GetDataTypeSize(), ")."));
-  }
   auto perform_search =
       [this, count, &filter, &ef_runtime](absl::string_view query)
           ABSL_NO_THREAD_SAFETY_ANALYSIS

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -137,6 +137,15 @@ static auto use_coordinator =
                                                // start-up
         .Build();
 
+// Kill switch for HNSW index load-time validation (corruption hardening).
+// Default true; can be disabled in the field if a bug in the validation logic
+// were to reject otherwise-valid indexes.
+constexpr absl::string_view kHNSWValidationEnable{"hnsw-validation-enable"};
+static auto hnsw_validation_enable =
+    config::BooleanBuilder(kHNSWValidationEnable, true)  // default true
+        .WithFlags(REDISMODULE_CONFIG_HIDDEN)
+        .Build();
+
 /// Control the modules log level verbosity
 static auto log_level =
     config::EnumBuilder(kLogLevel, static_cast<int>(LogLevel::kNotice),
@@ -180,6 +189,14 @@ const vmsdk::config::Boolean& GetUseCoordinator() {
 
 vmsdk::config::Enum& GetLogLevel() {
   return dynamic_cast<vmsdk::config::Enum&>(*log_level);
+}
+
+const config::Boolean& GetHNSWValidationEnable() {
+  return dynamic_cast<const config::Boolean&>(*hnsw_validation_enable);
+}
+
+config::Boolean& GetHNSWValidationEnableMutable() {
+  return dynamic_cast<config::Boolean&>(*hnsw_validation_enable);
 }
 
 absl::Status Reset() {

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -52,6 +52,12 @@ const config::Boolean& GetUseCoordinator();
 /// Return the log level
 config::Enum& GetLogLevel();
 
+/// Return the configuration entry for the HNSW load-time validation kill switch
+const config::Boolean& GetHNSWValidationEnable();
+
+/// Return a mutable reference for testing
+config::Boolean& GetHNSWValidationEnableMutable();
+
 /// Reset the state of the options (mainly needed for testing)
 absl::Status Reset();
 }  // namespace options

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -89,6 +89,7 @@ struct FTSearchParserTestCase {
   bool no_content{false};
   std::string search_parameters_str;
   uint64_t timeout_ms{kTimeoutMS};
+  std::optional<size_t> query_blob_num_floats;
 };
 
 class FTSearchParserTest
@@ -121,6 +122,9 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
   std::cerr << ", no_content: " << no_content << "\n";
 
   std::vector<float> floats = {0.1, 0.2, 0.3};
+  if (test_case.query_blob_num_floats.has_value()) {
+    floats.assign(*test_case.query_blob_num_floats, 0.1f);
+  }
   std::vector<RedisModuleString *> args;
   const std::string key_str = "my_schema_name";
   RedisModuleCtx fake_ctx;
@@ -420,6 +424,26 @@ INSTANTIATE_TEST_SUITE_P(
             .params_str = " PARAMS 2",
             .filter_str = " * => [KNN 10 @vec $BLOB]",
             .k = 10,
+        },
+        {
+            .test_name = "vector_blob_size_too_small",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = " * => [KNN 10 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing vector similarity parameters: query vector "
+                "blob size",
+            .query_blob_num_floats = 2,
+        },
+        {
+            .test_name = "vector_blob_size_too_large",
+            .success = false,
+            .params_str = " PARAMS 2",
+            .filter_str = " * => [KNN 10 @vec $BLOB]",
+            .expected_error_message =
+                "Error parsing vector similarity parameters: query vector "
+                "blob size",
+            .query_blob_num_floats = 4,
         },
         {
             .test_name = "happy_path_1_with_score_as",

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -27,10 +27,15 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <algorithm>
+#include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <deque>
-#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -39,6 +44,7 @@
 
 #include "absl/base/thread_annotations.h"
 #include "absl/container/flat_hash_map.h"
+#include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
@@ -580,6 +586,381 @@ TEST_F(VectorIndexTest, SaveAndLoadFlat) {
     }
   }
 }
+// ---------------------------------------------------------------------------
+// HNSW load-validation tests (corruption hardening).
+//
+// These exercise HierarchicalNSW::LoadIndex directly via in-memory chunk
+// streams, so a golden serialization can be built deterministically and then
+// surgically corrupted. A valid index must load; a corrupt one must be
+// rejected (status error) without crashing.
+// ---------------------------------------------------------------------------
+namespace {
+
+// A chunk store that is both an InputStream and an OutputStream. SaveIndex
+// writes into `chunks`, tests mutate `chunks` in place, and LoadIndex replays
+// it from the front -- so there is no copying between separate stream objects.
+// LoadChunk mirrors the real stream's exhaustion behavior (NotFound) so a
+// truncated input is realistic.
+class ChunkStream : public hnswlib::InputStream, public hnswlib::OutputStream {
+ public:
+  std::vector<std::string> chunks;
+
+  absl::Status SaveChunk(const char* data, size_t len) override {
+    chunks.emplace_back(data, len);
+    return absl::OkStatus();
+  }
+  absl::StatusOr<std::unique_ptr<std::string>> LoadChunk() override {
+    if (read_idx_ >= chunks.size()) {
+      return absl::NotFoundError("No more elements remaining");
+    }
+    return std::make_unique<std::string>(chunks[read_idx_++]);
+  }
+  // Reset the read cursor so the same store can be replayed again.
+  void Rewind() { read_idx_ = 0; }
+
+ private:
+  size_t read_idx_ = 0;
+};
+
+// VectorTracker that copies each vector into stable storage and hands back a
+// pointer to it (LoadIndex stores that pointer in the level-0 record).
+class BufTracker : public hnswlib::VectorTracker {
+ public:
+  char* TrackVector(uint64_t /*id*/, char* vector, size_t len) override {
+    storage_.emplace_back(vector, len);
+    return storage_.back().data();
+  }
+
+ private:
+  std::deque<std::string> storage_;
+};
+
+// On-disk geometry for kM / kDimensions, used to locate bytes for mutation.
+constexpr size_t kU32 = sizeof(uint32_t);
+constexpr size_t kStride = kM * kU32 + kU32;               // 68
+constexpr size_t kLinks0 = 2 * kM * kU32 + kU32;           // 132
+constexpr size_t kVecBytes = kDimensions * sizeof(float);  // 400
+constexpr size_t kLabelOff = kLinks0 + kVecBytes;          // 532
+constexpr size_t kElemChunkBytes = kLabelOff + sizeof(hnswlib::labeltype);
+
+template <typename T>
+T PeekAt(const std::string& c, size_t off) {
+  CHECK_LE(off + sizeof(T), c.size()) << "PeekAt out of bounds";
+  T v;
+  std::memcpy(&v, c.data() + off, sizeof(T));
+  return v;
+}
+template <typename T>
+void PokeAt(std::string* c, size_t off, T v) {
+  CHECK_LE(off + sizeof(T), c->size()) << "PokeAt out of bounds";
+  std::memcpy(c->data() + off, &v, sizeof(T));
+}
+
+// Build a deterministic HNSW index with explicit per-element levels (a level of
+// 0 falls back to the seeded RNG, since addPoint only forces level > 0) and
+// serialize it into a golden ChunkStream.
+ChunkStream BuildGoldenChunks(const std::vector<int>& force_levels,
+                              size_t max_elements) {
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space, max_elements, kM,
+                                       kEFConstruction,
+                                       /*random_seed=*/100,
+                                       /*allow_replace_deleted=*/false);
+  // HNSW stores a POINTER to each vector (it does not copy). Both addPoint
+  // (distance computations against earlier elements) and SaveIndex dereference
+  // those pointers, so the source vectors must outlive SaveIndex. Own them all
+  // here until the index is serialized; reserve() keeps the backing buffers
+  // stable as the container grows. After SaveIndex the golden ChunkStream owns
+  // its bytes by value, so this storage can safely be destroyed.
+  std::vector<std::vector<float>> vectors;
+  vectors.reserve(force_levels.size());
+  for (size_t i = 0; i < force_levels.size(); i++) {
+    std::vector<float> v(kDimensions, 0.1f);
+    v[i % kDimensions] = static_cast<float>(i + 1);
+    vectors.push_back(std::move(v));
+    algo.addPoint(vectors.back().data(), /*label=*/i, force_levels[i]);
+  }
+  ChunkStream golden;
+  EXPECT_TRUE(algo.SaveIndex(golden).ok());
+  return golden;
+}
+
+// Load a golden ChunkStream, returning a Status (validation throws; mirror the
+// real LoadFromRDB by converting the exception into an error status).
+absl::Status LoadGolden(ChunkStream& golden, size_t max_elements,
+                        bool validate) {
+  golden.Rewind();
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space);
+  BufTracker tracker;
+  try {
+    return algo.LoadIndex(golden, &space, max_elements, &tracker, kM, validate);
+  } catch (const std::exception& e) {
+    return absl::InternalError(e.what());
+  }
+}
+
+// Walk the golden stream and record, per element, the index of its link-list
+// size chunk and (if present) its upper-level data chunk. Robust to whatever
+// levels the RNG assigned to the un-forced elements.
+struct GoldenLayout {
+  uint32_t enterpoint = 0;
+  int32_t maxlevel = 0;
+  size_t num_elements = 0;
+  std::vector<size_t> size_chunk;
+  std::vector<int> data_chunk;  // -1 if the element has no upper levels
+};
+GoldenLayout AnalyzeGolden(const ChunkStream& golden) {
+  const std::vector<std::string>& chunks = golden.chunks;
+  GoldenLayout g;
+  hnswlib::data_model::HNSWIndexHeader h;
+  EXPECT_TRUE(h.ParseFromString(chunks[0]));
+  g.enterpoint = h.enterpoint_node();
+  g.maxlevel = h.max_level();
+  g.num_elements = h.curr_element_count();
+  size_t idx = 1 + g.num_elements;  // first link-list size chunk
+  for (size_t i = 0; i < g.num_elements; i++) {
+    g.size_chunk.push_back(idx);
+    // The size chunk holds the link-list BYTE size as a size_t (8 bytes); the
+    // layer count is derived from it, not stored directly.
+    uint64_t lls = PeekAt<uint64_t>(chunks[idx], 0);  // LE host == on-disk LE
+    idx++;
+    if (lls != 0) {
+      g.data_chunk.push_back(static_cast<int>(idx));
+      idx++;
+    } else {
+      g.data_chunk.push_back(-1);
+    }
+  }
+  return g;
+}
+
+hnswlib::data_model::HNSWIndexHeader GetHeader(const ChunkStream& golden) {
+  hnswlib::data_model::HNSWIndexHeader h;
+  EXPECT_TRUE(h.ParseFromString(golden.chunks[0]));
+  return h;
+}
+void SetHeader(ChunkStream* golden,
+               const hnswlib::data_model::HNSWIndexHeader& h) {
+  std::string s;
+  EXPECT_TRUE(h.SerializeToString(&s));
+  golden->chunks[0] = s;
+}
+
+// Multi-layer golden index reused across corruption tests: element 0 is forced
+// to level 2 (the entry point), element 1 to level 1, the rest level 0.
+constexpr size_t kGoldenMax = 32;
+ChunkStream MultiLayerGolden() {
+  return BuildGoldenChunks({2, 1, 0, 0, 0, 0, 0, 0}, kGoldenMax);
+}
+
+void ExpectReject(ChunkStream golden, absl::string_view substr) {
+  auto status = LoadGolden(golden, kGoldenMax, /*validate=*/true);
+  ASSERT_FALSE(status.ok());
+  EXPECT_THAT(std::string(status.message()), ::testing::HasSubstr(substr));
+}
+
+}  // namespace
+
+// ---- Happy path ----------------------------------------------------------
+
+TEST_F(VectorIndexTest, LoadValidatesEmptyIndex) {
+  auto golden = BuildGoldenChunks({}, kGoldenMax);
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/true));
+}
+
+TEST_F(VectorIndexTest, LoadValidatesSingleVector) {
+  auto golden = BuildGoldenChunks({0}, kGoldenMax);
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/true));
+}
+
+TEST_F(VectorIndexTest, LoadValidatesMultiLayerRoundTripIdentity) {
+  auto golden = MultiLayerGolden();
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space);
+  BufTracker tracker;
+  golden.Rewind();
+  VMSDK_EXPECT_OK(algo.LoadIndex(golden, &space, kGoldenMax, &tracker, kM,
+                                 /*validate=*/true));
+  EXPECT_EQ(algo.cur_element_count_, 8u);
+  EXPECT_EQ(algo.maxlevel_, 2);
+  EXPECT_EQ(algo.element_levels_[algo.enterpoint_node_], 2);
+  // save -> load -> save must be byte-identical for a valid index.
+  ChunkStream resaved;
+  VMSDK_EXPECT_OK(algo.SaveIndex(resaved));
+  EXPECT_EQ(resaved.chunks, golden.chunks);
+}
+
+// ---- Header corruption ---------------------------------------------------
+
+TEST_F(VectorIndexTest, RejectHeaderMMismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_m(kM + 1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "header M does not match");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMaxM0Mismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_max_m_0(2 * kM + 1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "maxM0 does not equal 2*M");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderEnterpointOutOfRange) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_enterpoint_node(h.curr_element_count());  // == cur, out of range
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "enterpoint_node is out of range");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMaxLevelTooLarge) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_max_level(1000);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "max_level exceeds the element count");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderSerializeSizeMismatch) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_serialize_size_data_per_element(h.serialize_size_data_per_element() +
+                                        1);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "serialized element size is inconsistent");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderOffsetLevel0Nonzero) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  h.set_offset_level_0(8);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "offset_level_0 must be 0");
+}
+
+TEST_F(VectorIndexTest, RejectHeaderMultInconsistentWithM) {
+  auto golden = MultiLayerGolden();
+  auto h = GetHeader(golden);
+  // 0.5 is well-formed (0 < 0.5 <= 2) but != 1/log(kM); the tightened check
+  // recomputes 1/log(M) and rejects it, where the old range check would not.
+  h.set_mult(0.5);
+  SetHeader(&golden, h);
+  ExpectReject(std::move(golden), "mult is inconsistent with M");
+}
+
+// ---- Level-0 record corruption -------------------------------------------
+
+TEST_F(VectorIndexTest, RejectLevel0ChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  golden.chunks[1].resize(kElemChunkBytes - 1);  // truncate element 0's chunk
+  ExpectReject(std::move(golden), "level-0 element chunk has the wrong size");
+}
+
+TEST_F(VectorIndexTest, RejectLevel0CountTooLarge) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[1], 0, 2 * kM + 1);  // count > maxM0_
+  ExpectReject(std::move(golden), "level-0 neighbor count exceeds 2*M");
+}
+
+TEST_F(VectorIndexTest, RejectLevel0NeighborOutOfRange) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);        // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32, 9999);  // neighbor[0] out of range
+  ExpectReject(std::move(golden), "level-0 neighbor id out of range");
+}
+
+TEST_F(VectorIndexTest, RejectDuplicateLabel) {
+  auto golden = MultiLayerGolden();
+  auto label0 = PeekAt<hnswlib::labeltype>(golden.chunks[1], kLabelOff);
+  PokeAt<hnswlib::labeltype>(&golden.chunks[3], kLabelOff,
+                             label0);  // element 2 dup
+  ExpectReject(std::move(golden), "duplicate label in index");
+}
+
+// ---- Upper-level record corruption ---------------------------------------
+
+TEST_F(VectorIndexTest, RejectSizeChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  golden.chunks[g.size_chunk[g.enterpoint]].resize(4);  // not sizeof(size_t)
+  ExpectReject(std::move(golden), "link-list size chunk has the wrong size");
+}
+
+TEST_F(VectorIndexTest, RejectLinkListSizeNotMultiple) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0,
+                   2 * kStride + 1);
+  ExpectReject(std::move(golden), "not a multiple of the stride");
+}
+
+TEST_F(VectorIndexTest, RejectElementLevelExceedsMaxLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Declare level 3 (> maxlevel 2) for the entry point.
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, 3 * kStride);
+  ExpectReject(std::move(golden), "element level exceeds max_level");
+}
+
+TEST_F(VectorIndexTest, RejectUpperChunkWrongSize) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  golden.chunks[g.data_chunk[g.enterpoint]].resize(
+      kStride);  // declared 2 levels
+  ExpectReject(std::move(golden), "upper-level link-list chunk has the wrong");
+}
+
+TEST_F(VectorIndexTest, RejectUpperCountTooLarge) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0,
+                   kM + 1);  // level 1
+  ExpectReject(std::move(golden), "upper-level neighbor count exceeds M");
+}
+
+TEST_F(VectorIndexTest, RejectUpperNeighborOutOfRange) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], 0, 1);
+  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kU32, 9999);
+  ExpectReject(std::move(golden), "upper-level neighbor id out of range");
+}
+
+TEST_F(VectorIndexTest, RejectUpperNeighborAbsentAtLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Entry point's level-2 list -> element 1, which exists only at level 1.
+  PokeAt<uint16_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride, 1);
+  PokeAt<uint32_t>(&golden.chunks[g.data_chunk[g.enterpoint]], kStride + kU32,
+                   1);
+  ExpectReject(std::move(golden), "neighbor is absent at that level");
+}
+
+TEST_F(VectorIndexTest, RejectEntrypointNotMaxLevel) {
+  auto golden = MultiLayerGolden();
+  auto g = AnalyzeGolden(golden);
+  // Demote the entry point to level 1 while the header still claims maxlevel 2.
+  PokeAt<uint64_t>(&golden.chunks[g.size_chunk[g.enterpoint]], 0, kStride);
+  golden.chunks[g.data_chunk[g.enterpoint]].resize(kStride);
+  ExpectReject(std::move(golden), "enterpoint node is not at max_level");
+}
+
+// ---- Kill switch ---------------------------------------------------------
+
+TEST_F(VectorIndexTest, ValidationDisabledBypassesChecks) {
+  auto golden = MultiLayerGolden();
+  PokeAt<uint16_t>(&golden.chunks[2], 0, 1);  // element 1: count = 1
+  PokeAt<uint32_t>(&golden.chunks[2], kU32,
+                   1);  // neighbor[0] == self (a self-loop)
+  // Enabled: rejected. Disabled: loads (the self-loop is not memory-unsafe).
+  EXPECT_FALSE(LoadGolden(golden, kGoldenMax, /*validate=*/true).ok());
+  VMSDK_EXPECT_OK(LoadGolden(golden, kGoldenMax, /*validate=*/false));
+}
+
 }  // namespace
 
 }  // namespace valkey_search::indexes

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -192,15 +192,6 @@ void TestIndex(T* index, int dimensions, int vector_size) {
   VerifyModify(index, vectors[vectors.size() - 2], vectors.size() - 1,
                ExpectedResults::kSuccess, true);
 
-  absl::string_view vector = VectorToStr(vectors_small_dim[0]);
-  auto res = index->Search(vector, 10);
-  EXPECT_FALSE(res.ok());
-  EXPECT_EQ(
-      res.status().message(),
-      absl::StrCat(
-          "Error parsing vector similarity query: query vector blob size (",
-          vector.size(), ") does not match index's expected size (",
-          dimensions * sizeof(float), ")."));
   for (size_t i = 1; i < vectors.size() - 1; ++i) {
     absl::string_view vector = VectorToStr(vectors[i]);
     auto res = index->Search(vector, 10);

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 
 #include <atomic>
+#include <cmath>
 #include <cstdint>
 #include <cstring>
 #include <deque>
@@ -23,6 +24,7 @@
 #include "iostream.h"
 #include "third_party/hnswlib/index.pb.h"
 #include "visited_list_pool.h"
+#include "vmsdk/src/log.h"
 #include "vmsdk/src/status/status_macros.h"
 
 #ifdef VMSDK_ENABLE_MEMORY_ALLOCATION_OVERRIDES
@@ -90,6 +92,10 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
   bool allow_replace_deleted_ = false;  // flag to replace deleted elements
                                         // (marked as deleted) during insertions
+
+  // Gate for load-time corruption validation, wired from the
+  // hnsw-validation-enable config via LoadIndex. Consulted only in loadCheck().
+  bool load_validation_enabled_ = false;
 
   std::mutex deleted_elements_lock;  // lock for deleted_elements
   std::unordered_set<tableint>
@@ -798,9 +804,31 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     return absl::OkStatus();
   }
 
+  // Single choke-point for load-time validation. The kill switch
+  // (load_validation_enabled_, wired from the hnsw-validation-enable config) is
+  // consulted here and nowhere else, so a defective check can be globally
+  // disabled. On failure it throws; VectorHNSW::LoadFromRDB converts the
+  // exception into a failed (rejected) RDB load.
+  inline void loadCheck(bool ok, absl::string_view msg) const {
+    if (ok) {
+      return;
+    }
+    if (load_validation_enabled_) {
+      throw std::runtime_error(
+          absl::StrCat("HNSW index load validation failed: ", msg));
+    }
+    // Validation disabled: don't fail the load, but log (throttled) the defect.
+    VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+        << "HNSW load validation is disabled; ignoring detected index "
+           "corruption: "
+        << msg;
+  }
+
   absl::Status LoadIndex(InputStream &input, SpaceInterface<dist_t> *s,
-                         size_t max_elements_i, VectorTracker *vector_tracker) {
+                         size_t max_elements_i, VectorTracker *vector_tracker,
+                         size_t expected_m, bool validate) {
     clear();
+    load_validation_enabled_ = validate;
 
     VMSDK_ASSIGN_OR_RETURN(auto serialized_header, input.LoadChunk());
     auto header = std::make_unique<data_model::HNSWIndexHeader>();
@@ -808,6 +836,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       return absl::InternalError("Could not deserialize HNSW header");
     }
 
+    // --- Read raw header fields (untrusted) ---
     offsetLevel0_ = header->offset_level_0();
     max_elements_ = header->max_elements();
     cur_element_count_ = header->curr_element_count();
@@ -823,27 +852,88 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     mult_ = header->mult();
     ef_construction_ = header->ef_construction();
 
-    size_t max_elements = max_elements_i;
-    if (max_elements < cur_element_count_) {
-      max_elements = max_elements_;
-    }
-    max_elements_ = max_elements;
+    // Authoritative parameters come from the index definition (the space and
+    // expected_m), never from the untrusted header.
+    vector_size_ = s->get_data_size();
+    fstdistfunc_ = s->get_dist_func();
+    dist_func_param_ = s->get_dist_func_param();
 
+    // Recompute the geometry that governs memory layout. When validation is
+    // enabled these are cross-checked against the header below; the header's
+    // own copies are only ever used as values to validate against.
     size_links_level0_ = maxM0_ * sizeof(tableint) + sizeof(linklistsizeint);
 
-    vector_size_ = s->get_data_size();
+    offsetData_ = size_links_level0_;
     size_data_per_element_ =
         size_links_level0_ + sizeof(char *) + sizeof(labeltype);
     label_offset_ = size_links_level0_ + sizeof(char *);
+    size_links_per_element_ =
+        maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
 
-    fstdistfunc_ = s->get_dist_func();
-    dist_func_param_ = s->get_dist_func_param();
+    // Resolve capacity: at least the live element count, honoring the larger of
+    // the caller-requested cap and the file's recorded capacity.
+    size_t cur_count = cur_element_count_;
+    size_t max_elements =
+        std::max(cur_count, std::max(max_elements_i, max_elements_));
+    max_elements_ = max_elements;
+
+    // --- Header validation (the kill switch lives inside loadCheck) ---
+    {
+      const size_t exp_m = expected_m > 10000 ? 10000 : expected_m;
+      // Layout parameters must match the index definition exactly.
+      loadCheck(exp_m >= 1, "M must be >= 1");
+      loadCheck(M_ == exp_m, "header M does not match index definition");
+      loadCheck(maxM_ == M_, "header maxM does not equal M");
+      loadCheck(maxM0_ == 2 * M_, "header maxM0 does not equal 2*M");
+      loadCheck(maxM0_ <= 0xFFFF,
+                "maxM0 exceeds the 16-bit neighbor-count field");
+      loadCheck(vector_size_ > 0, "vector size must be > 0");
+      loadCheck(serialize_size_data_per_element_ ==
+                    size_links_level0_ + vector_size_ + sizeof(labeltype),
+                "serialized element size is inconsistent with the geometry");
+      loadCheck(offsetLevel0_ == 0, "offset_level_0 must be 0");
+      // Recompute mult=1/log(M) and match within a guardband (cross-arch libm);
+      // skip M<2 where 1/log(M) is not finite. Soft, non-safety check.
+      if (M_ >= 2) {
+        const double expected_mult = 1.0 / std::log(static_cast<double>(M_));
+        loadCheck(mult_ > 0.0 &&
+                      std::fabs(mult_ - expected_mult) <= 1e-6 * expected_mult,
+                  "mult is inconsistent with M");
+      }
+
+      // Element-count / level / entry-point consistency.
+      loadCheck(cur_element_count_ <= max_elements_,
+                "curr_element_count exceeds max_elements");
+      if (cur_element_count_ == 0) {
+        loadCheck(maxlevel_ == -1 || maxlevel_ == 0,
+                  "empty index has a non-trivial max_level");
+      } else {
+        loadCheck(maxlevel_ >= 0, "non-empty index has a negative max_level");
+        loadCheck(maxlevel_ <= static_cast<int>(cur_element_count_),
+                  "max_level exceeds the element count");
+        loadCheck(enterpoint_node_ < cur_element_count_,
+                  "enterpoint_node is out of range");
+      }
+
+      // Guard every load allocation against size_t overflow / address-space
+      // wraparound, which also bounds an absurd element count.
+      loadCheck(size_data_per_element_ > 0, "size_data_per_element is 0");
+      loadCheck(max_elements_ <= SIZE_MAX / size_data_per_element_,
+                "level-0 allocation size overflows");
+      loadCheck(max_elements_ <= SIZE_MAX / sizeof(void *),
+                "linkLists allocation size overflows");
+      loadCheck(max_elements_ <= SIZE_MAX / sizeof(int),
+                "element_levels allocation size overflows");
+    }
 
     data_level0_memory_ = std::make_unique<ChunkedArray>(
         size_data_per_element_, k_elements_per_chunk, max_elements);
 
     for (size_t i = 0; i < cur_element_count_; i++) {
       VMSDK_ASSIGN_OR_RETURN(auto chunk, input.LoadChunk());
+      loadCheck(chunk->size() ==
+                    size_links_level0_ + vector_size_ + sizeof(labeltype),
+                "level-0 element chunk has the wrong size");
       memcpy((*data_level0_memory_)[i], chunk->data(), size_links_level0_);
       labeltype id;
       memcpy((char *)&id, chunk->data() + offsetData_ + vector_size_,
@@ -853,10 +943,21 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
                                       vector_size_);
       memcpy((*data_level0_memory_)[i] + label_offset_, (char *)&id,
              sizeof(labeltype));
-    }
 
-    size_links_per_element_ =
-        maxM_ * sizeof(tableint) + sizeof(linklistsizeint);
+      // Validate the level-0 link list now that it is in place. The neighbor
+      // scan is clamped to maxM0_ so it stays within the record even when the
+      // (corrupt) count is larger and validation is disabled.
+      linklistsizeint *ll0 = get_linklist0(i);
+      size_t l0_count = getListCount(ll0);
+      loadCheck(l0_count <= maxM0_, "level-0 neighbor count exceeds 2*M");
+      tableint *l0_neighbors = (tableint *)(ll0 + 1);
+      size_t l0_scan = std::min(l0_count, maxM0_);
+      for (size_t j = 0; j < l0_scan; j++) {
+        loadCheck(l0_neighbors[j] < cur_element_count_,
+                  "level-0 neighbor id out of range");
+        loadCheck(l0_neighbors[j] != i, "level-0 self-loop");
+      }
+    }
 
     std::vector<std::mutex>(max_elements).swap(link_list_locks_);
     std::vector<std::mutex>(MAX_LABEL_OPERATION_LOCKS).swap(label_op_locks_);
@@ -870,21 +971,85 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     revSize_ = 1.0 / mult_;
     ef_ = 10;
     for (size_t i = 0; i < cur_element_count_; i++) {
-      label_lookup_[getExternalLabel(i)] = i;
+      // Establish safe defaults first: element_levels_[i] stays 0 and the
+      // link-list pointer stays null until a valid allocation is stored, so an
+      // early return / thrown validation cannot leave clear() freeing an
+      // uninitialized pointer (ChunkedArray memory is not zeroed).
+      element_levels_[i] = 0;
+      *reinterpret_cast<char **>((*linkLists_)[i]) = nullptr;
+
+      labeltype ext_label = getExternalLabel(i);
+      loadCheck(label_lookup_.find(ext_label) == label_lookup_.end(),
+                "duplicate label in index");
+      label_lookup_[ext_label] = i;
       size_t linkListSize;
       VMSDK_ASSIGN_OR_RETURN(auto size_chunk, input.LoadChunk());
+      loadCheck(size_chunk->size() == sizeof(size_t),
+                "link-list size chunk has the wrong size");
       memcpy(&linkListSize, size_chunk->data(), sizeof(size_t));
       linkListSize = le64toh(linkListSize);
-      if (linkListSize == 0) {
-        element_levels_[i] = 0;
-        *reinterpret_cast<char **>((*linkLists_)[i]) = nullptr;
-      } else {
-        element_levels_[i] = linkListSize / size_links_per_element_;
+      if (linkListSize != 0) {
+        loadCheck(linkListSize % size_links_per_element_ == 0,
+                  "upper-level link-list size is not a multiple of the stride");
+        int level = linkListSize / size_links_per_element_;
+        loadCheck(level <= maxlevel_, "element level exceeds max_level");
         VMSDK_ASSIGN_OR_RETURN(auto link_list_chunk, input.LoadChunk());
-        *reinterpret_cast<char **>((*linkLists_)[i]) =
-            new char[link_list_chunk->size()];
-        memcpy(*reinterpret_cast<char **>((*linkLists_)[i]),
-               link_list_chunk->data(), link_list_chunk->size());
+        loadCheck(link_list_chunk->size() == linkListSize,
+                  "upper-level link-list chunk has the wrong size");
+        // Allocate from the derived level count (== linkListSize for valid
+        // data) so get_linklist() stays in-bounds for levels 1..level
+        // regardless of whether validation is enabled.
+        size_t alloc_size =
+            static_cast<size_t>(level) * size_links_per_element_;
+        char *links = new char[alloc_size];
+        memset(links, 0, alloc_size);
+        memcpy(links, link_list_chunk->data(),
+               std::min(alloc_size, link_list_chunk->size()));
+        // Store the pointer, then publish the level, so the two stay in sync
+        // for clear() even if a later check throws.
+        *reinterpret_cast<char **>((*linkLists_)[i]) = links;
+        element_levels_[i] = level;
+        // Validate per-level neighbor counts. Neighbor ids are validated in the
+        // global pass, since their target slots may not be loaded yet.
+        for (int l = 1; l <= level; l++) {
+          loadCheck(getListCount(get_linklist(i, l)) <= maxM_,
+                    "upper-level neighbor count exceeds M");
+        }
+      }
+    }
+
+    // --- Global graph-invariant pass (requires all element_levels_ loaded) ---
+    // The entry point must be one of the tallest nodes (proven invariant:
+    // maxlevel_ is only ever raised together with enterpoint_node_). The
+    // short-circuit also guards the array access if validation is disabled and
+    // enterpoint_node_ is out of range.
+    if (cur_element_count_ > 0) {
+      loadCheck(enterpoint_node_ < cur_element_count_ &&
+                    element_levels_[enterpoint_node_] == maxlevel_,
+                "enterpoint node is not at max_level");
+    }
+    // Every upper-level link must target a slot that actually exists at that
+    // level; otherwise a graph descent would over-read the target's smaller
+    // link-list allocation. This needs the full element_levels_, so it cannot
+    // be done in the streaming load loop above.
+    for (size_t i = 0; i < cur_element_count_; i++) {
+      for (int level = 1; level <= element_levels_[i]; level++) {
+        linklistsizeint *ll = get_linklist(i, level);
+        size_t count = getListCount(ll);
+        // count was bounded to maxM_ per-record; clamp the scan so a corrupt
+        // count cannot over-read the per-level region when validation is off.
+        size_t scan = std::min(count, maxM_);
+        tableint *neighbors = (tableint *)(ll + 1);
+        for (size_t j = 0; j < scan; j++) {
+          tableint e = neighbors[j];
+          loadCheck(e < cur_element_count_,
+                    "upper-level neighbor id out of range");
+          loadCheck(e != i, "upper-level self-loop");
+          // Short-circuit guards element_levels_[e] when validation is off and
+          // e is out of range (the first check above did not throw).
+          loadCheck(e >= cur_element_count_ || element_levels_[e] >= level,
+                    "upper-level neighbor is absent at that level");
+        }
       }
     }
 


### PR DESCRIPTION
WIP .

There were too many conflicts in bringing these changes in . Diff with merge conflict markers intact https://github.com/valkey-io/valkey-search/compare/1.0...Aksha1812:valkey-search:dev-backport-1191-1192-1.0-CONFLICTS
. Didn't have bandwidth to deep dive into each conflict and undertand the changes and decide on appropriate conflict resolutions. Since we need to release these security fixes asap, It would be better if original author of the security fixes take a look once at AI suggested resolutions . and see if any changes need to be made, will deep dive myself if required

---

## Merge conflict resolutions (AI-assisted, needs review)

Both PRs were cherry-picked in merge order: **#1192** first, then **#1191**. The `1.0` branch has diverged structurally from `main`, so most conflicts are **refactor drift** (git could not align relocated/renamed code) rather than genuine semantic conflicts. Only two are genuine semantic conflicts. Each row notes what conflicted and the resolution applied.

### Cherry-pick #1192 — "Validate query vector size against index dimensions at parse time"

| # | File | Conflict type | What conflicted | Resolution applied |
|---|------|--------------|-----------------|--------------------|
| 1 | `src/query/search.cc` | Refactor drift (false conflict) | The actual fix targets `PostParseVectorParameters`, which lives in `search.cc` on `main` but in `src/commands/ft_search_parser.cc` on `1.0`. Git dumped ~300 lines of `main`-only functions into one conflict. | **Took HEAD** — discarded the entire incoming block. No fix lands in this file on `1.0`. |
| 2 | `src/commands/ft_search_parser.cc` | *(no conflict — real fix relocated here)* | The 12-line size check had nowhere to auto-apply since `PostParseVectorParameters` does not exist on `1.0`. | **Hand-ported** the size check into `ParseQueryString`, after the existing "is a vector index" validation, reusing the already-fetched `index`. Added `#include "src/indexes/vector_base.h"` and `#include "absl/log/check.h"`. **Embedded the full `"Error parsing vector similarity parameters: query vector blob size…"` literal** so the parser test's `starts_with` assertion passes (on `main` this prefix is supplied structurally by a caller prepend; on `1.0` it is not). |
| 3 | `src/indexes/vector_flat.cc` | Mixed (removal + `main`-only addition) | #1192 removes the redundant `IsValidSizeVector` block; the incoming side also added a `&cancellation_token` capture (`main`-only). | Removed the `IsValidSizeVector` block; **kept `1.0`'s `[this, count, &filter]` capture** (no `cancellation_token`). |
| 4 | `src/indexes/vector_hnsw.cc` | Mixed (removal + `main`-only signature) | Same as above, plus a `main`-only `bool enable_partial_results` parameter and `cancellation_token`. | Removed the `IsValidSizeVector` block; **kept `1.0`'s signature `(…, std::optional<size_t> ef_runtime)` and capture list**. |
| 5 | `testing/vector_test.cc` | Semantic (behavior moved) | `1.0`'s test asserted that `Search()` rejects a wrong-size vector; #1192 moves that validation to parse time, so `Search()` no longer rejects. | **Took incoming** — deleted the now-invalid assertion block. |
| 6 | `testing/ft_search_parser_test.cc` (struct field) | Refactor drift (naming) | `1.0` uses `kTimeoutMS`; the test struct lacks `main`-only fields (`vector_query`, `verbatim`, `sortby…`). | Kept HEAD's `timeout_ms{kTimeoutMS}`; **grafted in only the new field `query_blob_num_floats`**. Dropped the `main`-only fields. |
| 7 | `testing/ft_search_parser_test.cc` (test helper) | Refactor drift (naming) | `1.0` uses `RedisModuleString`; `main` uses `ValkeyModuleString`. | Kept HEAD's `RedisModuleString`; **grafted in the `floats.assign(...)` hunk** that powers the two new too-small / too-large test cases. |
| 8 | `integration/test_query_parser.py` | Modify/delete | File does not exist on `1.0`. | **`git rm`** — kept deleted. |

### Cherry-pick #1191 — "Validate HNSW index data when loading from an external file"

| # | File | Conflict type | What conflicted | Resolution applied |
|---|------|--------------|-----------------|--------------------|
| 9 | `src/valkey_search_options.h` | Refactor drift | Incoming added both `GetHNSWAllowReplaceDeleted` (pre-existing `main` context, **absent on 1.0**) and `GetHNSWValidationEnable` (#1191's actual addition). | **Kept only the `GetHNSWValidationEnable` declarations**; dropped `GetHNSWAllowReplaceDeleted`. |
| 10 | `src/valkey_search_options.cc` (config def) | Refactor drift + **API gap** | Incoming bundled #1191's `hnsw_validation_enable` config with `main`-only code (`kReIndexVectorRDBLoad`, `kSkipCorruptedAOFEntries`, the log-level enum that already exists on `1.0`). It also used **`.Dev()`, which does not exist on `1.0`'s `ConfigBuilder`**. | Added **only** the `hnsw_validation_enable` config block; **adapted `.Dev()` → `.WithFlags(REDISMODULE_CONFIG_HIDDEN)`**, matching the existing `use_coordinator` pattern in the same file. ⚠️ Confirm Dev→Hidden equivalence is acceptable. |
| 11 | `src/valkey_search_options.cc` (getters) | Refactor drift | Incoming added both `GetHNSWAllowReplaceDeleted*` (absent on `1.0`) and `GetHNSWValidationEnable*` getters. | **Kept only `GetHNSWValidationEnable` / `…Mutable`**; dropped the `AllowReplaceDeleted` getters. |
| 12 | `third_party/hnswlib/hnswalg.h` | **Genuine semantic** 🔴 | Memory-layout computation in `LoadIndex`: `main` uses an **aligned** `offsetData_ = (size_links_level0_ + alignof(char*) - 1) & ~(alignof(char*) - 1)`; `1.0` uses an **unaligned** `offsetData_ = size_links_level0_`. Adopting `main`'s aligned layout would desync `LoadIndex` from `1.0`'s writer/insert layout → corruption. | **Kept `1.0`'s unaligned layout**, but pulled in the incoming `size_links_per_element_ = …` assignment (referenced by the validation code below). Verified #1191's golden tests use the compact serialized layout (`kLabelOff = kLinks0 + kVecBytes`, no padding), which matches the unaligned offset. **Highest-risk resolution — please review closely.** |
| 13 | `testing/vector_test.cc` (includes) | Refactor drift | Incoming include list is a superset (adds `<algorithm>`, `<chrono>`, `<cmath>`, `<cstdio>`, `<cstdlib>`, `<cstring>`). | **Took incoming** (superset). |
| 14 | `testing/vector_test.cc` (tests) | Refactor drift (bundled tests) | A ~480-line conflict bundling **three `main`-only tests** (`ReclaimableMemoryRaceReturnsToBaseline`, `OffsetDataIsPointerAlignedOnCreate`, `LoadRecomputesAlignedOffsetForOldSnapshot` + its `SingleChunkInputStream` helper) with **#1191's actual validation-test namespace block**. | **Kept only #1191's `namespace { … }` validation-test block**; dropped the three `main`-only tests. The two alignment tests assert the aligned `offsetData_` behavior that `1.0` deliberately does not have (see #12). ⚠️ Confirm no wanted #1191 coverage was dropped. |
| 15 | `src/indexes/vector_hnsw.cc` | *(no conflict — missing include)* | On `main` this file already used `options::` (for `GetHNSWAllowReplaceDeleted`); on `1.0` it did not, so the new `options::GetHNSWValidationEnable()` call site had no include. | **Added `#include "src/valkey_search_options.h"`**. |

### Open item not covered by the parse-time check
The coordinator (cluster) receiver path — `GRPCSearchRequestToParameters` in `src/coordinator/search_converter.cc` — builds `parameters->query` directly from the inter-node gRPC request and does **not** run through the parser, so #1192's parse-time check does not guard it. Since the backport also removes the `IsValidSizeVector` guard from `Search()`, this path loses the length check it previously had on stock `1.0`. Note that `main`'s post-#1192 `GRPCSearchRequestToParameters` appears to have the **same** limitation. Flagging for the author to decide whether the inter-node channel is trusted or the coordinator receiver should be explicitly guarded.

> Conflict resolutions above were AI-assisted and are **not yet build-verified** on this branch (local toolchain mismatch prevented a clean compile); please validate in CI / a Linux build.
