### PR TITLE
chore: bump module version to 1.3.0

### DIFF
--- a/src/version.h
+++ b/src/version.h
@@ -13,7 +13,7 @@
 //
 // Set the module version to the current release
 //
-constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 2, 1);
+constexpr auto kModuleVersion = vmsdk::ValkeyVersion(1, 3, 0);
 
 /* The release stage is used in order to provide release status information.
  * In unstable branch the status is always "dev".
@@ -97,6 +97,11 @@ constexpr vmsdk::ValkeyVersion kRelease11(1, 1, 0);
 // Release 1.2, added support for full text search.
 //
 constexpr vmsdk::ValkeyVersion kRelease12(1, 2, 0);
+
+//
+// Release 1.3
+//
+constexpr vmsdk::ValkeyVersion kRelease13(1, 3, 0);
 
 }  // namespace valkey_search
 


### PR DESCRIPTION
Set kModuleVersion to 1.3.0 and add the kRelease13 metadata encoding constant. MODULE_RELEASE_STAGE stays "dev" on main.