### PR TITLE
Scoring arguments updates

### DIFF
--- a/docs/commands/ft.search.md
+++ b/docs/commands/ft.search.md
@@ -13,8 +13,10 @@ FT.SEARCH <index> <query>
   [SLOP <slop>]
   [SORTBY <field> [ ASC | DESC]]
   [TIMEOUT <timeout>]
+  [SCORER <scorer>] 
   [VERBATIM]
   [WITHSORTKEYS]
+  [WITHSCORES]
 ```
 
 - `<index>` (required): This index name you want to query.
@@ -34,6 +36,8 @@ FT.SEARCH <index> <query>
 - `SORTBY <field> [ASC | DESC]` (Optional): If present, results are sorted according the value of the specified field and the optional sort-direction instruction. By default, vector results are sorted in distance order and non-vector results are not sorted in any particular order. Sorting is applied before the `LIMIT` clause is applied.
 - `TIMEOUT <timeout>` (optional): Lets you set a timeout value for the search command. This must be an integer in milliseconds.
 - `WITHSORTKEYS` (Optional): If `SORTBY` is specified then enabling this option augments the output with the value of the field used for sorting.
+- `WITHSCORES` (Optional): If present, results are augmented with the relative internal score of each document.
+- `SCORER <scorer>` (Optional): If present, uses a specific scoring function or the default scoring function.
 
 Response
 

--- a/src/commands/ft.search.json
+++ b/src/commands/ft.search.json
@@ -7,7 +7,7 @@
     ],
     "history": [
       [
-        "1.2.0", 
+        "1.2.0",
         "Added Text Indexing and Search support"
       ]
     ],
@@ -195,6 +195,22 @@
         ]
       },
       {
+        "name": "SCORER",
+        "type": "block",
+        "optional": true,
+        "arguments": [
+          {
+            "name": "scorer_token",
+            "type": "pure-token",
+            "token": "SCORER"
+          },
+          {
+            "name": "scorer",
+            "type": "string"
+          }
+        ]
+      },
+      {
         "name": "SORTBY",
         "type": "block",
         "optional": true,
@@ -254,6 +270,12 @@
         "type": "pure-token",
         "optional": true,
         "token": "WITHSORTKEYS"
+      },
+      {
+        "name": "WITHSCORES",
+        "type": "pure-token",
+        "optional": true,
+        "token": "WITHSCORES"
       }
     ],
     "arity": -3,

--- a/src/commands/ft_aggregate.cc
+++ b/src/commands/ft_aggregate.cc
@@ -285,7 +285,7 @@ absl::Status CreateRecordsFromNeighbors(
 
     // Set score field for vector queries
     if (parameters.IsVectorQuery()) {
-      rec->fields_.at(scores_index) = expr::Value(n.distance);
+      rec->fields_.at(scores_index) = expr::Value(n.score);
     }
 
     // Process attribute contents

--- a/src/commands/ft_aggregate_parser.cc
+++ b/src/commands/ft_aggregate_parser.cc
@@ -37,6 +37,7 @@ constexpr absl::string_view kTimeoutParam{"TIMEOUT"};
 constexpr absl::string_view kSlopParam{"SLOP"};
 constexpr absl::string_view kInorder{"INORDER"};
 constexpr absl::string_view kVerbatim{"VERBATIM"};
+constexpr absl::string_view kScorerParam{"SCORER"};
 
 std::unique_ptr<vmsdk::ParamParser<AggregateParameters>> ConstructLoadParser() {
   return std::make_unique<vmsdk::ParamParser<AggregateParameters>>(
@@ -249,6 +250,9 @@ vmsdk::KeyValueParser<AggregateParameters> CreateAggregateParser() {
                         GENERATE_FLAG_PARSER(AggregateParameters, inorder));
   parser.AddParamParser(kVerbatim,
                         GENERATE_FLAG_PARSER(AggregateParameters, verbatim));
+  parser.AddParamParser(
+      kScorerParam,
+      GENERATE_ENUM_PARSER(AggregateParameters, scorer, *query::kScorerByStr));
   parser.AddParamParser(kLoadParam, ConstructLoadParser());
   parser.AddParamParser(kApplyParam, ConstructApplyParser());
   parser.AddParamParser(kFilterParam, ConstructFilterParser());

--- a/src/commands/ft_search.cc
+++ b/src/commands/ft_search.cc
@@ -66,7 +66,16 @@ void SendReplyNoContent(ValkeyModuleCtx *ctx,
 void ReplyScore(ValkeyModuleCtx *ctx, ValkeyModuleString &score_as,
                 const indexes::Neighbor &neighbor) {
   ValkeyModule_ReplyWithString(ctx, &score_as);
-  auto score_value = absl::StrFormat("%.12g", neighbor.distance);
+  auto score_value = absl::StrFormat("%.12g", neighbor.score);
+  ValkeyModule_ReplyWithString(
+      ctx, vmsdk::MakeUniqueValkeyString(score_value).get());
+}
+
+// Reply with just the score value as a top-level element (Redis WITHSCORES
+// format: score appears between document ID and attributes array).
+void ReplyScoreTopLevel(ValkeyModuleCtx *ctx,
+                        const indexes::Neighbor &neighbor) {
+  auto score_value = absl::StrFormat("%.12g", neighbor.score);
   ValkeyModule_ReplyWithString(
       ctx, vmsdk::MakeUniqueValkeyString(score_value).get());
 }
@@ -140,15 +149,27 @@ void SerializeNonVectorNeighbors(ValkeyModuleCtx *ctx,
   const auto &neighbors = search_result.neighbors;
   auto range = search_result.GetSerializationRange(command);
 
-  // When with_sort_keys is true, we add an extra element per result (the sort
-  // key)
-  size_t elements_per_result = command.with_sort_keys ? 3 : 2;
+  // Each result has: doc_id [+ score if WITHSCORES] [+ sort_key if
+  // WITHSORTKEYS] + attributes array
+  size_t elements_per_result = 2;
+  if (command.with_scores) {
+    ++elements_per_result;
+  }
+  if (command.with_sort_keys) {
+    ++elements_per_result;
+  }
+
   ValkeyModule_ReplyWithArray(ctx, elements_per_result * range.count() + 1);
   ReplyAvailNeighbors(ctx, search_result, command);
   for (size_t i = range.start_index; i < range.end_index; ++i) {
     // Document ID
     ValkeyModule_ReplyWithString(
         ctx, vmsdk::MakeUniqueValkeyString(*neighbors[i].external_id).get());
+
+    // Score as top-level element when WITHSCORES is specified
+    if (command.with_scores) {
+      ReplyScoreTopLevel(ctx, neighbors[i]);
+    }
 
     // Sort key value (prefixed with #) when WITHSORTKEYS is specified
     if (command.with_sort_keys) {

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -226,6 +226,8 @@ vmsdk::KeyValueParser<SearchCommand> CreateSearchParser() {
                         GENERATE_FLAG_PARSER(SearchCommand, no_content));
   parser.AddParamParser(query::kWithSortKeysParam,
                         GENERATE_FLAG_PARSER(SearchCommand, with_sort_keys));
+  parser.AddParamParser(query::kWithScoresParam,
+                        GENERATE_FLAG_PARSER(SearchCommand, with_scores));
   parser.AddParamParser(query::kReturnParam, ConstructReturnParser());
   parser.AddParamParser(query::kSortByParam, ConstructSortByParser());
   parser.AddParamParser(query::kParamsParam, ConstructParamsParser());
@@ -235,6 +237,9 @@ vmsdk::KeyValueParser<SearchCommand> CreateSearchParser() {
                         GENERATE_FLAG_PARSER(SearchCommand, verbatim));
   parser.AddParamParser(query::kSlop,
                         GENERATE_VALUE_PARSER(SearchCommand, slop));
+  parser.AddParamParser(
+      query::kScorer,
+      GENERATE_ENUM_PARSER(SearchCommand, scorer, *query::kScorerByStr));
 
   return parser;
 }
@@ -250,6 +255,15 @@ absl::Status SearchCommand::PostParseQueryString() {
     // Validate sortby field exists in the index schema
     VMSDK_RETURN_IF_ERROR(
         index_schema->GetIdentifier(sortby_parameter->field).status());
+  }
+
+  // For non-vector queries with WITHSCORES, set a default score_as if not
+  // already set by the vector query parsing path.
+  // NOTE: score_as is not currently consumed by SerializeNonVectorNeighbors
+  // (which uses ReplyScoreTopLevel directly), but is retained for future use
+  // when scorer integration is implemented.
+  if (with_scores && IsNonVectorQuery() && !score_as) {
+    score_as = vmsdk::MakeUniqueValkeyString("__score");
   }
 
   return absl::OkStatus();

--- a/src/commands/ft_search_parser.h
+++ b/src/commands/ft_search_parser.h
@@ -40,6 +40,7 @@ struct SearchCommand : public QueryCommand {
   query::SerializationRange GetSerializationRange() const;
 
   bool with_sort_keys{false};
+  bool with_scores{false};
 };
 
 }  // namespace valkey_search

--- a/src/coordinator/coordinator.proto
+++ b/src/coordinator/coordinator.proto
@@ -150,6 +150,7 @@ message NeighborEntry {
   string key = 1;
   float score = 2;
   repeated AttributeContentEntry attribute_contents = 3;
+  float distance = 4;
 }
 
 message SearchIndexPartitionResponse {

--- a/src/coordinator/server.cc
+++ b/src/coordinator/server.cc
@@ -99,7 +99,8 @@ void SerializeNeighbors(SearchIndexPartitionResponse* response,
   for (const auto& neighbor : neighbors) {
     auto* neighbor_proto = response->add_neighbors();
     neighbor_proto->set_key(std::move(*neighbor.external_id));
-    neighbor_proto->set_score(neighbor.distance);
+    neighbor_proto->set_score(neighbor.score);
+    neighbor_proto->set_distance(neighbor.distance);
     if (neighbor.attribute_contents) {
       const auto& attribute_contents = neighbor.attribute_contents.value();
       for (const auto& [identifier, record] : attribute_contents) {

--- a/src/indexes/vector_base.cc
+++ b/src/indexes/vector_base.cc
@@ -267,7 +267,7 @@ absl::StatusOr<std::vector<Neighbor>> VectorBase::CreateReply(
       knn_res.pop();
       continue;
     }
-    // Insert in desc order.
+    // Insert in desc order. Will need an update with score in the future
     ret.emplace_back(Neighbor{vector_key.value(), ele.first});
     knn_res.pop();
   }

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -51,33 +51,49 @@ std::vector<char> NormalizeEmbedding(absl::string_view record, size_t type_size,
 struct BorrowedNeighbor {
   BorrowedInternedStringPtr key;
   float distance;
+  float score;
 };
 static_assert(std::is_trivially_destructible_v<BorrowedNeighbor>,
               "BorrowedNeighbor must be trivially destructible");
 
+// Default score value used when no scorer has been applied yet.
+inline constexpr float kDefaultScore = 0.0f;
+
 struct Neighbor {
   InternedStringPtr external_id;
   float distance;
+  float score;
   uint64_t sequence_number;
   std::optional<RecordsMap> attribute_contents;
-  Neighbor() : distance(0.0f), sequence_number(0) {}
+  Neighbor() : distance(0.0f), score(kDefaultScore), sequence_number(0) {}
   Neighbor(const InternedStringPtr& external_id, float distance)
-      : external_id(external_id), distance(distance), sequence_number(0) {}
+      : external_id(external_id),
+        distance(distance),
+        score(kDefaultScore),
+        sequence_number(0) {}
+  Neighbor(const InternedStringPtr& external_id, float distance, float score)
+      : external_id(external_id),
+        distance(distance),
+        score(score),
+        sequence_number(0) {}
   Neighbor(const InternedStringPtr& external_id, float distance,
            std::optional<RecordsMap>&& attribute_contents)
       : external_id(external_id),
         distance(distance),
+        score(kDefaultScore),
         sequence_number(0),
         attribute_contents(std::move(attribute_contents)) {}
   Neighbor(Neighbor&& other) noexcept
       : external_id(std::move(other.external_id)),
         distance(other.distance),
+        score(other.score),
         sequence_number(other.sequence_number),
         attribute_contents(std::move(other.attribute_contents)) {}
   Neighbor& operator=(Neighbor&& other) noexcept {
     if (this != &other) {
       external_id = std::move(other.external_id);
       distance = other.distance;
+      score = other.score;
       sequence_number = other.sequence_number;
       attribute_contents = std::move(other.attribute_contents);
     }
@@ -85,7 +101,7 @@ struct Neighbor {
   }
   friend std::ostream& operator<<(std::ostream& os, const Neighbor& n) {
     os << "Key: " << n.external_id->Str() << " Dist: " << n.distance
-       << " Seq: " << n.sequence_number;
+       << " Score: " << n.score << " Seq: " << n.sequence_number;
     if (n.attribute_contents.has_value()) {
       os << ' ' << *n.attribute_contents;
     } else {

--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -143,7 +143,8 @@ struct SearchPartitionResultsTracker {
       }
       indexes::Neighbor neighbor{
           StringInternStore::Intern(neighbor_entry->key()),
-          neighbor_entry->score(), std::move(attribute_contents)};
+          neighbor_entry->distance(), std::move(attribute_contents)};
+      neighbor.score = neighbor_entry->score();
       AddResult(neighbor);
     }
   }

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -634,7 +634,7 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
       fetch_limited = true;
       return false;
     }
-    borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f});
+    borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f, indexes::kDefaultScore});
     return true;
   };
   // Cannot skip evaluation if the query contains unsolved composed operations.
@@ -667,7 +667,7 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
           nonvector_results_fetched_limited_count.Increment();
           break;
         }
-        borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f});
+        borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f, indexes::kDefaultScore});
         iterator->Next();
         if (parameters.cancellation_token->IsCancelled()) {
           break;

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -17,10 +17,13 @@
 #include <utility>
 #include <vector>
 
+#include "absl/base/no_destructor.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
 #include "src/commands/filter_parser.h"
 #include "src/index_schema.h"
 #include "src/indexes/index_base.h"
@@ -69,10 +72,33 @@ constexpr absl::string_view kSomeShards{"SOMESHARDS"};
 constexpr absl::string_view kConsistent{"CONSISTENT"};
 constexpr absl::string_view kInconsistent{"INCONSISTENT"};
 constexpr absl::string_view kWithSortKeysParam{"WITHSORTKEYS"};
+constexpr absl::string_view kWithScoresParam{"WITHSCORES"};
 constexpr absl::string_view kVectorFilterDelimiter{"=>"};
 constexpr absl::string_view kSlop{"SLOP"};
+constexpr absl::string_view kScorer{"SCORER"};
 constexpr absl::string_view kInorder{"INORDER"};
 constexpr absl::string_view kVerbatim{"VERBATIM"};
+
+enum class Scorer {
+  kBM25STD,
+  kTFIDF,
+};
+
+inline absl::string_view ScorerToString(Scorer scorer) {
+  switch (scorer) {
+    case Scorer::kBM25STD:
+      return "BM25STD";
+    case Scorer::kTFIDF:
+      return "TFIDF";
+  }
+  return "BM25STD";
+}
+
+const absl::NoDestructor<absl::flat_hash_map<absl::string_view, Scorer>>
+    kScorerByStr({
+        {"BM25STD", Scorer::kBM25STD},
+        {"TFIDF", Scorer::kTFIDF},
+    });
 
 struct LimitParameter {
   uint64_t first_index{0};
@@ -214,6 +240,9 @@ struct SearchParameters {
   bool inorder{false};
   std::optional<uint32_t> slop;
   bool verbatim{false};
+  // TODO: Scorer is currently a placeholder. The selected scoring function is
+  // not yet invoked; non-vector queries will report a score of 0.0.
+  Scorer scorer{Scorer::kBM25STD};
   coordinator::IndexFingerprintVersion index_fingerprint_version;
   uint64_t slot_fingerprint;
   SearchResult search_result;

--- a/testing/common.cc
+++ b/testing/common.cc
@@ -176,7 +176,7 @@ indexes::Neighbor ToIndexesNeighbor(const NeighborTest &neighbor_test) {
   auto string_interned_external_id =
       StringInternStore::Intern(neighbor_test.external_id);
   indexes::Neighbor neighbor(string_interned_external_id,
-                             neighbor_test.distance);
+                             neighbor_test.distance, neighbor_test.distance);
   if (neighbor_test.attribute_contents.has_value()) {
     std::optional<RecordsMap> attribute_contents;
     neighbor.attribute_contents.value() = RecordsMap();

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -80,6 +80,9 @@ struct FTSearchParserTestCase {
   query::SortOrder sortby_order{query::SortOrder::kAscending};
   bool sortby_enabled{false};
   bool with_sort_keys{false};
+  // WITHSCORES and SCORER test fields
+  bool with_scores{false};
+  query::Scorer scorer{query::Scorer::kBM25STD};
 };
 
 class FTSearchParserTest
@@ -299,10 +302,12 @@ void DoVectorSearchParserTest(const FTSearchParserTestCase &test_case,
     EXPECT_EQ(search_params.value()->verbatim, test_case.verbatim);
     EXPECT_EQ(search_params.value()->inorder, test_case.inorder);
     EXPECT_EQ(search_params.value()->slop, test_case.slop);
+    EXPECT_EQ(search_params.value()->scorer, test_case.scorer);
     // Validate SORTBY parameters
     EXPECT_EQ(search_params.value()->sortby_parameter.has_value(),
               test_case.sortby_enabled);
     EXPECT_EQ(search_params.value()->with_sort_keys, test_case.with_sort_keys);
+    EXPECT_EQ(search_params.value()->with_scores, test_case.with_scores);
     if (test_case.sortby_enabled) {
       EXPECT_EQ(search_params.value()->sortby_parameter->field,
                 test_case.sortby_field);
@@ -961,6 +966,66 @@ INSTANTIATE_TEST_SUITE_P(
             .expected_error_message =
                 "Error parsing value for the parameter `SLOP`",
             .search_parameters_str = "SLOP -100",
+        },
+        // WITHSCORES parameter tests
+        {
+            .test_name = "withscores_vector_query",
+            .success = true,
+            .params_str = " PARAMS 2",
+            .filter_str = "* =>[KNN 5 @vec $BLOB]",
+            .k = 5,
+            .search_parameters_str = "WITHSCORES",
+            .with_scores = true,
+        },
+        {
+            .test_name = "withscores_non_vector_query",
+            .success = true,
+            .params_str = "",
+            .filter_str = "@attribute_identifier_1:[300 1000]",
+            .attribute_alias = "",
+            .k = 0,
+            .ef = 0,
+            .score_as = "",
+            .search_parameters_str = "WITHSCORES",
+            .vector_query = false,
+            .with_scores = true,
+        },
+        // SCORER parameter tests
+        {
+            .test_name = "scorer_vector_query",
+            .success = true,
+            .params_str = " PARAMS 2",
+            .filter_str = "* =>[KNN 5 @vec $BLOB]",
+            .k = 5,
+            .search_parameters_str = "SCORER BM25STD",
+            .scorer = query::Scorer::kBM25STD,
+        },
+        {
+            .test_name = "scorer_non_vector_query",
+            .success = true,
+            .params_str = "",
+            .filter_str = "@attribute_identifier_1:[300 1000]",
+            .attribute_alias = "",
+            .k = 0,
+            .ef = 0,
+            .score_as = "",
+            .search_parameters_str = "SCORER TFIDF",
+            .vector_query = false,
+            .scorer = query::Scorer::kTFIDF,
+        },
+        {
+            .test_name = "withscores_and_scorer_combined",
+            .success = true,
+            .params_str = "",
+            .filter_str = "@attribute_identifier_1:[300 1000]",
+            .attribute_alias = "",
+            .k = 0,
+            .ef = 0,
+            .score_as = "",
+            .search_parameters_str = "WITHSCORES SCORER TFIDF",
+            .vector_query = false,
+            .with_scores = true,
+            .scorer = query::Scorer::kTFIDF,
         },
         // SORTBY tests
         {


### PR DESCRIPTION
**Scoring arguments on the command surface**
  - Adds the `SCORER` and `WITHSCORES` arguments to `FT.SEARCH`, and the `SCORER`
    field to `FT.AGGREGATE`.
  - Clarifies the distinction between *score* and *distance* throughout the
    query/vector paths.
  - Plumbs the new field across the coordinator (`coordinator.proto`, `server.cc`)
    and fanout so scoring works in cluster mode.