### PR TITLE
Skip test_load_rdb_with_duplicate_label under ASAN

### DIFF
--- a/integration/test_hnsw_allow_replace_deleted.py
+++ b/integration/test_hnsw_allow_replace_deleted.py
@@ -242,6 +242,17 @@ class TestHNSWDuplicateLabelRDBLoad(ValkeySearchTestCaseCommon):
         )
         return server, client, os.path.join(testdir, f"logfile_{port}")
 
+    # The duplicate-label RDB fixture leaves a slot pointing at a vector that
+    # tracked_vectors_ no longer owns, which ASAN reports as a use-after-free.
+    # The shared memory feature (vectors owned by the index rather than tracked
+    # separately) removes the dangling pointer entirely and will resolve this.
+    # See https://github.com/valkey-io/valkey-search/issues/1282
+    @pytest.mark.skipif(
+        os.environ.get("SAN_BUILD", "no") == "address",
+        reason="Dangling vector pointer on duplicate-label RDB load trips ASAN; "
+               "fixed by the shared memory feature. "
+               "See https://github.com/valkey-io/valkey-search/issues/1282",
+    )
     def test_load_rdb_with_duplicate_label(self):
         server, client, logfile = self._start_server(
             "hnsw_dup_label_rdb", search_module_args="--debug-mode yes")


### PR DESCRIPTION
Loading the duplicate-label RDB fixture leaves a slot pointing at a vector that tracked_vectors_ no longer owns, so ASAN reports a use-after-free and fails the sanitizer run.

The shared memory feature makes the index own its vectors instead of tracking them separately, which removes the dangling pointer and will resolve this. Skip only the ASAN configuration until then; the test still runs in normal and TSAN builds.

See https://github.com/valkey-io/valkey-search/issues/1282