### PR TITLE
Feature add client-mode-aware replica routing for search fanout

### DIFF
--- a/integration/test_fanout_base.py
+++ b/integration/test_fanout_base.py
@@ -167,7 +167,7 @@ class TestFanout(ValkeySearchClusterTestCase):
         assert(primary.info("replication")["role"] == "master")
 
         if client_mode == "READONLY":
-            assert primary.execute_command("READONLY") == b"OK"
+            assert primary.execute_command("READONLY") is True
         
         index = Index("test", [Vector("v", 3, type="FLAT")], type=KeyDataType.HASH)
         index.create(primary)

--- a/integration/test_fanout_base.py
+++ b/integration/test_fanout_base.py
@@ -155,15 +155,19 @@ class TestFanout(ValkeySearchClusterTestCase):
     @pytest.mark.parametrize(
         "setup_test", [{"replica_count": 2}], indirect=True
     )
-    @pytest.mark.parametrize("threshold", [0, 100])
-    def test_fanout_low_utilization_fanout(self, threshold):
+    @pytest.mark.parametrize(
+        "client_mode, expects_replica_requests",
+        [("READWRITE", False), ("READONLY", True)],
+    )
+    def test_fanout_client_mode_routing(self, client_mode,
+                                        expects_replica_requests):
         number_of_searches_to_run = 10
         rg = self.get_replication_group(0)
         primary = rg.get_primary_connection()
         assert(primary.info("replication")["role"] == "master")
-        
-        # Set the fanout low utilization threshold
-        primary.execute_command("CONFIG", "SET", "search.local-fanout-queue-wait-threshold", threshold)
+
+        if client_mode == "READONLY":
+            assert primary.execute_command("READONLY") == b"OK"
         
         index = Index("test", [Vector("v", 3, type="FLAT")], type=KeyDataType.HASH)
         index.create(primary)
@@ -176,23 +180,16 @@ class TestFanout(ValkeySearchClusterTestCase):
         # Assert replicas of the primary didn't run any search queries
         assert(sum_of_remote_searches(rg.replicas) == 0)
 
-        # Verify the threshold was applied
-        result = primary.execute_command("CONFIG", "GET", "search.local-fanout-queue-wait-threshold")
-        assert result[1].decode() == str(threshold)
-
         # Execute searches
         for i in range(number_of_searches_to_run):
             result = primary.execute_command(*search_command(index.name))
             assert(len(result) > 1)
-        
-        if threshold:
-            # threshold == 100 means we are always under utilize and prefer to do local search on the shard
-            # Assert replicas of the primary didn't run any search queries
-            assert(sum_of_remote_searches(rg.replicas) == 0)
+
+        replica_searches = sum_of_remote_searches(rg.replicas)
+        if expects_replica_requests:
+            assert(replica_searches > 0)
         else:
-            # threshold == 0 means we are always "too busy"
-            # Assert replicas of the primary run some of the search queries 
-            assert(sum_of_remote_searches(rg.replicas) > 0)
+            assert(replica_searches == 0)
 
     def test_sample_queue_size_config(self):
         """Test thread-pool-wait-time-samples configuration parameter"""

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -95,6 +95,30 @@ void Free([[maybe_unused]] ValkeyModuleCtx *ctx, void *privdata) {
 CONTROLLED_BOOLEAN(ForceReplicasOnly, false);
 DEV_INTEGER_COUNTER(stats, single_slot_queries);
 
+// Separates request-derived routing policy from target selection. Client mode
+// controls the eligible node roles; ClusterMap applies that policy to the
+// current topology. Additional inputs such as remote load or health belong in
+// this policy rather than in ComputeSearchTargets().
+struct SearchRoutingPolicy {
+  vmsdk::cluster_map::FanoutTargetMode target_mode;
+  bool prefer_local;
+};
+
+SearchRoutingPolicy ComputeSearchRoutingPolicy(ValkeyModuleCtx *ctx) {
+  const bool prefer_local = query::fanout::IsSystemUnderLowUtilization();
+  if (ForceReplicasOnly.GetValue()) {
+    return {.target_mode =
+                vmsdk::cluster_map::FanoutTargetMode::kOneReplicaPerShard,
+            .prefer_local = prefer_local};
+  }
+
+  return {.target_mode =
+              vmsdk::IsReadOnly(ctx)
+                  ? vmsdk::cluster_map::FanoutTargetMode::kReplicaPreferred
+                  : vmsdk::cluster_map::FanoutTargetMode::kPrimary,
+          .prefer_local = prefer_local};
+}
+
 bool IsSingleSlotQueryRoutedToLocalNode(ValkeyModuleCtx *ctx,
                                         const QueryCommand &parameters) {
   if (!parameters.index_schema) {
@@ -113,10 +137,7 @@ bool IsSingleSlotQueryRoutedToLocalNode(ValkeyModuleCtx *ctx,
 
 std::vector<vmsdk::cluster_map::NodeInfo> ComputeSearchTargets(
     ValkeyModuleCtx *ctx, const QueryCommand &parameters) {
-  auto mode = /* !vmsdk::IsReadOnly(ctx) ? query::fanout::kPrimaries ? */
-      ForceReplicasOnly.GetValue()
-          ? vmsdk::cluster_map::FanoutTargetMode::kOneReplicaPerShard
-          : vmsdk::cluster_map::FanoutTargetMode::kRandom;
+  const auto routing_policy = ComputeSearchRoutingPolicy(ctx);
 
   // refresh cluster map if needed
   auto cluster_map = ValkeySearch::Instance().GetOrRefreshClusterMap(ctx);
@@ -125,12 +146,12 @@ std::vector<vmsdk::cluster_map::NodeInfo> ComputeSearchTargets(
       parameters.index_schema->GetSingleSlotNumber();
   if (single_slot_number.has_value()) {
     single_slot_queries.Increment();
-    return cluster_map->GetTargetsForSlot(
-        mode, query::fanout::IsSystemUnderLowUtilization(),
-        *single_slot_number);
+    return cluster_map->GetTargetsForSlot(routing_policy.target_mode,
+                                          routing_policy.prefer_local,
+                                          *single_slot_number);
   } else {
-    return cluster_map->GetTargets(
-        mode, query::fanout::IsSystemUnderLowUtilization());
+    return cluster_map->GetTargets(routing_policy.target_mode,
+                                   routing_policy.prefer_local);
   }
 }
 

--- a/src/commands/commands.cc
+++ b/src/commands/commands.cc
@@ -136,8 +136,12 @@ bool IsSingleSlotQueryRoutedToLocalNode(ValkeyModuleCtx *ctx,
 }
 
 std::vector<vmsdk::cluster_map::NodeInfo> ComputeSearchTargets(
-    ValkeyModuleCtx *ctx, const QueryCommand &parameters) {
+    ValkeyModuleCtx *ctx, const QueryCommand &parameters,
+    bool *allow_primary_fallback) {
   const auto routing_policy = ComputeSearchRoutingPolicy(ctx);
+  *allow_primary_fallback =
+      routing_policy.target_mode ==
+      vmsdk::cluster_map::FanoutTargetMode::kReplicaPreferred;
 
   // refresh cluster map if needed
   auto cluster_map = ValkeySearch::Instance().GetOrRefreshClusterMap(ctx);
@@ -229,8 +233,10 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
     }
 
     std::vector<vmsdk::cluster_map::NodeInfo> search_targets;
+    bool allow_primary_fallback = false;
     if (do_fanout) {
-      search_targets = ComputeSearchTargets(ctx, *parameters);
+      search_targets =
+          ComputeSearchTargets(ctx, *parameters, &allow_primary_fallback);
       if (search_targets.empty()) {
         return absl::InternalError("No available nodes to execute the query");
       }
@@ -268,7 +274,7 @@ absl::Status QueryCommand::Execute(ValkeyModuleCtx *ctx,
       }
 
       return query::fanout::PerformSearchFanoutAsync(
-          ctx, search_targets,
+          ctx, search_targets, allow_primary_fallback,
           ValkeySearch::Instance().GetCoordinatorClientPool(),
           std::move(parameters),
           ValkeySearch::Instance().GetReaderThreadPool());

--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -283,30 +283,48 @@ class LocalResponderSearch : public query::SearchParameters {
 
 void PerformRemoteSearchRequest(
     std::unique_ptr<coordinator::SearchIndexPartitionRequest> request,
-    const std::string &address,
+    const std::string &address, std::optional<std::string> fallback_address,
     coordinator::ClientPool *coordinator_client_pool,
     std::shared_ptr<SearchPartitionResultsTracker> tracker) {
+  std::unique_ptr<coordinator::SearchIndexPartitionRequest> fallback_request;
+  if (fallback_address.has_value()) {
+    fallback_request =
+        std::make_unique<coordinator::SearchIndexPartitionRequest>();
+    fallback_request->CopyFrom(*request);
+  }
   auto client = coordinator_client_pool->GetClient(address);
 
   client->SearchIndexPartition(
       std::move(request),
-      [tracker, address = std::string(address)](
+      [coordinator_client_pool, tracker, address = std::string(address),
+       fallback_address = std::move(fallback_address),
+       fallback_request = std::move(fallback_request)](
           grpc::Status status,
           coordinator::SearchIndexPartitionResponse &response) mutable {
+        if (fallback_address.has_value() &&
+            (status.error_code() == grpc::StatusCode::UNAVAILABLE ||
+             status.error_code() == grpc::StatusCode::DEADLINE_EXCEEDED)) {
+          PerformRemoteSearchRequest(std::move(fallback_request),
+                                     *fallback_address, std::nullopt,
+                                     coordinator_client_pool, tracker);
+          return;
+        }
         tracker->HandleResponse(response, address, status);
       });
 }
 
 void PerformRemoteSearchRequestAsync(
     std::unique_ptr<coordinator::SearchIndexPartitionRequest> request,
-    const std::string &address,
+    const std::string &address, std::optional<std::string> fallback_address,
     coordinator::ClientPool *coordinator_client_pool,
     std::shared_ptr<SearchPartitionResultsTracker> tracker,
     vmsdk::ThreadPool *thread_pool) {
   thread_pool->Schedule(
       [coordinator_client_pool, address = std::string(address),
+       fallback_address = std::move(fallback_address),
        request = std::move(request), tracker]() mutable {
         PerformRemoteSearchRequest(std::move(request), address,
+                                   std::move(fallback_address),
                                    coordinator_client_pool, tracker);
       },
       vmsdk::ThreadPool::Priority::kHigh);
@@ -315,6 +333,7 @@ void PerformRemoteSearchRequestAsync(
 absl::Status PerformSearchFanoutAsync(
     ValkeyModuleCtx *ctx,
     std::vector<vmsdk::cluster_map::NodeInfo> &search_targets,
+    bool allow_primary_fallback,
     coordinator::ClientPool *coordinator_client_pool,
     std::unique_ptr<SearchParameters> parameters,
     vmsdk::ThreadPool *thread_pool) {
@@ -396,14 +415,23 @@ absl::Status PerformSearchFanoutAsync(
     std::string target_address = coordinator::FormatAddressWithPort(
         node.socket_address.primary_endpoint,
         coordinator::GetCoordinatorPort(node.socket_address.port));
+    std::optional<std::string> fallback_address;
+    if (allow_primary_fallback && !node.is_primary && node.shard != nullptr &&
+        node.shard->primary.has_value()) {
+      const auto &primary = node.shard->primary.value();
+      fallback_address = coordinator::FormatAddressWithPort(
+          primary.socket_address.primary_endpoint,
+          coordinator::GetCoordinatorPort(primary.socket_address.port));
+    }
     if (search_targets.size() >=
             valkey_search::options::GetAsyncFanoutThreshold().GetValue() &&
         thread_pool->Size() > 1) {
-      PerformRemoteSearchRequestAsync(std::move(request_copy), target_address,
-                                      coordinator_client_pool, tracker,
-                                      thread_pool);
+      PerformRemoteSearchRequestAsync(
+          std::move(request_copy), target_address, std::move(fallback_address),
+          coordinator_client_pool, tracker, thread_pool);
     } else {
       PerformRemoteSearchRequest(std::move(request_copy), target_address,
+                                 std::move(fallback_address),
                                  coordinator_client_pool, tracker);
     }
   }

--- a/src/query/fanout.h
+++ b/src/query/fanout.h
@@ -23,6 +23,7 @@ namespace valkey_search::query::fanout {
 absl::Status PerformSearchFanoutAsync(
     ValkeyModuleCtx* ctx,
     std::vector<vmsdk::cluster_map::NodeInfo>& search_targets,
+    bool allow_primary_fallback,
     coordinator::ClientPool* coordinator_client_pool,
     std::unique_ptr<query::SearchParameters> parameters,
     vmsdk::ThreadPool* thread_pool);

--- a/src/version.h
+++ b/src/version.h
@@ -31,7 +31,7 @@ constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 3, 0);
 //
 // Set the minimum acceptable server version
 //
-constexpr auto kMinimumServerVersion = vmsdk::ValkeyVersion(9, 0, 1);
+constexpr auto kMinimumServerVersion = vmsdk::ValkeyVersion(9, 1, 0);
 
 namespace valkey_search {
 

--- a/vmsdk/src/cluster_map.cc
+++ b/vmsdk/src/cluster_map.cc
@@ -103,6 +103,10 @@ NodeInfo ShardInfo::GetRandomNode(bool replica_only, bool prefer_local) const {
 
 std::vector<NodeInfo> ClusterMap::GetTargets(FanoutTargetMode mode,
                                              bool prefer_local) const {
+  // `mode` establishes the role-based candidate set for each shard. Future
+  // health/CPU/latency-aware routing should rank eligible candidates here,
+  // while retaining the mode's fallback guarantees and one-target-per-shard
+  // behavior.
   switch (mode) {
     case FanoutTargetMode::kAll:
       return all_targets_;
@@ -120,6 +124,22 @@ std::vector<NodeInfo> ClusterMap::GetTargets(FanoutTargetMode mode,
         random_replicas.push_back(shard_info.GetRandomNode(true, prefer_local));
       }
       return random_replicas;
+    }
+    case FanoutTargetMode::kReplicaPreferred: {
+      std::vector<NodeInfo> targets;
+      targets.reserve(shards_.size());
+      for (const auto& [shard_id, shard_info] : shards_) {
+        // The replica list is the preferred candidate set. Selectors that use
+        // remote load signals should choose within this set before falling back
+        // to the primary; they must not promote a primary while a replica is
+        // eligible.
+        if (!shard_info.replicas.empty()) {
+          targets.push_back(shard_info.GetRandomNode(true, prefer_local));
+        } else if (shard_info.primary.has_value()) {
+          targets.push_back(shard_info.primary.value());
+        }
+      }
+      return targets;
     }
     case FanoutTargetMode::kRandom: {
       std::vector<NodeInfo> random_targets;
@@ -177,6 +197,14 @@ std::vector<NodeInfo> ClusterMap::GetTargetsForSlot(FanoutTargetMode mode,
     case FanoutTargetMode::kOneReplicaPerShard:
       if (!shard->replicas.empty()) {
         return {shard->GetRandomNode(true, prefer_local)};
+      }
+      return {};
+    case FanoutTargetMode::kReplicaPreferred:
+      if (!shard->replicas.empty()) {
+        return {shard->GetRandomNode(true, prefer_local)};
+      }
+      if (shard->primary.has_value()) {
+        return {shard->primary.value()};
       }
       return {};
     case FanoutTargetMode::kRandom:

--- a/vmsdk/src/cluster_map.h
+++ b/vmsdk/src/cluster_map.h
@@ -39,11 +39,11 @@ static constexpr highwayhash::HHKey kHashKey{
 enum class FanoutTargetMode {
   kRandom,              // Default: randomly select one node per shard
   kOneReplicaPerShard,  // Select only replicas, one per shard
-  kReplicaPreferred,    // Select one replica per shard; use the primary only
-                        // when the cluster map has no replica for the shard
-  kPrimary,             // Select all primary nodes
-  kReplicas,            // Select all replica nodes
-  kAll                  // Select all nodes (both primary and replica)
+  kReplicaPreferred,    // Select one replica per shard; fall back to primary
+                      // when no replica is mapped or the replica is unavailable
+  kPrimary,   // Select all primary nodes
+  kReplicas,  // Select all replica nodes
+  kAll        // Select all nodes (both primary and replica)
 };
 
 const size_t kNumSlots = 16384;

--- a/vmsdk/src/cluster_map.h
+++ b/vmsdk/src/cluster_map.h
@@ -39,6 +39,8 @@ static constexpr highwayhash::HHKey kHashKey{
 enum class FanoutTargetMode {
   kRandom,              // Default: randomly select one node per shard
   kOneReplicaPerShard,  // Select only replicas, one per shard
+  kReplicaPreferred,    // Select one replica per shard; use the primary only
+                        // when the cluster map has no replica for the shard
   kPrimary,             // Select all primary nodes
   kReplicas,            // Select all replica nodes
   kAll                  // Select all nodes (both primary and replica)

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -143,6 +143,19 @@ bool IsRealUserClient(ValkeyModuleCtx *ctx) {
   return true;
 }
 
+bool IsReadOnly(ValkeyModuleCtx *ctx) {
+  const auto client_id = ValkeyModule_GetClientId(ctx);
+  if (client_id == 0) {
+    return false;
+  }
+
+  ValkeyModuleClientInfo client_info =
+      VALKEYMODULE_CLIENTINFO_INITIALIZER_V1;
+  return ValkeyModule_GetClientInfoById(&client_info, client_id) ==
+             VALKEYMODULE_OK &&
+         (client_info.flags & VALKEYMODULE_CLIENTINFO_FLAG_READONLY) != 0;
+}
+
 bool MultiOrLua(ValkeyModuleCtx *ctx) {
   return (ValkeyModule_GetContextFlags(ctx) &
           (VALKEYMODULE_CTX_FLAGS_MULTI | VALKEYMODULE_CTX_FLAGS_LUA)) != 0;

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -149,8 +149,7 @@ bool IsReadOnly(ValkeyModuleCtx *ctx) {
     return false;
   }
 
-  ValkeyModuleClientInfo client_info =
-      VALKEYMODULE_CLIENTINFO_INITIALIZER_V1;
+  ValkeyModuleClientInfo client_info = VALKEYMODULE_CLIENTINFO_INITIALIZER_V1;
   return ValkeyModule_GetClientInfoById(&client_info, client_id) ==
              VALKEYMODULE_OK &&
          (client_info.flags & VALKEYMODULE_CLIENTINFO_FLAG_READONLY) != 0;

--- a/vmsdk/src/utils.h
+++ b/vmsdk/src/utils.h
@@ -111,6 +111,9 @@ inline std::ostream &operator<<(std::ostream &os, ValkeyModuleString *s) {
 std::optional<absl::string_view> ParseHashTag(absl::string_view);
 
 bool IsRealUserClient(ValkeyModuleCtx *ctx);
+// Returns whether the issuing client enabled cluster READONLY mode. This is a
+// client property, distinct from the server's read-only context flag.
+bool IsReadOnly(ValkeyModuleCtx *ctx);
 bool MultiOrLua(ValkeyModuleCtx *ctx);
 
 size_t DisplayAsSIBytes(size_t value, char *buffer, size_t buffer_size);

--- a/vmsdk/src/valkey_module_api/valkey_module.h
+++ b/vmsdk/src/valkey_module_api/valkey_module.h
@@ -661,6 +661,7 @@ static const ValkeyModuleEvent
 #define VALKEYMODULE_CLIENTINFO_FLAG_TRACKING (1 << 3)
 #define VALKEYMODULE_CLIENTINFO_FLAG_UNIXSOCKET (1 << 4)
 #define VALKEYMODULE_CLIENTINFO_FLAG_MULTI (1 << 5)
+#define VALKEYMODULE_CLIENTINFO_FLAG_READONLY (1 << 6)
 
 /* Here we take all the structures that the module pass to the core
  * and the other way around. Notably the list here contains the structures

--- a/vmsdk/testing/cluster_map_test.cc
+++ b/vmsdk/testing/cluster_map_test.cc
@@ -850,6 +850,40 @@ TEST_F(ClusterMapTest, GetRandomReplicaPerShardTest) {
   EXPECT_EQ(shard_ids.size(), 3);
 }
 
+TEST_F(ClusterMapTest, ReplicaPreferredFallsBackToPrimary) {
+  std::vector<SlotRangeConfig> ranges = {
+      {.start_slot = 0,
+       .end_slot = 5460,
+       .primary = NodeConfig{"127.0.0.1", 30001, primary_ids.at(0), {}},
+       .replicas = {NodeConfig{"127.0.0.1", 30004, replica_ids.at(0), {}}}},
+      {.start_slot = 5461,
+       .end_slot = 10922,
+       .primary = NodeConfig{"127.0.0.1", 30002, primary_ids.at(1), {}},
+       .replicas = {}},
+      {.start_slot = 10923,
+       .end_slot = 16383,
+       .primary = NodeConfig{"127.0.0.1", 30003, primary_ids.at(2), {}},
+       .replicas = {NodeConfig{"127.0.0.1", 30006, replica_ids.at(2), {}}}}};
+  auto cluster_map = CreateClusterMapWithConfig(ranges, primary_ids.at(0));
+  ASSERT_NE(cluster_map, nullptr);
+
+  auto targets = cluster_map->GetTargets(FanoutTargetMode::kReplicaPreferred);
+  ASSERT_EQ(targets.size(), 3);
+  for (const auto& target : targets) {
+    if (target.node_id == primary_ids.at(1)) {
+      EXPECT_TRUE(target.is_primary);
+    } else {
+      EXPECT_FALSE(target.is_primary);
+    }
+  }
+
+  auto single_slot_target = cluster_map->GetTargetsForSlot(
+      FanoutTargetMode::kReplicaPreferred, false, 8192);
+  ASSERT_EQ(single_slot_target.size(), 1);
+  EXPECT_EQ(single_slot_target[0].node_id, primary_ids.at(1));
+  EXPECT_TRUE(single_slot_target[0].is_primary);
+}
+
 // ============================================================================
 // Fingerprint and Metadata Tests
 // ============================================================================

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -171,8 +171,8 @@ TEST_F(UtilsTest, IsReadOnly) {
   EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
       .WillOnce(testing::Return(43));
   EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 43))
-      .WillOnce([](void *client_info, uint64_t) {
-        static_cast<ValkeyModuleClientInfo *>(client_info)->flags = 0;
+      .WillOnce([](void* client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo*>(client_info)->flags = 0;
         return VALKEYMODULE_OK;
       });
   EXPECT_FALSE(IsReadOnly(&fake_ctx));
@@ -180,8 +180,8 @@ TEST_F(UtilsTest, IsReadOnly) {
   EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
       .WillOnce(testing::Return(44));
   EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 44))
-      .WillOnce([](void *client_info, uint64_t) {
-        static_cast<ValkeyModuleClientInfo *>(client_info)->flags =
+      .WillOnce([](void* client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo*>(client_info)->flags =
             VALKEYMODULE_CLIENTINFO_FLAG_READONLY;
         return VALKEYMODULE_OK;
       });

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -156,6 +156,38 @@ TEST_F(UtilsTest, IsRealUserClient) {
   }
 }
 
+TEST_F(UtilsTest, IsReadOnly) {
+  ValkeyModuleCtx fake_ctx;
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
+      .WillOnce(testing::Return(0));
+  EXPECT_FALSE(IsReadOnly(&fake_ctx));
+
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
+      .WillOnce(testing::Return(42));
+  EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 42))
+      .WillOnce(testing::Return(VALKEYMODULE_ERR));
+  EXPECT_FALSE(IsReadOnly(&fake_ctx));
+
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
+      .WillOnce(testing::Return(43));
+  EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 43))
+      .WillOnce([](void *client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo *>(client_info)->flags = 0;
+        return VALKEYMODULE_OK;
+      });
+  EXPECT_FALSE(IsReadOnly(&fake_ctx));
+
+  EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
+      .WillOnce(testing::Return(44));
+  EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 44))
+      .WillOnce([](void *client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo *>(client_info)->flags =
+            VALKEYMODULE_CLIENTINFO_FLAG_READONLY;
+        return VALKEYMODULE_OK;
+      });
+  EXPECT_TRUE(IsReadOnly(&fake_ctx));
+}
+
 TEST_F(UtilsTest, DisplayAsSIBytes) {
   std::vector<std::pair<size_t, std::string>> testcases{
       {0.0, "0"},

--- a/vmsdk/testing/utils_test.cc
+++ b/vmsdk/testing/utils_test.cc
@@ -171,8 +171,8 @@ TEST_F(UtilsTest, IsReadOnly) {
   EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
       .WillOnce(testing::Return(43));
   EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 43))
-      .WillOnce([](void* client_info, uint64_t) {
-        static_cast<ValkeyModuleClientInfo*>(client_info)->flags = 0;
+      .WillOnce([](void *client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo *>(client_info)->flags = 0;
         return VALKEYMODULE_OK;
       });
   EXPECT_FALSE(IsReadOnly(&fake_ctx));
@@ -180,8 +180,8 @@ TEST_F(UtilsTest, IsReadOnly) {
   EXPECT_CALL(*kMockValkeyModule, GetClientId(&fake_ctx))
       .WillOnce(testing::Return(44));
   EXPECT_CALL(*kMockValkeyModule, GetClientInfoById(testing::_, 44))
-      .WillOnce([](void* client_info, uint64_t) {
-        static_cast<ValkeyModuleClientInfo*>(client_info)->flags =
+      .WillOnce([](void *client_info, uint64_t) {
+        static_cast<ValkeyModuleClientInfo *>(client_info)->flags =
             VALKEYMODULE_CLIENTINFO_FLAG_READONLY;
         return VALKEYMODULE_OK;
       });


### PR DESCRIPTION
Added client-mode-aware search fanout routing using Valkey’s READONLY client flag.
READONLY clients prefer replicas per shard with primary fallback, while READWRITE clients target primaries.

Closes : #1290