### PR TITLE
Fix search release trigger on 1.0 branch (valkey-bundle + component payload)

### DIFF
--- a/.github/workflows/trigger-search-release.yml
+++ b/.github/workflows/trigger-search-release.yml
@@ -30,10 +30,10 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.EXTENSION_PAT }}
-          repository: ${{ github.repository_owner }}/valkey-extensions
+          repository: ${{ github.repository_owner }}/valkey-bundle
           event-type: search-release
           client-payload: >
             {
               "version": "${{ steps.determine-vars.outputs.version }}",
-              "module": "search"
+              "component": "search"
             }


### PR DESCRIPTION
## Summary

The 1.0.3 release dispatch to valkey-bundle failed with `KeyError: 'valkey-'` in `update-versions.py` ([failing run](https://github.com/valkey-io/valkey-bundle/actions/runs/29459192222/job/87498923996)).

Root cause: the `1.0` branch's `trigger-search-release.yml` never received the fixes that landed on `1.1`/`1.2`:
- The bundle repo was renamed `valkey-extensions` -> `valkey-bundle`, but the 1.0 workflow still dispatched to `valkey-extensions`.
- The dispatch payload key was renamed `module` -> `component`. The bundle's `update-versions.py` reads `component`; on 1.0 it was sent as `module`, so `component` arrived empty and the module key resolved to `valkey-` (empty component), throwing `KeyError: 'valkey-'`.

This change brings the 1.0 workflow in line with `1.1`/`1.2`:
- `repository`: `valkey-extensions` -> `valkey-bundle`
- payload: `"module": "search"` -> `"component": "search"`

## Note
The `1.1` branch already has the correct workflow, so no fix is needed there.

Ref: #1237
