### PR TITLE
Fix HNSW allow-replace-deleted mode before shared memory

### DIFF
--- a/integration/test_hnsw_allow_replace_deleted.py
+++ b/integration/test_hnsw_allow_replace_deleted.py
@@ -197,7 +197,7 @@ class TestReplaceDeletedOnLoad(ValkeySearchTestCaseDebugMode):
 
 class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
     """
-    Regression test for loading an RDB that carries a duplicate label.
+    Regression tests for loading an RDB that carries a duplicate label.
 
     Previously ModifyRecordImpl first called markDelete() on the record to
     tombstone the existing slot with the label and then called addPoint() to add
@@ -211,7 +211,7 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
 
     RDB_FILENAME = "hnsw_duplicate_label.rdb"
     RDB_FIXTURE = f"rdbs/{RDB_FILENAME}"
-    SURVIVOR_VEC = struct.pack('<4f', 10.0, 20.0, 30.0, 40.0)
+    LIVE_VEC = struct.pack('<4f', 10.0, 20.0, 30.0, 40.0)
 
     # TODO: Make functionality common once https://github.com/valkey-io/valkey-search/pull/1172 is merged
     def _start_server(self, test_name, search_module_args=""):
@@ -246,9 +246,15 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
         )
         return server, client, os.path.join(testdir, f"logfile_{port}")
 
-    def test_load_rdb_with_duplicate_label(self):
+    def test_label_lookup_reconstructed(self):
+        '''
+        The HNSW index in the RDB has two slots with the same label.
+        The first slot has the live vector. Previously the label lookup
+        would always point to the largest slot with the label.
+        '''
         server, client, logfile = self._start_server(
-            "hnsw_dup_label_rdb", search_module_args="--debug-mode yes")
+            "hnsw_dup_label_rdb",
+            search_module_args="--debug-mode yes")
         client.config_set("search.info-developer-visible", "yes")
 
         hnsw_index = Index(
@@ -261,7 +267,7 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
         )
 
         dup_on_load = int(client.info("SEARCH").get(
-            "search_hnsw_duplicate_label_on_load_count", 0))
+            "search_hnsw_duplicate_label_on_load_count"))
         assert dup_on_load == 1, \
             f"Expected a duplicate label on load, got {dup_on_load}"
 
@@ -269,11 +275,11 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
         assert ft_info.num_docs == 1, \
             f"Expected 1 doc after load, got {ft_info.num_docs}"
 
-        # The survivor should be doc:1 carrying its updated vector.
+        # The survivor should be doc:1 carrying the live vector.
         search_result = client.execute_command(
             "FT.SEARCH", "idx",
             "*=>[KNN 2 @vector $q]",
-            "PARAMS", "2", "q", self.SURVIVOR_VEC,
+            "PARAMS", "2", "q", self.LIVE_VEC,
             "RETURN", "1", "vector",
         )
         assert search_result[0] == 1, \
@@ -282,7 +288,7 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
             f"Expected doc:1 to survive, got {search_result[1]}"
         returned_fields = search_result[2]
         vector_value = returned_fields[returned_fields.index(b"vector") + 1]
-        assert vector_value == self.SURVIVOR_VEC, \
+        assert vector_value == self.LIVE_VEC, \
             f"Expected doc:1 to carry the updated vector, got {vector_value!r}"
 
         # Deleting the survivor must actually remove it, proving label_lookup_
@@ -294,7 +300,62 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
         search_result = client.execute_command(
             "FT.SEARCH", "idx",
             "*=>[KNN 2 @vector $q]",
-            "PARAMS", "2", "q", self.SURVIVOR_VEC,
+            "PARAMS", "2", "q", self.LIVE_VEC,
         )
         assert search_result[0] == 0, \
             f"Expected doc:1 to be deleted, got {search_result[0]} results"
+
+    def test_label_uniqueness_restored(self):
+        '''
+        The vectors in HNSW are owned by tracked_vectors_ at the module level
+        which maps labels to vectors. The HNSW library holds a raw pointer to them.
+        This pattern enforces that there can only be at most one vector alive per
+        label. The HNSW index in the RDB has two slots with the same label. Both
+        alive and tombstoned slots are traversed during searches and need valid
+        vectors, but previously every one with a duplicate label except the last
+        would be left with a dangling pointer. In our case, that would be slot 0
+        with the live vector. To be absolutely certain that we would be hitting the
+        dangling pointer, we will overwrite the tombstoned slot which erases the
+        label from tracked_vectors_, so that live slot is guaranteed to have a
+        dangling pointer.
+
+        In the end, the fix is all the same. Ensure that every slot corresponds with
+        a unique label on restore.
+        '''
+        server, client, logfile = self._start_server(
+            "hnsw_dup_label_rdb",
+            search_module_args="--debug-mode yes --hnsw-allow-replace-deleted yes")
+        client.config_set("search.info-developer-visible", "yes")
+
+        hnsw_index = Index(
+            "idx",
+            [Vector("vector", 4, type="HNSW", distance="L2")],
+            prefixes=["doc:"]
+        )
+        waiters.wait_for_true(
+            lambda: hnsw_index.backfill_complete(client), timeout=10
+        )
+
+        # Confirm the fixture actually carried a duplicate label into this load.
+        assert int(client.info("SEARCH").get(
+            "search_hnsw_duplicate_label_on_load_count", 0)) == 1
+
+        # Fresh key reuses the dup tombstone's slot.
+        new_vec = struct.pack('<4f', 1.0, 2.0, 3.0, 4.0)
+        client.hset("doc:2", mapping={"vector": new_vec})
+        waiters.wait_for_equal(lambda: hnsw_index.info(client).num_docs, 2)
+
+        # The survivor's RETURN bytes must still be its own.
+        search_result = client.execute_command(
+            "FT.SEARCH", "idx",
+            "*=>[KNN 1 @vector $q]",
+            "PARAMS", "2", "q", self.LIVE_VEC,
+            "RETURN", "1", "vector",
+        )
+        assert search_result[0] == 1, \
+            f"Expected 1 search result, got {search_result[0]}"
+        returned_fields = search_result[2]
+        vector_value = returned_fields[returned_fields.index(b"vector") + 1]
+        assert vector_value == self.LIVE_VEC, \
+            f"Expected survivor to carry its vector, got {vector_value!r}"
+

--- a/src/indexes/vector_base.cc
+++ b/src/indexes/vector_base.cc
@@ -471,9 +471,8 @@ absl::Status VectorBase::LoadTrackedKeys(
     ExternalizeVector(ctx, attribute_data_type, tracked_key_metadata.key(),
                       attribute_identifier_);
   }
-  // Use max label from label_lookup_
-  inc_id_ = GetMaxInternalLabel();
-  ++inc_id_;
+  // Seed above every label stamped at load, including re-labeled tombstones.
+  inc_id_ = GetMaxLoadedLabel() + 1;
   return absl::OkStatus();
 }
 

--- a/src/indexes/vector_base.h
+++ b/src/indexes/vector_base.h
@@ -181,7 +181,7 @@ class VectorBase : public IndexBase, public hnswlib::VectorTracker {
   char* TrackVector(uint64_t internal_id, char* vector, size_t len) override;
   InternedStringPtr InternVector(absl::string_view record,
                                  std::optional<float>& magnitude);
-  virtual uint64_t GetMaxInternalLabel() const { return 0; }
+  virtual uint64_t GetMaxLoadedLabel() const { return 0; }
   virtual size_t GetLabelCount() const { return 0; }
 
   bool IsVectorIndex() const override { return true; }

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -179,8 +179,12 @@ absl::Status VectorHNSW<T>::AddRecordImpl(uint64_t internal_id,
     try {
       absl::ReaderMutexLock lock(&resize_mutex_);
 
-      algo_->addPoint((T *)record.data(), internal_id,
-                      algo_->allow_replace_deleted_);
+      auto evicted = algo_->addPoint((T *)record.data(), internal_id,
+                                     algo_->allow_replace_deleted_);
+      if (evicted.has_value()) {
+        absl::MutexLock lock(&tracked_vectors_mutex_);
+        tracked_vectors_.erase(*evicted);
+      }
       return absl::OkStatus();
     } catch (const std::exception &e) {
       std::string error_msg = e.what();
@@ -275,8 +279,10 @@ absl::Status VectorHNSW<T>::ModifyRecordImpl(uint64_t internal_id,
   try {
     absl::ReaderMutexLock lock(&resize_mutex_);
     // addPoint() routes an existing label to an in-place update.
-    algo_->addPoint((T *)record.data(), internal_id,
-                    algo_->allow_replace_deleted_);
+    auto evicted = algo_->addPoint((T *)record.data(), internal_id,
+                                   algo_->allow_replace_deleted_);
+    CHECK(!evicted.has_value()) << "modify of live label " << internal_id
+                                << " unexpectedly displaced " << *evicted;
   } catch (const std::exception &e) {
     ++Metrics::GetStats().hnsw_modify_exceptions_cnt;
     return absl::InternalError(
@@ -382,21 +388,23 @@ VectorHNSW<T>::ComputeDistanceFromRecordImpl(uint64_t internal_id,
       internal_id};
 }
 
-// Getting max label from label_lookup_ (active + tombstoned).
+// Max label stamped on any slot at load time (includes re-labeled tombstones,
+// which are absent from label_lookup_). Used to seed inc_id_ on load.
 template <typename T>
-uint64_t VectorHNSW<T>::GetMaxInternalLabel() const {
-  std::unique_lock<std::mutex> lock_label(algo_->label_lookup_lock);
-  uint64_t max_label = 0;
-  for (const auto &[label, _] : algo_->label_lookup_) {
-    max_label = std::max(max_label, static_cast<uint64_t>(label));
-  }
-  return max_label;
+uint64_t VectorHNSW<T>::GetMaxLoadedLabel() const {
+  return static_cast<uint64_t>(algo_->max_loaded_label_);
 }
 
 template <typename T>
 size_t VectorHNSW<T>::GetLabelCount() const {
   std::unique_lock<std::mutex> lock_label(algo_->label_lookup_lock);
   return algo_->label_lookup_.size();
+}
+
+template <typename T>
+size_t VectorHNSW<T>::GetTrackedVectorCount() const {
+  absl::ReaderMutexLock lock(&tracked_vectors_mutex_);
+  return tracked_vectors_.size();
 }
 
 template class VectorHNSW<float>;

--- a/src/indexes/vector_hnsw.h
+++ b/src/indexes/vector_hnsw.h
@@ -51,6 +51,8 @@ class VectorHNSW : public VectorBase {
   }
 
   int GetDimensions() const { return dimensions_; }
+  size_t GetTrackedVectorCount() const
+      ABSL_LOCKS_EXCLUDED(tracked_vectors_mutex_);
   size_t GetCapacity() const override
       ABSL_SHARED_LOCKS_REQUIRED(resize_mutex_) {
     return algo_->max_elements_;
@@ -101,7 +103,7 @@ class VectorHNSW : public VectorBase {
       ABSL_LOCKS_EXCLUDED(tracked_vectors_mutex_);
   void UnTrackVector(uint64_t internal_id) override
       ABSL_LOCKS_EXCLUDED(tracked_vectors_mutex_);
-  uint64_t GetMaxInternalLabel() const override ABSL_NO_THREAD_SAFETY_ANALYSIS;
+  uint64_t GetMaxLoadedLabel() const override ABSL_NO_THREAD_SAFETY_ANALYSIS;
   size_t GetLabelCount() const override ABSL_NO_THREAD_SAFETY_ANALYSIS;
 
  private:

--- a/testing/vector_test.cc
+++ b/testing/vector_test.cc
@@ -591,12 +591,12 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
     VerifyAdd(index->get(), vectors, i, ExpectedResults::kSuccess);
   }
   VectorBase *base = index->get();
-  EXPECT_EQ(base->GetMaxInternalLabel(), 9u);
+  VMSDK_EXPECT_OK((*index)->RemoveRecord(IndexToKey(7), DeletionType::kNone));
   VMSDK_EXPECT_OK((*index)->RemoveRecord(IndexToKey(8), DeletionType::kNone));
-  VMSDK_EXPECT_OK((*index)->RemoveRecord(IndexToKey(9), DeletionType::kNone));
-  EXPECT_EQ(base->GetMaxInternalLabel(), 9u);
-  EXPECT_EQ(base->GetLabelCount(), 10u);
+  // Deletes drop those labels from the live-only label_lookup_.
+  EXPECT_EQ(base->GetLabelCount(), 8u);
   EXPECT_EQ(base->GetTrackedKeyCount(), 8u);
+  EXPECT_EQ((*index)->GetTrackedVectorCount(), 10u);
   auto new_vectors = DeterministicallyGenerateVectors(5, kDimensions, 20.0);
   for (size_t i = 0; i < new_vectors.size(); ++i) {
     auto key = StringInternStore::Intern(absl::StrCat("new_", i, "_key"));
@@ -608,6 +608,11 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
   EXPECT_EQ(base->GetTrackedKeyCount(), 13u);
   // Verifies we reused tombstoned hnsw nodes
   EXPECT_EQ(base->GetLabelCount(), 13u);
+
+  // VERY IMPORTANT. Previously we weren't actually freeing
+  // vectors of reused slots.
+  EXPECT_EQ((*index)->GetTrackedVectorCount(), 13u);
+
   absl::string_view query = VectorToStr(new_vectors[0]);
   auto search_result = (*index)->Search(query, 13, CancelNever());
   VMSDK_EXPECT_OK(search_result);
@@ -714,8 +719,9 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
   for (int t = 0; t < kThreads; ++t) {
     threads.emplace_back([&algo, t]() {
       for (int i = 0; i < kIters; ++i) {
-        algo.markDelete(t);    // += vector_size_
-        algo.unmarkDelete(t);  // -= vector_size_  (net per cycle: 0)
+        // Labels and slot numbers should match, so we can use "internal" API.
+        algo.markDeletedInternal(t);    // += vector_size_
+        algo.unmarkDeletedInternal(t);  // -= vector_size_  (net per cycle: 0)
       }
     });
   }
@@ -828,16 +834,26 @@ class ChunkStream : public hnswlib::InputStream, public hnswlib::OutputStream {
 };
 
 // VectorTracker that copies each vector into stable storage and hands back a
-// pointer to it (LoadIndex stores that pointer in the level-0 record).
+// pointer to it (LoadIndex stores that pointer in the level-0 record). Records
+// bytes by label, mirroring how the real tracker keys tracked_vectors_.
 class BufTracker : public hnswlib::VectorTracker {
  public:
-  char *TrackVector(uint64_t /*id*/, char *vector, size_t len) override {
+  char *TrackVector(uint64_t id, char *vector, size_t len) override {
     storage_.emplace_back(vector, len);
+    by_label_[id] = &storage_.back();
     return storage_.back().data();
   }
 
+  const std::string *GetByLabel(uint64_t label) const {
+    auto it = by_label_.find(label);
+    return it == by_label_.end() ? nullptr : it->second;
+  }
+
+  size_t LabelCount() const { return by_label_.size(); }
+
  private:
   std::deque<std::string> storage_;
+  absl::flat_hash_map<uint64_t, std::string *> by_label_;
 };
 
 // On-disk geometry for kM / kDimensions, used to locate bytes for mutation.
@@ -987,13 +1003,110 @@ TEST_F(VectorIndexTest, HnswAddPointReplaceDeletedDoesNotDuplicateLabel) {
   // label.
   algo.addPoint(vectors[0].data(), /*label=*/1, /*replace_deleted=*/true);
 
-  // Each label keeps its own slot: label 1 stays live on slot 1 and label 0
-  // stays on the still-tombstoned slot 0.
-  EXPECT_EQ(algo.label_lookup_.size(), 2u);
-  EXPECT_EQ(algo.label_lookup_[0], 0u);
+  // label 1 updates in place on its own slot rather than reusing tombstoned
+  // slot 0. label_lookup_ is live-only, so it holds just label 1; slot 0 stays
+  // tombstoned.
+  EXPECT_EQ(algo.label_lookup_.size(), 1u);
   EXPECT_EQ(algo.label_lookup_[1], 1u);
   EXPECT_TRUE(algo.isMarkedDeleted(0));
   EXPECT_FALSE(algo.isMarkedDeleted(1));
+}
+
+namespace {
+// Build a golden of `num_slots` slots that all share the live slot's label, as
+// a legacy dup-label RDB does. Every slot in `tombstone_slots` is deleted; the
+// one live slot keeps the shared label. Each slot still holds its own distinct
+// bytes.
+ChunkStream DuplicateLabelGolden(size_t num_slots,
+                                 const std::vector<size_t> &tombstone_slots) {
+  hnswlib::L2Space space{kDimensions};
+  hnswlib::HierarchicalNSW<float> algo(&space, kGoldenMax, kM, kEFConstruction,
+                                       /*random_seed=*/100,
+                                       /*allow_replace_deleted=*/true);
+  auto vectors = DeterministicallyGenerateVectors(num_slots, kDimensions, 10.0);
+  for (size_t i = 0; i < num_slots; i++) {
+    algo.addPoint(vectors[i].data(), /*label=*/i);
+  }
+  size_t live_slot = num_slots;
+  for (size_t t : tombstone_slots) {
+    algo.markDelete(t);
+  }
+  for (size_t i = 0; i < num_slots; i++) {
+    if (std::find(tombstone_slots.begin(), tombstone_slots.end(), i) ==
+        tombstone_slots.end()) {
+      live_slot = i;
+    }
+  }
+  ChunkStream golden;
+  EXPECT_TRUE(algo.SaveIndex(golden).ok());
+  // Collide every slot's stored label with the live slot's.
+  for (size_t i = 0; i < num_slots; i++) {
+    PokeAt<hnswlib::labeltype>(&golden.chunks[1 + i], kLabelOff, live_slot);
+  }
+  return golden;
+}
+}  // namespace
+
+// Loading a dup-label RDB must give every slot a unique label and leave each
+// slot's own vector intact. The live slot keeps the shared label; each
+// tombstone is re-labeled uniquely. label_lookup_ holds live labels only.
+// Covers both 2-slot orderings and a 3-slot group (two tombstones, one live).
+TEST_F(VectorIndexTest, LoadDuplicateLabelReassignsUniqueLabels) {
+  struct Case {
+    size_t num_slots;
+    std::vector<size_t> tombstones;
+  };
+  for (const Case &c : std::vector<Case>{{2, {1}}, {2, {0}}, {3, {0, 2}}}) {
+    size_t live_slot = c.num_slots;  // set below
+    for (size_t i = 0; i < c.num_slots; i++) {
+      if (std::find(c.tombstones.begin(), c.tombstones.end(), i) ==
+          c.tombstones.end()) {
+        live_slot = i;
+      }
+    }
+    auto vectors =
+        DeterministicallyGenerateVectors(c.num_slots, kDimensions, 10.0);
+    auto golden = DuplicateLabelGolden(c.num_slots, c.tombstones);
+
+    hnswlib::L2Space space{kDimensions};
+    hnswlib::HierarchicalNSW<float> algo(&space);
+    algo.allow_replace_deleted_ = true;
+    BufTracker tracker;
+    golden.Rewind();
+    VMSDK_EXPECT_OK(algo.LoadIndex(golden, &space, kGoldenMax, &tracker, kM,
+                                   /*validate=*/true));
+
+    // The live slot keeps the shared label; label_lookup_ is live-only.
+    EXPECT_EQ(algo.label_lookup_.size(), 1u);
+    EXPECT_EQ(algo.label_lookup_[live_slot], live_slot);
+
+    // Every slot has a unique label and reads back its own bytes (no dangling
+    // or cross-contaminated data_ptr), all seeded below max_loaded_label_.
+    std::set<hnswlib::labeltype> labels;
+    for (size_t i = 0; i < c.num_slots; i++) {
+      hnswlib::labeltype label = algo.getExternalLabel(i);
+      EXPECT_TRUE(labels.insert(label).second)
+          << "duplicate label on slot " << i;
+      EXPECT_LE(label, algo.max_loaded_label_);
+      EXPECT_EQ(std::string(algo.getDataByInternalId(i), kVecBytes),
+                VectorToStr(vectors[i]));
+      // The vector is tracked under the slot's final label, not a stale one.
+      const std::string *tracked = tracker.GetByLabel(label);
+      ASSERT_NE(tracked, nullptr) << "no tracked vector for slot " << i;
+      EXPECT_EQ(*tracked, VectorToStr(vectors[i]));
+    }
+    // One tracked entry per slot: no stale duplicate-label entry left behind.
+    EXPECT_EQ(tracker.LabelCount(), c.num_slots);
+
+    // Reusing a tombstone returns its displaced (synthetic) label so the caller
+    // can drop it from tracked_vectors_, and must not disturb the live slot.
+    auto evicted = algo.addPoint(vectors[live_slot].data(), /*label=*/1000,
+                                 /*replace_deleted=*/true);
+    ASSERT_TRUE(evicted.has_value());
+    EXPECT_GT(*evicted, live_slot);
+    EXPECT_EQ(algo.label_lookup_[live_slot], live_slot);
+    EXPECT_FALSE(algo.isMarkedDeleted(live_slot));
+  }
 }
 
 // ---- Happy path ----------------------------------------------------------

--- a/third_party/hnswlib/bruteforce.h
+++ b/third_party/hnswlib/bruteforce.h
@@ -63,7 +63,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
     }
 
 
-    void addPoint(const void *datapoint, labeltype label, bool replace_deleted = false) {
+    std::optional<labeltype> addPoint(const void *datapoint, labeltype label, bool replace_deleted = false) {
         int idx;
         std::unique_lock<std::mutex> lock(index_lock);
         auto search = dict_external_to_internal.find(label);
@@ -79,6 +79,7 @@ class BruteforceSearch : public AlgorithmInterface<dist_t> {
         }
         memcpy((*data_)[idx] + data_ptr_size_, &label, sizeof(labeltype));
         *(char**)((*data_)[idx]) = (char*)datapoint;
+        return std::nullopt;
     }
 
     char *getPoint(labeltype cur_external) {

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -90,7 +90,9 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
   void *dist_func_param_{nullptr};
 
   mutable std::mutex label_lookup_lock;  // lock for label_lookup_
-  std::unordered_map<labeltype, tableint> label_lookup_;
+  std::unordered_map<labeltype, tableint>
+      label_lookup_;  // only contains live slots
+  labeltype max_loaded_label_{0};  // max label stamped on any slot at load time
 
   std::default_random_engine level_generator_;
   std::default_random_engine update_probability_generator_;
@@ -987,6 +989,11 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
     data_level0_memory_ = std::make_unique<ChunkedArray>(
         size_data_per_element_, k_elements_per_chunk, max_elements);
 
+    labeltype max_label = 0;
+    // Tracks tombstoned slots by label to detect duplicates during load.
+    std::unordered_map<labeltype, tableint> tombstoned_label_lookup_;
+    // Slots whose duplicate label must be reassigned, mapped to their vector.
+    std::unordered_map<tableint, std::string> dup_label_slots;
     for (size_t i = 0; i < cur_element_count_; i++) {
       VMSDK_ASSIGN_OR_RETURN(auto chunk, input.LoadChunk());
       loadCheck(chunk->size() ==
@@ -996,9 +1003,43 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       labeltype id;
       memcpy((char *)&id, chunk->data() + size_links_level0_ + vector_size_,
              sizeof(labeltype));
-      *(char **)((*data_level0_memory_)[i] + offsetData_) =
+      max_label = std::max(max_label, id);
+
+      // A label can appear on multiple slots in RDBs written by older versions.
+      // We ensure that the live slot wins the label in a duplicate label situation,
+      // and any duplicate tombstone slots get re-labeled to a new unique label.
+      if (!isMarkedDeleted(static_cast<tableint>(i))) {
+        loadCheck(label_lookup_.find(id) == label_lookup_.end(),
+                  "duplicate live label in index");
+
+        // Mark any tombstones slots with the same label for duplicate handling
+        auto tomb_dup_it = tombstoned_label_lookup_.find(id);
+        if (tomb_dup_it != tombstoned_label_lookup_.end()) {
+          dup_label_slots[tomb_dup_it->second] = std::string(
+              getDataByInternalId(tomb_dup_it->second), vector_size_);
+          tombstoned_label_lookup_.erase(tomb_dup_it);
+        }
+
+        // Track the vector
+        *(char **)((*data_level0_memory_)[i] + offsetData_) =
           vector_tracker->TrackVector(id, chunk->data() + size_links_level0_,
                                       vector_size_);
+        label_lookup_[id] = i;
+      } else {
+        if (tombstoned_label_lookup_.find(id) != tombstoned_label_lookup_.end()
+            || label_lookup_.find(id) != label_lookup_.end()) {
+          // Allow the first tombstone with the label to maintain ownership
+          dup_label_slots[i] =
+              std::string(chunk->data() + size_links_level0_, vector_size_);
+        } else {
+          // Track the vector
+          *(char **)((*data_level0_memory_)[i] + offsetData_) =
+              vector_tracker->TrackVector(id, chunk->data() + size_links_level0_,
+                                          vector_size_);
+          tombstoned_label_lookup_[id] = i;
+        }
+      }
+
       memcpy((*data_level0_memory_)[i] + label_offset_, (char *)&id,
              sizeof(labeltype));
 
@@ -1016,6 +1057,8 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         loadCheck(l0_neighbors[j] != i, "level-0 self-loop");
       }
     }
+    valkey_search::Metrics::GetStats().hnsw_duplicate_label_on_load_cnt +=
+        dup_label_slots.size();
 
     std::vector<std::mutex>(max_elements).swap(link_list_locks_);
     std::vector<std::mutex>(MAX_LABEL_OPERATION_LOCKS).swap(label_op_locks_);
@@ -1036,25 +1079,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       element_levels_[i] = 0;
       *reinterpret_cast<char **>((*linkLists_)[i]) = nullptr;
 
-      labeltype ext_label = getExternalLabel(i);
-
-      // A label can appear on multiple slots in RDBs written by older versions.
-      // There can be one live slot and any number of tombstoned slots all
-      // carrying the same label. We just need to rebuild the label lookup to
-      // point the label at the live slot if there is one.
-      auto dup_it = label_lookup_.find(ext_label);
-      if (dup_it == label_lookup_.end()) {
-        label_lookup_[ext_label] = i;
-      } else {
-        valkey_search::Metrics::GetStats().hnsw_duplicate_label_on_load_cnt +=
-            1;
-        if (!isMarkedDeleted(static_cast<tableint>(i))) {
-          loadCheck(isMarkedDeleted(dup_it->second),
-                    "duplicate live label in index");
-          // Overwrite mapping to tombstoned slot with the live one.
-          dup_it->second = i;
-        }
-      }
       size_t linkListSize;
       VMSDK_ASSIGN_OR_RETURN(auto size_chunk, input.LoadChunk());
       loadCheck(size_chunk->size() == sizeof(size_t),
@@ -1090,6 +1114,16 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
         }
       }
     }
+
+    // Re-label the duplicates with unique labels
+    for (auto &[slot, vec] : dup_label_slots) {
+      labeltype label = ++max_label;
+      setExternalLabel(slot, label);
+      // Track the vector
+      *(char **)((*data_level0_memory_)[slot] + offsetData_) =
+          vector_tracker->TrackVector(label, vec.data(), vector_size_);
+    }
+    max_loaded_label_ = max_label;
 
     // --- Global graph-invariant pass (requires all element_levels_ loaded) ---
     // The entry point must be one of the tallest nodes (proven invariant:
@@ -1180,6 +1214,7 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       throw std::runtime_error("Label not found");
     }
     tableint internalId = search->second;
+    label_lookup_.erase(search);
     lock_table.unlock();
 
     markDeletedInternal(internalId);
@@ -1206,29 +1241,6 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       throw std::runtime_error(
           "The requested to delete element is already deleted");
     }
-  }
-
-  /*
-   * Removes the deleted mark of the node, does NOT really change the current
-   * graph.
-   *
-   * Note: the method is not safe to use when replacement of deleted elements is
-   * enabled, because elements marked as deleted can be completely removed by
-   * addPoint
-   */
-  void unmarkDelete(labeltype label) {
-    // lock all operations with element by label
-    std::unique_lock<std::mutex> lock_label(getLabelOpMutex(label));
-
-    std::unique_lock<std::mutex> lock_table(label_lookup_lock);
-    auto search = label_lookup_.find(label);
-    if (search == label_lookup_.end()) {
-      throw std::runtime_error("Label not found");
-    }
-    tableint internalId = search->second;
-    lock_table.unlock();
-
-    unmarkDeletedInternal(internalId);
   }
 
   /*
@@ -1271,11 +1283,10 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
   /*
    * Adds point. Updates the point if it is already in the index.
-   * If replacement of deleted elements is enabled: replaces previously deleted
-   * point if any, updating it with new point. If the label already exists in a
-   * slot, the same slot will be used.
+   * If replacement of deleted elements is enabled, a tombstoned slot is reused
+   * if there are any available, and the old label of the slot is returned.
    */
-  void addPoint(const void *data_point, labeltype label,
+  std::optional<labeltype> addPoint(const void *data_point, labeltype label,
                 bool replace_deleted = false) {
     if ((allow_replace_deleted_ == false) && (replace_deleted == true)) {
       throw std::runtime_error(
@@ -1284,29 +1295,23 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
 
     // lock all operations with element by label
     std::unique_lock<std::mutex> lock_label(getLabelOpMutex(label));
-    if (!replace_deleted) {
-      addPoint(data_point, label, -1);
-      return;
-    }
 
     // If the label already exists, reuse the same slot.
+    // WARN: Labels are not to be reused unless updating a live slot.
     {
       std::unique_lock<std::mutex> lock_table(label_lookup_lock);
       auto search = label_lookup_.find(label);
       if (search != label_lookup_.end()) {
         tableint existing = search->second;
         lock_table.unlock();
-        if (isMarkedDeleted(existing)) {
-          {
-            std::unique_lock<std::mutex> lock_deleted_elements(
-                deleted_elements_lock);
-            deleted_elements.erase(existing);
-          }
-          unmarkDeletedInternal(existing);
-        }
         updatePoint(data_point, existing, 1.0);
-        return;
+        return std::nullopt;
       }
+    }
+
+    if (!replace_deleted) {
+      addPoint(data_point, label, -1);
+      return std::nullopt;
     }
 
     // Otherwise, reuse a vacant tombstoned slot if any.
@@ -1329,14 +1334,16 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
       labeltype label_replaced = getExternalLabel(internal_id_replaced);
       setExternalLabel(internal_id_replaced, label);
 
+      // Add the slot back to the label lookup now that it's live again
       std::unique_lock<std::mutex> lock_table(label_lookup_lock);
-      label_lookup_.erase(label_replaced);
       label_lookup_[label] = internal_id_replaced;
       lock_table.unlock();
 
       unmarkDeletedInternal(internal_id_replaced);
       updatePoint(data_point, internal_id_replaced, 1.0);
+      return std::optional<labeltype>(label_replaced);
     }
+    return std::nullopt;
   }
 
   void updatePoint(const void *dataPoint, tableint internalId,
@@ -1521,36 +1528,14 @@ class HierarchicalNSW : public AlgorithmInterface<dist_t> {
   }
 
   tableint addPoint(const void *data_point, labeltype label, int level) {
+    if (cur_element_count_ >= max_elements_) {
+      throw std::runtime_error(
+          "The number of elements exceeds the specified limit");
+    }
+
     tableint cur_c = 0;
     {
-      // Checking if the element with the same label already exists
-      // if so, updating it *instead* of creating a new element.
       std::unique_lock<std::mutex> lock_table(label_lookup_lock);
-      auto search = label_lookup_.find(label);
-      if (search != label_lookup_.end()) {
-        tableint existingInternalId = search->second;
-        if (allow_replace_deleted_) {
-          if (isMarkedDeleted(existingInternalId)) {
-            throw std::runtime_error(
-                "Can't use addPoint to update deleted elements if replacement "
-                "of deleted elements is enabled.");
-          }
-        }
-        lock_table.unlock();
-
-        if (isMarkedDeleted(existingInternalId)) {
-          unmarkDeletedInternal(existingInternalId);
-        }
-        updatePoint(data_point, existingInternalId, 1.0);
-
-        return existingInternalId;
-      }
-
-      if (cur_element_count_ >= max_elements_) {
-        throw std::runtime_error(
-            "The number of elements exceeds the specified limit");
-      }
-
       cur_c = cur_element_count_;
       cur_element_count_++;
       label_lookup_[label] = cur_c;

--- a/third_party/hnswlib/hnswlib.h
+++ b/third_party/hnswlib/hnswlib.h
@@ -134,6 +134,7 @@ static bool AVX512Capable() {
 #include <string.h>
 
 #include <iostream>
+#include <optional>
 #include <queue>
 #include <vector>
 
@@ -215,8 +216,9 @@ class SpaceInterface {
 template <typename dist_t>
 class AlgorithmInterface {
  public:
-  virtual void addPoint(const void *datapoint, labeltype label,
-                        bool replace_deleted = false) = 0;
+  virtual std::optional<labeltype> addPoint(const void *datapoint,
+                                            labeltype label,
+                                            bool replace_deleted = false) = 0;
 
   virtual std::priority_queue<std::pair<dist_t, labeltype>> searchKnn(
       const void *, size_t, BaseFilterFunctor *isIdAllowed = nullptr,


### PR DESCRIPTION
Finishes solving #1282 and solves #1288.

There are three things addressed here:
##### 1. Fully recovering to a healthy state when loading an RDB that contains an HNSW index with duplicate labels.

#1283 prevents new instances of duplicate labels being created. It also prevents the validation logic from rejecting existing RDBs with duplicate labels and restores the HNSW index to the state it was in at the time of save, but that isn't a fully healthy state. There will be dangling vector pointers in the index (see https://github.com/valkey-io/valkey-search/issues/1282#issuecomment-5186675853). This PR actually repairs the HNSW state so that there are no dangling pointers by enforcing label uniqueness. This gives a clear one-to-one mapping of labels in `tracked_vectors_` and labels in `data_level0_memory_`.

##### 2. Cleaning up an overwritten slot's vector from `tracked_vectors_`.

The whole point of enabling `allow-replace-deleted` is to reduce memory usage with the potential risk of reducing the quality of the graph structure (incoming edges lose effectiveness when the vector is arbitrarily replaced). The problem was, when a slot was overwritten, we weren't actually freeing the most significant part of the memory associated with it: the old vector (#1288). Now the HNSW library layer returns the label of an overwritten slot so that `tracked_vectors_` can be cleaned up.

##### 3. Removes tombstoned labels from `label_lookup_`.

Labels are used by the search module to operate on live vectors. Once a vector is deleted from the keyspace, and the module has told the HNSW library to tombstone the slot with that label, there is no more use for mapping from label -> slot. `label_lookup_` now only contains live labels as a simplification and space optimization.