### PR TITLE
Avoid main-thread deadlock when draining the multi/exec queue during a fork

### DIFF
--- a/integration/test_multi_queue_fork_deadlock.py
+++ b/integration/test_multi_queue_fork_deadlock.py
@@ -1,0 +1,54 @@
+"""Regression test for the fork-window deadlock reported in issue #1260.
+
+A write to an indexed key inside MULTI/EXEC is deferred to the multi/exec queue
+and only drained on the next FT.SEARCH. If a fork is in flight at that point the
+mutations thread pool is suspended, and draining it from the main thread never
+completes: the only paths that resume the pool run on that same thread.
+"""
+
+from valkey.client import Valkey
+from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+from utils import run_in_thread
+from indexes import *
+
+# A single pending mutation must stay below the auto-drain threshold, which is
+# search.writer-threads.
+WRITER_THREADS = 2
+FILLER_KEYS = 1000
+SEARCH_TIMEOUT = 10
+
+index = Index("idx", [Tag("t")], prefixes=["p:"])
+
+
+class TestMultiQueueForkDeadlock(ValkeySearchTestCaseBase):
+    def test_search_during_fork_with_pending_multi_mutation(self):
+        """FT.SEARCH must not hang while a fork is in flight."""
+        client: Valkey = self.server.get_new_client()
+        client.execute_command("CONFIG SET", "search.writer-threads", WRITER_THREADS)
+        index.create(client)
+
+        # Give the RDB child enough work to outlive the pipeline below
+        for i in range(FILLER_KEYS):
+            client.hset(f"filler:{i}", mapping={"t": "x"})
+
+        # One pipeline, so the server handles all of it within a single event
+        # loop iteration and the fork child cannot be reaped in between
+        def bgsave_then_search():
+            pipe = self.server.get_new_client().pipeline(transaction=False)
+            pipe.execute_command("BGSAVE")
+            pipe.execute_command("MULTI")
+            pipe.execute_command("HSET", "p:1", "t", "run")
+            pipe.execute_command("EXEC")
+            pipe.execute_command("FT.SEARCH", index.name, "@t:{run}", "LIMIT", "0", "1")
+            return pipe.execute(raise_on_error=False)
+
+        thread, result, error = run_in_thread(bgsave_then_search)
+        thread.join(SEARCH_TIMEOUT)
+        assert not thread.is_alive(), "FT.SEARCH deadlocked during the fork window"
+        assert error[0] is None, error[0]
+
+        search_reply = result[0][-1]
+        assert not isinstance(search_reply, Exception), search_reply
+        assert search_reply[0] == 1
+        assert client.ping()

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -820,6 +820,15 @@ void IndexSchema::ProcessMultiQueue() {
   Metrics::GetStats().ingest_last_batch_size = multi_mutations_keys.size();
   Metrics::GetStats().ingest_total_batches++;
 
+  // While a fork is in flight the mutations thread pool is suspended, and every
+  // path that resumes it runs on this thread, so waiting below would never
+  // return. Drain inline instead: the workers are parked, hence no concurrent
+  // writer to race with.
+  if (ABSL_PREDICT_FALSE(mutations_thread_pool_->IsSuspended())) {
+    ProcessMultiQueueInline();
+    return;
+  }
+
   absl::BlockingCounter blocking_counter(multi_mutations_keys.size());
   vmsdk::WriterMutexLock lock(&time_sliced_mutex_, false, true);
   while (!multi_mutations_keys.empty()) {
@@ -829,6 +838,23 @@ void IndexSchema::ProcessMultiQueue() {
                      &blocking_counter);
   }
   blocking_counter.Wait();
+}
+
+void IndexSchema::ProcessMultiQueueInline() {
+  auto &multi_mutations_keys = multi_mutations_keys_.Get();
+  while (!multi_mutations_keys.empty()) {
+    auto key = multi_mutations_keys.front();
+    multi_mutations_keys.pop_front();
+    {
+      // Balances the decrement inside ProcessSingleMutationAsync.
+      absl::MutexLock lock(&stats_.mutex_);
+      ++stats_.mutation_queue_size_;
+    }
+    // time_sliced_mutex_ is left unheld: the callee takes it and it is not
+    // recursive.
+    ProcessSingleMutationAsync(detached_ctx_.get(), /*from_backfill=*/false,
+                               key, /*delay_capturer=*/nullptr);
+  }
 }
 
 void IndexSchema::EnqueueMultiMutation(const Key &key) {

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -496,6 +496,9 @@ class IndexSchema : public KeyspaceEventSubscription,
                         vmsdk::ThreadPool::Priority priority,
                         absl::BlockingCounter *blocking_counter);
   void EnqueueMultiMutation(const Key &key);
+  // Drains the multi/exec queue on the calling thread, for when the mutations
+  // thread pool is suspended.
+  void ProcessMultiQueueInline();
   void DrainMutationQueue(ValkeyModuleCtx *ctx) const
       ABSL_LOCKS_EXCLUDED(mutated_records_mutex_);
 


### PR DESCRIPTION
## Summary

Fix a permanent main-thread deadlock when `FT.SEARCH` drains the multi/exec mutation queue
while a fork is in flight. Adds a deterministic regression test.

Fixes #1260

## Root cause

`IndexSchema::ProcessMultiQueue` unconditionally schedules pending multi/exec mutations onto
`mutations_thread_pool_` and waits for them on the calling thread. During a fork (BGSAVE,
AOF rewrite or replica full sync) that pool is suspended by `AtForkPrepare` and stays
suspended until the child is reaped, while every path that resumes it —
`OnForkChildCallback` and the `max-worker-suspension-secs` check in `OnServerCronCallback` —
runs on the main thread, i.e. the thread parked in `BlockingCounter::Wait()`. The server
stops answering, never processes SIGTERM, and has to be SIGKILLed.

Reproduced on 1.2.1 with a single `MULTI`/`HSET`/`EXEC` followed by one `FT.SEARCH` inside
the fork window; details in #1260.

## Fix

When the pool is suspended, drain the queue inline on the calling thread instead of handing
work to parked workers. The workers are stopped, so there is no concurrent writer to race
with, and the normal path is untouched.

`ProcessMultiQueueInline` deliberately does not hold `time_sliced_mutex_`:
`ProcessSingleMutationAsync` acquires it per mutation and the mutex is not recursive.
`stats_.mutation_queue_size_` is incremented before the call to stay balanced with the
decrement inside, mirroring `ScheduleMutation`.

This leaves the `max-worker-suspension-secs` valve still being checked from
`OnServerCronCallback`, i.e. on the main thread, so it cannot fire while that thread is
blocked — I can address that in a follow-up if you'd like it out of this PR.

## Testing

`integration/test_multi_queue_fork_deadlock.py` sends `BGSAVE`, one `MULTI`/`HSET`/`EXEC`
into an indexed prefix and `FT.SEARCH` as a single pipeline, so the server handles them in
one event loop iteration and the fork child cannot be reaped in between — deterministic
rather than timing dependent. It hangs and fails without the fix, passes with it.

Unit tests 22/22 binaries, integration suite 269 passed / 8 skipped, `clang-format` clean,
no new warnings including `-Wthread-safety`. Also verified A/B on `valkey-bundle:9.1.1` with
the same pod and dataset, only the module path differing: the stock module hangs on the
first attempt with every thread in `futex_wait_queue_me`, the patched one survives 5/5 runs.
