### PR TITLE
Follow-ups from #1268 (the PR search benchmark workflow)

### DIFF
--- a/.github/workflows/search-benchmark-pr.yml
+++ b/.github/workflows/search-benchmark-pr.yml
@@ -257,8 +257,15 @@ jobs:
 
       # Install the valkey-search build dependencies and toolchain via the
       # single maintained script (ci/install_deps.sh).
+      #
+      # SECURITY: this runs with sudo, and pull_request_target executes with
+      # base-repo secrets. We therefore run the script from the BASELINE
+      # checkout (base_sha, a commit in the target repo that a fork PR cannot
+      # modify) — never from the PR merge commit (MODULE_DIR), which is
+      # fork-controlled. This keeps privileged setup on trusted content while
+      # still using the single maintained script.
       - name: Install build dependencies and toolchain
-        working-directory: ${{ env.MODULE_DIR }}
+        working-directory: ${{ env.MODULE_BASELINE_DIR }}
         run: ./ci/install_deps.sh
 
       - name: Install benchmark Python dependencies

--- a/.github/workflows/search-benchmark-pr.yml
+++ b/.github/workflows/search-benchmark-pr.yml
@@ -155,7 +155,7 @@ jobs:
 
   benchmark:
     needs: resolve
-    runs-on: [self-hosted, valkey-search-arm-pr]
+    runs-on: [self-hosted, ec2-al-2023-pr-benchmarking-arm64]
     timeout-minutes: ${{ fromJSON(inputs.timeout_minutes || '1440') }}
     env:
       # Module configuration

--- a/.github/workflows/search-benchmark-pr.yml
+++ b/.github/workflows/search-benchmark-pr.yml
@@ -255,17 +255,23 @@ jobs:
           echo "✓ Dataset directory linked to persistent cache: $DATASET_CACHE"
           ls -lh "$PERF_BENCHMARK_PATH/" | grep datasets
 
+      # Fetch a trusted copy of the CI scripts from the base branch tip.
+      # base_ref names a branch in the target repo, so a fork PR cannot modify
+      # its contents, and (unlike base_sha) its tip always contains the current
+      # installer even for PRs that forked before it was added.
+      - name: Checkout trusted CI scripts (base branch)
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ needs.resolve.outputs.base_ref }}
+          path: valkey-search-trusted-ci
+          fetch-depth: 1
+          persist-credentials: false
+
       # Install the valkey-search build dependencies and toolchain via the
       # single maintained script (ci/install_deps.sh).
-      #
-      # SECURITY: this runs with sudo, and pull_request_target executes with
-      # base-repo secrets. We therefore run the script from the BASELINE
-      # checkout (base_sha, a commit in the target repo that a fork PR cannot
-      # modify) — never from the PR merge commit (MODULE_DIR), which is
-      # fork-controlled. This keeps privileged setup on trusted content while
-      # still using the single maintained script.
       - name: Install build dependencies and toolchain
-        working-directory: ${{ env.MODULE_BASELINE_DIR }}
+        working-directory: valkey-search-trusted-ci
         run: ./ci/install_deps.sh
 
       - name: Install benchmark Python dependencies
@@ -479,6 +485,7 @@ jobs:
           echo "Datasets persist at /home/ec2-user/search-datasets-cache"
           rm -rf "${{ github.workspace }}/comparison.md" \
                  "${{ github.workspace }}/valkey_ram" \
+                 "${{ github.workspace }}/valkey-search-trusted-ci" \
                  "$CORE_PATH" \
                  "$MODULE_PATH" \
                  "$MODULE_BASELINE_PATH" \

--- a/.github/workflows/search-benchmark-pr.yml
+++ b/.github/workflows/search-benchmark-pr.yml
@@ -272,7 +272,15 @@ jobs:
       # single maintained script (ci/install_deps.sh).
       - name: Install build dependencies and toolchain
         working-directory: valkey-search-trusted-ci
-        run: ./ci/install_deps.sh
+        run: |
+          # The installer only exists on base branches that carry
+          # it. If a benchmarked PR targets a branch without it, fail fast with
+          # an actionable message instead of a cryptic 127 from a missing file.
+          if [[ ! -x ./ci/install_deps.sh ]]; then
+            echo "::error::ci/install_deps.sh not found on base branch '${{ needs.resolve.outputs.base_ref }}'. This branch must contain the installer to run the benchmark; rebase it onto a revision that includes ci/install_deps.sh."
+            exit 1
+          fi
+          ./ci/install_deps.sh
 
       - name: Install benchmark Python dependencies
         working-directory: ${{ env.PERF_BENCHMARK_DIR }}

--- a/.github/workflows/search-benchmark-pr.yml
+++ b/.github/workflows/search-benchmark-pr.yml
@@ -255,52 +255,15 @@ jobs:
           echo "✓ Dataset directory linked to persistent cache: $DATASET_CACHE"
           ls -lh "$PERF_BENCHMARK_PATH/" | grep datasets
 
-      - name: Install dependencies
+      # Install the valkey-search build dependencies and toolchain via the
+      # single maintained script (ci/install_deps.sh).
+      - name: Install build dependencies and toolchain
+        working-directory: ${{ env.MODULE_DIR }}
+        run: ./ci/install_deps.sh
+
+      - name: Install benchmark Python dependencies
         working-directory: ${{ env.PERF_BENCHMARK_DIR }}
-        run: |
-          sudo dnf groupinstall "Development Tools" -y
-          sudo dnf install -y gcc gcc-c++ cmake \
-              ninja-build \
-              python3-devel \
-              openssl-devel \
-              systemd-devel \
-              bzip2-devel \
-              libffi-devel \
-              perf
-
-          gcc --version
-          g++ --version
-
-          pip install --require-hashes -r requirements.txt
-
-      - name: Ensure GCC >= 12 (required for valkey-search build)
-        # NOTE: This uses AL2023-specific packages. Update if runner OS changes.
-        run: |
-          GCC_MIN_VERSION=12
-          CURRENT_VERSION=0
-
-          if /usr/local/bin/gcc --version 2>/dev/null; then
-            CURRENT_VERSION=$(/usr/local/bin/gcc -dumpversion | cut -d. -f1)
-          fi
-
-          if [[ "$CURRENT_VERSION" -ge "$GCC_MIN_VERSION" ]]; then
-            echo "✓ GCC $CURRENT_VERSION already available at /usr/local/bin/gcc (>= $GCC_MIN_VERSION)"
-            /usr/local/bin/gcc --version
-            /usr/local/bin/g++ --version
-          else
-            echo "GCC >= $GCC_MIN_VERSION not found (current: $CURRENT_VERSION) — installing GCC 14 from AL2023 repos..."
-            sudo dnf install -y gcc14 gcc14-c++
-
-            # Create symlinks in /usr/local/bin so builds pick up GCC 14 by default
-            sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/gcc
-            sudo ln -sf /usr/bin/gcc14-g++ /usr/local/bin/g++
-            sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/cc
-            sudo ln -sf /usr/bin/gcc14-g++ /usr/local/bin/c++
-
-            echo "✓ GCC 14 installed and symlinked"
-            /usr/local/bin/gcc --version
-            /usr/local/bin/g++ --version
-          fi
+        run: pip install --require-hashes -r requirements.txt
 
       - name: Build valkey_ram (for dataset-enabled valkey-benchmark)
         working-directory: valkey_ram

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -87,6 +87,13 @@ fi
 
 case "${ID}" in
     amzn)
+        # ID=amzn covers both Amazon Linux 2 (VERSION_ID=2) and AL2023
+        # (VERSION_ID=2023). Only AL2023 is supported; reject anything else
+        # before we start installing AL2023-only packages (e.g. gcc14).
+        if [[ "${VERSION_ID}" != "2023" ]]; then
+            LOG_ERROR "Unsupported Amazon Linux version '${VERSION_ID}'. Only Amazon Linux 2023 is currently supported."
+            exit 1
+        fi
         install_amazon_linux
         ;;
     *)

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -1,0 +1,99 @@
+#!/bin/bash -e
+
+# install_deps.sh
+#
+# Installs the system packages and C++ toolchain (GCC >= 12) required to build
+# valkey-search from source. This is the single, maintained source of truth for
+# "pre-build installation activities" — it is invoked by CI (the PR search
+# benchmark workflow) and can be run directly by any developer preparing a fresh
+# machine:
+#
+#     ./ci/install_deps.sh
+#     ./build.sh
+#
+# The script is install-only: it does not build the module. After it completes,
+# `./build.sh` is expected to succeed. It is idempotent and safe to re-run.
+#
+# NOTE: Only Amazon Linux 2023 is supported today. 
+
+# Minimum GCC major version required to build valkey-search.
+GCC_MIN_VERSION=12
+
+# Constants
+RESET='\e[0m'
+GREEN='\e[32;1m'
+RED='\e[31;1m'
+
+function LOG_INFO() {
+    printf "${GREEN}INFO ${RESET} $1\n"
+}
+
+function LOG_ERROR() {
+    printf "${RED}ERROR${RESET} $1\n"
+}
+
+# Install the compiler toolchain and development headers needed to build
+# valkey-search (and the valkey-server / valkey-benchmark it is exercised
+# against) on Amazon Linux 2023.
+function install_amazon_linux() {
+    LOG_INFO "Installing build dependencies via dnf..."
+    sudo dnf groupinstall "Development Tools" -y
+    sudo dnf install -y \
+        gcc gcc-c++ cmake \
+        ninja-build \
+        python3-devel \
+        openssl-devel \
+        systemd-devel \
+        bzip2-devel \
+        libffi-devel \
+        perf
+
+    ensure_gcc_amazon_linux
+}
+
+# valkey-search requires GCC >= 12
+function ensure_gcc_amazon_linux() {
+    local current_version=0
+    if /usr/local/bin/gcc --version >/dev/null 2>&1; then
+        current_version=$(/usr/local/bin/gcc -dumpversion | cut -d. -f1)
+    fi
+
+    if [[ "${current_version}" -ge "${GCC_MIN_VERSION}" ]]; then
+        LOG_INFO "✓ GCC ${current_version} already available at /usr/local/bin/gcc (>= ${GCC_MIN_VERSION})"
+    else
+        LOG_INFO "GCC >= ${GCC_MIN_VERSION} not found (current: ${current_version}) — installing GCC 14 from AL2023 repos..."
+        sudo dnf install -y gcc14 gcc14-c++
+
+        # Create symlinks in /usr/local/bin so builds pick up GCC 14 by default.
+        sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/gcc
+        sudo ln -sf /usr/bin/gcc14-g++ /usr/local/bin/g++
+        sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/cc
+        sudo ln -sf /usr/bin/gcc14-g++ /usr/local/bin/c++
+        LOG_INFO "✓ GCC 14 installed and symlinked into /usr/local/bin"
+    fi
+
+    /usr/local/bin/gcc --version
+    /usr/local/bin/g++ --version
+}
+
+# Detect the distro and dispatch. Extend with additional cases (e.g. ubuntu)
+# as more build environments are supported.
+if [ -f /etc/os-release ]; then
+    . /etc/os-release
+else
+    LOG_ERROR "Cannot detect OS: /etc/os-release not found"
+    exit 1
+fi
+
+case "${ID}" in
+    amzn)
+        install_amazon_linux
+        ;;
+    *)
+        LOG_ERROR "Unsupported distro '${ID}'. Only Amazon Linux 2023 (amzn) is currently supported."
+        LOG_ERROR "Add a case for '${ID}' in ci/install_deps.sh to support it."
+        exit 1
+        ;;
+esac
+
+LOG_INFO "Build dependencies installed. You can now run ./build.sh"

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -14,7 +14,12 @@
 # The script is install-only: it does not build the module. After it completes,
 # `./build.sh` is expected to succeed. It is idempotent and safe to re-run.
 #
-# NOTE: Only Amazon Linux 2023 is supported today. 
+# SCOPE: this script currently automates dependency installation for Amazon
+# Linux 2023 only. That is a limitation of this script, not of valkey-search --
+# the module builds on a range of platforms (see the build instructions in
+# README.md). On other distributions, install the equivalent packages listed in
+# install_amazon_linux() below and run ./build.sh directly, or add a case to the
+# distro dispatch at the bottom of this file.
 
 # Minimum GCC major version required to build valkey-search.
 GCC_MIN_VERSION=12
@@ -76,8 +81,8 @@ function ensure_gcc_amazon_linux() {
     /usr/local/bin/g++ --version
 }
 
-# Detect the distro and dispatch. Extend with additional cases (e.g. ubuntu)
-# as more build environments are supported.
+# Detect the distro and dispatch. Add cases here (e.g. an apt-based branch for
+# ubuntu) to automate installation on additional build environments.
 if [ -f /etc/os-release ]; then
     . /etc/os-release
 else
@@ -88,17 +93,18 @@ fi
 case "${ID}" in
     amzn)
         # ID=amzn covers both Amazon Linux 2 (VERSION_ID=2) and AL2023
-        # (VERSION_ID=2023). Only AL2023 is supported; reject anything else
-        # before we start installing AL2023-only packages (e.g. gcc14).
+        # (VERSION_ID=2023). This script only automates AL2023; reject anything
+        # else before we start installing AL2023-only packages (e.g. gcc14).
         if [[ "${VERSION_ID}" != "2023" ]]; then
-            LOG_ERROR "Unsupported Amazon Linux version '${VERSION_ID}'. Only Amazon Linux 2023 is currently supported."
+            LOG_ERROR "This script only automates dependency installation for Amazon Linux 2023 (found version '${VERSION_ID}')."
             exit 1
         fi
         install_amazon_linux
         ;;
     *)
-        LOG_ERROR "Unsupported distro '${ID}'. Only Amazon Linux 2023 (amzn) is currently supported."
-        LOG_ERROR "Add a case for '${ID}' in ci/install_deps.sh to support it."
+        LOG_ERROR "This script only automates dependency installation for Amazon Linux 2023; it has no case for distro '${ID}'."
+        LOG_ERROR "valkey-search itself builds on other platforms: install the equivalent packages manually and run ./build.sh,"
+        LOG_ERROR "or add a case for '${ID}' to the dispatch in ci/install_deps.sh."
         exit 1
         ;;
 esac


### PR DESCRIPTION
## What

Follow-ups from #1268 (the PR search benchmark workflow):

- **Item 2 — single install script.** Extracts the pre-build setup that was inlined in `search-benchmark-pr.yml` (system packages + GCC>=12 toolchain) into a new install-only script `ci/install_deps.sh`. The workflow now calls `./ci/install_deps.sh` instead of carrying two bash-heavy steps. The script is idempotent, AL2023-only today, with an `/etc/os-release` distro-case dispatch so apt-based distros can be added later. `build.sh` stays the build entry point; the benchmark `pip install` stays in the workflow since it's a valkey-perf-benchmark dependency, not a valkey-search build dep.
- **Item 4— runner label.** `valkey-search-arm-pr` → `ec2-al-2023-pr-benchmarking-arm64`. `EC2_SEARCH_IP` is unchanged. 
