### PR TITLE
Add pre-compute for text scoring

### DIFF
--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -674,7 +674,7 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
     ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
   if (text_index_schema_) {
     // Always clean up indexed words from all text attributes of the key up
-    // front
+    // front. DeleteKeyData also decrements total_doc_len internally.
     text_index_schema_->DeleteKeyData(key);
   }
   bool all_deletes = true;
@@ -703,7 +703,8 @@ void IndexSchema::SyncProcessMutation(ValkeyModuleCtx *ctx,
   }
   if (text_index_schema_) {
     // Text index structures operate at the schema-level so we commit the
-    // updates to all Text attributes in one operation for efficiency
+    // updates to all Text attributes in one operation for efficiency.
+    // CommitKeyData stores doc_len/norm in TextIndexSchema internally.
     text_index_schema_->CommitKeyData(key);
   }
 

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -194,6 +194,30 @@ class IndexSchema : public KeyspaceEventSubscription,
     return itr->second.document_score;
   }
 
+  uint32_t GetDocumentLength(const Key &key) const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    if (!text_index_schema_) {
+      return 0;
+    }
+    return text_index_schema_->GetKeyDocLen(key);
+  }
+
+  uint32_t GetDocumentNorm(const Key &key) const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    if (!text_index_schema_) {
+      return 0;
+    }
+    return text_index_schema_->GetKeyNorm(key);
+  }
+
+  uint64_t GetTotalDocumentLength() const
+      ABSL_SHARED_LOCKS_REQUIRED(time_sliced_mutex_) {
+    if (!text_index_schema_) {
+      return 0;
+    }
+    return text_index_schema_->GetMetadata().total_doc_len.load();
+  }
+
   void CreateTextIndexSchema() {
     text_index_schema_ = std::make_shared<indexes::text::TextIndexSchema>(
         language_, punctuation_, with_offsets_, stop_words_, min_stem_size_);

--- a/src/indexes/text/flat_position_map.cc
+++ b/src/indexes/text/flat_position_map.cc
@@ -37,6 +37,7 @@ constexpr uint8_t kSevenBitMask = 0x7F;    // Bits 0-6: data
 constexpr uint8_t kBitsPerByte = 7;        // 7 bits of data per byte
 constexpr uint8_t kTerminatorByte = 0x00;  // Terminator byte
 constexpr uint8_t kPartitionDeltaBytes = 4;
+constexpr size_t kTermFrequencyBytes = 4;  // Pre-computed TF stored at start
 
 // Type conversion helpers
 inline uint8_t U8(char c) { return static_cast<uint8_t>(c); }
@@ -109,6 +110,12 @@ FlatPositionMap* FlatPositionMap::Create(
   CHECK(!position_map.empty())
       << "Cannot create FlatPositionMap from empty position_map";
 
+  // Pre-compute term frequency from the position map
+  size_t tf = ComputeTermFrequency(position_map);
+  CHECK_LE(tf, static_cast<size_t>(UINT32_MAX))
+      << "Term frequency exceeds FlatPositionMap storage";
+  uint32_t term_frequency = static_cast<uint32_t>(tf);
+
   // First pass: compute data size (same logic as old constructor)
   uint32_t num_positions = position_map.size();
 
@@ -162,7 +169,8 @@ FlatPositionMap* FlatPositionMap::Create(
   uint8_t part_bytes = BytesNeeded(num_partitions) - 1;
   size_t partition_map_size = num_partitions * kPartitionDeltaBytes * 2;
   size_t counts_size = (pos_bytes + 1) + (part_bytes + 1);
-  size_t data_size = counts_size + partition_map_size + position_data.size();
+  size_t data_size = kTermFrequencyBytes + counts_size + partition_map_size +
+                     position_data.size();
   size_t total_size = sizeof(FlatPositionMap) + data_size;
 
   // Allocate single block: [FlatPositionMap | data...]
@@ -178,6 +186,10 @@ FlatPositionMap* FlatPositionMap::Create(
 
   // Write data immediately after struct
   char* p = map->data();
+
+  // Write pre-computed term frequency first (4 bytes, little-endian)
+  std::memcpy(p, &term_frequency, kTermFrequencyBytes);
+  p += kTermFrequencyBytes;
 
   // Write counts
   map->WriteCounts(p, num_positions, num_partitions);
@@ -235,7 +247,7 @@ void FlatPositionMap::WriteCounts(char*& p, uint32_t num_positions,
 //=============================================================================
 
 PositionIterator::PositionIterator(const FlatPositionMap& flat_map)
-    : flat_map_(flat_map.data()),
+    : flat_map_(flat_map.data() + kTermFrequencyBytes),
       current_ptr_(nullptr),
       data_start_(nullptr),
       cumulative_position_(0),
@@ -388,21 +400,28 @@ uint64_t PositionIterator::GetFieldMask() const { return current_field_mask_; }
 //=============================================================================
 
 uint32_t FlatPositionMap::CountPositions() const {
-  const char* p = data();
+  const char* p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [num_positions, _] = ReadCounts(p);
   return num_positions;
 }
 
 uint32_t FlatPositionMap::GetNumPartitions() const {
-  const char* p = data();
+  const char* p = data() + kTermFrequencyBytes;  // Skip pre-computed TF
   auto [_, num_partitions] = ReadCounts(p);
   return num_partitions;
 }
 
-size_t FlatPositionMap::CountTermFrequency() const {
+size_t FlatPositionMap::GetTermFrequency() const {
+  uint32_t tf = 0;
+  std::memcpy(&tf, data(), kTermFrequencyBytes);
+  return static_cast<size_t>(tf);
+}
+
+size_t FlatPositionMap::ComputeTermFrequency(
+    const absl::btree_map<Position, FieldMask>& position_map) {
   size_t total_frequency = 0;
-  for (PositionIterator iter(*this); iter.IsValid(); iter.NextPosition()) {
-    total_frequency += __builtin_popcountll(iter.GetFieldMask());
+  for (const auto& [pos, field_mask] : position_map) {
+    total_frequency += __builtin_popcountll(field_mask.GetMask());
   }
   return total_frequency;
 }

--- a/src/indexes/text/flat_position_map.h
+++ b/src/indexes/text/flat_position_map.h
@@ -85,10 +85,16 @@ class FlatPositionMap {
   // Get partition count
   uint32_t GetNumPartitions() const;
 
-  // Get total term frequency
-  size_t CountTermFrequency() const;
+  // Get total term frequency (pre-computed during Create, O(1) lookup)
+  size_t GetTermFrequency() const;
+
+  // Compute term frequency by iterating (used internally during Create)
+  static size_t ComputeTermFrequency(
+      const absl::btree_map<Position, FieldMask>& position_map);
 
   // Access to raw data pointer (stored immediately after this object)
+  // Layout: [term_frequency (4 bytes)] [header counts] [partition map]
+  // [position data]
   inline char* data() { return reinterpret_cast<char*>(this + 1); }
 
   inline const char* data() const {

--- a/src/indexes/text/posting.cc
+++ b/src/indexes/text/posting.cc
@@ -69,7 +69,7 @@ void Postings::RemoveKey(const Key& key, TextIndexMetadata* metadata) {
 
   // Use member functions to get counts
   size_t position_count = flat_map->CountPositions();
-  size_t term_frequency = flat_map->CountTermFrequency();
+  size_t term_frequency = flat_map->GetTermFrequency();
 
   metadata->total_positions -= position_count;
   metadata->total_term_frequency -= term_frequency;
@@ -94,7 +94,7 @@ size_t Postings::GetPositionCount() const {
 size_t Postings::GetTotalTermFrequency() const {
   size_t total_frequency = 0;
   for (const auto& [key, flat_map] : key_to_positions_) {
-    total_frequency += flat_map->CountTermFrequency();
+    total_frequency += flat_map->GetTermFrequency();
   }
   return total_frequency;
 }

--- a/src/indexes/text/text_index.cc
+++ b/src/indexes/text/text_index.cc
@@ -188,7 +188,8 @@ absl::StatusOr<bool> TextIndexSchema::StageAttributeData(
   return true;
 }
 
-void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
+TextIndexSchema::CommitResult TextIndexSchema::CommitKeyData(
+    const InternedStringPtr &key) {
   // Retrieve the key's staged data
   TokenPositions token_positions;
   {
@@ -196,7 +197,7 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     auto node = in_progress_key_updates_.extract(key);
     // Exit early if the key contains no new text updates
     if (node.empty()) {
-      return;
+      return {};
     }
     token_positions = std::move(node.mapped());
   }
@@ -213,6 +214,10 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
   TextIndex key_index{with_suffix_trie_};
 
+  // Accumulate document length (total term frequency for this key)
+  uint32_t doc_len = 0;
+  uint32_t norm = 0;
+
   // Index the key's tokens
   for (auto &entry : token_positions) {
     const std::string &token = entry.first;
@@ -225,9 +230,14 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
 
     // Update metadata from PositionMap
     metadata_.total_positions += pos_map.size();
+    uint32_t token_freq = 0;
     for (const auto &[_, field_mask] : pos_map) {
-      metadata_.total_term_frequency += field_mask.CountSetFields();
+      uint32_t fields_count = field_mask.CountSetFields();
+      metadata_.total_term_frequency += fields_count;
+      token_freq += fields_count;
+      doc_len += fields_count;
     }
+    norm = std::max(norm, token_freq);
 
     // Create FlatPositionMap from PositionMap
     FlatPositionMap *flat_map =
@@ -281,21 +291,29 @@ void TextIndexSchema::CommitKeyData(const InternedStringPtr &key) {
     }
   }
 
-  // Map the key to the newly created per-key index
+  // Map the key to the newly created per-key index and scoring info
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     per_key_text_indexes_.emplace(key, std::move(key_index));
+    per_key_scoring_info_[key] = {doc_len, norm};
+    metadata_.total_doc_len += doc_len;
   }
+
+  return {doc_len, norm};
 }
 
 void TextIndexSchema::DeleteKeyData(const InternedStringPtr &key) {
-  // Extract the per-key index
+  // Extract the per-key index and scoring info
   absl::node_hash_map<Key, TextIndex>::node_type node;
   {
     std::lock_guard<std::mutex> per_key_guard(per_key_text_indexes_mutex_);
     node = per_key_text_indexes_.extract(key);
     if (node.empty()) {
       return;
+    }
+    auto scoring_node = per_key_scoring_info_.extract(key);
+    if (!scoring_node.empty()) {
+      metadata_.total_doc_len -= scoring_node.mapped().doc_len;
     }
   }
   TextIndex &key_index = node.mapped();

--- a/src/indexes/text/text_index.h
+++ b/src/indexes/text/text_index.h
@@ -47,6 +47,8 @@ struct TextIndexMetadata {
   std::atomic<uint64_t> total_positions{0};
   std::atomic<uint64_t> num_unique_terms{0};
   std::atomic<uint64_t> total_term_frequency{0};
+  std::atomic<uint64_t> total_doc_len{
+      0};  // Sum of all doc_lens for avg_doc_len
 
   // Memory pools for text index components
   MemoryPool posting_memory_pool_{0};
@@ -96,7 +98,13 @@ class TextIndexSchema {
                                           absl::string_view data,
                                           size_t text_field_number, bool stem,
                                           bool suffix);
-  void CommitKeyData(const InternedStringPtr &key);
+  // Commits staged key data into the text index structures.
+  // Returns the document length and norm (max term frequency).
+  struct CommitResult {
+    uint32_t doc_len{0};
+    uint32_t norm{0};
+  };
+  CommitResult CommitKeyData(const InternedStringPtr &key);
   void DeleteKeyData(const InternedStringPtr &key);
 
   uint8_t AllocateTextFieldNumber() { return num_text_fields_++; }
@@ -107,6 +115,17 @@ class TextIndexSchema {
 
   // Access to metadata for memory pool usage
   TextIndexMetadata &GetMetadata() { return metadata_; }
+
+  uint32_t GetKeyDocLen(const InternedStringPtr &key) const {
+    std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
+    auto itr = per_key_scoring_info_.find(key);
+    return itr != per_key_scoring_info_.end() ? itr->second.doc_len : 0;
+  }
+  uint32_t GetKeyNorm(const InternedStringPtr &key) const {
+    std::lock_guard<std::mutex> guard(per_key_text_indexes_mutex_);
+    auto itr = per_key_scoring_info_.find(key);
+    return itr != per_key_scoring_info_.end() ? itr->second.norm : 0;
+  }
 
   // Access stem tree for word expansion during search
   const Rax &GetStemTree() const { return stem_tree_; }
@@ -170,8 +189,16 @@ class TextIndexSchema {
   //
   absl::node_hash_map<Key, TextIndex> per_key_text_indexes_;
 
-  // Prevent concurrent mutations to per-key text index map
-  std::mutex per_key_text_indexes_mutex_;
+  // Per-key scoring metadata (doc_len and norm), populated alongside
+  // per_key_text_indexes_ during CommitKeyData/DeleteKeyData.
+  struct KeyScoringInfo {
+    uint32_t doc_len{0};
+    uint32_t norm{0};
+  };
+  absl::node_hash_map<Key, KeyScoringInfo> per_key_scoring_info_;
+
+  // Prevent concurrent mutations to per-key text index map and scoring info
+  mutable std::mutex per_key_text_indexes_mutex_;
 
   Lexer lexer_;
 

--- a/testing/flat_position_map_test.cc
+++ b/testing/flat_position_map_test.cc
@@ -116,7 +116,7 @@ TEST_F(FlatPositionMapTest, SinglePositionSingleField) {
   EXPECT_FALSE(iter.IsValid());
 
   EXPECT_EQ(flat_map->CountPositions(), 1);
-  EXPECT_EQ(flat_map->CountTermFrequency(), 1);
+  EXPECT_EQ(flat_map->GetTermFrequency(), 1);
 }
 
 TEST_F(FlatPositionMapTest, MultiplePositionsIteration) {
@@ -197,7 +197,7 @@ TEST_F(FlatPositionMapTest, TermFrequencyCalculation) {
       CreatePositionMap({{10, 0b001}, {20, 0b011}, {30, 0b111}}, 3);
   FlatPositionMapPtr flat_map(position_map, 3);
 
-  EXPECT_EQ(flat_map->CountTermFrequency(), 6);  // 1+2+3
+  EXPECT_EQ(flat_map->GetTermFrequency(), 6);  // 1+2+3
 }
 
 //=============================================================================
@@ -768,7 +768,7 @@ TEST_F(FlatPositionMapTest, RandomMapWithTermFrequencyVerification) {
       expected_freq += __builtin_popcountll(mask);
     }
 
-    EXPECT_EQ(flat_map->CountTermFrequency(), expected_freq)
+    EXPECT_EQ(flat_map->GetTermFrequency(), expected_freq)
         << "Test " << test << " failed: term frequency mismatch";
   }
 }
@@ -796,7 +796,7 @@ TEST_F(FlatPositionMapTest, VeryLargeMapScenarios) {
       FlatPositionMapPtr flat_map(position_map, 1);
 
       ASSERT_EQ(flat_map->CountPositions(), target_size);
-      EXPECT_EQ(flat_map->CountTermFrequency(), target_size);
+      EXPECT_EQ(flat_map->GetTermFrequency(), target_size);
 
       // Test skip to various positions
       PositionIterator iter1(*flat_map);

--- a/testing/text_index_schema_test.cc
+++ b/testing/text_index_schema_test.cc
@@ -63,6 +63,118 @@ TEST_F(TextIndexSchemaTest, ConcurrentCommitKeyData) {
   EXPECT_EQ(schema->GetNumUniqueTerms(), 7);
 }
 
+TEST_F(TextIndexSchemaTest, CommitKeyDataReturnsDocLen) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // With with_offsets=false, all tokens get position 0.
+  // "hello world hello" has 2 unique tokens -> doc_len = 2
+  // (duplicate "hello" merges into same position entry)
+  auto key = StringInternStore::Intern("doc1");
+  auto result =
+      schema->StageAttributeData(key, "hello world hello", 0, false, false);
+  ASSERT_TRUE(result.ok());
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 2);
+  EXPECT_EQ(commit.norm, 1);  // Each unique token appears once (position 0)
+}
+
+TEST_F(TextIndexSchemaTest, CommitKeyDataReturnsZeroForEmptyStage) {
+  auto schema = CreateSchema();
+
+  // CommitKeyData without staging returns 0
+  auto key = StringInternStore::Intern("no_data");
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 0);
+  EXPECT_EQ(commit.norm, 0);
+}
+
+TEST_F(TextIndexSchemaTest, TotalDocLenAccumulatesAcrossDocuments) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // doc1: "hello world" -> 2 terms
+  auto key1 = StringInternStore::Intern("doc1");
+  auto r1 = schema->StageAttributeData(key1, "hello world", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+  schema->CommitKeyData(key1);
+
+  // doc2: "foo bar baz" -> 3 terms
+  auto key2 = StringInternStore::Intern("doc2");
+  auto r2 = schema->StageAttributeData(key2, "foo bar baz", 0, false, false);
+  ASSERT_TRUE(r2.ok());
+  schema->CommitKeyData(key2);
+
+  // total_doc_len should be 2 + 3 = 5
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 5);
+}
+
+TEST_F(TextIndexSchemaTest, TotalDocLenDecrementsOnDelete) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // doc1: "hello world foo" -> 3 terms
+  auto key1 = StringInternStore::Intern("doc1");
+  auto r1 =
+      schema->StageAttributeData(key1, "hello world foo", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+  uint32_t doc_len = schema->CommitKeyData(key1).doc_len;
+  EXPECT_EQ(doc_len, 3);
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 3);
+
+  // DeleteKeyData decrements total_doc_len internally
+  schema->DeleteKeyData(key1);
+  EXPECT_EQ(schema->GetMetadata().total_doc_len.load(), 0);
+}
+
+TEST_F(TextIndexSchemaTest, DocLenWithMultipleFields) {
+  auto schema = CreateSchema();
+  data_model::TextIndex proto;
+
+  // Create two Text instances to allocate field numbers 0 and 1
+  auto text1 = std::make_shared<Text>(proto, schema);
+  auto text2 = std::make_shared<Text>(proto, schema);
+
+  auto key = StringInternStore::Intern("doc1");
+
+  // Field 0: "hello world" -> 2 terms
+  auto r1 = schema->StageAttributeData(key, "hello world", 0, false, false);
+  ASSERT_TRUE(r1.ok());
+
+  // Field 1: "foo bar baz" -> 3 terms
+  auto r2 = schema->StageAttributeData(key, "foo bar baz", 1, false, false);
+  ASSERT_TRUE(r2.ok());
+
+  // doc_len should be total across both fields = 5
+  auto commit = schema->CommitKeyData(key);
+  EXPECT_EQ(commit.doc_len, 5);
+  // norm = max token freq; each token appears once per field = 1
+  EXPECT_EQ(commit.norm, 1);
+}
+
+TEST_F(TextIndexSchemaTest, NormReflectsMaxTermFrequency) {
+  // with_offsets=true so duplicate tokens get distinct positions
+  std::vector<std::string> empty_stop_words;
+  auto schema = std::make_shared<TextIndexSchema>(
+      data_model::LANGUAGE_ENGLISH, " \t\n\r!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~",
+      true, empty_stop_words, 4);
+  data_model::TextIndex proto;
+  auto text = std::make_shared<Text>(proto, schema);
+
+  // "hello hello hello world" -> "hello" appears 3 times, "world" 1 time
+  auto key = StringInternStore::Intern("doc1");
+  auto r = schema->StageAttributeData(key, "hello hello hello world", 0, false,
+                                      false);
+  ASSERT_TRUE(r.ok());
+  auto commit = schema->CommitKeyData(key);
+  // doc_len = 4 (total tokens), norm = 3 (max freq is "hello" with 3)
+  EXPECT_EQ(commit.doc_len, 4);
+  EXPECT_EQ(commit.norm, 3);
+}
+
 TEST_F(TextIndexSchemaTest, FieldAllocationAcrossMultipleTexts) {
   // Test that TextIndexSchema properly manages field number allocation
   // across multiple Text instances - this is the key schema responsibility


### PR DESCRIPTION
 **Pre-compute for text scoring**
  - Precomputes and stores per-document length / norm on `TextIndexSchema`
    (moved out of `IndexKeyInfo`) so scoring avoids recomputation at query time.
  - Precomputes IDF and fixes a data race in the precompute path.