### PR TITLE
Bump version to 1.0.3 and add release notes

### DIFF
--- a/00-RELEASENOTES
+++ b/00-RELEASENOTES
@@ -2,6 +2,19 @@ Valkey Search 1.0 release notes
 =================================
 
 ================================================================================
+Valkey Search 1.0.3 - Released <RELEASE DATE TBD>
+================================================================================
+
+Bug fixes
+=========
+* Hardened load and command paths against crashes found through fuzzing: added validation for HNSW index data loaded from an external file and for query vector size against index dimensions at parse time (#1191, #1192)
+* Fixed an out-of-bounds access in pagination with LIMIT offset (#748)
+* Fixed an unexpected vk-search flag left in the RDB after all indexes are dropped (#847)
+* Avoid a deadlock while processing MULTI/EXEC mutations (#1018)
+* Fixed tag query parsing, including tag OR syntax in hybrid queries (#452, #602)
+* Fixed a use-after-free race in DefaultReplyScoreAs() (#565)
+
+================================================================================
 Valkey Search 1.0.2 - Released Tue 25 November 2025
 ================================================================================
 
@@ -85,7 +98,8 @@ New configurations
 ===========================
 * Add support for the following configurations: reader-threads, writer-threads, use-coordinator, log-level
 
-We appreciate the efforts of all who contributed code to this release!
+================================================================================
+Contributors
+================================================================================
 
-Yair Gottdenker (yairgott), Jacob Murphy (murphyjacob4), Allen Samuels (allenss-amazon), Eran Ifrah (eifrah-aws),
-Chanil Jeon (jeon1226), Qu Chen (QuChen88), DP (dpbnasika), Shivshankar-Reddy, KarthikSubbarao, Hyeonho Kim (proost)
+@yairgott, @murphyjacob4, @allenss-amazon, @eifrah-aws, @jeon1226, @QuChen88, @dpbnasika, @Shivshankar-Reddy, @KarthikSubbarao, @proost, @baswanth09, @boda26, @VoletiRam, @zvi-code, @Aksha1812

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -35,7 +35,7 @@
 #include "vmsdk/src/module.h"
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
-#define MODULE_VERSION 10002
+#define MODULE_VERSION 10003
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
  * During release process the status will be set to rc1,rc2...rcN.


### PR DESCRIPTION
## Summary

Release step 3 of the 1.0.3 patch checklist (#1237): bump the module version and add release notes on the `1.0` branch.

- `src/module_loader.cc`: `MODULE_VERSION` `10002` -> `10003` (the 1.0 branch keeps the version inline here, not in `version.h`)
- `00-RELEASENOTES`: add the `1.0.3` section (newest-first)
- Moved contributors into a single banner `Contributors` section at the end of the file, consistent with the `1.2` branch, appending the new contributors.

`kMinimumServerVersion` (Valkey 8.1.1+) is unchanged and no new metadata encoding is introduced.

## Notes
- Release date is a placeholder (`<RELEASE DATE TBD>`) pending the release cut.
- The security fixes (#1191, #1192) are backported via #1235, which is still open/WIP — this notes entry anticipates that landing.
- Please do **not** squash-merge. DCO: the commit is signed off.

Ref: #1237
