### PR TITLE
Backport fixes to 1.2

### DIFF
--- a/integration/test_fanout_base.py
+++ b/integration/test_fanout_base.py
@@ -161,9 +161,6 @@ class TestFanout(ValkeySearchClusterTestCase):
         rg = self.get_replication_group(0)
         primary = rg.get_primary_connection()
         assert(primary.info("replication")["role"] == "master")
-
-        # Wait for cluster topology to propagate to all nodes
-        self.wait_for_cluster_setup()
         
         # Set the fanout low utilization threshold
         primary.execute_command("CONFIG", "SET", "search.local-fanout-queue-wait-threshold", threshold)

--- a/integration/test_singleslot.py
+++ b/integration/test_singleslot.py
@@ -88,3 +88,60 @@ class TestSingleSlot(ValkeySearchClusterTestCaseDebugMode):
             assert(requests() == expected_requests)
             assert(rpcs() == expected_rpcs)
             assert result[0] == 10  # number of results
+
+    @pytest.mark.parametrize(
+        "setup_test", [{"replica_count": 1}], indirect=True
+    )
+    def test_single_slot_force_replicas_only(self):
+        """
+        Regression test: single-slot index + ForceReplicasOnly must not crash.
+
+        ForceReplicasOnly sets mode=kOneReplicaPerShard in ComputeSearchTargets.
+        For single-slot indexes this calls GetTargetsForSlot(kOneReplicaPerShard)
+        which previously had no case for that mode → CHECK(false) → SIGABRT.
+
+        Fix: added kOneReplicaPerShard case to GetTargetsForSlot in
+        vmsdk/src/cluster_map.cc.
+        """
+        cluster = self.new_cluster_client()
+        nodes = self.get_all_primary_clients()
+        primary = nodes[0]
+
+        # Create single-slot index
+        primary.execute_command(
+            "FT.CREATE", "idx{shard0}",
+            "PREFIX", "1", "doc:{shard0}",
+            "SCHEMA", "price", "NUMERIC"
+        )
+
+        # Add data
+        for i in range(10):
+            cluster.execute_command(
+                "HSET", f"doc:{{shard0}}:{i}", "price", str(i * 10)
+            )
+
+        # Wait for backfill
+        waiters.wait_for_true(
+            lambda: primary.execute_command(
+                "FT.SEARCH", "idx{shard0}", "@price:[0 100]"
+            )[0] == 10
+        )
+
+        # Verify query works before ForceReplicasOnly (uses kRandom → handled)
+        result = primary.execute_command(
+            "FT.SEARCH", "idx{shard0}", "@price:[0 100]"
+        )
+        assert result[0] == 10
+
+        # Enable ForceReplicasOnly on ALL nodes → mode = kOneReplicaPerShard
+        for n in self.nodes:
+            n.client.execute_command(
+                "ft._debug CONTROLLED_VARIABLE set ForceReplicasOnly yes"
+            )
+
+        # Query with ForceReplicasOnly: validates that single-slot indexes
+        # correctly handle replica-targeted fanout modes in GetTargetsForSlot
+        result = primary.execute_command(
+            "FT.SEARCH", "idx{shard0}", "@price:[0 100]"
+        )
+        assert result[0] == 10

--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -468,6 +468,9 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
             )
             rg.setup_replications_cluster()
         logging.info("Cluster is up and running!")
+
+        # Wait for cluster topology to settle
+        self.wait_for_cluster_topology_to_settle()
         yield
 
         # Cleanup
@@ -546,8 +549,8 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
                 return False
         return True
 
-    def wait_for_cluster_setup(self):
-        """Wait for cluster topology to propagate to all nodes."""
+    def wait_for_cluster_topology_to_settle(self):
+        # Wait for the core's cluster view to sync.
         replica_count = len(self.replication_groups[0].replicas)
         expected_nodes_per_shard = 1 + replica_count
         for node in self.get_nodes():
@@ -555,6 +558,12 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
                 lambda n=node: self._cluster_slots_complete(n.client, expected_nodes_per_shard),
                 timeout=30
             )
+        # Then wait for the search module's cached cluster map to expire and update.
+        # TODO: Replace the sleep with a wait on condition.
+        expiration_ms = int(self.client_for_primary(0).config_get(
+            "search.cluster-map-expiration-ms"
+        )["search.cluster-map-expiration-ms"])
+        time.sleep(expiration_ms / 1000.0)
 
 class ValkeySearchClusterTestCaseDebugMode(ValkeySearchClusterTestCase):
     '''

--- a/vmsdk/src/cluster_map.cc
+++ b/vmsdk/src/cluster_map.cc
@@ -174,6 +174,11 @@ std::vector<NodeInfo> ClusterMap::GetTargetsForSlot(FanoutTargetMode mode,
       } else {
         return {};
       }
+    case FanoutTargetMode::kOneReplicaPerShard:
+      if (!shard->replicas.empty()) {
+        return {shard->GetRandomNode(true, prefer_local)};
+      }
+      return {};
     case FanoutTargetMode::kRandom:
       return {shard->GetRandomNode(false, prefer_local)};
     default:


### PR DESCRIPTION
 | Source PR | Title | Detail |
  |---|---|---|
  | #1226 | Handle kOneReplicaPerShard in GetTargetsForSlot for single-slot indexes |  |
  | #952 | Wait for cluster topology map refresh | |