### PR TITLE
Initial commit for QMA for weight parameter

### DIFF
--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -903,6 +903,72 @@ FilterParser::ParseTextTokens(
   return pred;
 }
 
+// Parses a QMA block. Expects the parser position to be after `=> {`.
+// Parses `$weight:` followed by a positive float, expects closing `}`.
+// Returns the weight value on success.
+absl::StatusOr<double> FilterParser::ParseQMABlock() {
+  SkipWhitespace();
+  // Parse attribute name starting with $
+  if (!Match('$')) {
+    if (IsEnd() || Peek() == '}') {
+      return absl::InvalidArgumentError("Missing value for $weight attribute");
+    }
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unexpected character in QMA block at position ", pos_ + 1,
+                     ": expected '$'"));
+  }
+  // Parse the attribute name
+  std::string attr_name;
+  while (!IsEnd() && Peek() != ':' && !std::isspace(Peek()) && Peek() != '}') {
+    attr_name += expression_[pos_++];
+  }
+  // Only $weight is supported
+  if (attr_name != "weight") {
+    return absl::InvalidArgumentError(
+        absl::StrCat("Unsupported QMA attribute: `$", attr_name, "`"));
+  }
+  // Expect colon after attribute name
+  if (!Match(':')) {
+    return absl::InvalidArgumentError("Missing value for $weight attribute");
+  }
+  SkipWhitespace();
+  // Parse the weight value
+  if (IsEnd() || Peek() == ';' || Peek() == '}') {
+    return absl::InvalidArgumentError("Missing value for $weight attribute");
+  }
+  // Parse the number manually to handle positive-only constraint
+  std::string number_str;
+  bool has_negative = false;
+  if (!IsEnd() && Peek() == '-') {
+    has_negative = true;
+    number_str += expression_[pos_++];
+  }
+  while (!IsEnd() && (std::isdigit(Peek()) || Peek() == '.')) {
+    number_str += expression_[pos_++];
+  }
+  double value;
+  if (number_str.empty() || (has_negative && number_str.size() == 1)) {
+    return absl::InvalidArgumentError(
+        "Invalid weight value: expected a positive number");
+  }
+  if (!absl::SimpleAtod(number_str, &value)) {
+    return absl::InvalidArgumentError(
+        "Invalid weight value: expected a positive number");
+  }
+  if (value <= 0.0) {
+    return absl::InvalidArgumentError("Weight must be a positive number");
+  }
+  SkipWhitespace();
+  // Consume optional semicolon
+  Match(';');
+  SkipWhitespace();
+  // Expect closing brace
+  if (!Match('}')) {
+    return absl::InvalidArgumentError("Missing closing '}' in QMA block");
+  }
+  return value;
+}
+
 // Parsing rules:
 // 1. Predicate evaluation is done with left-associative grouping while the OR
 // operator has lower precedence than the AND operator. precedence. For
@@ -961,6 +1027,30 @@ absl::StatusOr<FilterParser::ParseResult> FilterParser::ParseExpression(
       if (!predicate) {
         return absl::InvalidArgumentError(
             absl::StrCat("Empty brackets detected at Position: ", pos_ - 1));
+      }
+      // Check for QMA block: => { ... } after closing )
+      {
+        SkipWhitespace();
+        size_t saved_pos = pos_;
+        if (!IsEnd() && pos_ + 1 < expression_.size() &&
+            expression_[pos_] == '=' && expression_[pos_ + 1] == '>') {
+          // Look ahead past => and optional whitespace for {
+          size_t lookahead = pos_ + 2;
+          while (lookahead < expression_.size() &&
+                 std::isspace(expression_[lookahead])) {
+            lookahead++;
+          }
+          if (lookahead < expression_.size() && expression_[lookahead] == '{') {
+            // This is a QMA block, consume => and { then parse
+            pos_ = lookahead + 1;
+            VMSDK_ASSIGN_OR_RETURN(auto weight, ParseQMABlock());
+            predicate->SetWeight(static_cast<float>(weight));
+          } else {
+            // Not a QMA block (could be => [ which is vector delimiter,
+            // but that should have been handled upstream). Restore position.
+            pos_ = saved_pos;
+          }
+        }
       }
       if (result.prev_predicate) {
         node_count_++;

--- a/src/commands/filter_parser.h
+++ b/src/commands/filter_parser.h
@@ -142,6 +142,8 @@ class FilterParser {
       bool not_rightmost_bracket);
   void FlagNestedComposedPredicate(
       std::unique_ptr<query::Predicate>& predicate);
+  // Parses a QMA block after `=> {`. Returns the weight value on success.
+  absl::StatusOr<double> ParseQMABlock();
 };
 
 // Helper function to print predicate tree structure using DFS

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -51,6 +51,7 @@ std::vector<char> NormalizeEmbedding(absl::string_view record, size_t type_size,
 struct BorrowedNeighbor {
   BorrowedInternedStringPtr key;
   float distance;
+  float score;
 };
 static_assert(std::is_trivially_destructible_v<BorrowedNeighbor>,
               "BorrowedNeighbor must be trivially destructible");
@@ -58,11 +59,17 @@ static_assert(std::is_trivially_destructible_v<BorrowedNeighbor>,
 struct Neighbor {
   InternedStringPtr external_id;
   float distance;
+  float score{0.0f};
   uint64_t sequence_number;
   std::optional<RecordsMap> attribute_contents;
   Neighbor() : distance(0.0f), sequence_number(0) {}
   Neighbor(const InternedStringPtr& external_id, float distance)
       : external_id(external_id), distance(distance), sequence_number(0) {}
+  Neighbor(const InternedStringPtr& external_id, float distance, float score)
+      : external_id(external_id),
+        distance(distance),
+        score(score),
+        sequence_number(0) {}
   Neighbor(const InternedStringPtr& external_id, float distance,
            std::optional<RecordsMap>&& attribute_contents)
       : external_id(external_id),
@@ -72,12 +79,14 @@ struct Neighbor {
   Neighbor(Neighbor&& other) noexcept
       : external_id(std::move(other.external_id)),
         distance(other.distance),
+        score(other.score),
         sequence_number(other.sequence_number),
         attribute_contents(std::move(other.attribute_contents)) {}
   Neighbor& operator=(Neighbor&& other) noexcept {
     if (this != &other) {
       external_id = std::move(other.external_id);
       distance = other.distance;
+      score = other.score;
       sequence_number = other.sequence_number;
       attribute_contents = std::move(other.attribute_contents);
     }

--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -105,9 +105,12 @@ class Predicate {
   virtual EvaluationResult Evaluate(Evaluator& evaluator) const = 0;
   virtual ~Predicate() = default;
   PredicateType GetType() const { return type_; }
+  float GetWeight() const { return weight_; }
+  void SetWeight(float weight) { weight_ = weight; }
 
  private:
   PredicateType type_;
+  float weight_{1.0f};
 };
 
 class NegatePredicate : public Predicate {

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -604,6 +604,42 @@ absl::StatusOr<std::vector<indexes::Neighbor>> MaybeAddIndexedContent(
   return results;
 }
 
+// Computes the weighted score for a predicate tree where the document is known
+// to match. For AND predicates, all children match so we sum their weighted
+// contributions. For OR predicates, we use the predicate's own weight (since we
+// don't know which branch matched without re-evaluation). For leaf predicates,
+// the contribution is 1.0 * weight.
+float ComputeMatchedPredicateScore(const Predicate *predicate) {
+  if (!predicate) {
+    return 0.0f;
+  }
+  switch (predicate->GetType()) {
+    case PredicateType::kComposedAnd: {
+      auto composed = dynamic_cast<const ComposedPredicate *>(predicate);
+      float score = 0.0f;
+      for (const auto &child : composed->GetChildren()) {
+        score += ComputeMatchedPredicateScore(child.get());
+      }
+      // Apply the composed predicate's own weight as a multiplier
+      return score * predicate->GetWeight();
+    }
+    case PredicateType::kComposedOr: {
+      // Use the predicate's own weight as the contribution
+      return 1.0f * predicate->GetWeight();
+    }
+    case PredicateType::kNegate: {
+      // Negation is a filter, not a scoring clause.
+      return 0.0f;
+    }
+    case PredicateType::kTag:
+    case PredicateType::kNumeric:
+    case PredicateType::kText:
+      return 1.0f * predicate->GetWeight();
+    default:
+      return 0.0f;
+  }
+}
+
 absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
     const SearchParameters &parameters) {
   std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> entries_fetchers;
@@ -619,6 +655,14 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
         entries_fetchers, false);
   }
 
+  // Compute the weighted score for matching documents
+  float weighted_score = 0.0f;
+  if (!parameters.filter_parse_results.is_match_all &&
+      parameters.filter_parse_results.root_predicate) {
+    weighted_score = ComputeMatchedPredicateScore(
+        parameters.filter_parse_results.root_predicate.get());
+  }
+
   // Get the config for maximum number of keys to accumulate before content
   // fetching
   const size_t max_keys = static_cast<size_t>(
@@ -627,14 +671,14 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
   borrowed.reserve(std::min(qualified_entries, static_cast<size_t>(5000)));
   bool fetch_limited = false;
   auto results_appender =
-      [&borrowed, &parameters, max_keys, &fetch_limited](
+      [&borrowed, &parameters, max_keys, &fetch_limited, weighted_score](
           const InternedStringPtr &key,
           absl::flat_hash_set<const char *> &top_keys) -> bool {
     if (borrowed.size() >= max_keys) {
       fetch_limited = true;
       return false;
     }
-    borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f});
+    borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f, weighted_score});
     return true;
   };
   // Cannot skip evaluation if the query contains unsolved composed operations.
@@ -667,7 +711,8 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
           nonvector_results_fetched_limited_count.Increment();
           break;
         }
-        borrowed.push_back({BorrowedInternedStringPtr(key), 0.0f});
+        borrowed.push_back(
+            {BorrowedInternedStringPtr(key), 0.0f, weighted_score});
         iterator->Next();
         if (parameters.cancellation_token->IsCancelled()) {
           break;
@@ -772,7 +817,7 @@ SearchResult::SearchResult(size_t total_count,
   // Materialize only the survivors into owning Neighbor vector.
   neighbors.reserve(borrowed.size());
   for (auto &b : borrowed) {
-    neighbors.emplace_back(b.key.Materialize(), b.distance);
+    neighbors.emplace_back(b.key.Materialize(), b.distance, b.score);
   }
 }
 
@@ -1063,6 +1108,28 @@ absl::Status ParseKNN(query::SearchParameters &parameters,
 }
 
 //
+// Scans for the vector filter delimiter `=>` that is followed by `[` (after
+// optional whitespace). This distinguishes the vector KNN delimiter from QMA
+// blocks which use `=> {`.
+//
+size_t FindVectorDelimiter(absl::string_view expr) {
+  size_t pos = 0;
+  while ((pos = expr.find(kVectorFilterDelimiter, pos)) !=
+         absl::string_view::npos) {
+    // Skip whitespace after =>
+    size_t after = pos + kVectorFilterDelimiter.size();
+    while (after < expr.size() && std::isspace(expr[after])) {
+      after++;
+    }
+    if (after < expr.size() && expr[after] == '[') {
+      return pos;  // This is the vector delimiter
+    }
+    pos += kVectorFilterDelimiter.size();  // Continue searching
+  }
+  return absl::string_view::npos;  // No vector delimiter found
+}
+
+//
 // We don't have values for the $ substitution yet. so we break the parsing into
 // two pieces
 //
@@ -1077,7 +1144,7 @@ absl::Status query::SearchParameters::PreParseQueryString() {
   VMSDK_LOG(DEBUG, nullptr)
       << "Query: '" << vmsdk::config::RedactIfNeeded(parse_vars.query_string)
       << "'";
-  auto pos = filter_expression.find(kVectorFilterDelimiter);
+  auto pos = FindVectorDelimiter(filter_expression);
   absl::string_view pre_filter;
   absl::string_view vector_filter;
   // If the delimiter is not found (ie - non vector query), treat the whole

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -345,5 +345,14 @@ bool QueryHasTextPredicate(const SearchParameters& parameters);
 // Check if no results should be returned based on limit parameters
 bool ShouldReturnNoResults(const SearchParameters& parameters);
 
+// Scans for the vector filter delimiter `=>` that is followed by `[` (after
+// optional whitespace). Returns the position of `=>` or npos if not found.
+// Exposed for testing.
+size_t FindVectorDelimiter(absl::string_view expr);
+
+// Computes the weighted score for a predicate tree where the document is known
+// to match. Exposed for testing.
+float ComputeMatchedPredicateScore(const Predicate* predicate);
+
 }  // namespace valkey_search::query
 #endif  // VALKEYSEARCH_SRC_QUERY_SEARCH_H_

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -58,7 +58,8 @@ set(COMMANDS_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/ft_info_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/ft_create_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/commands/ft_internal_update_test.cc
-    ${CMAKE_CURRENT_LIST_DIR}/filter_test.cc)
+    ${CMAKE_CURRENT_LIST_DIR}/filter_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/qma_weight_parser_test.cc)
 
 add_executable(commands_test ${COMMANDS_TEST_SOURCES})
 target_include_directories(commands_test PUBLIC ${CMAKE_CURRENT_LIST_DIR})
@@ -112,6 +113,8 @@ finalize_test_flags(core_test)
 # 1. Query Test Suite - consolidates query and search related tests
 set(QUERY_TEST_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/search_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/find_vector_delimiter_test.cc
+    ${CMAKE_CURRENT_LIST_DIR}/weight_score_test.cc
     ${CMAKE_CURRENT_LIST_DIR}/query/response_generator_test.cc)
 
 add_executable(query_test ${QUERY_TEST_SOURCES})

--- a/testing/find_vector_delimiter_test.cc
+++ b/testing/find_vector_delimiter_test.cc
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include <cstddef>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "gtest/gtest.h"
+#include "src/query/search.h"
+
+namespace valkey_search {
+namespace {
+
+using testing::TestParamInfo;
+using testing::ValuesIn;
+
+struct FindVectorDelimiterTestCase {
+  std::string test_name;
+  std::string query;
+  bool should_find{false};
+  // If should_find is true, the character after => should be '['.
+};
+
+class FindVectorDelimiterTest
+    : public testing::TestWithParam<FindVectorDelimiterTestCase> {};
+
+TEST_P(FindVectorDelimiterTest, Disambiguate) {
+  const auto &test_case = GetParam();
+  size_t pos = query::FindVectorDelimiter(test_case.query);
+
+  if (!test_case.should_find) {
+    EXPECT_EQ(pos, absl::string_view::npos)
+        << "Should not find vector delimiter in: " << test_case.query;
+    return;
+  }
+
+  ASSERT_NE(pos, absl::string_view::npos)
+      << "Failed to find vector delimiter in: " << test_case.query;
+  EXPECT_EQ(test_case.query.substr(pos, 2), "=>");
+  // After => and optional whitespace, next char should be '['
+  size_t after = pos + 2;
+  while (after < test_case.query.size() &&
+         std::isspace(test_case.query[after])) {
+    after++;
+  }
+  ASSERT_LT(after, test_case.query.size());
+  EXPECT_EQ(test_case.query[after], '[');
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    FindVectorDelimiterTests, FindVectorDelimiterTest,
+    ValuesIn<FindVectorDelimiterTestCase>({
+        // Property 3: => followed by [ is identified as vector delimiter
+        {
+            .test_name = "vector_delimiter_no_whitespace",
+            .query = "(@title:dogs)=>[KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        {
+            .test_name = "vector_delimiter_one_space",
+            .query = "(@title:dogs)=> [KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        {
+            .test_name = "vector_delimiter_multiple_spaces",
+            .query = "(@title:dogs)=>   [KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        {
+            .test_name = "vector_delimiter_with_complex_prefilter",
+            .query = "(@price:[10 100] @tag:{electronics})=>[KNN 5 @vec $B]",
+            .should_find = true,
+        },
+        {
+            .test_name = "vector_delimiter_wildcard_prefilter",
+            .query = "*=>[KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        // Property 3: => followed by { is NOT a vector delimiter
+        {
+            .test_name = "qma_block_not_vector_delimiter",
+            .query = "(@title:{dogs}) => { $weight: 2.0; }",
+            .should_find = false,
+        },
+        {
+            .test_name = "qma_block_no_whitespace",
+            .query = "(@title:{dogs})=>{ $weight: 5.0; }",
+            .should_find = false,
+        },
+        {
+            .test_name = "qma_block_multiple_spaces",
+            .query = "(@title:{dogs})=>   { $weight: 1.5; }",
+            .should_find = false,
+        },
+        {
+            .test_name = "qma_only_no_vector",
+            .query = "(@body:cats) => { $weight: 3.0; } (@title:{dogs})",
+            .should_find = false,
+        },
+        // Property 3: Multiple => - only the one followed by [ is found
+        {
+            .test_name = "qma_then_vector",
+            .query =
+                "(@title:{dogs}) => { $weight: 2.0; } =>[KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        {
+            .test_name = "qma_then_vector_with_spaces",
+            .query = "(@title:{dogs})=> { $weight: 2.0; } => [KNN 10 @vec "
+                     "$BLOB]",
+            .should_find = true,
+        },
+        // Property 4: Mixed QMA and vector - split is correct
+        {
+            .test_name = "multiple_qma_then_vector",
+            .query = "(@title:dogs)=> { $weight: 2.0; } (@body:cats)=> { "
+                     "$weight: 3.0; } =>[KNN 10 @vec $BLOB]",
+            .should_find = true,
+        },
+        {
+            .test_name = "complex_mixed_query",
+            .query = "(@price:[1 100]) => { $weight: 5.0; } (@tag:{foo} | "
+                     "@tag:{bar}) => { $weight: 1.5; } => [KNN 20 @vec $BLOB]",
+            .should_find = true,
+        },
+        // Edge cases
+        {
+            .test_name = "no_arrow_at_all",
+            .query = "(@title:{dogs}) (@body:cats)",
+            .should_find = false,
+        },
+        {
+            .test_name = "arrow_followed_by_text",
+            .query = "(@title:{dogs}) => something",
+            .should_find = false,
+        },
+        {
+            .test_name = "empty_query",
+            .query = "",
+            .should_find = false,
+        },
+    }),
+    [](const TestParamInfo<FindVectorDelimiterTestCase> &info) {
+      return info.param.test_name;
+    });
+
+// Verify the split position puts QMA in pre-filter
+TEST(FindVectorDelimiterSplitTest, QMABlockRemainsInPreFilter) {
+  std::string query =
+      "(@title:{dogs}) => { $weight: 5.0; } =>[KNN 10 @vec $BLOB]";
+  size_t pos = query::FindVectorDelimiter(query);
+  ASSERT_NE(pos, absl::string_view::npos);
+
+  absl::string_view before_split = absl::string_view(query).substr(0, pos);
+  absl::string_view after_split = absl::string_view(query).substr(pos + 2);
+
+  // Pre-filter should contain the QMA block
+  EXPECT_NE(before_split.find("$weight"), absl::string_view::npos);
+  EXPECT_NE(before_split.find('{'), absl::string_view::npos);
+  // Vector portion should contain [KNN
+  EXPECT_NE(after_split.find("[KNN"), absl::string_view::npos);
+}
+
+TEST(FindVectorDelimiterSplitTest, MultipleQMABlocksInPreFilter) {
+  std::string query =
+      "(@title:dogs)=> { $weight: 2.0; } (@body:cats)=> { $weight: 3.0; } "
+      "=> [KNN 10 @vec $BLOB]";
+  size_t pos = query::FindVectorDelimiter(query);
+  ASSERT_NE(pos, absl::string_view::npos);
+
+  absl::string_view before_split = absl::string_view(query).substr(0, pos);
+
+  // Count => occurrences in pre-filter - should be 2 (the QMA ones)
+  size_t arrow_count = 0;
+  size_t search_pos = 0;
+  while ((search_pos = before_split.find("=>", search_pos)) !=
+         absl::string_view::npos) {
+    arrow_count++;
+    search_pos += 2;
+  }
+  EXPECT_EQ(arrow_count, 2u);
+}
+
+}  // namespace
+}  // namespace valkey_search

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -715,10 +715,11 @@ INSTANTIATE_TEST_SUITE_P(
             .test_name = "invalid_vector_parameters_1",
             .success = false,
             .params_str = " PARAMS 2",
+            // `=>ss[` is not a vector delimiter (non-whitespace between => and
+            // [), so the whole string is treated as a pre-filter expression,
+            // which fails to parse.
             .filter_str = "(*)=>ss[KNN 10 @vec $BLOB]",
-            .expected_error_message =
-                "Error parsing vector similarity parameters: `ss[KNN 10 @vec "
-                "$BLOB]`. Expecting '[' got 's'",
+            .expected_error_message = "Invalid filter expression:",
         },
         {
             .test_name = "invalid_vector_parameters_2",

--- a/testing/qma_weight_parser_test.cc
+++ b/testing/qma_weight_parser_test.cc
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include <memory>
+#include <string>
+
+#include "absl/strings/string_view.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "src/commands/filter_parser.h"
+#include "src/index_schema.pb.h"
+#include "src/indexes/numeric.h"
+#include "src/indexes/tag.h"
+#include "src/indexes/text.h"
+#include "src/query/predicate.h"
+#include "src/utils/string_interning.h"
+#include "testing/common.h"
+
+namespace valkey_search {
+namespace {
+
+using testing::TestParamInfo;
+using testing::ValuesIn;
+
+void InitQMATestIndexSchema(MockIndexSchema *index_schema) {
+  data_model::TagIndex tag_index_proto;
+  tag_index_proto.set_separator(",");
+  tag_index_proto.set_case_sensitive(true);
+  auto tag_index =
+      std::make_shared<IndexTeser<indexes::Tag, data_model::TagIndex>>(
+          tag_index_proto);
+  VMSDK_EXPECT_OK(tag_index->AddRecord("key1", "dogs"));
+  VMSDK_EXPECT_OK(index_schema->AddIndex("title", "title", tag_index));
+
+  data_model::NumericIndex numeric_index_proto;
+  auto numeric_index =
+      std::make_shared<IndexTeser<indexes::Numeric, data_model::NumericIndex>>(
+          numeric_index_proto);
+  VMSDK_EXPECT_OK(numeric_index->AddRecord("key1", "50"));
+  VMSDK_EXPECT_OK(index_schema->AddIndex("price", "price", numeric_index));
+
+  index_schema->CreateTextIndexSchema();
+  auto text_index_schema = index_schema->GetTextIndexSchema();
+  data_model::TextIndex text_index_proto =
+      CreateTextIndexProto(true, false, 1.0);
+  auto text_index =
+      std::make_shared<indexes::Text>(text_index_proto, text_index_schema);
+  VMSDK_EXPECT_OK(index_schema->AddIndex("body", "body", text_index));
+
+  auto key1 = StringInternStore::Intern("key1");
+  std::string test_data = "dogs cats hello world";
+  VMSDK_EXPECT_OK(text_index->AddRecord(key1, test_data));
+  text_index_schema->CommitKeyData(key1);
+}
+
+struct QMAParserTestCase {
+  std::string test_name;
+  std::string filter;
+  bool parse_success{false};
+  std::string expected_error_substr;
+  // Expected weight on root predicate (only checked if parse_success)
+  float expected_weight{1.0f};
+  // For multi-clause tests: expected weights on children
+  bool check_children{false};
+  size_t expected_child_count{0};
+  float expected_child_weight_0{1.0f};
+  float expected_child_weight_1{1.0f};
+};
+
+class QMAWeightParserTest
+    : public ValkeySearchTestWithParam<QMAParserTestCase> {};
+
+TEST_P(QMAWeightParserTest, ParseQMA) {
+  const auto &test_case = GetParam();
+  auto index_schema = CreateIndexSchema("qma_parser_test").value();
+  InitQMATestIndexSchema(index_schema.get());
+  EXPECT_CALL(*index_schema, GetIdentifier(::testing::_))
+      .Times(::testing::AnyNumber());
+
+  TextParsingOptions options{};
+  FilterParser parser(*index_schema, test_case.filter, options);
+  auto result = parser.Parse();
+
+  EXPECT_EQ(test_case.parse_success, result.ok())
+      << "Filter: " << test_case.filter << " Error: "
+      << (result.ok() ? "" : std::string(result.status().message()));
+
+  if (!test_case.parse_success) {
+    if (!test_case.expected_error_substr.empty()) {
+      EXPECT_THAT(std::string(result.status().message()),
+                  ::testing::HasSubstr(test_case.expected_error_substr))
+          << "Filter: " << test_case.filter;
+    }
+    return;
+  }
+
+  ASSERT_NE(result.value().root_predicate, nullptr);
+
+  if (test_case.check_children) {
+    auto *root = result.value().root_predicate.get();
+    ASSERT_EQ(root->GetType(), query::PredicateType::kComposedAnd);
+    auto *composed = dynamic_cast<query::ComposedPredicate *>(root);
+    ASSERT_NE(composed, nullptr);
+    ASSERT_EQ(composed->GetChildCount(), test_case.expected_child_count);
+    EXPECT_NEAR(composed->GetChildren()[0]->GetWeight(),
+                test_case.expected_child_weight_0, 0.01f);
+    EXPECT_NEAR(composed->GetChildren()[1]->GetWeight(),
+                test_case.expected_child_weight_1, 0.01f);
+  } else {
+    EXPECT_NEAR(result.value().root_predicate->GetWeight(),
+                test_case.expected_weight, 0.01f)
+        << "Filter: " << test_case.filter;
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    QMAWeightParserTests, QMAWeightParserTest,
+    ValuesIn<QMAParserTestCase>({
+        // Property 1: QMA block parsing extracts correct weight
+        {
+            .test_name = "weight_integer",
+            .filter = "(@title:{dogs}) => { $weight: 2; }",
+            .parse_success = true,
+            .expected_weight = 2.0f,
+        },
+        {
+            .test_name = "weight_small_float",
+            .filter = "(@title:{dogs}) => { $weight: 0.01; }",
+            .parse_success = true,
+            .expected_weight = 0.01f,
+        },
+        {
+            .test_name = "weight_large_float",
+            .filter = "(@title:{dogs}) => { $weight: 99.9; }",
+            .parse_success = true,
+            .expected_weight = 99.9f,
+        },
+        {
+            .test_name = "weight_no_semicolon",
+            .filter = "(@title:{dogs}) => { $weight: 5.0 }",
+            .parse_success = true,
+            .expected_weight = 5.0f,
+        },
+        // OR clause with QMA weight
+        {
+            .test_name = "or_clause_with_weight",
+            .filter = "(@title:{dogs} | @body:cats) => { $weight: 6.0; }",
+            .parse_success = true,
+            .expected_weight = 6.0f,
+        },
+        // Numeric predicate with weight
+        {
+            .test_name = "numeric_with_weight",
+            .filter = "(@price:[10 100]) => { $weight: 2.5; }",
+            .parse_success = true,
+            .expected_weight = 2.5f,
+        },
+        // Multiple clauses each with their own weight (nested composition)
+        {
+            .test_name = "two_clauses_each_with_weight",
+            .filter = "(@title:{dogs}) => { $weight: 3.0; } "
+                      "(@price:[10 100]) => { $weight: 8.0; }",
+            .parse_success = true,
+            .check_children = true,
+            .expected_child_count = 2,
+            .expected_child_weight_0 = 3.0f,
+            .expected_child_weight_1 = 8.0f,
+        },
+        // Unrecognized QMA attributes are rejected
+        {
+            .test_name = "unrecognized_attr_word",
+            .filter = "(@title:{dogs}) => { $none: 2.0; }",
+            .parse_success = false,
+            .expected_error_substr = "Unsupported QMA attribute",
+        },
+        {
+            .test_name = "unrecognized_attr_number",
+            .filter = "(@title:{dogs}) => { $1234: 1.0; }",
+            .parse_success = false,
+            .expected_error_substr = "Unsupported QMA attribute",
+        },
+        // Invalid weight values are rejected
+        {
+            .test_name = "weight_zero",
+            .filter = "(@title:{dogs}) => { $weight: 0; }",
+            .parse_success = false,
+            .expected_error_substr = "positive",
+        },
+        {
+            .test_name = "weight_negative",
+            .filter = "(@title:{dogs}) => { $weight: -1.0; }",
+            .parse_success = false,
+        },
+        {
+            .test_name = "weight_non_numeric_abc",
+            .filter = "(@title:{dogs}) => { $weight: abc; }",
+            .parse_success = false,
+        },
+        {
+            .test_name = "weight_non_numeric_true",
+            .filter = "(@title:{dogs}) => { $weight: true; }",
+            .parse_success = false,
+        },
+        {
+            .test_name = "weight_non_numeric_nan",
+            .filter = "(@title:{dogs}) => { $weight: NaN; }",
+            .parse_success = false,
+        },
+        {
+            .test_name = "weight_missing_value_semicolon",
+            .filter = "(@title:{dogs}) => { $weight: ; }",
+            .parse_success = false,
+        },
+        {
+            .test_name = "weight_missing_value_brace",
+            .filter = "(@title:{dogs}) => { $weight: }",
+            .parse_success = false,
+        },
+        // Malformed QMA block
+        {
+            .test_name = "missing_closing_brace",
+            .filter = "(@title:{dogs}) => { $weight: 2.0; ",
+            .parse_success = false,
+        },
+    }),
+    [](const TestParamInfo<QMAParserTestCase> &info) {
+      return info.param.test_name;
+    });
+
+}  // namespace
+}  // namespace valkey_search

--- a/testing/weight_score_test.cc
+++ b/testing/weight_score_test.cc
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2025, valkey-search contributors
+ * All rights reserved.
+ * SPDX-License-Identifier: BSD 3-Clause
+ *
+ */
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "src/query/predicate.h"
+#include "src/query/search.h"
+
+namespace valkey_search {
+
+namespace {
+
+using testing::TestParamInfo;
+using testing::ValuesIn;
+
+using query::ComposedPredicate;
+using query::ComputeMatchedPredicateScore;
+using query::LogicalOperator;
+using query::NegatePredicate;
+using query::Predicate;
+using query::PredicateType;
+
+// Concrete minimal predicate for testing score computation
+class ScoreTestPredicate : public Predicate {
+ public:
+  explicit ScoreTestPredicate(PredicateType type) : Predicate(type) {}
+  query::EvaluationResult Evaluate(
+      query::Evaluator & /*evaluator*/) const override {
+    return query::EvaluationResult(true);
+  }
+};
+
+struct LeafScoreTestCase {
+  std::string test_name;
+  PredicateType type;
+  float weight;
+  float expected_score;
+};
+
+class LeafScoreTest : public testing::TestWithParam<LeafScoreTestCase> {};
+
+TEST_P(LeafScoreTest, ScoreEqualsWeight) {
+  const auto &test_case = GetParam();
+  auto pred = std::make_unique<ScoreTestPredicate>(test_case.type);
+  pred->SetWeight(test_case.weight);
+  float score = ComputeMatchedPredicateScore(pred.get());
+  EXPECT_FLOAT_EQ(score, test_case.expected_score);
+}
+
+INSTANTIATE_TEST_SUITE_P(LeafScoreTests, LeafScoreTest,
+                         ValuesIn<LeafScoreTestCase>({
+                             {
+                                 .test_name = "tag_default_weight",
+                                 .type = PredicateType::kTag,
+                                 .weight = 1.0f,
+                                 .expected_score = 1.0f,
+                             },
+                             {
+                                 .test_name = "numeric_weight_2_5",
+                                 .type = PredicateType::kNumeric,
+                                 .weight = 2.5f,
+                                 .expected_score = 2.5f,
+                             },
+                             {
+                                 .test_name = "text_weight_0_1",
+                                 .type = PredicateType::kText,
+                                 .weight = 0.1f,
+                                 .expected_score = 0.1f,
+                             },
+                             {
+                                 .test_name = "text_weight_100",
+                                 .type = PredicateType::kText,
+                                 .weight = 100.0f,
+                                 .expected_score = 100.0f,
+                             },
+                         }),
+                         [](const TestParamInfo<LeafScoreTestCase> &info) {
+                           return info.param.test_name;
+                         });
+
+TEST(WeightScoreTest, AndPredicateScoreSumsChildWeights) {
+  std::vector<std::unique_ptr<Predicate>> children;
+  auto child1 = std::make_unique<ScoreTestPredicate>(PredicateType::kTag);
+  child1->SetWeight(2.0f);
+  children.push_back(std::move(child1));
+  auto child2 = std::make_unique<ScoreTestPredicate>(PredicateType::kNumeric);
+  child2->SetWeight(3.0f);
+  children.push_back(std::move(child2));
+
+  auto composed = std::make_unique<ComposedPredicate>(LogicalOperator::kAnd,
+                                                      std::move(children));
+  float score = ComputeMatchedPredicateScore(composed.get());
+  // 2.0 + 3.0 = 5.0, AND weight is default 1.0
+  EXPECT_FLOAT_EQ(score, 5.0f);
+}
+
+TEST(WeightScoreTest, AndPredicateOwnWeightMultipliesSum) {
+  std::vector<std::unique_ptr<Predicate>> children;
+  auto child1 = std::make_unique<ScoreTestPredicate>(PredicateType::kTag);
+  child1->SetWeight(2.0f);
+  children.push_back(std::move(child1));
+  auto child2 = std::make_unique<ScoreTestPredicate>(PredicateType::kNumeric);
+  child2->SetWeight(3.0f);
+  children.push_back(std::move(child2));
+
+  auto composed = std::make_unique<ComposedPredicate>(LogicalOperator::kAnd,
+                                                      std::move(children));
+  composed->SetWeight(4.0f);
+  float score = ComputeMatchedPredicateScore(composed.get());
+  // (2.0 + 3.0) * 4.0 = 20.0
+  EXPECT_FLOAT_EQ(score, 20.0f);
+}
+
+TEST(WeightScoreTest, AndDefaultWeightChildrenSumToCount) {
+  std::vector<std::unique_ptr<Predicate>> children;
+  children.push_back(std::make_unique<ScoreTestPredicate>(PredicateType::kTag));
+  children.push_back(
+      std::make_unique<ScoreTestPredicate>(PredicateType::kNumeric));
+  children.push_back(
+      std::make_unique<ScoreTestPredicate>(PredicateType::kText));
+
+  auto composed = std::make_unique<ComposedPredicate>(LogicalOperator::kAnd,
+                                                      std::move(children));
+  float score = ComputeMatchedPredicateScore(composed.get());
+  // 3 children * 1.0 each = 3.0
+  EXPECT_FLOAT_EQ(score, 3.0f);
+}
+
+TEST(WeightScoreTest, OrPredicateDefaultWeightScoresOne) {
+  std::vector<std::unique_ptr<Predicate>> children;
+  auto child1 = std::make_unique<ScoreTestPredicate>(PredicateType::kTag);
+  child1->SetWeight(50.0f);
+  children.push_back(std::move(child1));
+  auto child2 = std::make_unique<ScoreTestPredicate>(PredicateType::kNumeric);
+  child2->SetWeight(25.0f);
+  children.push_back(std::move(child2));
+
+  auto composed = std::make_unique<ComposedPredicate>(LogicalOperator::kOr,
+                                                      std::move(children));
+  // Default weight 1.0
+  float score = ComputeMatchedPredicateScore(composed.get());
+  EXPECT_FLOAT_EQ(score, 1.0f);
+}
+
+TEST(WeightScoreTest, NestedAndWeightsComposeMultiplicatively) {
+  // Inner AND: (child1=2.0 + child2=3.0) * inner_weight=4.0 = 20.0
+  std::vector<std::unique_ptr<Predicate>> inner_children;
+  auto leaf1 = std::make_unique<ScoreTestPredicate>(PredicateType::kTag);
+  leaf1->SetWeight(2.0f);
+  inner_children.push_back(std::move(leaf1));
+  auto leaf2 = std::make_unique<ScoreTestPredicate>(PredicateType::kNumeric);
+  leaf2->SetWeight(3.0f);
+  inner_children.push_back(std::move(leaf2));
+
+  auto inner_and = std::make_unique<ComposedPredicate>(
+      LogicalOperator::kAnd, std::move(inner_children));
+  inner_and->SetWeight(4.0f);
+
+  // Outer AND: inner_and(20.0) + outer_leaf(5.0) = 25.0
+  std::vector<std::unique_ptr<Predicate>> outer_children;
+  outer_children.push_back(std::move(inner_and));
+  auto outer_leaf = std::make_unique<ScoreTestPredicate>(PredicateType::kText);
+  outer_leaf->SetWeight(5.0f);
+  outer_children.push_back(std::move(outer_leaf));
+
+  auto outer_and = std::make_unique<ComposedPredicate>(
+      LogicalOperator::kAnd, std::move(outer_children));
+  float score = ComputeMatchedPredicateScore(outer_and.get());
+  // (2+3)*4 + 5 = 25.0
+  EXPECT_FLOAT_EQ(score, 25.0f);
+}
+
+TEST(WeightScoreTest, NegateContributesZero) {
+  // Negation is a filter, not a scoring clause: it must contribute 0 even if
+  // a weight was attached, since there is no term occurrence to score.
+  auto inner = std::make_unique<ScoreTestPredicate>(PredicateType::kText);
+  inner->SetWeight(5.0f);
+  auto negate = std::make_unique<NegatePredicate>(std::move(inner));
+  negate->SetWeight(7.0f);
+  float score = ComputeMatchedPredicateScore(negate.get());
+  EXPECT_FLOAT_EQ(score, 0.0f);
+}
+
+TEST(WeightScoreTest, NegateDoesNotInflateEnclosingAnd) {
+  // `hello -world`: the matched text leaf contributes its weight, the negation
+  // contributes nothing, so the AND sum is the leaf weight alone.
+  std::vector<std::unique_ptr<Predicate>> children;
+  auto matched = std::make_unique<ScoreTestPredicate>(PredicateType::kText);
+  matched->SetWeight(3.0f);
+  children.push_back(std::move(matched));
+
+  auto negated_inner =
+      std::make_unique<ScoreTestPredicate>(PredicateType::kTag);
+  negated_inner->SetWeight(9.0f);
+  children.push_back(
+      std::make_unique<NegatePredicate>(std::move(negated_inner)));
+
+  auto composed = std::make_unique<ComposedPredicate>(LogicalOperator::kAnd,
+                                                      std::move(children));
+  float score = ComputeMatchedPredicateScore(composed.get());
+  // 3.0 (text) + 0.0 (negate) = 3.0
+  EXPECT_FLOAT_EQ(score, 3.0f);
+}
+
+}  // namespace
+}  // namespace valkey_search


### PR DESCRIPTION
**QMA weight parameter**
  - Adds per-clause `=>{$weight:N}` query weights, parsed in `filter_parser.cc`
    and applied during query execution in `search.cc`.
  - New parser / weight-score / vector-delimiter test suites.