### PR TITLE
Lower per-field info definition log from WARNING to DEBUG

### DIFF
--- a/vmsdk/src/info.cc
+++ b/vmsdk/src/info.cc
@@ -202,7 +202,7 @@ bool Validate(ValkeyModuleCtx* ctx) {
         VMSDK_LOG(WARNING, ctx) << "Non-unique name: " << name;
         failed = true;
       }
-      VMSDK_LOG(WARNING, ctx)
+      VMSDK_LOG(DEBUG, ctx)
           << "Defined Info Field: " << name << " Flags:" << info->GetFlags();
     }
   }


### PR DESCRIPTION
The info field registration logged every field as WARNING at startup, producing ~150 noisy lines on module load.
This commit changes the log level to DEBUG.

Fixes #1280