### PR TITLE
fix hardcoded db_num in metadata_manager.cc

### DIFF
--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -757,8 +757,7 @@ void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
                               .at(kSchemaManagerMetadataTypeName)
                               .entries();
     for (const auto &[name, entry] : entries) {
-      // In cluster mode, only support DB 0 for now
-      uint32_t db_num = 0;
+      uint32_t db_num = ValkeyModule_GetSelectedDb(ctx);
       uint64_t fingerprint = entry.fingerprint();
       uint32_t version = entry.version();
       SchemaManager::Instance().PopulateFingerprintVersionFromMetadata(

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -756,12 +756,12 @@ void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
     const auto &entries = global_metadata->type_namespace_map()
                               .at(kSchemaManagerMetadataTypeName)
                               .entries();
-    for (const auto &[name, entry] : entries) {
-      uint32_t db_num = ValkeyModule_GetSelectedDb(ctx);
+    for (const auto &[id, entry] : entries) {
+      auto obj_name = ObjName::Decode(id);
       uint64_t fingerprint = entry.fingerprint();
       uint32_t version = entry.version();
       SchemaManager::Instance().PopulateFingerprintVersionFromMetadata(
-          db_num, name, fingerprint, version);
+          obj_name.GetDbNum(), obj_name.GetName(), fingerprint, version);
     }
   }
 }

--- a/testing/schema_manager_test.cc
+++ b/testing/schema_manager_test.cc
@@ -356,6 +356,65 @@ TEST_F(SchemaManagerTest, TestLoadIndexNoReplication) {
       SchemaManager::Instance().GetIndexSchema(db_num_, index_name_));
 }
 
+TEST_F(SchemaManagerTest,
+       TestCreateIndexSchemaSetsFingerprintVersionForNonZeroDb) {
+  constexpr uint32_t kDbNum = 5;
+  ON_CALL(*kMockValkeyModule, SelectDb(testing::_, kDbNum))
+      .WillByDefault(testing::Return(VALKEYMODULE_OK));
+
+  coordinator::MetadataManager::InitInstance(std::move(test_metadata_manager_));
+  SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
+      &fake_ctx_, []() {}, nullptr, /*coordinator_enabled=*/true));
+
+  // Normal (non-RDB) path: creating in coordinator mode records the entry and
+  // stamps the schema fingerprint/version via OnMetadataCallback, which decodes
+  // the {db}name entry key so a non-zero DB is handled correctly.
+  auto proto = test_index_schema_proto_;
+  proto.set_db_num(kDbNum);
+  auto created = SchemaManager::Instance().CreateIndexSchema(&fake_ctx_, proto);
+  VMSDK_EXPECT_OK(created);
+
+  auto schema =
+      SchemaManager::Instance().GetIndexSchema(kDbNum, index_name_).value();
+  EXPECT_EQ(schema->GetFingerprint(), created->fingerprint());
+  EXPECT_EQ(schema->GetVersion(), created->version());
+}
+
+TEST_F(SchemaManagerTest,
+       TestOnLoadingEndedRestoresFingerprintVersionForNonZeroDb) {
+  constexpr uint32_t kDbNum = 5;
+  ON_CALL(*kMockValkeyModule, SelectDb(testing::_, kDbNum))
+      .WillByDefault(testing::Return(VALKEYMODULE_OK));
+
+  coordinator::MetadataManager::InitInstance(std::move(test_metadata_manager_));
+  SchemaManager::InitInstance(std::make_unique<TestableSchemaManager>(
+      &fake_ctx_, []() {}, nullptr, /*coordinator_enabled=*/true));
+
+  // Creating in coordinator mode records the entry in the MetadataManager and
+  // stamps the schema fingerprint/version via the metadata callback.
+  auto proto = test_index_schema_proto_;
+  proto.set_db_num(kDbNum);
+  auto created = SchemaManager::Instance().CreateIndexSchema(&fake_ctx_, proto);
+  VMSDK_EXPECT_OK(created);
+  const uint64_t expected_fingerprint = created->fingerprint();
+  const uint32_t expected_version = created->version();
+
+  auto schema =
+      SchemaManager::Instance().GetIndexSchema(kDbNum, index_name_).value();
+
+  // An RDB-loaded schema comes up with default 0/0; OnLoadingEnded must
+  // reconcile it from metadata by decoding the {db}name entry key. The old
+  // code hardcoded db 0 and used the encoded key as the name, so a non-zero
+  // DB schema was never found and stayed at 0/0.
+  schema->SetFingerprint(0);
+  schema->SetVersion(0);
+
+  coordinator::MetadataManager::Instance().OnLoadingEnded(&fake_ctx_);
+
+  EXPECT_EQ(schema->GetFingerprint(), expected_fingerprint);
+  EXPECT_EQ(schema->GetVersion(), expected_version);
+}
+
 TEST_F(SchemaManagerTest, TestLoadIndexExistingData) {
   ValkeyModuleEvent eid;
   ON_CALL(*kMockValkeyModule, GetContextFromIO(testing::_))


### PR DESCRIPTION
fix hardcoded db_num in metadata_manager.cc

Bug trigger (without the fix)

Requires all three: cluster mode + an index in a non-zero DB + an RDB load (restart, failover, or replica sync).

On RDB load, the schema is rebuilt with fingerprint/version = 0 (they aren't serialized). OnLoadingEnded should backfill them from metadata, but the buggy loop hardcodes db_num = 0 and uses the encoded key as the name, so the lookup misses and the values stay 0. A later cluster query then hits FAILED_PRECONDITION "Slot fingerprint mismatch" and returns an error.

Not affected: DB 0 indexes, or non-DB-0 indexes that never reload (the live OnMetadataCallback path sets them correctly).