### PR TITLE
BM25STD Scorer and Scoring Session Implementation

### DIFF
--- a/src/indexes/CMakeLists.txt
+++ b/src/indexes/CMakeLists.txt
@@ -1,6 +1,19 @@
 valkey_search_create_proto_library("src/index_schema.proto"
                                    "index_schema_cc_proto")
 
+set(SRCS_SCORING
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_stats.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scorer.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scorer.cc
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer.cc
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_session.h
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/scoring_session.cc)
+
+valkey_search_add_static_library(scoring "${SRCS_SCORING}")
+target_include_directories(scoring PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(scoring PUBLIC vmsdklib)
+
 add_library(index_base INTERFACE ${SRCS_INDEX_BASE})
 target_include_directories(index_base INTERFACE ${CMAKE_CURRENT_LIST_DIR})
 target_link_libraries(index_base INTERFACE index_schema_cc_proto)

--- a/src/indexes/scoring/bm25std_scorer.cc
+++ b/src/indexes/scoring/bm25std_scorer.cc
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/bm25std_scorer.h"
+
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+
+#include "absl/log/check.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+namespace {
+
+float Idf(uint32_t total_docs, uint32_t num_doc_contain_term) {
+  CHECK_LE(num_doc_contain_term, total_docs);
+  const float n = static_cast<float>(total_docs);
+  const float dt = static_cast<float>(num_doc_contain_term);
+  return std::log1pf((n - dt + 0.5f) / (dt + 0.5f));
+}
+
+}  // namespace
+
+float Bm25StdScorer::ScoreLeaf(const ScoringStats& stats,
+                               float leaf_weight) const {
+  const auto* bm25_stats = dynamic_cast<const Bm25StdStats*>(&stats);
+  CHECK(bm25_stats != nullptr);
+
+  if (bm25_stats->avg_doc_len <= 0.0f) return 0.0f;
+
+  const float idf =
+      Idf(bm25_stats->total_docs, bm25_stats->num_doc_contain_term);
+
+  const float f = static_cast<float>(bm25_stats->term_frequency);
+  const float dl = static_cast<float>(bm25_stats->doc_len);
+  const float avgdl = bm25_stats->avg_doc_len;
+
+  const float numerator = f * (kK1 + 1.0f);
+  const float denominator = f + kK1 * (1.0f - kB + kB * dl / avgdl);
+  return leaf_weight * idf * (numerator / denominator);
+}
+
+float Bm25StdScorer::ComposeDocumentScore(float sum_of_terms,
+                                          float document_score) const {
+  // Avoid 0 * inf -> NaN; propagate ±inf as the final score.
+  if (IsInf(document_score)) {
+    return document_score;
+  }
+  return sum_of_terms * document_score;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/bm25std_scorer.h
+++ b/src/indexes/scoring/bm25std_scorer.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_BM25STD_SCORER_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_BM25STD_SCORER_H_
+
+#include <string_view>
+
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+// Standard Okapi BM25 ("BM25STD"). k1=1.2, b=0.75.
+//
+//   IDF       = ln(1 + (N - dt + 0.5) / (dt + 0.5))
+//   bm25_leaf = leaf_weight * IDF *
+//               F * (k1 + 1) /
+//               (F + k1 * (1 - b + b * doc_len / avg_doc_len))
+//   final     = sum_of_leaves * document_score
+class Bm25StdScorer : public Scorer {
+ public:
+  static constexpr std::string_view kName = "BM25STD";
+  static constexpr float kK1 = 1.2f;
+  static constexpr float kB = 0.75f;
+
+  std::string_view Name() const override { return kName; }
+  ScorerType Type() const override { return ScorerType::kBm25Std; }
+
+  float ScoreLeaf(const ScoringStats& stats, float leaf_weight) const override;
+
+  float ComposeDocumentScore(float sum_of_terms,
+                             float document_score) const override;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scorer.cc
+++ b/src/indexes/scoring/scorer.cc
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/scorer.h"
+
+#include <cstdint>
+#include <cstring>
+
+#include "absl/types/span.h"
+
+namespace valkey_search::indexes::scoring {
+
+bool IsInf(float f) {
+  static constexpr uint32_t kExponentMask = 0x7F800000U;
+  static constexpr uint32_t kMantissaMask = 0x007FFFFFU;
+  uint32_t bits;
+  std::memcpy(&bits, &f, sizeof(bits));
+  return (bits & kExponentMask) == kExponentMask && (bits & kMantissaMask) == 0;
+}
+
+float Scorer::CombineGroup(absl::Span<const float> child_scores,
+                           float group_weight) const {
+  float sum = 0.0f;
+  for (float s : child_scores) sum += s;
+  return group_weight * sum;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/scorer.h
+++ b/src/indexes/scoring/scorer.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORER_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORER_H_
+
+#include <string_view>
+
+#include "absl/types/span.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+// std::isinf is unreliable under -ffast-math (which this code is built with);
+// detect ±inf by IEEE 754 bit pattern instead.
+bool IsInf(float f);
+
+enum class ScorerType {
+  kBm25Std,
+  kTfidf,
+};
+
+// Stateless, thread-safe scoring algorithm. Per-query state lives in
+// ScoringSession. Concrete scorers expect a specific ScoringStats
+// subtype and CHECK the contract.
+class Scorer {
+ public:
+  virtual ~Scorer() = default;
+
+  virtual std::string_view Name() const = 0;
+  virtual ScorerType Type() const = 0;
+
+  virtual float ScoreLeaf(const ScoringStats& stats,
+                          float leaf_weight) const = 0;
+
+  virtual float ComposeDocumentScore(float sum_of_terms,
+                                     float document_score) const = 0;
+
+  float CombineGroup(absl::Span<const float> child_scores,
+                     float group_weight) const;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scoring_session.cc
+++ b/src/indexes/scoring/scoring_session.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/scoring_session.h"
+
+#include <algorithm>
+
+#include "absl/log/check.h"
+
+namespace valkey_search::indexes::scoring {
+
+ScoringSession::ScoringSession(const Scorer* scorer) : scorer_(scorer) {
+  CHECK(scorer_ != nullptr);
+  group_stack_.emplace_back();
+}
+
+void ScoringSession::RecordLeaf(const ScoringStats& stats, float leaf_weight) {
+  CHECK(!group_stack_.empty());
+
+  const float leaf_score = scorer_->ScoreLeaf(stats, leaf_weight);
+  group_stack_.back()[stats.doc_id] += leaf_score;
+
+  doc_score_.try_emplace(stats.doc_id, stats.document_score);
+}
+
+void ScoringSession::EnterGroup() {
+  CHECK(!group_stack_.empty());
+  group_stack_.emplace_back();
+}
+
+void ScoringSession::ExitGroup(float group_weight) {
+  CHECK_GE(group_stack_.size(), 2u);
+
+  auto inner = std::move(group_stack_.back());
+  group_stack_.pop_back();
+
+  auto& outer = group_stack_.back();
+  for (const auto& [doc_id, partial] : inner) {
+    outer[doc_id] += group_weight * partial;
+  }
+}
+
+std::vector<RankedDoc> ScoringSession::Rank() {
+  CHECK_EQ(group_stack_.size(), 1u);
+
+  auto root = std::move(group_stack_.back());
+  group_stack_.clear();
+
+  std::vector<RankedDoc> results;
+  results.reserve(root.size());
+  for (const auto& [doc_id, sum] : root) {
+    auto it = doc_score_.find(doc_id);
+    CHECK(it != doc_score_.end());
+    const float final_score = scorer_->ComposeDocumentScore(sum, it->second);
+    results.push_back({doc_id, final_score});
+  }
+  doc_score_.clear();
+
+  std::sort(results.begin(), results.end(),
+            [](const RankedDoc& a, const RankedDoc& b) {
+              if (a.score != b.score) return a.score > b.score;
+              return a.doc_id < b.doc_id;
+            });
+  return results;
+}
+
+}  // namespace valkey_search::indexes::scoring

--- a/src/indexes/scoring/scoring_session.h
+++ b/src/indexes/scoring/scoring_session.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_SESSION_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_SESSION_H_
+
+#include <cstdint>
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_stats.h"
+
+namespace valkey_search::indexes::scoring {
+
+using DocId = uint64_t;
+
+struct RankedDoc {
+  DocId doc_id;
+  float score;
+};
+
+// Per-query collector and ranker. Driven by a depth-first walk of the
+// predicate tree:
+//   ScoringSession session(scorer);
+//   for each node (depth-first):
+//     leaf:        session.RecordLeaf(stats, leaf_weight);
+//     group enter: session.EnterGroup();
+//     group exit:  session.ExitGroup(group_weight);
+//   auto results = session.Rank();
+//
+// Doc-level fields in `stats` (e.g. document_score) must be invariant
+// across all leaves recorded for the same doc_id. Rank() returns every
+// candidate sorted by score desc, doc_id asc; LIMIT is applied by the
+// caller.
+class ScoringSession {
+ public:
+  // The Scorer is borrowed and must outlive this session.
+  explicit ScoringSession(const Scorer* scorer);
+
+  void RecordLeaf(const ScoringStats& stats, float leaf_weight);
+
+  void EnterGroup();
+  void ExitGroup(float group_weight);
+
+  // Must be called exactly once, after all groups have been exited.
+  std::vector<RankedDoc> Rank();
+
+ private:
+  const Scorer* scorer_;
+
+  std::vector<absl::flat_hash_map<DocId, float>> group_stack_;
+
+  absl::flat_hash_map<DocId, float> doc_score_;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/src/indexes/scoring/scoring_stats.h
+++ b/src/indexes/scoring/scoring_stats.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_STATS_H_
+#define VALKEYSEARCH_SRC_INDEXES_SCORING_SCORING_STATS_H_
+
+#include <cstdint>
+#include <string>
+
+#include "absl/types/span.h"
+
+namespace valkey_search::indexes::scoring {
+
+struct ScoringStats {
+  virtual ~ScoringStats() = default;
+
+  uint32_t total_docs = 0;
+  uint64_t doc_id = 0;
+  float document_score = 1.0f;
+  std::string term;
+  uint32_t num_doc_contain_term = 0;
+  uint32_t term_frequency = 0;
+};
+
+struct Bm25StdStats : ScoringStats {
+  float avg_doc_len = 0.0f;
+  uint32_t doc_len = 0;
+};
+
+// `positions` is a non-owning view; storage must outlive the stats.
+// `norm` of 0 means the document has no TEXT fields and forces score to 0.
+struct TfidfStats : ScoringStats {
+  uint32_t norm = 0;
+  absl::Span<const uint32_t> positions;
+};
+
+}  // namespace valkey_search::indexes::scoring
+
+#endif

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -168,7 +168,7 @@ target_link_libraries(valkey_utils_test PRIVATE segment_tree)
 finalize_test_flags(valkey_utils_test)
 
 # 7. Text Index Test Suite
-add_executable(text_index_test 
+add_executable(text_index_test
     ${CMAKE_CURRENT_LIST_DIR}/flat_position_map_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/radix_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/rax_wrapper_test.cc
@@ -178,5 +178,13 @@ target_link_libraries(text_index_test PRIVATE testing_common_base)
 target_link_libraries(text_index_test PRIVATE text)
 finalize_test_flags(text_index_test)
 
-# 8. Expr Test Suite
+# 8. Scoring Test Suite
+add_executable(scoring_test
+    ${CMAKE_CURRENT_LIST_DIR}/scoring/bm25std_scorer_test.cc)
+target_include_directories(scoring_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(scoring_test PRIVATE testing_common_base)
+target_link_libraries(scoring_test PRIVATE scoring)
+finalize_test_flags(scoring_test)
+
+# 9. Expr Test Suite
 add_subdirectory(expr)

--- a/testing/scoring/bm25std_scorer_test.cc
+++ b/testing/scoring/bm25std_scorer_test.cc
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include "src/indexes/scoring/bm25std_scorer.h"
+
+#include <limits>
+#include <vector>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/indexes/scoring/scorer.h"
+#include "src/indexes/scoring/scoring_session.h"
+#include "src/indexes/scoring/scoring_stats.h"
+#include "testing/scoring/scoring_test_data.h"
+
+namespace valkey_search::indexes::scoring {
+namespace {
+
+using ::testing::ElementsAre;
+
+constexpr float kFloatTolerance = 1e-4f;
+
+Bm25StdStats MakeStats(uint32_t total_docs, float avg_doc_len,
+                       uint32_t num_doc_contain_term, uint32_t term_frequency,
+                       uint32_t doc_len, float document_score = 1.0f) {
+  Bm25StdStats s;
+  s.total_docs = total_docs;
+  s.avg_doc_len = avg_doc_len;
+  s.num_doc_contain_term = num_doc_contain_term;
+  s.term_frequency = term_frequency;
+  s.doc_len = doc_len;
+  s.document_score = document_score;
+  return s;
+}
+
+std::vector<DocId> RankOrder(const std::vector<RankedDoc>& ranked) {
+  std::vector<DocId> ids;
+  ids.reserve(ranked.size());
+  for (const auto& r : ranked) ids.push_back(r.doc_id);
+  return ids;
+}
+
+float ScoreFor(const std::vector<RankedDoc>& ranked, DocId id) {
+  for (const auto& r : ranked) {
+    if (r.doc_id == id) return r.score;
+  }
+  ADD_FAILURE() << "doc_id " << id << " not in ranked results";
+  return 0.0f;
+}
+
+template <typename Builder>
+std::vector<Bm25StdStats> BuildStatsForTerm(Builder builder) {
+  std::vector<Bm25StdStats> out;
+  out.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    Bm25StdStats s = builder(doc);
+    if (s.term_frequency > 0) out.push_back(s);
+  }
+  return out;
+}
+
+// --- Direct scorer math ---
+
+TEST(Bm25StdScorerTest, IdentityNameAndType) {
+  Bm25StdScorer scorer;
+  EXPECT_EQ(scorer.Name(), "BM25STD");
+  EXPECT_EQ(scorer.Type(), ScorerType::kBm25Std);
+}
+
+TEST(Bm25StdScorerTest, ScoreLeafCorpusReference) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[4]);
+  EXPECT_NEAR(scorer.ScoreLeaf(stats, 1.0f), 0.574385f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerTest, ScoreLeafLeafWeightScalesLinearly) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  const float base = scorer.ScoreLeaf(stats, 1.0f);
+  EXPECT_NEAR(scorer.ScoreLeaf(stats, 5.0f), 5.0f * base, kFloatTolerance);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 0.0f), 0.0f);
+}
+
+TEST(Bm25StdScorerTest, ScoreLeafZeroFrequencyReturnsZero) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = test_data::StatsForWorld(test_data::kDocs[4]);
+  ASSERT_EQ(stats.term_frequency, 0u);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 1.0f), 0.0f);
+}
+
+TEST(Bm25StdScorerTest, ScoreLeafEmptyIndexReturnsZero) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = MakeStats(/*N=*/0, /*avg_doc_len=*/0.0f,
+                                 /*dt=*/0, /*F=*/0, /*doc_len=*/0);
+  EXPECT_EQ(scorer.ScoreLeaf(stats, 1.0f), 0.0f);
+}
+
+TEST(Bm25StdScorerTest, IdfDifferentiatesByDt) {
+  Bm25StdScorer scorer;
+  const float hello =
+      scorer.ScoreLeaf(test_data::StatsForHello(test_data::kDocs[0]), 1.0f);
+  const float rare =
+      scorer.ScoreLeaf(test_data::StatsForRare(test_data::kDocs[5]), 1.0f);
+  const float unique =
+      scorer.ScoreLeaf(test_data::StatsForUnique(test_data::kDocs[5]), 1.0f);
+  EXPECT_GT(rare, hello);
+  EXPECT_GT(unique, rare);
+}
+
+TEST(Bm25StdScorerTest, LengthNormalizationFavorsShorterDoc) {
+  Bm25StdScorer scorer;
+  const float doc4 =
+      scorer.ScoreLeaf(test_data::StatsForHello(test_data::kDocs[3]), 1.0f);
+  const float doc5 =
+      scorer.ScoreLeaf(test_data::StatsForHello(test_data::kDocs[4]), 1.0f);
+  EXPECT_GT(doc5, doc4);
+}
+
+TEST(Bm25StdScorerDeathTest, DtGreaterThanNCrashes) {
+  Bm25StdScorer scorer;
+  Bm25StdStats stats = MakeStats(/*N=*/2, /*avg_doc_len=*/10.0f,
+                                 /*dt=*/3, /*F=*/1, /*doc_len=*/10);
+  EXPECT_DEATH(scorer.ScoreLeaf(stats, 1.0f), "");
+}
+
+TEST(Bm25StdScorerDeathTest, WrongStatsSubtypeCrashes) {
+  Bm25StdScorer scorer;
+  ScoringStats base_stats;
+  base_stats.total_docs = 10;
+  base_stats.num_doc_contain_term = 1;
+  base_stats.term_frequency = 1;
+  EXPECT_DEATH(scorer.ScoreLeaf(base_stats, 1.0f), "");
+}
+
+TEST(Bm25StdScorerTest, ComposeMultipliesByDocumentScore) {
+  Bm25StdScorer scorer;
+  EXPECT_NEAR(scorer.ComposeDocumentScore(0.5f, /*document_score=*/0.7f),
+              0.5f * 0.7f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerTest, ComposeInfinityShortCircuits) {
+  Bm25StdScorer scorer;
+  const float kInf = std::numeric_limits<float>::infinity();
+  EXPECT_EQ(scorer.ComposeDocumentScore(0.5f, kInf), kInf);
+  EXPECT_EQ(scorer.ComposeDocumentScore(0.5f, -kInf), -kInf);
+}
+
+TEST(Bm25StdScorerTest, CombineGroupAppliesWeight) {
+  Bm25StdScorer scorer;
+  std::vector<float> children = {1.0f, 2.0f, 3.0f};
+  EXPECT_NEAR(scorer.CombineGroup(children, /*group_weight=*/2.0f), 12.0f,
+              kFloatTolerance);
+}
+
+TEST(Bm25StdScorerTest, CombineGroupEmptyChildrenIsZero) {
+  Bm25StdScorer scorer;
+  EXPECT_EQ(scorer.CombineGroup({}, 5.0f), 0.0f);
+}
+
+// --- Query-driven tests (scorer + session integration) ---
+
+TEST(Bm25StdScorerQueryTest, SingleLeafHelloRankOrder) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 1.0f);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 5), 0.574385f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.523122f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.477286f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.430172f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.430172f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.331888f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, MultiLeafHelloWorld) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> hello_stats, world_stats;
+  hello_stats.reserve(std::size(test_data::kDocs));
+  world_stats.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello > 0 && doc.f_world > 0) {
+      hello_stats.push_back(test_data::StatsForHello(doc));
+      world_stats.push_back(test_data::StatsForWorld(doc));
+    }
+  }
+  for (size_t i = 0; i < hello_stats.size(); ++i) {
+    session.RecordLeaf(hello_stats[i], 1.0f);
+    session.RecordLeaf(world_stats[i], 1.0f);
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, LeafWeightScalesScore) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 5.0f);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 5), 2.871923f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 2.615608f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 2.386431f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 2.150861f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 2.150861f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 1.659439f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, NestedGroupsLayeredWeights) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> hello_stats, world_stats;
+  hello_stats.reserve(std::size(test_data::kDocs));
+  world_stats.reserve(std::size(test_data::kDocs));
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello > 0 && doc.f_world > 0) {
+      hello_stats.push_back(test_data::StatsForHello(doc));
+      world_stats.push_back(test_data::StatsForWorld(doc));
+    }
+  }
+
+  session.EnterGroup();
+  for (size_t i = 0; i < hello_stats.size(); ++i) {
+    session.RecordLeaf(hello_stats[i], 4.0f);
+    session.RecordLeaf(world_stats[i], 3.0f);
+  }
+  session.ExitGroup(2.0f);
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 5.695980f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 5.536520f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 5.286103f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 5.286103f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 4.646429f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, OrAtTopMixedAdmissionPaths) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    const bool rare_branch = doc.f_rare > 0;
+    const bool and_branch = doc.f_hello > 0 && doc.f_world > 0;
+    if (rare_branch) {
+      all_stats.push_back(test_data::StatsForRare(doc));
+      session.RecordLeaf(all_stats.back(), 1.0f);
+    } else if (and_branch) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 1.0f);
+      all_stats.push_back(test_data::StatsForWorld(doc));
+      session.RecordLeaf(all_stats.back(), 1.0f);
+    }
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(8, 6, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 8), 1.915183f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 6), 1.419164f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, AndOfLeafAndOrGroup) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    const bool or_match = doc.f_world > 0 || doc.f_rare > 0;
+    if (doc.f_hello > 0 && or_match) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 1.0f);
+      session.EnterGroup();
+      if (doc.f_world > 0) {
+        all_stats.push_back(test_data::StatsForWorld(doc));
+        session.RecordLeaf(all_stats.back(), 1.0f);
+      }
+      if (doc.f_rare > 0) {
+        all_stats.push_back(test_data::StatsForRare(doc));
+        session.RecordLeaf(all_stats.back(), 1.0f);
+      }
+      session.ExitGroup(1.0f);
+    }
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 4), 0.774956f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 0.763658f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 0.737626f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 0.663776f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, PerLeafWeightInsideOrWithGroupWeight) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+
+  std::vector<Bm25StdStats> all_stats;
+  all_stats.reserve(2 * std::size(test_data::kDocs));
+
+  for (const auto& doc : test_data::kDocs) {
+    if (doc.f_hello == 0 && doc.f_rare == 0) continue;
+    session.EnterGroup();
+    if (doc.f_hello > 0) {
+      all_stats.push_back(test_data::StatsForHello(doc));
+      session.RecordLeaf(all_stats.back(), 4.0f);
+    }
+    if (doc.f_rare > 0) {
+      all_stats.push_back(test_data::StatsForRare(doc));
+      session.RecordLeaf(all_stats.back(), 2.0f);
+    }
+    session.ExitGroup(3.0f);
+  }
+
+  auto ranked = session.Rank();
+  EXPECT_THAT(RankOrder(ranked), ElementsAre(8, 6, 5, 4, 3, 2, 7, 1));
+  EXPECT_NEAR(ScoreFor(ranked, 8), 11.491096f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 6), 8.514985f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 5), 6.892615f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 4), 6.277460f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 3), 5.727435f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 2), 5.162066f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 7), 5.162066f, kFloatTolerance);
+  EXPECT_NEAR(ScoreFor(ranked, 1), 3.982653f, kFloatTolerance);
+}
+
+TEST(Bm25StdScorerQueryTest, NonExistentTermEmpty) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto ranked = session.Rank();
+  EXPECT_TRUE(ranked.empty());
+}
+
+TEST(Bm25StdScorerQueryTest, TiesBrokenByDocIdAscending) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  auto stats = BuildStatsForTerm(test_data::StatsForHello);
+  for (const auto& s : stats) session.RecordLeaf(s, 1.0f);
+
+  auto ranked = session.Rank();
+  int pos2 = -1, pos7 = -1;
+  for (size_t i = 0; i < ranked.size(); ++i) {
+    if (ranked[i].doc_id == 2) pos2 = static_cast<int>(i);
+    if (ranked[i].doc_id == 7) pos7 = static_cast<int>(i);
+  }
+  ASSERT_NE(pos2, -1);
+  ASSERT_NE(pos7, -1);
+  EXPECT_LT(pos2, pos7);
+  EXPECT_FLOAT_EQ(ranked[pos2].score, ranked[pos7].score);
+}
+
+// --- Death tests (session misuse) ---
+
+TEST(Bm25StdScorerDeathTest, RecordLeafAfterRankCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  (void)session.Rank();
+  Bm25StdStats stats = test_data::StatsForHello(test_data::kDocs[0]);
+  EXPECT_DEATH(session.RecordLeaf(stats, 1.0f), "");
+}
+
+TEST(Bm25StdScorerDeathTest, ExitGroupWithoutEnterCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  EXPECT_DEATH(session.ExitGroup(1.0f), "");
+}
+
+TEST(Bm25StdScorerDeathTest, RankWithUnbalancedStackCrashes) {
+  Bm25StdScorer scorer;
+  ScoringSession session(&scorer);
+  session.EnterGroup();
+  EXPECT_DEATH((void)session.Rank(), "");
+}
+
+TEST(Bm25StdScorerDeathTest, NullScorerCrashes) {
+  EXPECT_DEATH({ ScoringSession session(nullptr); }, "");
+}
+
+}  // namespace
+}  // namespace valkey_search::indexes::scoring

--- a/testing/scoring/scoring_test_data.h
+++ b/testing/scoring/scoring_test_data.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#ifndef VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_
+#define VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_
+
+#include <cstdint>
+
+#include "src/indexes/scoring/scoring_stats.h"
+
+// Shared test data for Bm25StdScorer and ScoringSession unit tests.
+namespace valkey_search::indexes::scoring::test_data {
+
+inline constexpr uint32_t kTotalDocs = 8;
+// total_doc_len = 5+6+7+9+4+4+6+1 = 42; avg = 42 / 8 = 5.25.
+inline constexpr float kAvgDocLen = 5.25f;
+inline constexpr uint32_t kDtHello = 6;
+inline constexpr uint32_t kDtWorld = 6;
+inline constexpr uint32_t kDtRare = 2;
+inline constexpr uint32_t kDtUnique = 1;
+
+struct DocInfo {
+  uint64_t doc_id;
+  uint32_t doc_len;
+  uint32_t f_hello;
+  uint32_t f_world;
+  uint32_t f_rare;
+  uint32_t f_unique;
+};
+
+// {doc_id, doc_len, f_hello, f_world, f_rare, f_unique}
+// doc:2 / doc:7 are byte-identical for the tie-break test.
+inline constexpr DocInfo kDocs[] = {
+    {1, 5, 1, 1, 0, 0}, {2, 6, 2, 1, 0, 0}, {3, 7, 3, 1, 0, 0},
+    {4, 9, 5, 1, 0, 0}, {5, 4, 4, 0, 0, 0}, {6, 4, 0, 1, 1, 1},
+    {7, 6, 2, 1, 0, 0}, {8, 1, 0, 0, 1, 0},
+};
+
+inline Bm25StdStats StatsForHello(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "hello";
+  s.num_doc_contain_term = kDtHello;
+  s.term_frequency = doc.f_hello;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForWorld(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "world";
+  s.num_doc_contain_term = kDtWorld;
+  s.term_frequency = doc.f_world;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForRare(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "rare";
+  s.num_doc_contain_term = kDtRare;
+  s.term_frequency = doc.f_rare;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+inline Bm25StdStats StatsForUnique(const DocInfo& doc) {
+  Bm25StdStats s;
+  s.total_docs = kTotalDocs;
+  s.doc_id = doc.doc_id;
+  s.term = "unique";
+  s.num_doc_contain_term = kDtUnique;
+  s.term_frequency = doc.f_unique;
+  s.avg_doc_len = kAvgDocLen;
+  s.doc_len = doc.doc_len;
+  return s;
+}
+
+}  // namespace valkey_search::indexes::scoring::test_data
+
+#endif  // VALKEYSEARCH_TESTING_SCORING_SCORING_TEST_DATA_H_


### PR DESCRIPTION
 **BM25STD scorer + scoring session**
  - New `src/indexes/scoring/` module: a text-agnostic `Scorer` interface,
    `ScoringStats` input contract (`Bm25StdStats` / `TfidfStats`), the
    `Bm25StdScorer` implementation, and a `ScoringSession` that owns per-doc
    score accumulation.
  - `ScoringSession` stores a plain score rather than full stats in the
    `doc_score_` map to reduce memory cost.
  - Wired into `src/indexes/CMakeLists.txt`; unit tests with a fixed corpus
    verified against RediSearch ground truth.
