### PR TITLE
Add CODEOWNERS to auto-request team review on all PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @valkey-io/search-reviewers


### PR DESCRIPTION
Triggers round-robin reviewer assignment via the
search-reviewers team so every PR gets a first-pass reviewer without manual intervention.