### PR TITLE
Simplify logging with a module-scoped detached context

### DIFF
--- a/src/attribute_data_type.cc
+++ b/src/attribute_data_type.cc
@@ -259,7 +259,7 @@ bool IsJsonModuleSupported(ValkeyModuleCtx *ctx) {
   // the JSON shared API. Otherwise, invoking commands via ValkeyModule_Call
   // from a replica will result in a MOVED response.
   if (!json_get && ValkeySearch::Instance().IsCluster()) {
-    VMSDK_LOG(WARNING, ctx)
+    VMSDK_LOG(WARNING)
         << "Note: When cluster mode is enabled, valkey-search requires "
            "valkey-json version 1.02 or higher for proper JSON support.";
   }

--- a/src/commands/filter_parser.cc
+++ b/src/commands/filter_parser.cc
@@ -460,9 +460,9 @@ absl::StatusOr<FilterParseResults> FilterParser::Parse() {
         PrintPredicateTree(results.root_predicate.get(), 0);
     size_t chunk_size = 500;
     for (size_t i = 0; i < tree_output.length(); i += chunk_size) {
-      VMSDK_LOG(DEBUG, nullptr)
-          << "Parsed QuerySyntaxTree (Part " << (i / chunk_size + 1) << "):\n"
-          << tree_output.substr(i, chunk_size);
+      VMSDK_LOG(DEBUG) << "Parsed QuerySyntaxTree (Part "
+                       << (i / chunk_size + 1) << "):\n"
+                       << tree_output.substr(i, chunk_size);
     }
   }
   return results;

--- a/src/commands/ft_create.cc
+++ b/src/commands/ft_create.cc
@@ -76,9 +76,9 @@ absl::Status FTCreateCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
     op->StartOperation(ctx);
   } else {
     if (is_loading || inside_multi_exec) {
-      VMSDK_LOG(NOTICE, nullptr) << "The server is loading AOF or inside "
-                                    "multi/exec or lua script, skip "
-                                    "fanout operation";
+      VMSDK_LOG(NOTICE) << "The server is loading AOF or inside "
+                           "multi/exec or lua script, skip "
+                           "fanout operation";
     }
     ValkeyModule_ReplyWithSimpleString(ctx, "OK");
   }

--- a/src/commands/ft_debug.cc
+++ b/src/commands/ft_debug.cc
@@ -285,32 +285,28 @@ absl::Status StringPoolStats(ValkeyModuleCtx *ctx, vmsdk::ArgsIterator &itr) {
   //
   // Put the stats into the log
   //
-  VMSDK_LOG(NOTICE, ctx) << "<<<< Start InternStringPool Stats >>>>>";
-  VMSDK_LOG(NOTICE, ctx) << "Inline Total: " << stats.inline_total_stats_;
-  VMSDK_LOG(NOTICE, ctx) << "OutOfLine Total: "
-                         << stats.out_of_line_total_stats_;
-  VMSDK_LOG(NOTICE, ctx) << "ByRefCount Buckets: "
-                         << stats.by_ref_stats_.size();
+  VMSDK_LOG(NOTICE) << "<<<< Start InternStringPool Stats >>>>>";
+  VMSDK_LOG(NOTICE) << "Inline Total: " << stats.inline_total_stats_;
+  VMSDK_LOG(NOTICE) << "OutOfLine Total: " << stats.out_of_line_total_stats_;
+  VMSDK_LOG(NOTICE) << "ByRefCount Buckets: " << stats.by_ref_stats_.size();
   for (auto &hist : stats.by_ref_stats_) {
     if (hist.first > 0) {
-      VMSDK_LOG(NOTICE, ctx)
-          << "InlineRef: " << hist.first << " " << hist.second;
+      VMSDK_LOG(NOTICE) << "InlineRef: " << hist.first << " " << hist.second;
     } else {
-      VMSDK_LOG(NOTICE, ctx)
-          << "OutOfLineRef: " << -hist.first << " " << hist.second;
+      VMSDK_LOG(NOTICE) << "OutOfLineRef: " << -hist.first << " "
+                        << hist.second;
     }
   }
-  VMSDK_LOG(NOTICE, ctx) << "BySize Buckets: " << stats.by_size_stats_.size();
+  VMSDK_LOG(NOTICE) << "BySize Buckets: " << stats.by_size_stats_.size();
   for (auto &hist : stats.by_size_stats_) {
     if (hist.first > 0) {
-      VMSDK_LOG(NOTICE, ctx)
-          << "InlineSize: " << hist.first << " " << hist.second;
+      VMSDK_LOG(NOTICE) << "InlineSize: " << hist.first << " " << hist.second;
     } else {
-      VMSDK_LOG(NOTICE, ctx)
-          << "OutOfLineSize: " << -hist.first << " " << hist.second;
+      VMSDK_LOG(NOTICE) << "OutOfLineSize: " << -hist.first << " "
+                        << hist.second;
     }
   }
-  VMSDK_LOG(NOTICE, ctx) << "<<<< End InternStringPool Stats >>>>>";
+  VMSDK_LOG(NOTICE) << "<<<< End InternStringPool Stats >>>>>";
   return absl::OkStatus();
 }
 
@@ -373,7 +369,7 @@ absl::Status FTDebugCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
     msg += ' ';
     msg += vmsdk::ToStringView(argv[i]);
   }
-  VMSDK_LOG(WARNING, ctx) << "FT._DEBUG: " << msg;
+  VMSDK_LOG(WARNING) << "FT._DEBUG: " << msg;
   vmsdk::ArgsIterator itr{argv, argc};
   itr.Next();  // Skip the command name
   std::string keyword;

--- a/src/commands/ft_dropindex.cc
+++ b/src/commands/ft_dropindex.cc
@@ -136,9 +136,9 @@ absl::Status FTDropIndexCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
     op->StartOperation(ctx);
   } else {
     if (is_loading || inside_multi_exec) {
-      VMSDK_LOG(NOTICE, nullptr) << "The server is loading AOF or inside "
-                                    "multi/exec or lua script, skip "
-                                    "fanout operation";
+      VMSDK_LOG(NOTICE) << "The server is loading AOF or inside "
+                           "multi/exec or lua script, skip "
+                           "fanout operation";
     }
     ValkeyModule_ReplyWithSimpleString(ctx, "OK");
   }

--- a/src/commands/ft_info_parser.cc
+++ b/src/commands/ft_info_parser.cc
@@ -132,9 +132,9 @@ absl::Status InfoCommand::Execute(ValkeyModuleCtx *ctx) {
   switch (scope) {
     case InfoScope::kPrimary: {
       if (is_loading || inside_multi_exec) {
-        VMSDK_LOG(NOTICE, nullptr) << "The server is loading AOF or inside "
-                                      "multi/exec or lua script, skip "
-                                      "fanout operation";
+        VMSDK_LOG(NOTICE) << "The server is loading AOF or inside "
+                             "multi/exec or lua script, skip "
+                             "fanout operation";
         index_schema->RespondWithInfo(ctx);
       } else {
         auto op = new query::primary_info_fanout::PrimaryInfoFanoutOperation(
@@ -146,9 +146,9 @@ absl::Status InfoCommand::Execute(ValkeyModuleCtx *ctx) {
     }
     case InfoScope::kCluster: {
       if (is_loading || inside_multi_exec) {
-        VMSDK_LOG(NOTICE, nullptr) << "The server is loading AOF or inside "
-                                      "multi/exec or lua script, skip "
-                                      "fanout operation";
+        VMSDK_LOG(NOTICE) << "The server is loading AOF or inside "
+                             "multi/exec or lua script, skip "
+                             "fanout operation";
         index_schema->RespondWithInfo(ctx);
       } else {
         auto op = new query::cluster_info_fanout::ClusterInfoFanoutOperation(
@@ -160,7 +160,7 @@ absl::Status InfoCommand::Execute(ValkeyModuleCtx *ctx) {
     }
     case InfoScope::kLocal:
     default:
-      VMSDK_LOG(DEBUG, ctx) << "Using Local Scope";
+      VMSDK_LOG(DEBUG) << "Using Local Scope";
       index_schema->RespondWithInfo(ctx);
       break;
   }

--- a/src/commands/ft_internal_update.cc
+++ b/src/commands/ft_internal_update.cc
@@ -24,9 +24,9 @@ absl::Status HandleInternalUpdateFailure(ValkeyModuleCtx *ctx,
                                          const std::string &operation_type,
                                          const std::string &id,
                                          const absl::Status &error_status) {
-  VMSDK_LOG(WARNING, ctx) << "CRITICAL: " << operation_type
-                          << " failed in FT.INTERNAL_UPDATE. "
-                          << "Index ID: " << vmsdk::config::RedactIfNeeded(id);
+  VMSDK_LOG(WARNING) << "CRITICAL: " << operation_type
+                     << " failed in FT.INTERNAL_UPDATE. "
+                     << "Index ID: " << vmsdk::config::RedactIfNeeded(id);
 
   if (operation_type.find("parse") != std::string::npos) {
     Metrics::GetStats().ft_internal_update_parse_failures_cnt++;
@@ -36,7 +36,7 @@ absl::Status HandleInternalUpdateFailure(ValkeyModuleCtx *ctx,
 
   if (ValkeyModule_GetContextFlags(ctx) & VALKEYMODULE_CTX_FLAGS_LOADING) {
     if (options::GetSkipCorruptedInternalUpdateEntries().GetValue()) {
-      VMSDK_LOG(WARNING, ctx)
+      VMSDK_LOG(WARNING)
           << "SKIPPING corrupted FT.INTERNAL_UPDATE AOF entry due to "
              "configuration";
       Metrics::GetStats().ft_internal_update_skipped_entries_cnt++;

--- a/src/coordinator/metadata_manager.cc
+++ b/src/coordinator/metadata_manager.cc
@@ -172,7 +172,7 @@ absl::Status MetadataManager::TriggerCallbacks(
         obj_name, entry.has_content() ? &entry.content() : nullptr,
         entry.fingerprint(), entry.version());
   }
-  VMSDK_LOG_EVERY_N_SEC(WARNING, detached_ctx_.get(), 10)
+  VMSDK_LOG_EVERY_N_SEC(WARNING, 10)
       << "No type registered for: " << type_name << ", skipping callback";
   return absl::OkStatus();
 }
@@ -322,7 +322,7 @@ void MetadataManager::RegisterType(absl::string_view type_name,
               .fingerprint_callback = std::move(fingerprint_callback),
               .update_callback = std::move(callback),
               .min_version_callback = std::move(min_version_callback)}});
-  VMSDK_LOG(DEBUG, nullptr) << "Registering type: " << type_name;
+  VMSDK_LOG(DEBUG) << "Registering type: " << type_name;
   CHECK(insert_result.second) << "Type already registered: " << type_name;
 }
 
@@ -333,7 +333,7 @@ void MetadataManager::BroadcastMetadata(ValkeyModuleCtx *ctx) {
 void MetadataManager::BroadcastMetadata(
     ValkeyModuleCtx *ctx, const GlobalMetadataVersionHeader &version_header) {
   if (is_loading_.Get()) {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "Skipping send of metadata header due to loading";
     return;
   }
@@ -351,7 +351,7 @@ void MetadataManager::DelayHandleClusterMessage(
     std::unique_ptr<GlobalMetadataVersionHeader> header) {
   if (PauseHandleClusterMessage.GetValue()) {
     Metrics::GetStats().pause_handle_cluster_message_round_cnt++;
-    VMSDK_LOG_EVERY_N_SEC(DEBUG, nullptr, 2)
+    VMSDK_LOG_EVERY_N_SEC(DEBUG, 2)
         << "DEBUG: Paused round is "
         << Metrics::GetStats().pause_handle_cluster_message_round_cnt;
     std::string sender_id_str(sender_id, VALKEYMODULE_NODE_ID_LEN);
@@ -378,8 +378,7 @@ void MetadataManager::HandleClusterMessage(ValkeyModuleCtx *ctx,
     std::string sender_id_str(sender_id, VALKEYMODULE_NODE_ID_LEN);
     DelayHandleClusterMessage(ctx, sender_id_str.c_str(), std::move(header));
   } else {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 10)
-        << "Unsupported message type: " << type;
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 10) << "Unsupported message type: " << type;
   }
 }
 
@@ -387,7 +386,7 @@ void MetadataManager::HandleBroadcastedMetadata(
     ValkeyModuleCtx *ctx, const char *sender_id,
     std::unique_ptr<GlobalMetadataVersionHeader> header) {
   if (is_loading_.Get()) {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 10)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 10)
         << "Ignoring incoming metadata message due to loading...";
     return;
   }
@@ -399,7 +398,7 @@ void MetadataManager::HandleBroadcastedMetadata(
   }
 
   if (header->top_level_min_version() > kModuleVersion.ToInt()) {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 10)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 10)
         << "Ignoring incoming metadata message from "
         << std::string(sender_id, VALKEYMODULE_NODE_ID_LEN)
         << " due to minimum version requirement of "
@@ -419,7 +418,7 @@ void MetadataManager::HandleBroadcastedMetadata(
     if (header->top_level_fingerprint() == top_level_fingerprint) {
       return;
     }
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "Got conflicting contents from " << sender_id_str << " for version "
         << top_level_version
         << ": have "
@@ -429,7 +428,7 @@ void MetadataManager::HandleBroadcastedMetadata(
         << ". Retrieving full "
            "GlobalMetadata.";
   } else {
-    VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(NOTICE, 1)
         << "Got newer version from " << sender_id_str << ": have "
         << top_level_version << ", got " << header->top_level_version()
         << ". Retrieving full GlobalMetadata.";
@@ -441,7 +440,7 @@ void MetadataManager::HandleBroadcastedMetadata(
   if (ValkeyModule_GetClusterNodeInfo(ctx, sender_id_str.c_str(), node_ip,
                                       nullptr, &node_port,
                                       nullptr) != VALKEYMODULE_OK) {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "Failed to get cluster node info for node " << sender_id
         << " broadcasting "
            "version "
@@ -456,7 +455,7 @@ void MetadataManager::HandleBroadcastedMetadata(
   client->GetGlobalMetadata(
       [address, this](grpc::Status s, GetGlobalMetadataResponse &response) {
         if (!s.ok()) {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, detached_ctx_.get(), 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << "Failed to get GlobalMetadata from " << address
               << ", Error code: " << s.error_code();
           return;
@@ -465,17 +464,17 @@ void MetadataManager::HandleBroadcastedMetadata(
                           schema = std::unique_ptr<GlobalMetadata>(
                               response.release_metadata()),
                           address = std::move(address)] {
-          VMSDK_LOG_EVERY_N_SEC(DEBUG, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(DEBUG, 1)
               << "Got GlobalMetadata from " << address << ": "
               << schema->DebugString();
           auto &metadata_manager = MetadataManager::Instance();
           auto status = metadata_manager.ReconcileMetadata(*schema, address);
           if (!status.ok()) {
-            VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+            VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
                 << "Failed to reconcile schemas: " << status.message();
             return;
           }
-          VMSDK_LOG_EVERY_N_SEC(DEBUG, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(DEBUG, 1)
               << "Successfully reconciled schemas! New GlobalMetadata: "
               << metadata_manager.GetGlobalMetadata()->DebugString();
         });
@@ -487,11 +486,10 @@ absl::Status MetadataManager::ReconcileMetadata(const GlobalMetadata &proposed,
                                                 bool trigger_callbacks,
                                                 bool prefer_incoming) {
   if (proposed.version_header().top_level_version() > kModuleVersion.ToInt()) {
-    VMSDK_LOG(WARNING, nullptr)
-        << "Proposed GlobalMetadata from " << source
-        << " requires minimum version "
-        << proposed.version_header().top_level_version()
-        << ", current version is " << kModuleVersion.ToString();
+    VMSDK_LOG(WARNING) << "Proposed GlobalMetadata from " << source
+                       << " requires minimum version "
+                       << proposed.version_header().top_level_version()
+                       << ", current version is " << kModuleVersion.ToString();
     return absl::InternalError(absl::StrCat(
         "Proposed GlobalMetadata from ", source, " requires minimum version ",
         proposed.version_header().top_level_version(), ", current version is ",
@@ -561,7 +559,7 @@ absl::Status MetadataManager::ReconcileMetadata(const GlobalMetadata &proposed,
         auto obj_name = ObjName::Decode(id);
         auto result = TriggerCallbacks(type_name, obj_name, proposed_entry);
         if (!result.ok()) {
-          VMSDK_LOG(WARNING, detached_ctx_.get())
+          VMSDK_LOG(WARNING)
               << "Failed during reconciliation callback: %s"
               << result.message().data() << " for type " << type_name << ", id "
               << vmsdk::config::RedactIfNeeded(id) << " from " << source;
@@ -645,14 +643,13 @@ absl::Status MetadataManager::SaveMetadata(ValkeyModuleCtx *ctx, SafeRDB *rdb,
   if (!DoesGlobalMetadataContainEntry(metadata_.Get())) {
     // Auxsave2 will ensure nothing is written to the aux section if we write
     // nothing.
-    VMSDK_LOG(NOTICE, ctx)
+    VMSDK_LOG(NOTICE)
         << "Skipping aux metadata for MetadataManager since there is no "
            "content";
     return absl::OkStatus();
   }
 
-  VMSDK_LOG(NOTICE, ctx)
-      << "Saving aux metadata for MetadataManager to aux RDB";
+  VMSDK_LOG(NOTICE) << "Saving aux metadata for MetadataManager to aux RDB";
   data_model::RDBSection section;
   std::string serialized_metadata;
   section.set_type(data_model::RDB_SECTION_GLOBAL_METADATA);
@@ -731,8 +728,7 @@ void MetadataManager::OnServerCronCallback(
 void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
   // Only on loading ended do we apply the staged changes.
   if (staging_metadata_due_to_repl_load_.Get()) {
-    VMSDK_LOG(NOTICE, ctx)
-        << "Applying staged metadata at the end of RDB loading";
+    VMSDK_LOG(NOTICE) << "Applying staged metadata at the end of RDB loading";
 
     // Clear the local metadata, then use ReconcileMetadata to recompute
     // fingerprints in case encoding has changed.
@@ -741,8 +737,8 @@ void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
                                     /*trigger_callbacks=*/false,
                                     /*prefer_incoming=*/true);
     if (!status.ok()) {
-      VMSDK_LOG(WARNING, ctx)
-          << "Failed to apply staged metadata: %s" << status.message().data();
+      VMSDK_LOG(WARNING) << "Failed to apply staged metadata: %s"
+                         << status.message().data();
     }
     staged_metadata_ = GlobalMetadata();
     staging_metadata_due_to_repl_load_ = false;
@@ -767,14 +763,13 @@ void MetadataManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
 }
 
 void MetadataManager::OnReplicationLoadStart(ValkeyModuleCtx *ctx) {
-  VMSDK_LOG(NOTICE, ctx) << "Staging metadata during RDB load due to "
-                            "replication, will apply on loading finished";
+  VMSDK_LOG(NOTICE) << "Staging metadata during RDB load due to "
+                       "replication, will apply on loading finished";
   staging_metadata_due_to_repl_load_ = true;
 }
 
 void MetadataManager::OnLoadingStarted(ValkeyModuleCtx *ctx) {
-  VMSDK_LOG(NOTICE, ctx)
-      << "Loading started, stopping incoming metadata updates";
+  VMSDK_LOG(NOTICE) << "Loading started, stopping incoming metadata updates";
   is_loading_ = true;
 }
 
@@ -822,7 +817,7 @@ void MetadataManager::RegisterForClusterMessages(ValkeyModuleCtx *ctx) {
 absl::Status MetadataManager::ShowMetadata(
     ValkeyModuleCtx *ctx, [[maybe_unused]] vmsdk::ArgsIterator &itr) const {
   auto metadata = metadata_.Get().DebugString();
-  VMSDK_LOG(DEBUG, ctx) << "Metadata: " << metadata;
+  VMSDK_LOG(DEBUG) << "Metadata: " << metadata;
   ValkeyModule_ReplyWithStringBuffer(ctx, metadata.data(), metadata.size());
   return absl::OkStatus();
 }
@@ -884,7 +879,7 @@ ObjName ObjName::Decode(absl::string_view encoded) {
         front_tag.remove_prefix(1);
       }
       if (!front_tag.empty()) {
-        VMSDK_LOG_EVERY_N_SEC(NOTICE, nullptr, 10)
+        VMSDK_LOG_EVERY_N_SEC(NOTICE, 10)
             << "Ignoring extended index name metadata";
       }
       if (!db_num_str.empty()) {
@@ -893,9 +888,8 @@ ObjName ObjName::Decode(absl::string_view encoded) {
                 encoded.substr(hash_tag->size() + 2)};
       }
     }
-    VMSDK_LOG_EVERY_N(WARNING, nullptr, 10)
-        << "Found invalid encoded index name: "
-        << vmsdk::config::RedactIfNeeded(encoded);
+    VMSDK_LOG_EVERY_N(WARNING, 10) << "Found invalid encoded index name: "
+                                   << vmsdk::config::RedactIfNeeded(encoded);
   }
   // Assume 8/1.0 encoding.
   return {0, encoded};

--- a/src/coordinator/server.cc
+++ b/src/coordinator/server.cc
@@ -197,8 +197,8 @@ void Service::EnqueueSearchRequest(
                          query::SearchMode::kRemote);
 
   if (!status.ok()) {
-    VMSDK_LOG(WARNING, detached_ctx)
-        << "Failed to enqueue search request: " << status.message();
+    VMSDK_LOG(WARNING) << "Failed to enqueue search request: "
+                       << status.message();
     RecordSearchMetrics(true, nullptr);
     reactor->Finish(ToGrpcStatus(status));
   }
@@ -294,9 +294,8 @@ Service::GenerateInfoResponse(
         "Index fingerprint/version or slot fingerprint mismatch");
     response.set_error_type(
         coordinator::FanoutErrorType::INCONSISTENT_STATE_ERROR);
-    VMSDK_LOG_EVERY_N_SEC(NOTICE, nullptr, 1)
-        << "Fingerprint, version or slot "
-           "fingerprint mismatch at server.cc";
+    VMSDK_LOG_EVERY_N_SEC(NOTICE, 1) << "Fingerprint, version or slot "
+                                        "fingerprint mismatch at server.cc";
     grpc::Status error_status(
         grpc::StatusCode::FAILED_PRECONDITION,
         "Cluster not in a consistent state, please retry.");
@@ -399,47 +398,44 @@ std::unique_ptr<Server> ServerImpl::Create(
   builder.AddChannelArgument(GRPC_ARG_TCP_TX_ZEROCOPY_ENABLED, 1);
   auto server = builder.BuildAndStart();
   if (server == nullptr) {
-    VMSDK_LOG(WARNING, ctx)
-        << "Failed to start Coordinator Server on port " << port;
+    VMSDK_LOG(WARNING) << "Failed to start Coordinator Server on port " << port;
     for (size_t attempt = 2; attempt <= 10; ++attempt) {
       std::string lsof_cmd =
           "lsof -i :" + std::to_string(port) + " 2>/dev/null";
       FILE *pipe = popen(lsof_cmd.c_str(), "r");
       if (pipe) {
         char buffer[256];
-        VMSDK_LOG(WARNING, ctx)
-            << "Diagnosing other usage with this shell command:";
-        VMSDK_LOG(WARNING, ctx) << ">> lsof -i: " << port;
+        VMSDK_LOG(WARNING) << "Diagnosing other usage with this shell command:";
+        VMSDK_LOG(WARNING) << ">> lsof -i: " << port;
         while (fgets(buffer, sizeof(buffer), pipe)) {
           std::string line(buffer);
           if (!line.empty() && line.back() == '\n') {
             line.pop_back();
           }
-          VMSDK_LOG(WARNING, ctx) << ">> " << line;
+          VMSDK_LOG(WARNING) << ">> " << line;
         }
-        VMSDK_LOG(WARNING, ctx) << ">> <end of lsof output>";
+        VMSDK_LOG(WARNING) << ">> <end of lsof output>";
         pclose(pipe);
       } else {
-        VMSDK_LOG(WARNING, ctx) << "Could not check port " << port << " usage";
+        VMSDK_LOG(WARNING) << "Could not check port " << port << " usage";
       }
       std::this_thread::sleep_for(
           std::chrono::milliseconds(100 * attempt));  // backoff
-      VMSDK_LOG(WARNING, ctx)
-          << "Retrying to start Coordinator Server (attempt " << attempt << ")";
+      VMSDK_LOG(WARNING) << "Retrying to start Coordinator Server (attempt "
+                         << attempt << ")";
       server = builder.BuildAndStart();
       if (server != nullptr) {
-        VMSDK_LOG(NOTICE, ctx)
-            << "Successfully started Coordinator Server on " << server_address
-            << " after " << attempt << " attempts";
+        VMSDK_LOG(NOTICE) << "Successfully started Coordinator Server on "
+                          << server_address << " after " << attempt
+                          << " attempts";
         break;
       }
     }
-    VMSDK_LOG(WARNING, ctx)
-        << "Failed to start Coordinator Server on " << server_address;
+    VMSDK_LOG(WARNING) << "Failed to start Coordinator Server on "
+                       << server_address;
     return nullptr;
   }
-  VMSDK_LOG(NOTICE, ctx) << "Coordinator Server listening on "
-                         << server_address;
+  VMSDK_LOG(NOTICE) << "Coordinator Server listening on " << server_address;
   return std::unique_ptr<Server>(
       new ServerImpl(std::move(coordinator_service), std::move(server), port));
 }

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -139,7 +139,7 @@ IndexSchema::BackfillJob::BackfillJob(ValkeyModuleCtx *ctx,
   scan_ctx = vmsdk::MakeUniqueValkeyDetachedThreadSafeContext(ctx);
   ValkeyModule_SelectDb(scan_ctx.get(), db_num);
   db_size = ValkeyModule_DbSize(scan_ctx.get());
-  VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 1)
+  VMSDK_LOG_EVERY_N_SEC(NOTICE, 1)
       << "Starting backfill for index schema in DB " << db_num << ": "
       << vmsdk::config::RedactIfNeeded(name) << " (size: " << db_size << ")";
 }
@@ -271,11 +271,10 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::Create(
   if (!reload && index_schema_proto.skip_initial_scan()) {
     // Creating a new Index with SkipInitialScan. Mark the backfill as done
     // since we are skipping it.
-    VMSDK_LOG(DEBUG, ctx) << "Index "
-                          << vmsdk::config::RedactIfNeeded(
-                                 index_schema_proto.name())
-                          << " created with skip_initial_scan. "
-                             "Marking backfill as done.";
+    VMSDK_LOG(DEBUG) << "Index "
+                     << vmsdk::config::RedactIfNeeded(index_schema_proto.name())
+                     << " created with skip_initial_scan. "
+                        "Marking backfill as done.";
     res->backfill_job_.Get()->MarkScanAsDone();
   }
   return res;
@@ -347,7 +346,7 @@ absl::Status IndexSchema::Init(ValkeyModuleCtx *ctx) {
 }
 
 IndexSchema::~IndexSchema() {
-  VMSDK_LOG_EVERY_N_SEC(NOTICE, detached_ctx_.get(), 1)
+  VMSDK_LOG_EVERY_N_SEC(NOTICE, 1)
       << "Index schema " << vmsdk::config::RedactIfNeeded(name_)
       << " dropped from DB " << db_num_;
 
@@ -522,11 +521,11 @@ void TrackResults(
   }
   // Separate errors and successes so that they log on different timers.
   if (ABSL_PREDICT_TRUE(status.ok())) {
-    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), ctx, 5)
+    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), 5)
         << operation_str
         << " succeeded with result: " << status.status().ToString();
   } else {
-    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), 1)
         << operation_str
         << " failed with result: " << status.status().ToString();
   }
@@ -550,7 +549,7 @@ void TrackResults(
     ++counter.skipped_cnt;
   }
   if (ABSL_PREDICT_FALSE(!status.ok())) {
-    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), ctx, 1)
+    VMSDK_LOG_EVERY_N_SEC(GetLogSeverity(status.ok()), 1)
         << operation_str
         << " failed with result: " << status.status().ToString();
   }
@@ -859,9 +858,9 @@ void IndexSchema::ProcessMultiQueue() {
 void IndexSchema::EnqueueMultiMutation(const Key &key) {
   auto &multi_mutations_keys = multi_mutations_keys_.Get();
   multi_mutations_keys.push_back(key);
-  VMSDK_LOG(DEBUG, nullptr) << "Enqueueing multi mutation for key: "
-                            << vmsdk::config::RedactIfNeeded(key->Str())
-                            << " Size is now " << multi_mutations_keys.size();
+  VMSDK_LOG(DEBUG) << "Enqueueing multi mutation for key: "
+                   << vmsdk::config::RedactIfNeeded(key->Str())
+                   << " Size is now " << multi_mutations_keys.size();
   if (multi_mutations_keys.size() >= mutations_thread_pool_->Size() &&
       !schedule_multi_exec_processing_.Get()) {
     schedule_multi_exec_processing_.Get() = true;
@@ -1065,7 +1064,7 @@ uint32_t IndexSchema::PerformBackfill(ValkeyModuleCtx *ctx,
   }
 
   if (StopBackfill.GetValue()) {
-    VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 1) << "Backfill stopped by request";
+    VMSDK_LOG_EVERY_N_SEC(NOTICE, 1) << "Backfill stopped by request";
     return 0;
   }
 
@@ -1094,7 +1093,7 @@ uint32_t IndexSchema::PerformBackfill(ValkeyModuleCtx *ctx,
     if (!ValkeyModule_Scan(backfill_job->scan_ctx.get(),
                            backfill_job->cursor.get(), BackfillScanCallback,
                            reinterpret_cast<void *>(this))) {
-      VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 1)
+      VMSDK_LOG_EVERY_N_SEC(NOTICE, 1)
           << "Index schema " << vmsdk::config::RedactIfNeeded(name_)
           << " finished backfill. Scanned " << backfill_job->scanned_key_count
           << " keys in "
@@ -1343,8 +1342,8 @@ static absl::Status SaveSupplementalSection(
   rdb_save_sections.Increment();
   auto header = std::make_unique<data_model::SupplementalContentHeader>();
   header->set_type(type);
-  VMSDK_LOG(DEBUG, nullptr) << "Writing supplemental section type "
-                            << data_model::SupplementalContentType_Name(type);
+  VMSDK_LOG(DEBUG) << "Writing supplemental section type "
+                   << data_model::SupplementalContentType_Name(type);
   init(*header);
   auto header_str = header->SerializeAsString();
   VMSDK_RETURN_IF_ERROR(rdb->SaveStringBuffer(header_str));
@@ -1358,16 +1357,15 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
   int flags = ValkeyModule_GetContextFlags(nullptr);
   bool is_bgsave = (flags & VALKEYMODULE_CTX_FLAGS_IS_CHILD) != 0;
   if (options::GetDrainMutationQueueOnSave().GetValue() && !is_bgsave) {
-    VMSDK_LOG(NOTICE, nullptr)
-        << "Draining mutation queue before RDB save for index "
-        << vmsdk::config::RedactIfNeeded(name_);
+    VMSDK_LOG(NOTICE) << "Draining mutation queue before RDB save for index "
+                      << vmsdk::config::RedactIfNeeded(name_);
     DrainMutationQueue(detached_ctx_.get());
   }
 
-  VMSDK_LOG(NOTICE, nullptr)
-      << "Starting RDB save for index schema: "
-      << vmsdk::config::RedactIfNeeded(name_) << " Saving in version "
-      << (RDBWriteV2() ? "2" : "1") << " format";
+  VMSDK_LOG(NOTICE) << "Starting RDB save for index schema: "
+                    << vmsdk::config::RedactIfNeeded(name_)
+                    << " Saving in version " << (RDBWriteV2() ? "2" : "1")
+                    << " format";
 
   auto index_schema_proto = ToProto();
   auto rdb_section = std::make_unique<data_model::RDBSection>();
@@ -1392,14 +1390,14 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
       << vmsdk::config::RedactIfNeeded(this->name_)
       << " in DB: " << this->db_num_ << " to RDB";
 
-  VMSDK_LOG(NOTICE, nullptr)
-      << "Starting to save " << attributes_.size() << " attributes.";
+  VMSDK_LOG(NOTICE) << "Starting to save " << attributes_.size()
+                    << " attributes.";
 
   for (const auto &attribute_ref : GetSortedAttributes()) {
     const auto &attribute = attribute_ref.get();
-    VMSDK_LOG(DEBUG, nullptr)
-        << "Starting to save attribute: "
-        << vmsdk::config::RedactIfNeeded(attribute.second.GetAlias());
+    VMSDK_LOG(DEBUG) << "Starting to save attribute: "
+                     << vmsdk::config::RedactIfNeeded(
+                            attribute.second.GetAlias());
     // Note that the serialized attribute proto is also stored as part of the
     // serialized index schema proto above. We store here again to avoid any
     // dependencies on the ordering of multiple attributes.
@@ -1435,9 +1433,8 @@ absl::Status IndexSchema::RDBSave(SafeRDB *rdb) const {
           rdb_save_backfilling_indexes.Increment(int(IsBackfillInProgress()));
           header.mutable_mutation_queue_header()->set_backfilling(
               IsBackfillInProgress());
-          VMSDK_LOG(DEBUG, nullptr)
-              << "RDB: Saving Index Extension Backfill = "
-              << header.mutation_queue_header().backfilling();
+          VMSDK_LOG(DEBUG) << "RDB: Saving Index Extension Backfill = "
+                           << header.mutation_queue_header().backfilling();
         },
         std::bind_front(&IndexSchema::SaveIndexExtension, this)));
   }
@@ -1480,10 +1477,10 @@ absl::Status IndexSchema::ValidateIndex() const {
                                     : cnt == oracle_key_count) {
       continue;
     }
-    VMSDK_LOG(WARNING, nullptr)
-        << "Index validation failed for index "
-        << vmsdk::config::RedactIfNeeded(name) << " expected key count "
-        << oracle_key_count << " got " << cnt;
+    VMSDK_LOG(WARNING) << "Index validation failed for index "
+                       << vmsdk::config::RedactIfNeeded(name)
+                       << " expected key count " << oracle_key_count << " got "
+                       << cnt;
     //
     // Ok, do a detailed comparison
     //
@@ -1493,10 +1490,11 @@ absl::Status IndexSchema::ValidateIndex() const {
     auto smaller_name = (cnt > oracle_key_count) ? oracle_name : name;
     auto key_check = [&](const Key &key) {
       if (!smaller_index->IsTracked(key) && !smaller_index->IsUnTracked(key)) {
-        VMSDK_LOG(WARNING, nullptr)
-            << "Key found in " << vmsdk::config::RedactIfNeeded(larger_name)
-            << " not found in " << vmsdk::config::RedactIfNeeded(smaller_name)
-            << ": " << vmsdk::config::RedactIfNeeded(key->Str());
+        VMSDK_LOG(WARNING) << "Key found in "
+                           << vmsdk::config::RedactIfNeeded(larger_name)
+                           << " not found in "
+                           << vmsdk::config::RedactIfNeeded(smaller_name)
+                           << ": " << vmsdk::config::RedactIfNeeded(key->Str());
         status = absl::InternalError(
             absl::StrCat("Key found in ", larger_name, " not found in ",
                          smaller_name, ": ", key->Str()));
@@ -1534,7 +1532,7 @@ absl::Status IndexSchema::SaveIndexExtension(RDBChunkOutputStream out) const {
   size_t key_count = db_key_info_.Get().size();
   VMSDK_RETURN_IF_ERROR(out.SaveObject(key_count));
   rdb_save_keys.Increment(key_count);
-  VMSDK_LOG(NOTICE, nullptr) << "Writing Index Extension, keys = " << key_count;
+  VMSDK_LOG(NOTICE) << "Writing Index Extension, keys = " << key_count;
   for (const auto &[key, _] : db_key_info_.Get()) {
     VMSDK_RETURN_IF_ERROR(out.SaveString(key->Str()));
   }
@@ -1552,9 +1550,8 @@ absl::Status IndexSchema::SaveIndexExtension(RDBChunkOutputStream out) const {
                                            [](const auto &entry) {
                                              return !entry.second.from_backfill;
                                            });
-  VMSDK_LOG(NOTICE, nullptr)
-      << "Writing mutation queue records = " << count
-      << " Total queue:" << tracked_mutated_records_.size();
+  VMSDK_LOG(NOTICE) << "Writing mutation queue records = " << count
+                    << " Total queue:" << tracked_mutated_records_.size();
   VMSDK_RETURN_IF_ERROR(out.SaveObject(count));
   rdb_save_mutation_entries.Increment(count);
   for (const auto &[key, value] : tracked_mutated_records_) {
@@ -1573,8 +1570,8 @@ absl::Status IndexSchema::SaveIndexExtension(RDBChunkOutputStream out) const {
   VMSDK_RETURN_IF_ERROR(
       out.SaveObject<size_t>(multi_mutations_keys_.Get().size()));
   rdb_save_multi_exec_entries.Increment(multi_mutations_keys_.Get().size());
-  VMSDK_LOG(DEBUG, nullptr) << "Writing Multi/Exec Queue, records = "
-                            << multi_mutations_keys_.Get().size();
+  VMSDK_LOG(DEBUG) << "Writing Multi/Exec Queue, records = "
+                   << multi_mutations_keys_.Get().size();
   for (const auto &key : multi_mutations_keys_.Get()) {
     CHECK(tracked_mutated_records_.find(key) != tracked_mutated_records_.end());
     VMSDK_RETURN_IF_ERROR(out.SaveString(key->Str()));
@@ -1592,7 +1589,7 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
   Metrics::GetStats().rdb_restore_current_index_keys_total = key_count;
   Metrics::GetStats().rdb_restore_current_index_keys_loaded = 0;
 
-  VMSDK_LOG(NOTICE, ctx) << "Loading Index Extension, keys = " << key_count;
+  VMSDK_LOG(NOTICE) << "Loading Index Extension, keys = " << key_count;
 
   const size_t max_queue_size =
       options::GetMaxMutationQueueSizeOnRestore().GetValue();
@@ -1620,7 +1617,7 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
         current_queue_size = GetMutatedRecordsSize();
 
         // Log periodically to show progress
-        VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 30)
+        VMSDK_LOG_EVERY_N_SEC(NOTICE, 30)
             << "RDB restore backpressure: waiting for mutation queue to drain. "
             << "Queue size: " << current_queue_size << ", Progress: " << i
             << "/" << key_count << " keys loaded";
@@ -1643,7 +1640,7 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
   }
 
   if (Metrics::GetStats().rdb_restore_backpressure_wait_cycles > 0) {
-    VMSDK_LOG(NOTICE, ctx)
+    VMSDK_LOG(NOTICE)
         << "RDB restore completed with backpressure. Total wait cycles: "
         << Metrics::GetStats().rdb_restore_backpressure_wait_cycles
         << " (max queue size: " << max_queue_size << ")";
@@ -1654,7 +1651,7 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
       ValkeySearch::Instance().GetWriterThreadPool()->SuspendWorkers());
   auto reload_queues = [&]() -> absl::Status {
     VMSDK_ASSIGN_OR_RETURN(size_t count, input.LoadObject<size_t>());
-    VMSDK_LOG(NOTICE, ctx) << "Loading Mutation Entries, entries = " << count;
+    VMSDK_LOG(NOTICE) << "Loading Mutation Entries, entries = " << count;
     rdb_load_mutation_entries.Increment(count);
     for (size_t i = 0; i < count; ++i) {
       VMSDK_ASSIGN_OR_RETURN(auto keyname_str, input.LoadString());
@@ -1667,8 +1664,8 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
     }
     VMSDK_ASSIGN_OR_RETURN(size_t multi_count, input.LoadObject<size_t>());
     rdb_load_multi_exec_entries.Increment(multi_count);
-    VMSDK_LOG(NOTICE, ctx) << "Loading Multi/Exec Entries, entries = "
-                           << multi_count;
+    VMSDK_LOG(NOTICE) << "Loading Multi/Exec Entries, entries = "
+                      << multi_count;
     for (size_t i = 0; i < multi_count; ++i) {
       VMSDK_ASSIGN_OR_RETURN(auto keyname_str, input.LoadString());
       auto keyname = StringInternStore::Intern(keyname_str);
@@ -1687,8 +1684,8 @@ absl::Status IndexSchema::LoadIndexExtension(ValkeyModuleCtx *ctx,
 static absl::Status SkipSupplementalContent(
     SupplementalContentIter &supplemental_iter, std::string_view reason) {
   rdb_load_sections_skipped.Increment();
-  VMSDK_LOG(NOTICE, nullptr)
-      << "Skipping supplemental content section (" << reason << ")";
+  VMSDK_LOG(NOTICE) << "Skipping supplemental content section (" << reason
+                    << ")";
   auto chunk_it = supplemental_iter.IterateChunks();
   while (chunk_it.HasNext()) {
     VMSDK_ASSIGN_OR_RETURN([[maybe_unused]] auto chunk_result, chunk_it.Next());
@@ -1740,9 +1737,8 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
             SUPPLEMENTAL_CONTENT_INDEX_CONTENT: {
           const auto &attribute =
               supplemental_content->index_content_header().attribute();
-          VMSDK_LOG(DEBUG, nullptr)
-              << "Loading Index Content for attribute: "
-              << vmsdk::config::RedactIfNeeded(attribute.alias());
+          VMSDK_LOG(DEBUG) << "Loading Index Content for attribute: "
+                           << vmsdk::config::RedactIfNeeded(attribute.alias());
           VMSDK_ASSIGN_OR_RETURN(
               std::shared_ptr<indexes::IndexBase> index,
               IndexFactory(ctx, index_schema.get(), attribute,
@@ -1755,9 +1751,8 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
             SUPPLEMENTAL_CONTENT_KEY_TO_ID_MAP: {
           const auto &attribute =
               supplemental_content->key_to_id_map_header().attribute();
-          VMSDK_LOG(DEBUG, nullptr)
-              << "Loading Key to ID Map Content for attribute: "
-              << vmsdk::config::RedactIfNeeded(attribute.alias());
+          VMSDK_LOG(DEBUG) << "Loading Key to ID Map Content for attribute: "
+                           << vmsdk::config::RedactIfNeeded(attribute.alias());
           VMSDK_ASSIGN_OR_RETURN(
               auto index, index_schema->GetIndex(attribute.alias()),
               _ << "Key to ID mapping found before index definition.");
@@ -1773,7 +1768,7 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
         }
         case data_model::SupplementalContentType::
             SUPPLEMENTAL_CONTENT_INDEX_EXTENSION: {
-          VMSDK_LOG(DEBUG, nullptr) << "Loading Mutation Queue";
+          VMSDK_LOG(DEBUG) << "Loading Mutation Queue";
           if (!RDBReadV2()) {
             VMSDK_RETURN_IF_ERROR(
                 SkipSupplementalContent(supplemental_iter, "mutation queue"));
@@ -1783,7 +1778,7 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
                   ctx, RDBChunkInputStream(supplemental_iter.IterateChunks())));
               if (!supplemental_content->mutation_queue_header()
                        .backfilling()) {
-                VMSDK_LOG(DEBUG, ctx) << "Backfill suppressed.";
+                VMSDK_LOG(DEBUG) << "Backfill suppressed.";
                 index_schema->backfill_job_.Get()->MarkScanAsDone();
               } else {
                 rdb_load_backfilling_indexes.Increment();
@@ -1796,16 +1791,16 @@ absl::StatusOr<std::shared_ptr<IndexSchema>> IndexSchema::LoadFromRDB(
           break;
         }
         default:
-          VMSDK_LOG(NOTICE, ctx) << "Unknown supplemental content type: "
-                                 << supplemental_content->type();
+          VMSDK_LOG(NOTICE) << "Unknown supplemental content type: "
+                            << supplemental_content->type();
           VMSDK_RETURN_IF_ERROR(
               SkipSupplementalContent(supplemental_iter, "unknown type"));
           break;
       }
     }
   }
-  VMSDK_LOG(NOTICE, ctx) << "Loaded index schema with "
-                         << index_schema->GetAttributeCount() << " attributes";
+  VMSDK_LOG(NOTICE) << "Loaded index schema with "
+                    << index_schema->GetAttributeCount() << " attributes";
   std::move(mark_destructing_on_error)
       .Cancel();  // Don't mark for destruction since no error has been returned
   return index_schema;
@@ -1845,10 +1840,9 @@ void IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
         break;
       }
     }
-    VMSDK_LOG_EVERY_N_SEC(NOTICE, ctx, 10)
-        << "Draining Mutation Queue for index "
-        << vmsdk::config::RedactIfNeeded(name_)
-        << ", entries remaining: " << queue_size;
+    VMSDK_LOG_EVERY_N_SEC(NOTICE, 10) << "Draining Mutation Queue for index "
+                                      << vmsdk::config::RedactIfNeeded(name_)
+                                      << ", entries remaining: " << queue_size;
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start < yield_duration) {
       ValkeyModule_Yield(ctx, VALKEYMODULE_YIELD_FLAG_CLIENTS, nullptr);
@@ -1861,13 +1855,12 @@ void IndexSchema::DrainMutationQueue(ValkeyModuleCtx *ctx) const {
 void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
   if (loaded_v2_) {
     loaded_v2_ = false;
-    VMSDK_LOG(NOTICE, ctx) << "RDB load completed, "
-                           << " Mutation Queue contains "
-                           << GetMutatedRecordsSize() << " entries."
-                           << (backfill_job_.Get().has_value() &&
-                                       !backfill_job_.Get()->IsScanDone()
-                                   ? " Backfill still required."
-                                   : " Backfill not needed.");
+    VMSDK_LOG(NOTICE) << "RDB load completed, " << " Mutation Queue contains "
+                      << GetMutatedRecordsSize() << " entries."
+                      << (backfill_job_.Get().has_value() &&
+                                  !backfill_job_.Get()->IsScanDone()
+                              ? " Backfill still required."
+                              : " Backfill not needed.");
     if (options::GetDrainMutationQueueOnLoad().GetValue()) {
       DrainMutationQueue(ctx);
     }
@@ -1897,26 +1890,23 @@ void IndexSchema::OnLoadingEnded(ValkeyModuleCtx *ctx) {
       key_size++;
       return absl::OkStatus();
     });
-    VMSDK_LOG(DEBUG, ctx) << "Deleting " << stale_entries
-                          << " stale entries of " << key_size
-                          << " total keys for {Index: "
-                          << vmsdk::config::RedactIfNeeded(name_)
-                          << ", Attribute: "
-                          << vmsdk::config::RedactIfNeeded(attribute.first)
-                          << "}";
+    VMSDK_LOG(DEBUG) << "Deleting " << stale_entries << " stale entries of "
+                     << key_size << " total keys for {Index: "
+                     << vmsdk::config::RedactIfNeeded(name_) << ", Attribute: "
+                     << vmsdk::config::RedactIfNeeded(attribute.first) << "}";
   }
-  VMSDK_LOG(NOTICE, ctx) << "Deleting " << deletion_attributes.size()
-                         << " stale entries for {Index: "
-                         << vmsdk::config::RedactIfNeeded(name_) << "}";
+  VMSDK_LOG(NOTICE) << "Deleting " << deletion_attributes.size()
+                    << " stale entries for {Index: "
+                    << vmsdk::config::RedactIfNeeded(name_) << "}";
 
   for (auto &[key, attributes] : deletion_attributes) {
     auto interned_key = StringInternStore::Intern(key);
     ProcessMutation(ctx, attributes, interned_key, true, true);
   }
-  VMSDK_LOG(NOTICE, ctx) << "Scanned index schema "
-                         << vmsdk::config::RedactIfNeeded(name_)
-                         << " for stale entries in "
-                         << absl::FormatDuration(stop_watch.Duration());
+  VMSDK_LOG(NOTICE) << "Scanned index schema "
+                    << vmsdk::config::RedactIfNeeded(name_)
+                    << " for stale entries in "
+                    << absl::FormatDuration(stop_watch.Duration());
 }
 
 vmsdk::BlockedClientCategory IndexSchema::GetBlockedCategoryFromProto() const {
@@ -2081,7 +2071,7 @@ void IndexSchema::MarkAsDestructing() {
   absl::MutexLock lock(&mutated_records_mutex_);
   auto status = keyspace_event_manager_->RemoveSubscription(this);
   if (!status.ok()) {
-    VMSDK_LOG(WARNING, detached_ctx_.get())
+    VMSDK_LOG(WARNING)
         << "Failed to remove keyspace event subscription for index "
            "schema "
         << vmsdk::config::RedactIfNeeded(name_) << ": " << status.message();
@@ -2196,9 +2186,8 @@ CONTROLLED_INT(override_min_version, -1);
 absl::StatusOr<vmsdk::ValkeyVersion> IndexSchema::GetMinVersion(
     const google::protobuf::Any &metadata) {
   if (override_min_version.GetValue() != -1) {
-    VMSDK_LOG(WARNING, nullptr)
-        << "Overriding index schema semantic version to "
-        << override_min_version.GetValue();
+    VMSDK_LOG(WARNING) << "Overriding index schema semantic version to "
+                       << override_min_version.GetValue();
     return vmsdk::ValkeyVersion(override_min_version.GetValue());
   }
   auto unpacked = std::make_unique<data_model::IndexSchema>();

--- a/src/indexes/vector_base.cc
+++ b/src/indexes/vector_base.cc
@@ -293,7 +293,7 @@ void VectorBase::RemoveRecordDueToError(const InternedStringPtr &key,
                                         std::optional<uint64_t> internal_id) {
   auto res = UnTrackKey(key);
   if (!res.ok()) {
-    VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "While processing error, failed to untrack the key "
            "with id: "
         << (internal_id.has_value() ? std::to_string(internal_id.value())
@@ -303,7 +303,7 @@ void VectorBase::RemoveRecordDueToError(const InternedStringPtr &key,
   if (internal_id.has_value()) {
     auto remove_vector_res = RemoveRecordImpl(internal_id.value());
     if (!remove_vector_res.ok()) {
-      VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+      VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
           << "While processing error, failed to remove vector with id: "
           << internal_id.value() << ": " << remove_vector_res.message();
     }

--- a/src/indexes/vector_flat.cc
+++ b/src/indexes/vector_flat.cc
@@ -141,7 +141,7 @@ absl::Status VectorFlat<T>::ResizeIfFull() {
     if (block_size_ == 0) {
       return absl::InternalError("Cannot resize FLAT index: block_size is 0");
     }
-    VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "Resizing FLAT Index, current size: " << GetCapacity()
         << ", expand by: " << block_size_;
     algo_->resizeIndex(GetCapacity() + block_size_);

--- a/src/indexes/vector_hnsw.cc
+++ b/src/indexes/vector_hnsw.cc
@@ -254,10 +254,10 @@ absl::Status VectorHNSW<T>::ResizeIfFull() {
       // thread is reading/writing during resize
       auto block_size = ValkeySearch::Instance().GetHNSWBlockSize();
       algo_->resizeIndex(algo_->getMaxElements() + block_size);
-      VMSDK_LOG(WARNING, nullptr)
-          << "Resizing HNSW Index, current size: " << max_elements
-          << ", expand by: " << block_size << ", resize time took: "
-          << absl::FormatDuration(stop_watch.Duration());
+      VMSDK_LOG(WARNING) << "Resizing HNSW Index, current size: "
+                         << max_elements << ", expand by: " << block_size
+                         << ", resize time took: "
+                         << absl::FormatDuration(stop_watch.Duration());
     }
   } catch (const std::exception &e) {
     ++Metrics::GetStats().hnsw_add_exceptions_cnt;

--- a/src/query/fanout.cc
+++ b/src/query/fanout.cc
@@ -117,7 +117,7 @@ struct SearchPartitionResultsTracker {
       if (should_cancel) {
         parameters->cancellation_token->Cancel();
       }
-      VMSDK_LOG_EVERY_N_SEC(DEBUG, nullptr, 1)
+      VMSDK_LOG_EVERY_N_SEC(DEBUG, 1)
           << "Error during handling of FT.SEARCH on node " << address
           << ", Error code: " << status.error_code();
       return;
@@ -259,7 +259,7 @@ class LocalResponderSearch : public query::SearchParameters {
         tracker->AddResults(search_result.neighbors);
         tracker->AddTotalCount(search_result.total_count);
       }
-      VMSDK_LOG_EVERY_N_SEC(DEBUG, nullptr, 1)
+      VMSDK_LOG_EVERY_N_SEC(DEBUG, 1)
           << "Error during local handling of the search operation";
     }
     // Stash `self` (the LocalResponderSearch) in the tracker so that its

--- a/src/query/fanout_operation_base.h
+++ b/src/query/fanout_operation_base.h
@@ -109,7 +109,7 @@ class FanoutOperationBase {
           this->OnResponse(resp, target);
         } else {
           ++Metrics::GetStats().info_fanout_fail_cnt;
-          VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << "Local node error, status code: " << status.error_code();
           this->OnError(status, resp.error_type(), target);
         }
@@ -122,7 +122,7 @@ class FanoutOperationBase {
       auto client = client_pool_->GetClient(client_address);
       if (!client) {
         ++Metrics::GetStats().info_fanout_fail_cnt;
-        VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+        VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
             << "Found invalid client on target " << client_address;
         this->OnError(grpc::Status(grpc::StatusCode::INTERNAL, ""),
                       coordinator::FanoutErrorType::COMMUNICATION_ERROR,
@@ -137,7 +137,7 @@ class FanoutOperationBase {
               this->OnResponse(resp, target);
             } else {
               ++Metrics::GetStats().info_fanout_fail_cnt;
-              VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+              VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
                   << "InvokeRemoteRpc error on target " << client_address
                   << ", status code: " << status.error_code();
               // if grpc failed, the response is invalid, so we need to manually
@@ -224,10 +224,10 @@ class FanoutOperationBase {
       for (const vmsdk::cluster_map::NodeInfo& target :
            index_name_error_nodes) {
         if (target.is_local) {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << INDEX_NAME_ERROR_LOG_PREFIX << "LOCAL NODE";
         } else {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << INDEX_NAME_ERROR_LOG_PREFIX
               << absl::StrCat(target.socket_address.primary_endpoint, ":",
                               coordinator::GetCoordinatorPort(
@@ -241,10 +241,10 @@ class FanoutOperationBase {
       for (const vmsdk::cluster_map::NodeInfo& target :
            communication_error_nodes) {
         if (target.is_local) {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << COMMUNICATION_ERROR_LOG_PREFIX << "LOCAL NODE";
         } else {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << COMMUNICATION_ERROR_LOG_PREFIX
               << absl::StrCat(target.socket_address.primary_endpoint, ":",
                               coordinator::GetCoordinatorPort(
@@ -258,10 +258,10 @@ class FanoutOperationBase {
       for (const vmsdk::cluster_map::NodeInfo& target :
            inconsistent_state_error_nodes) {
         if (target.is_local) {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << INCONSISTENT_STATE_ERROR_LOG_PREFIX << "LOCAL NODE";
         } else {
-          VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+          VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
               << INCONSISTENT_STATE_ERROR_LOG_PREFIX
               << absl::StrCat(target.socket_address.primary_endpoint, ":",
                               coordinator::GetCoordinatorPort(

--- a/src/query/predicate.cc
+++ b/src/query/predicate.cc
@@ -468,8 +468,8 @@ EvaluationResult ComposedPredicate::EvaluateWithContext(Evaluator &evaluator,
         query_field_mask &= result.filter_iterator->QueryFieldMask();
         iterators.push_back(std::move(result.filter_iterator));
       }
-      VMSDK_LOG(DEBUG, nullptr)
-          << "Inline evaluate AND predicate child: " << result.matches;
+      VMSDK_LOG(DEBUG) << "Inline evaluate AND predicate child: "
+                       << result.matches;
     }
     // Proximity check: Only if slop/inorder set and both sides have
     // iterators. This ensures we only check proximity for text predicates,

--- a/src/query/response_generator.cc
+++ b/src/query/response_generator.cc
@@ -410,7 +410,7 @@ void ProcessNeighborsForReply(
     bool size_exceeded = false;
     if (content.value().size() > max_content_fields) {
       ++Metrics::GetStats().query_result_record_dropped_cnt;
-      VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+      VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
           << "Content field number exceeds configured limit of "
           << max_content_fields << " for neighbor with ID: "
           << vmsdk::config::RedactIfNeeded((*neighbor.external_id).Str());
@@ -422,7 +422,7 @@ void ProcessNeighborsForReply(
       total_size += vmsdk::ToStringView(item.second.value.get()).size();
       if (total_size > max_content_size) {
         ++Metrics::GetStats().query_result_record_dropped_cnt;
-        VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 1)
+        VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
             << "Content size exceeds configured limit of " << max_content_size
             << " bytes for neighbor with ID: "
             << vmsdk::config::RedactIfNeeded((*neighbor.external_id).Str());

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -137,7 +137,7 @@ absl::StatusOr<std::vector<indexes::Neighbor>> PerformVectorSearch(
     inline_filter = std::make_unique<InlineVectorFilter>(
         parameters.filter_parse_results.root_predicate.get(), vector_index,
         text_index_schema, parameters.filter_parse_results.query_operations);
-    VMSDK_LOG(DEBUG, nullptr) << "Performing vector search with inline filter";
+    VMSDK_LOG(DEBUG) << "Performing vector search with inline filter";
   }
   if (vector_index->GetIndexerType() == indexes::IndexerType::kHNSW) {
     auto vector_hnsw = dynamic_cast<indexes::VectorHNSW<float> *>(vector_index);
@@ -567,7 +567,7 @@ absl::StatusOr<std::vector<indexes::Neighbor>> MaybeAddIndexedContent(
                       nullptr, vector->data(), vector->size()));
             }
           } else {
-            VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+            VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
                 << "Failed to get vector value during fetching through index "
                    "contents: "
                 << vector.status();
@@ -715,9 +715,8 @@ absl::StatusOr<std::vector<indexes::Neighbor>> DoSearchVector(
 
   // Query planner makes the decision for pre-filtering vs inline-filtering.
   if (UsePreFiltering(qualified_entries, vector_index)) {
-    VMSDK_LOG(DEBUG, nullptr)
-        << "Using pre-filter query execution, qualified entries="
-        << qualified_entries;
+    VMSDK_LOG(DEBUG) << "Using pre-filter query execution, qualified entries="
+                     << qualified_entries;
     // Do an exact nearest neighbour search on the reduced search space.
     ++Metrics::GetStats().query_prefiltering_requests_cnt;
     std::priority_queue<std::pair<float, hnswlib::labeltype>> results =
@@ -1091,9 +1090,9 @@ absl::Status query::SearchParameters::PreParseQueryString() {
                      options::GetQueryStringBytes(), " bytes."));
   }
   auto filter_expression = absl::string_view(parse_vars.query_string);
-  VMSDK_LOG(DEBUG, nullptr)
-      << "Query: '" << vmsdk::config::RedactIfNeeded(parse_vars.query_string)
-      << "'";
+  VMSDK_LOG(DEBUG) << "Query: '"
+                   << vmsdk::config::RedactIfNeeded(parse_vars.query_string)
+                   << "'";
   auto pos = filter_expression.find(kVectorFilterDelimiter);
   absl::string_view pre_filter;
   absl::string_view vector_filter;

--- a/src/rdb_serialization.cc
+++ b/src/rdb_serialization.cc
@@ -163,8 +163,8 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
       auto rdb_section_count, rdb->LoadUnsigned(),
       _ << "IO error reading RDB section count from RDB. Failing RDB load.");
 
-  VMSDK_LOG(NOTICE, ctx) << "Loading RDB from version: " << rdb_version
-                         << " with " << rdb_section_count << " sections.";
+  VMSDK_LOG(NOTICE) << "Loading RDB from version: " << rdb_version << " with "
+                    << rdb_section_count << " sections.";
 
   // Initialize restore progress tracking
   auto rdb_load_start = absl::Now();
@@ -185,9 +185,8 @@ absl::Status PerformRDBLoad(ValkeyModuleCtx *ctx, SafeRDB *rdb, int encver) {
       VMSDK_RETURN_IF_ERROR(load_callback(ctx, std::move(section),
                                           it.IterateSupplementalContent()));
     } else {
-      VMSDK_LOG(WARNING, ctx)
-          << "Ignoring unknown RDB section with type "
-          << data_model::RDBSectionType_Name(section->type());
+      VMSDK_LOG(WARNING) << "Ignoring unknown RDB section with type "
+                         << data_model::RDBSectionType_Name(section->type());
       // Need to consume all supplemental data
       auto supp_it = it.IterateSupplementalContent();
       while (supp_it.HasNext()) {
@@ -225,7 +224,7 @@ int AuxLoadCallback(ValkeyModuleIO *rdb, int encver, int when) {
     return VALKEYMODULE_OK;
   }
   Metrics::GetStats().rdb_load_failure_cnt++;
-  VMSDK_LOG_EVERY_N_SEC(WARNING, ctx.get(), 0.1)
+  VMSDK_LOG_EVERY_N_SEC(WARNING, 0.1)
       << "Failed to load ValkeySearch aux section from RDB: "
       << result.message();
   return VALKEYMODULE_ERR;
@@ -251,9 +250,9 @@ absl::Status PerformRDBSave(ValkeyModuleCtx *ctx, SafeRDB *rdb, int when) {
     return absl::OkStatus();
   }
 
-  VMSDK_LOG(NOTICE, ctx) << "Saving " << rdb_section_count
-                         << " ValkeySearch RDB sections with minimum version "
-                         << vmsdk::ValkeyVersion(min_version).ToString();
+  VMSDK_LOG(NOTICE) << "Saving " << rdb_section_count
+                    << " ValkeySearch RDB sections with minimum version "
+                    << vmsdk::ValkeyVersion(min_version).ToString();
 
   // Save the header
   VMSDK_RETURN_IF_ERROR(rdb->SaveUnsigned(min_version.ToInt()));
@@ -281,7 +280,7 @@ void AuxSaveCallback(ValkeyModuleIO *rdb, int when) {
     return;
   }
   Metrics::GetStats().rdb_save_failure_cnt++;
-  VMSDK_LOG_EVERY_N_SEC(WARNING, ctx, 0.1)
+  VMSDK_LOG_EVERY_N_SEC(WARNING, 0.1)
       << "Failed to save ValkeySearch aux section to RDB: " << result.message();
 }
 

--- a/src/rdb_serialization.h
+++ b/src/rdb_serialization.h
@@ -189,7 +189,7 @@ class SupplementalContentChunkIter {
   bool HasNext() const { return !done_; }
   ~SupplementalContentChunkIter() {
     if (!done_) {
-      VMSDK_LOG(WARNING, nullptr)
+      VMSDK_LOG(WARNING)
           << "SupplementalContentChunkIter was not fully iterated";
       DCHECK(done_);
     }
@@ -225,7 +225,7 @@ class SupplementalContentIter {
   }
   ~SupplementalContentIter() {
     if (remaining_ > 0) {
-      VMSDK_LOG(WARNING, nullptr)
+      VMSDK_LOG(WARNING)
           << "SupplementalContentIter was not fully iterated. remaining_ == "
           << remaining_;
       DCHECK(remaining_ == 0);
@@ -273,7 +273,7 @@ class RDBSectionIter {
   bool HasNext() { return remaining_ > 0; }
   ~RDBSectionIter() {
     if (remaining_ > 0) {
-      VMSDK_LOG(WARNING, nullptr)
+      VMSDK_LOG(WARNING)
           << "RDBSectionIter was not fully iterated. remaining_ == "
           << remaining_;
       DCHECK(remaining_ == 0);
@@ -343,7 +343,7 @@ class RDBChunkOutputStream : public hnswlib::OutputStream {
     if (!closed_) {
       auto status = Close();
       if (!status.ok()) {
-        VMSDK_LOG(WARNING, nullptr)
+        VMSDK_LOG(WARNING)
             << "Failed to write final chunk on closing output stream: "
             << status.message();
       }

--- a/src/schema_manager.cc
+++ b/src/schema_manager.cc
@@ -509,18 +509,17 @@ void SchemaManager::OnFlushDBEnded(ValkeyModuleCtx *ctx) {
   }
 
   auto to_delete = GetIndexSchemasInDBInternal(selected_db);
-  VMSDK_LOG(NOTICE, ctx) << "Deleting index schema on FLUSHDB of DB "
-                         << selected_db;
+  VMSDK_LOG(NOTICE) << "Deleting index schema on FLUSHDB of DB " << selected_db;
   absl::once_flag log_recreate_once;
   for (const auto &name : to_delete) {
-    VMSDK_LOG(DEBUG, ctx) << "Deleting index schema "
-                          << vmsdk::config::RedactIfNeeded(name)
-                          << " on FLUSHDB of DB " << selected_db;
+    VMSDK_LOG(DEBUG) << "Deleting index schema "
+                     << vmsdk::config::RedactIfNeeded(name)
+                     << " on FLUSHDB of DB " << selected_db;
     auto old_schema = RemoveIndexSchemaInternal(selected_db, name);
     if (!old_schema.ok()) {
-      VMSDK_LOG(WARNING, ctx) << "Unable to delete index schema "
-                              << vmsdk::config::RedactIfNeeded(name)
-                              << " on FLUSHDB of DB " << selected_db;
+      VMSDK_LOG(WARNING) << "Unable to delete index schema "
+                         << vmsdk::config::RedactIfNeeded(name)
+                         << " on FLUSHDB of DB " << selected_db;
       continue;
     }
     if (coordinator_enabled_) {
@@ -528,18 +527,18 @@ void SchemaManager::OnFlushDBEnded(ValkeyModuleCtx *ctx) {
       // cluster-level construct, not a node-level construct. To delete,
       // FT.DROPINDEX must be done explicitly.
       absl::call_once(log_recreate_once, [&]() {
-        VMSDK_LOG(NOTICE, ctx)
-            << "Recreating index schema on FLUSHDB of DB " << selected_db;
+        VMSDK_LOG(NOTICE) << "Recreating index schema on FLUSHDB of DB "
+                          << selected_db;
       });
       auto to_add = old_schema.value()->ToProto();
-      VMSDK_LOG(DEBUG, ctx)
-          << "Recreating index schema " << vmsdk::config::RedactIfNeeded(name)
-          << " on FLUSHDB of DB " << selected_db;
+      VMSDK_LOG(DEBUG) << "Recreating index schema "
+                       << vmsdk::config::RedactIfNeeded(name)
+                       << " on FLUSHDB of DB " << selected_db;
       auto add_status = CreateIndexSchemaInternal(ctx, *to_add);
       if (!add_status.ok()) {
-        VMSDK_LOG(WARNING, ctx) << "Unable to recreate index schema "
-                                << vmsdk::config::RedactIfNeeded(name)
-                                << " on FLUSHDB of DB " << selected_db;
+        VMSDK_LOG(WARNING) << "Unable to recreate index schema "
+                           << vmsdk::config::RedactIfNeeded(name)
+                           << " on FLUSHDB of DB " << selected_db;
         continue;
       }
     }
@@ -584,8 +583,8 @@ void SchemaManager::OnReplicationLoadStart(ValkeyModuleCtx *ctx) {
   // first have flushed the DB, so there should be no additional memory
   // pressure, and the final swap from the staging schema set to the live schema
   // set is very cheap.
-  VMSDK_LOG(NOTICE, ctx) << "Staging indices during RDB load due to "
-                            "replication, will apply on loading finished";
+  VMSDK_LOG(NOTICE) << "Staging indices during RDB load due to "
+                       "replication, will apply on loading finished";
   staging_indices_due_to_repl_load_ = true;
 }
 
@@ -595,12 +594,11 @@ void SchemaManager::OnLoadingEnded(ValkeyModuleCtx *ctx) {
     // Perform swap of staged schemas to main schemas. Note that no merge
     // occurs here, since for RDB load we are guaranteed that the new state
     // is not applied incrementally.
-    VMSDK_LOG(NOTICE, ctx)
-        << "Applying staged indices at the end of RDB loading";
+    VMSDK_LOG(NOTICE) << "Applying staged indices at the end of RDB loading";
     auto status = RemoveAll();
     if (!status.ok()) {
-      VMSDK_LOG(WARNING, ctx) << "Failed to remove contents of existing "
-                                 "schemas on loading end.";
+      VMSDK_LOG(WARNING) << "Failed to remove contents of existing "
+                            "schemas on loading end.";
     }
     db_to_index_schemas_ = staged_db_to_index_schemas_.Get();
     staged_db_to_index_schemas_ = absl::flat_hash_map<
@@ -696,9 +694,9 @@ absl::Status SchemaManager::LoadIndex(
   // the existing index schemas. The loading ended callback will swap these
   // atomically.
   if (staging_indices_due_to_repl_load_.Get()) {
-    VMSDK_LOG(NOTICE, ctx) << "Staging index from RDB: "
-                           << vmsdk::config::RedactIfNeeded(name) << " (in db "
-                           << db_num << ")";
+    VMSDK_LOG(NOTICE) << "Staging index from RDB: "
+                      << vmsdk::config::RedactIfNeeded(name) << " (in db "
+                      << db_num << ")";
     staged_db_to_index_schemas_.Get()[db_num][name] = std::move(index_schema);
 
     // Increment completed index counter for restore progress tracking
@@ -711,9 +709,9 @@ absl::Status SchemaManager::LoadIndex(
   // case we are loading on top of an existing index schema set. This
   // happens for example when a module triggers RDB load on a running
   // server. In this case, we may have existing indices when we load the DB.
-  VMSDK_LOG(NOTICE, detached_ctx_.get())
-      << "Loading index from RDB: " << vmsdk::config::RedactIfNeeded(name)
-      << " (in db " << db_num << ")";
+  VMSDK_LOG(NOTICE) << "Loading index from RDB: "
+                    << vmsdk::config::RedactIfNeeded(name) << " (in db "
+                    << db_num << ")";
   absl::MutexLock lock(&db_to_index_schemas_mutex_);
   auto remove_existing_status = RemoveIndexSchemaInternal(db_num, name);
   if (remove_existing_status.ok()) {
@@ -771,10 +769,10 @@ void SchemaManager::OnShutdownCallback(ValkeyModuleCtx *ctx,
   if (db_to_index_schemas_.empty()) {
     return;
   }
-  VMSDK_LOG(NOTICE, ctx) << "Deleting all index schemas on SHUTDOWN event";
+  VMSDK_LOG(NOTICE) << "Deleting all index schemas on SHUTDOWN event";
   auto status = RemoveAll();
   if (!status.ok()) {
-    VMSDK_LOG(WARNING, ctx)
+    VMSDK_LOG(WARNING)
         << "Failed to delete all index schemas on SHUTDOWN event: "
         << status.message();
   }
@@ -818,9 +816,9 @@ absl::Status SchemaManager::ShowIndexSchemas(ValkeyModuleCtx *ctx,
     ValkeyModule_ReplyWithArray(ctx, inner_map.size());
     for (const auto &[name, schema] : inner_map) {
       auto proto = schema->ToProto()->DebugString();
-      VMSDK_LOG(DEBUG, ctx) << "Index Schema in DB " << db_num << ": "
-                            << vmsdk::config::RedactIfNeeded(name) << " "
-                            << vmsdk::config::RedactIfNeeded(proto);
+      VMSDK_LOG(DEBUG) << "Index Schema in DB " << db_num << ": "
+                       << vmsdk::config::RedactIfNeeded(name) << " "
+                       << vmsdk::config::RedactIfNeeded(proto);
       ValkeyModule_ReplyWithStringBuffer(ctx, proto.data(), proto.size());
     }
   }

--- a/src/utils/cancel.cc
+++ b/src/utils/cancel.cc
@@ -43,16 +43,15 @@ struct TokenImpl : public Base {
         if (ValkeyModule_Milliseconds() >= deadline_ms_) {
           is_cancelled_ = true;  // Operation should be cancelled
           Timeouts.Increment(1);
-          VMSDK_LOG(DEBUG, nullptr)
-              << "CANCEL: Timeout reached, cancelling operation";
+          VMSDK_LOG(DEBUG) << "CANCEL: Timeout reached, cancelling operation";
         } else if (context_ && context_->IsCancelled()) {
           is_cancelled_ = true;  // Operation should be cancelled
           gRPCCancels.Increment(1);
-          VMSDK_LOG(DEBUG, nullptr) << "CANCEL: gRPC context cancelled";
+          VMSDK_LOG(DEBUG) << "CANCEL: gRPC context cancelled";
         } else if (ForceTimeout.GetValue()) {
           is_cancelled_ = true;  // Operation should be cancelled
           ForceCancels.Increment(1);
-          VMSDK_LOG(WARNING, nullptr) << "CANCEL: Timeout forced";
+          VMSDK_LOG(WARNING) << "CANCEL: Timeout forced";
         } else if (!vmsdk::IsMainThread()) {
           PAUSEPOINT("Cancel");
         }

--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -1044,21 +1044,21 @@ void ValkeySearch::AtForkPrepare() {
   }
   Metrics::GetStats().worker_thread_pool_suspend_cnt++;
   auto status = writer_thread_pool_->SuspendWorkers();
-  VMSDK_LOG(WARNING, nullptr) << "At prepare fork callback, suspend writer "
-                                 "worker thread pool returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "At prepare fork callback, suspend writer "
+                        "worker thread pool returned message: "
+                     << status.message();
   status = reader_thread_pool_->SuspendWorkers();
-  VMSDK_LOG(WARNING, nullptr) << "At prepare fork callback, suspend reader "
-                                 "worker thread pool returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "At prepare fork callback, suspend reader "
+                        "worker thread pool returned message: "
+                     << status.message();
   status = utility_thread_pool_->SuspendWorkers();
-  VMSDK_LOG(WARNING, nullptr) << "At prepare fork callback, suspend utility "
-                                 "worker thread pool returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "At prepare fork callback, suspend utility "
+                        "worker thread pool returned message: "
+                     << status.message();
   status = coordinator::GRPCSuspender::Instance().Suspend();
-  VMSDK_LOG(WARNING, nullptr) << "At prepare fork callback, suspend gRPC "
-                                 "returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "At prepare fork callback, suspend gRPC "
+                        "returned message: "
+                     << status.message();
 }
 
 void ValkeySearch::AfterForkParent() {
@@ -1069,18 +1069,18 @@ void ValkeySearch::AfterForkParent() {
   }
   auto status = reader_thread_pool_->ResumeWorkers();
   Metrics::GetStats().reader_worker_thread_pool_resumed_cnt++;
-  VMSDK_LOG(WARNING, nullptr) << "After fork parent callback, resume reader "
-                                 "worker thread pool returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "After fork parent callback, resume reader "
+                        "worker thread pool returned message: "
+                     << status.message();
   status = utility_thread_pool_->ResumeWorkers();
-  VMSDK_LOG(WARNING, nullptr) << "After fork parent callback, resume utility "
-                                 "worker thread pool returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "After fork parent callback, resume utility "
+                        "worker thread pool returned message: "
+                     << status.message();
   writer_thread_pool_suspend_watch_ = vmsdk::StopWatch();
   status = coordinator::GRPCSuspender::Instance().Resume();
-  VMSDK_LOG(WARNING, nullptr) << "After fork parent callback, resume gRPC "
-                                 "returned message: "
-                              << status.message();
+  VMSDK_LOG(WARNING) << "After fork parent callback, resume gRPC "
+                        "returned message: "
+                     << status.message();
 }
 
 void ValkeySearch::OnServerCronCallback(ValkeyModuleCtx *ctx,
@@ -1188,16 +1188,14 @@ absl::Status ValkeySearch::Startup(ValkeyModuleCtx *ctx) {
       options::GetThreadPoolWaitTimeSamples().GetValue());
   utility_thread_pool_->StartWorkers();
 
-  VMSDK_LOG(NOTICE, ctx) << "use_coordinator: "
-                         << options::GetUseCoordinator().GetValue()
-                         << ", IsCluster: " << IsCluster();
+  VMSDK_LOG(NOTICE) << "use_coordinator: "
+                    << options::GetUseCoordinator().GetValue()
+                    << ", IsCluster: " << IsCluster();
 
-  VMSDK_LOG(NOTICE, ctx) << "Reader workers count: "
-                         << reader_thread_pool_->Size();
-  VMSDK_LOG(NOTICE, ctx) << "Writer workers count: "
-                         << writer_thread_pool_->Size();
-  VMSDK_LOG(NOTICE, ctx) << "Utility workers count: "
-                         << utility_thread_pool_->Size();
+  VMSDK_LOG(NOTICE) << "Reader workers count: " << reader_thread_pool_->Size();
+  VMSDK_LOG(NOTICE) << "Writer workers count: " << writer_thread_pool_->Size();
+  VMSDK_LOG(NOTICE) << "Utility workers count: "
+                    << utility_thread_pool_->Size();
 
   if (options::GetUseCoordinator().GetValue() && IsCluster()) {
     client_pool_ = std::make_unique<coordinator::ClientPool>(
@@ -1236,13 +1234,13 @@ void ValkeySearch::ResumeWriterThreadPool(ValkeyModuleCtx *ctx,
     Metrics::GetStats().writer_worker_thread_pool_suspension_expired_cnt++;
   }
   Metrics::GetStats().writer_worker_thread_pool_resumed_cnt++;
-  VMSDK_LOG(WARNING, ctx) << msg
-                          << ". Resuming writer "
-                             "worker thread pool returned message: "
-                          << status.message() << " Suspend duration: "
-                          << FormatDuration(writer_thread_pool_suspend_watch_
-                                                .value_or(vmsdk::StopWatch())
-                                                .Duration());
+  VMSDK_LOG(WARNING) << msg
+                     << ". Resuming writer "
+                        "worker thread pool returned message: "
+                     << status.message() << " Suspend duration: "
+                     << FormatDuration(writer_thread_pool_suspend_watch_
+                                           .value_or(vmsdk::StopWatch())
+                                           .Duration());
   writer_thread_pool_suspend_watch_ = std::nullopt;
 }
 
@@ -1269,12 +1267,11 @@ absl::Status ValkeySearch::OnLoad(ValkeyModuleCtx *ctx,
       ctx, VALKEYMODULE_OPTIONS_HANDLE_IO_ERRORS |
                VALKEYMODULE_OPTIONS_HANDLE_REPL_ASYNC_LOAD |
                VALKEYMODULE_OPTION_NO_IMPLICIT_SIGNAL_MODIFIED);
-  VMSDK_LOG(NOTICE, ctx) << "Json "
-                         << (IsJsonModuleSupported(ctx) ? "" : "not ")
-                         << "supported!";
+  VMSDK_LOG(NOTICE) << "Json " << (IsJsonModuleSupported(ctx) ? "" : "not ")
+                    << "supported!";
   VectorRegistry::Construct(ctx_);
   ValkeyModule_Assert(vmsdk::info_field::Validate(ctx));
-  VMSDK_LOG(DEBUG, ctx) << "Search module completed initialization!";
+  VMSDK_LOG(DEBUG) << "Search module completed initialization!";
   return absl::OkStatus();
 }
 
@@ -1318,7 +1315,7 @@ ValkeySearch::GetOrRefreshClusterMap(ValkeyModuleCtx *ctx) {
       !current_map || !current_map->IsConsistent() ||
       std::chrono::steady_clock::now() > current_map->GetExpirationTime();
   if (needs_refresh) {
-    VMSDK_LOG_EVERY_N_SEC(DEBUG, nullptr, 1) << "Creating a new cluster map";
+    VMSDK_LOG_EVERY_N_SEC(DEBUG, 1) << "Creating a new cluster map";
     auto new_map = vmsdk::cluster_map::ClusterMap::CreateNewClusterMap(ctx);
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -195,7 +195,7 @@ static auto log_level =
         .WithModifyCallback([](int value) {
           auto res = ValidateLogLevel(value);
           if (!res.ok()) {
-            VMSDK_LOG(WARNING, nullptr)
+            VMSDK_LOG(WARNING)
                 << "Invalid value: '" << value << "' provided to enum: '"
                 << kLogLevel << "'. " << res.message();
             return;
@@ -205,7 +205,7 @@ static auto log_level =
           auto log_level_str = kLogLevelNames[value];
           res = vmsdk::InitLogging(nullptr, log_level_str.data());
           if (!res.ok()) {
-            VMSDK_LOG(WARNING, nullptr)
+            VMSDK_LOG(WARNING)
                 << "Failed to initialize log with new value: " << log_level_str
                 << ". " << res.message();
           }

--- a/third_party/hnswlib/hnswalg.h
+++ b/third_party/hnswlib/hnswalg.h
@@ -935,7 +935,7 @@ class HierarchicalNSW
           absl::StrCat("HNSW index load validation failed: ", msg));
     }
     // Validation disabled: don't fail the load, but log (throttled) the defect.
-    VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 1)
+    VMSDK_LOG_EVERY_N_SEC(WARNING, 1)
         << "HNSW load validation is disabled; ignoring detected index "
            "corruption: "
         << msg;

--- a/vmsdk/src/cluster_map.cc
+++ b/vmsdk/src/cluster_map.cc
@@ -228,7 +228,7 @@ std::optional<NodeInfo> ClusterMap::ParseNodeInfo(
   ValkeyModuleCallReply* primary_endpoint_reply =
       ValkeyModule_CallReplyArrayElement(node_arr, 0);
   if (!primary_endpoint_reply) {
-    VMSDK_LOG(WARNING, nullptr) << "Invalid node primary endpoint";
+    VMSDK_LOG(WARNING) << "Invalid node primary endpoint";
     return std::nullopt;
   }
 
@@ -256,7 +256,7 @@ std::optional<NodeInfo> ClusterMap::ParseNodeInfo(
       (!node_primary_endpoint_char || node_primary_endpoint_len == 0 ||
        (node_primary_endpoint_len == 1 &&
         node_primary_endpoint_char[0] == '?'))) {
-    VMSDK_LOG(WARNING, nullptr) << "Invalid node primary endpoint";
+    VMSDK_LOG(WARNING) << "Invalid node primary endpoint";
     return std::nullopt;
   }
 
@@ -316,10 +316,9 @@ std::optional<NodeInfo> ClusterMap::ParseNodeInfo(
   if (it != socket_addr_to_node_map_.end()) {
     // socket address already seen - check if it's the same node
     if (it->second != node_id_str) {
-      VMSDK_LOG(WARNING, nullptr)
-          << "Socket address " << it->first.primary_endpoint << ":"
-          << it->first.port << " collision between nodes " << node_id_str
-          << " and " << it->second;
+      VMSDK_LOG(WARNING) << "Socket address " << it->first.primary_endpoint
+                         << ":" << it->first.port << " collision between nodes "
+                         << node_id_str << " and " << it->second;
       this->is_consistent_ = false;
     }
   } else {
@@ -413,8 +412,8 @@ bool ClusterMap::ProcessSlotRange(ValkeyModuleCallReply* slot_range,
       ValkeyModule_CallReplyArrayElement(slot_range, 2);
   auto primary_node_opt = ParseNodeInfo(primary_node_arr, my_node_id, true);
   if (!primary_node_opt.has_value()) {
-    VMSDK_LOG(WARNING, nullptr) << "Dropping slot range [" << start << "-"
-                                << end << "] due to invalid primary node";
+    VMSDK_LOG(WARNING) << "Dropping slot range [" << start << "-" << end
+                       << "] due to invalid primary node";
     is_consistent_ = false;
     return false;
   }
@@ -428,8 +427,8 @@ bool ClusterMap::ProcessSlotRange(ValkeyModuleCallReply* slot_range,
         ValkeyModule_CallReplyArrayElement(slot_range, j);
     auto replica_opt = ParseNodeInfo(replica_node_arr, my_node_id, false);
     if (!replica_opt.has_value()) {
-      VMSDK_LOG(WARNING, nullptr) << "Skipping invalid replica in slot range ["
-                                  << start << "-" << end << "]";
+      VMSDK_LOG(WARNING) << "Skipping invalid replica in slot range [" << start
+                         << "-" << end << "]";
       is_consistent_ = false;
       return false;
     }
@@ -465,7 +464,7 @@ bool ClusterMap::ProcessSlotRange(ValkeyModuleCallReply* slot_range,
 
     // check shard consistency between existing and new one
     if (!IsExistingShardConsistent(shard_it->second, primary_node, replicas)) {
-      VMSDK_LOG(WARNING, nullptr)
+      VMSDK_LOG(WARNING)
           << "Inconsistency shard info found on existing slot ranges!";
       is_consistent_ = false;
     }
@@ -502,9 +501,8 @@ bool ClusterMap::CheckClusterMapFull() {
         << "Slot " << start_slot << " overlaps with previous range ending at "
         << (expected_next - 1);
     if (start_slot != expected_next) {
-      VMSDK_LOG(WARNING, nullptr)
-          << "Slot gap found: slots " << expected_next << " to "
-          << (start_slot - 1) << " are not covered";
+      VMSDK_LOG(WARNING) << "Slot gap found: slots " << expected_next << " to "
+                         << (start_slot - 1) << " are not covered";
       return false;
     }
     expected_next = range_and_shard.first + 1;
@@ -512,10 +510,9 @@ bool ClusterMap::CheckClusterMapFull() {
   }
   // Verify we processed all entries in the map
   if (entries_processed != slot_to_shard_map_.size()) {
-    VMSDK_LOG(WARNING, nullptr)
-        << "Slot map inconsistency: processed " << entries_processed
-        << " entries but map contains " << slot_to_shard_map_.size()
-        << " entries";
+    VMSDK_LOG(WARNING) << "Slot map inconsistency: processed "
+                       << entries_processed << " entries but map contains "
+                       << slot_to_shard_map_.size() << " entries";
     return false;
   }
   return expected_next == kNumSlots;
@@ -619,14 +616,14 @@ std::shared_ptr<ClusterMap> ClusterMap::CreateNewClusterMap(
 
 // debug only, print out cluster map
 void ClusterMap::PrintClusterMap(std::shared_ptr<ClusterMap> map) {
-  VMSDK_LOG(NOTICE, nullptr) << "=== Cluster Map Created ===";
-  VMSDK_LOG(NOTICE, nullptr) << "is_consistent_: " << map->is_consistent_;
-  VMSDK_LOG(NOTICE, nullptr)
-      << "cluster_slots_fingerprint_: " << map->cluster_slots_fingerprint_;
+  VMSDK_LOG(NOTICE) << "=== Cluster Map Created ===";
+  VMSDK_LOG(NOTICE) << "is_consistent_: " << map->is_consistent_;
+  VMSDK_LOG(NOTICE) << "cluster_slots_fingerprint_: "
+                    << map->cluster_slots_fingerprint_;
 
   // Print owned slots using slot_to_shard_map_
   size_t owned_count = map->owned_slots_.count();
-  VMSDK_LOG(NOTICE, nullptr) << "owned_slots_ count: " << owned_count;
+  VMSDK_LOG(NOTICE) << "owned_slots_ count: " << owned_count;
   if (owned_count > 0) {
     std::string owned_ranges;
     for (const auto& [start_slot, range_and_shard] : map->slot_to_shard_map_) {
@@ -655,18 +652,18 @@ void ClusterMap::PrintClusterMap(std::shared_ptr<ClusterMap> map) {
       }
     }
     if (!owned_ranges.empty()) {
-      VMSDK_LOG(NOTICE, nullptr) << "owned_slots_ ranges: " << owned_ranges;
+      VMSDK_LOG(NOTICE) << "owned_slots_ ranges: " << owned_ranges;
     }
   }
 
   // Print shards
-  VMSDK_LOG(NOTICE, nullptr) << "shards_ count: " << map->shards_.size();
+  VMSDK_LOG(NOTICE) << "shards_ count: " << map->shards_.size();
   for (const auto& [shard_id, shard_info] : map->shards_) {
-    VMSDK_LOG(NOTICE, nullptr) << "Shard ID: " << shard_id;
-    VMSDK_LOG(NOTICE, nullptr)
-        << "  owned_slots count: " << shard_info.owned_slots.size();
-    VMSDK_LOG(NOTICE, nullptr)
-        << "  slots_fingerprint: " << shard_info.slots_fingerprint;
+    VMSDK_LOG(NOTICE) << "Shard ID: " << shard_id;
+    VMSDK_LOG(NOTICE) << "  owned_slots count: "
+                      << shard_info.owned_slots.size();
+    VMSDK_LOG(NOTICE) << "  slots_fingerprint: "
+                      << shard_info.slots_fingerprint;
 
     // Simplified slot range printing using slot_to_shard_map_
     if (!shard_info.owned_slots.empty()) {
@@ -680,67 +677,65 @@ void ClusterMap::PrintClusterMap(std::shared_ptr<ClusterMap> map) {
               std::to_string(start_slot) + "-" + std::to_string(end_slot);
         }
       }
-      VMSDK_LOG(NOTICE, nullptr) << "  slot ranges: " << slot_ranges;
+      VMSDK_LOG(NOTICE) << "  slot ranges: " << slot_ranges;
     }
 
     // Print primary node info
     if (shard_info.primary.has_value()) {
       const auto& primary = shard_info.primary.value();
-      VMSDK_LOG(NOTICE, nullptr) << "  Primary Node:";
-      VMSDK_LOG(NOTICE, nullptr) << "    node_id: " << primary.node_id;
-      VMSDK_LOG(NOTICE, nullptr)
-          << "    role: " << (primary.is_primary ? "Primary" : "Replica");
-      VMSDK_LOG(NOTICE, nullptr)
-          << "    location: " << (primary.is_local ? "Local" : "Remote");
-      VMSDK_LOG(NOTICE, nullptr) << "    primary_endpoint: "
-                                 << primary.socket_address.primary_endpoint;
-      VMSDK_LOG(NOTICE, nullptr) << "    port: " << primary.socket_address.port;
+      VMSDK_LOG(NOTICE) << "  Primary Node:";
+      VMSDK_LOG(NOTICE) << "    node_id: " << primary.node_id;
+      VMSDK_LOG(NOTICE) << "    role: "
+                        << (primary.is_primary ? "Primary" : "Replica");
+      VMSDK_LOG(NOTICE) << "    location: "
+                        << (primary.is_local ? "Local" : "Remote");
+      VMSDK_LOG(NOTICE) << "    primary_endpoint: "
+                        << primary.socket_address.primary_endpoint;
+      VMSDK_LOG(NOTICE) << "    port: " << primary.socket_address.port;
       if (!primary.additional_network_metadata.empty()) {
-        VMSDK_LOG(NOTICE, nullptr) << "    additional_network_metadata:";
+        VMSDK_LOG(NOTICE) << "    additional_network_metadata:";
         for (const auto& [key, value] : primary.additional_network_metadata) {
-          VMSDK_LOG(NOTICE, nullptr) << "      " << key << ": " << value;
+          VMSDK_LOG(NOTICE) << "      " << key << ": " << value;
         }
       } else {
-        VMSDK_LOG(NOTICE, nullptr) << "additional_network_metadata is empty";
+        VMSDK_LOG(NOTICE) << "additional_network_metadata is empty";
       }
     } else {
-      VMSDK_LOG(NOTICE, nullptr) << "  Primary Node: (none)";
+      VMSDK_LOG(NOTICE) << "  Primary Node: (none)";
     }
 
     // Print replica nodes info
-    VMSDK_LOG(NOTICE, nullptr)
-        << "  Replicas count: " << shard_info.replicas.size();
+    VMSDK_LOG(NOTICE) << "  Replicas count: " << shard_info.replicas.size();
     for (size_t i = 0; i < shard_info.replicas.size(); ++i) {
       const auto& replica = shard_info.replicas[i];
-      VMSDK_LOG(NOTICE, nullptr) << "  Replica[" << i << "]:";
-      VMSDK_LOG(NOTICE, nullptr) << "    node_id: " << replica.node_id;
-      VMSDK_LOG(NOTICE, nullptr)
-          << "    role: " << (replica.is_primary ? "Primary" : "Replica");
-      VMSDK_LOG(NOTICE, nullptr)
-          << "    location: " << (replica.is_local ? "Local" : "Remote");
-      VMSDK_LOG(NOTICE, nullptr) << "    primary_endpoint: "
-                                 << replica.socket_address.primary_endpoint;
-      VMSDK_LOG(NOTICE, nullptr) << "    port: " << replica.socket_address.port;
+      VMSDK_LOG(NOTICE) << "  Replica[" << i << "]:";
+      VMSDK_LOG(NOTICE) << "    node_id: " << replica.node_id;
+      VMSDK_LOG(NOTICE) << "    role: "
+                        << (replica.is_primary ? "Primary" : "Replica");
+      VMSDK_LOG(NOTICE) << "    location: "
+                        << (replica.is_local ? "Local" : "Remote");
+      VMSDK_LOG(NOTICE) << "    primary_endpoint: "
+                        << replica.socket_address.primary_endpoint;
+      VMSDK_LOG(NOTICE) << "    port: " << replica.socket_address.port;
       if (!replica.additional_network_metadata.empty()) {
-        VMSDK_LOG(NOTICE, nullptr) << "    additional_network_metadata:";
+        VMSDK_LOG(NOTICE) << "    additional_network_metadata:";
         for (const auto& [key, value] : replica.additional_network_metadata) {
-          VMSDK_LOG(NOTICE, nullptr) << "      " << key << ": " << value;
+          VMSDK_LOG(NOTICE) << "      " << key << ": " << value;
         }
       } else {
-        VMSDK_LOG(NOTICE, nullptr) << "additional_network_metadata is empty";
+        VMSDK_LOG(NOTICE) << "additional_network_metadata is empty";
       }
     }
   }
 
   // Print pre-computed target lists (unchanged)
-  VMSDK_LOG(NOTICE, nullptr)
-      << "primary_targets_ count: " << map->primary_targets_.size();
-  VMSDK_LOG(NOTICE, nullptr)
-      << "replica_targets_ count: " << map->replica_targets_.size();
-  VMSDK_LOG(NOTICE, nullptr)
-      << "all_targets_ count: " << map->all_targets_.size();
+  VMSDK_LOG(NOTICE) << "primary_targets_ count: "
+                    << map->primary_targets_.size();
+  VMSDK_LOG(NOTICE) << "replica_targets_ count: "
+                    << map->replica_targets_.size();
+  VMSDK_LOG(NOTICE) << "all_targets_ count: " << map->all_targets_.size();
 
-  VMSDK_LOG(NOTICE, nullptr) << "=== End Cluster Map ===";
+  VMSDK_LOG(NOTICE) << "=== End Cluster Map ===";
 }
 
 }  // namespace cluster_map

--- a/vmsdk/src/concurrency.cc
+++ b/vmsdk/src/concurrency.cc
@@ -109,10 +109,10 @@ size_t ParseLscpuOutput(const std::string& lscpu_output) {
   }
 
   if (sockets_count < 0 || cores_per_socket < 0) {
-    VMSDK_LOG(NOTICE, nullptr) << "Error while parsing 'lscpu' output:\n"
-                               << lscpu_output << "\n"
-                               << ". Returning value from "
-                                  "std::thread::hardware_concurrency()";
+    VMSDK_LOG(NOTICE) << "Error while parsing 'lscpu' output:\n"
+                      << lscpu_output << "\n"
+                      << ". Returning value from "
+                         "std::thread::hardware_concurrency()";
     return std::thread::hardware_concurrency();
   }
   return sockets_count * cores_per_socket;
@@ -126,9 +126,9 @@ size_t GetPhysicalCPUCoresCount() {
 #if defined(__linux__) && defined(__aarch64__)
   auto res = helper::ExecuteCommand("/usr/bin/lscpu");
   if (!res.ok()) {
-    VMSDK_LOG(WARNING, nullptr) << res.status().message()
-                                << ". Returning value from "
-                                   "std::thread::hardware_concurrency()";
+    VMSDK_LOG(WARNING) << res.status().message()
+                       << ". Returning value from "
+                          "std::thread::hardware_concurrency()";
   } else {
     const auto& lscpu_output = res.value();
     cpu_cores = helper::ParseLscpuOutput(lscpu_output);
@@ -136,14 +136,13 @@ size_t GetPhysicalCPUCoresCount() {
 #elif defined(__linux__)
   std::ifstream cpuinfo("/proc/cpuinfo");
   if (!cpuinfo.is_open()) {
-    VMSDK_LOG(NOTICE, nullptr)
-        << "Could not read /proc/cpuinfo. Returning value from "
-           "std::thread::hardware_concurrency()";
+    VMSDK_LOG(NOTICE) << "Could not read /proc/cpuinfo. Returning value from "
+                         "std::thread::hardware_concurrency()";
   } else {
     cpu_cores = helper::ParseCPUInfo(cpuinfo);
   }
 #endif
-  VMSDK_LOG(DEBUG, nullptr) << "Cores count is set to:" << cpu_cores;
+  VMSDK_LOG(DEBUG) << "Cores count is set to:" << cpu_cores;
   return cpu_cores;
 }
 

--- a/vmsdk/src/debug.cc
+++ b/vmsdk/src/debug.cc
@@ -57,21 +57,20 @@ void PausePoint(absl::string_view point, std::source_location location) {
         .start_time_ = absl::Now(),
     });  // Indicate that I'm waiting.
   }
-  VMSDK_LOG(WARNING, nullptr)
-      << "Waiting at pause point " << point << " @ " << ToString(location);
+  VMSDK_LOG(WARNING) << "Waiting at pause point " << point << " @ "
+                     << ToString(location);
   auto message_time = absl::Now() + absl::Seconds(10);
   while (true) {
     absl::SleepFor(absl::Milliseconds(1));
     {
       absl::MutexLock lock(&pause_point_lock);
       if (!pause_point_waiters.contains(point)) {
-        VMSDK_LOG(WARNING, nullptr)
-            << "End of waiting at pause point " << point;
+        VMSDK_LOG(WARNING) << "End of waiting at pause point " << point;
         return;
       }
     }
     if (absl::Now() > message_time) {
-      VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 10)
+      VMSDK_LOG_EVERY_N_SEC(WARNING, 10)
           << "Waiting > 10 seconds at pause point " << point
           << " Location:" << ToString(location);
     }
@@ -103,11 +102,10 @@ absl::StatusOr<size_t> PausePointWaiters(absl::string_view point) {
   absl::MutexLock lock(&pause_point_lock);
   auto it = pause_point_waiters.find(point);
   if (it == pause_point_waiters.end()) {
-    VMSDK_LOG(DEBUG, nullptr) << "PAUSEPOINT: " << point << " not found";
+    VMSDK_LOG(DEBUG) << "PAUSEPOINT: " << point << " not found";
     return absl::NotFoundError("Pause Point not found");
   } else {
-    VMSDK_LOG(DEBUG, nullptr)
-        << "PAUSEPOINT: " << it->second.size() << " Waiters";
+    VMSDK_LOG(DEBUG) << "PAUSEPOINT: " << it->second.size() << " Waiters";
     return it->second.size();
   }
 }

--- a/vmsdk/src/info.cc
+++ b/vmsdk/src/info.cc
@@ -105,8 +105,8 @@ void DoSections(ValkeyModuleInfoCtx* ctx, int for_crash_report) {
   //
   for (auto& [section, section_info] : section_map) {
     if (section_info.handled_) {
-      VMSDK_LOG(DEBUG, nullptr)
-          << "Skipping Section " << section << " as it was already handled";
+      VMSDK_LOG(DEBUG) << "Skipping Section " << section
+                       << " as it was already handled";
       section_info.handled_ = false;
       continue;
     }
@@ -142,7 +142,7 @@ void DoSections(ValkeyModuleInfoCtx* ctx, int for_crash_report) {
 void DoSection(ValkeyModuleInfoCtx* ctx, absl::string_view section,
                int for_crash_report) {
   if (ValkeyModule_InfoAddSection(ctx, section.data()) == VALKEYMODULE_ERR) {
-    VMSDK_LOG(DEBUG, nullptr) << "Info Section " << section << " Skipped";
+    VMSDK_LOG(DEBUG) << "Info Section " << section << " Skipped";
     return;
   }
   // Find the section without a memory allocation....
@@ -179,31 +179,29 @@ bool Validate(ValkeyModuleCtx* ctx) {
   SectionMap& section_map = GetSectionMap();
   for (auto& [section, section_info] : section_map) {
     if (!IsValidName(section)) {
-      VMSDK_LOG(WARNING, ctx)
-          << "Invalid characters in section name: " << section;
+      VMSDK_LOG(WARNING) << "Invalid characters in section name: " << section;
       failed = true;
     }
     for (auto& [name, info] : section_info.fields_) {
       if (name != info->GetName()) {
-        VMSDK_LOG(WARNING, ctx) << "Map corruption";
+        VMSDK_LOG(WARNING) << "Map corruption";
         return true;
       }
       if (!(info->GetFlags() ^ (Flags::kDeveloper | Flags::kApplication))) {
-        VMSDK_LOG(WARNING, ctx)
-            << "Missing App/Dev for Section:" << section << " Name:" << name;
+        VMSDK_LOG(WARNING) << "Missing App/Dev for Section:" << section
+                           << " Name:" << name;
         failed = true;
       }
       if (!IsValidName(name)) {
-        VMSDK_LOG(WARNING, ctx)
-            << "Invalid characters in info field name: " << name;
+        VMSDK_LOG(WARNING) << "Invalid characters in info field name: " << name;
         failed = true;
       }
       if (unique_names.contains(name)) {
-        VMSDK_LOG(WARNING, ctx) << "Non-unique name: " << name;
+        VMSDK_LOG(WARNING) << "Non-unique name: " << name;
         failed = true;
       }
-      VMSDK_LOG(DEBUG, ctx)
-          << "Defined Info Field: " << name << " Flags:" << info->GetFlags();
+      VMSDK_LOG(DEBUG) << "Defined Info Field: " << name
+                       << " Flags:" << info->GetFlags();
     }
   }
   return !failed;
@@ -281,9 +279,8 @@ void String::Dump(ValkeyModuleInfoCtx* ctx) const {
     std::string s = (*compute_string_func_)();
     ValkeyModule_InfoAddFieldCString(ctx, GetName().data(), s.data());
   } else {
-    VMSDK_LOG(WARNING, nullptr)
-        << "Invalid state for Info String: " << GetSection() << "/"
-        << GetName();
+    VMSDK_LOG(WARNING) << "Invalid state for Info String: " << GetSection()
+                       << "/" << GetName();
   }
 }
 
@@ -297,9 +294,8 @@ void String::Reply(ValkeyModuleCtx* ctx) const {
     std::string s = (*compute_string_func_)();
     ValkeyModule_ReplyWithCString(ctx, s.data());
   } else {
-    VMSDK_LOG(WARNING, nullptr)
-        << "Invalid state for Info String: " << GetSection() << "/"
-        << GetName();
+    VMSDK_LOG(WARNING) << "Invalid state for Info String: " << GetSection()
+                       << "/" << GetName();
   }
 }
 
@@ -329,8 +325,8 @@ static absl::flat_hash_map<Units, absl::string_view> kUnitsToString{
 static size_t DumpNames(ValkeyModuleCtx* ctx,
                         const vmsdk::module::Options& options,
                         const Base* field) {
-  VMSDK_LOG(WARNING, ctx) << "Dumping Info Field: " << field->GetSection()
-                          << "/" << field->GetName();
+  VMSDK_LOG(WARNING) << "Dumping Info Field: " << field->GetSection() << "/"
+                     << field->GetName();
   ValkeyModule_ReplyWithCString(ctx, "Section");
   ValkeyModule_ReplyWithCString(ctx, field->GetSection().data());
   std::string external_name = options.name + "." + field->GetName();

--- a/vmsdk/src/latency_sampler.h
+++ b/vmsdk/src/latency_sampler.h
@@ -56,7 +56,7 @@ class LatencySampler {
     absl::MutexLock lock(&histogram_lock_);
     if (!initialized_) {
       if (hdr_init(min_value_, max_value_, precision_, &histogram_) != 0) {
-        VMSDK_LOG_EVERY_N_SEC(WARNING, nullptr, 60)
+        VMSDK_LOG_EVERY_N_SEC(WARNING, 60)
             << "Failed to initialize latency histogram, dropping sample";
         return;
       }

--- a/vmsdk/src/log.cc
+++ b/vmsdk/src/log.cc
@@ -55,6 +55,7 @@ struct SinkOptions {
 };
 
 static SinkOptions sink_options;
+static UniqueValkeyDetachedThreadSafeContext logging_context;
 
 LogFormatterFunc GetSinkFormatter() { return sink_options.formatter; }
 void SetSinkFormatter(LogFormatterFunc formatter) {
@@ -105,15 +106,20 @@ absl::StatusOr<std::string> FetchEngineLogLevel(ValkeyModuleCtx *ctx) {
 
 absl::Status InitLogging(ValkeyModuleCtx *ctx,
                          std::optional<std::string> log_level_str) {
+  // A detached context preserves the module identity for logs emitted from
+  // worker threads and is valid for the module's full lifetime.
+  if (ctx != nullptr && logging_context == nullptr) {
+    logging_context = MakeUniqueValkeyDetachedThreadSafeContext(ctx);
+  }
   if (!log_level_str.has_value()) {
     auto engine_log_level = FetchEngineLogLevel(ctx);
     if (!engine_log_level.ok()) {
       // It is possible we can't get it, e.g. if the CONFIG command is renamed.
       // In such a case, we log a warning and default to NOTICE.
-      VMSDK_LOG(WARNING, ctx)
-          << "Failed to fetch Valkey Engine log level, "
-          << engine_log_level.status() << ", using default log level: "
-          << ToStrLogLevel(static_cast<int>(LogLevel::kNotice));
+      VMSDK_LOG(WARNING) << "Failed to fetch Valkey Engine log level, "
+                         << engine_log_level.status()
+                         << ", using default log level: "
+                         << ToStrLogLevel(static_cast<int>(LogLevel::kNotice));
       log_level_str = ToStrLogLevel(static_cast<int>(LogLevel::kNotice));
     } else {
       log_level_str = engine_log_level.value();
@@ -131,6 +137,10 @@ absl::Status InitLogging(ValkeyModuleCtx *ctx,
   return absl::OkStatus();
 }
 
+void ShutdownLogging() { logging_context.reset(); }
+
+ValkeyModuleCtx *GetLoggingContext() { return logging_context.get(); }
+
 const char *ReportedLogLevel(int log_level) {
   if (sink_options.log_level_specified) {
     return VALKEYMODULE_LOGLEVEL_WARNING;
@@ -139,8 +149,8 @@ const char *ReportedLogLevel(int log_level) {
 }
 
 void ValkeyLogSink::Send(const absl::LogEntry &entry) {
-  ValkeyModule_Log(ctx_, ReportedLogLevel(entry.verbosity()), "%s",
-                   GetSinkFormatter()(entry).c_str());
+  ValkeyModule_Log(GetLoggingContext(), ReportedLogLevel(entry.verbosity()),
+                   "%s", GetSinkFormatter()(entry).c_str());
 }
 
 void ValkeyIOLogSink::Send(const absl::LogEntry &entry) {

--- a/vmsdk/src/log.cc
+++ b/vmsdk/src/log.cc
@@ -7,11 +7,13 @@
 
 #include "vmsdk/src/log.h"
 
+#include <atomic>
 #include <cerrno>
 #include <cstddef>
 #include <optional>
 #include <string>
 
+#include "absl/base/no_destructor.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/check.h"
 #include "absl/log/globals.h"
@@ -55,7 +57,11 @@ struct SinkOptions {
 };
 
 static SinkOptions sink_options;
-static UniqueValkeyDetachedThreadSafeContext logging_context;
+// Keep ownership alive after module unload: an asynchronous callback may have
+// already loaded the context pointer before logging is disabled.
+static absl::NoDestructor<UniqueValkeyDetachedThreadSafeContext>
+    logging_context;
+static std::atomic<ValkeyModuleCtx *> active_logging_context{nullptr};
 
 LogFormatterFunc GetSinkFormatter() { return sink_options.formatter; }
 void SetSinkFormatter(LogFormatterFunc formatter) {
@@ -108,8 +114,10 @@ absl::Status InitLogging(ValkeyModuleCtx *ctx,
                          std::optional<std::string> log_level_str) {
   // A detached context preserves the module identity for logs emitted from
   // worker threads and is valid for the module's full lifetime.
-  if (ctx != nullptr && logging_context == nullptr) {
-    logging_context = MakeUniqueValkeyDetachedThreadSafeContext(ctx);
+  if (ctx != nullptr && *logging_context == nullptr) {
+    *logging_context = MakeUniqueValkeyDetachedThreadSafeContext(ctx);
+    active_logging_context.store(logging_context->get(),
+                                 std::memory_order_release);
   }
   if (!log_level_str.has_value()) {
     auto engine_log_level = FetchEngineLogLevel(ctx);
@@ -137,9 +145,18 @@ absl::Status InitLogging(ValkeyModuleCtx *ctx,
   return absl::OkStatus();
 }
 
-void ShutdownLogging() { logging_context.reset(); }
+void ShutdownLogging() {
+  active_logging_context.store(nullptr, std::memory_order_release);
+  logging_context->reset();
+}
 
-ValkeyModuleCtx *GetLoggingContext() { return logging_context.get(); }
+void DisableLoggingContext() {
+  active_logging_context.store(nullptr, std::memory_order_release);
+}
+
+ValkeyModuleCtx *GetLoggingContext() {
+  return active_logging_context.load(std::memory_order_acquire);
+}
 
 const char *ReportedLogLevel(int log_level) {
   if (sink_options.log_level_specified) {

--- a/vmsdk/src/log.h
+++ b/vmsdk/src/log.h
@@ -62,6 +62,11 @@ absl::Status InitLogging(
 // on the main thread after all module worker threads have stopped.
 void ShutdownLogging();
 
+// Stops associating logs with the module without releasing the detached
+// context. This is safe to call during module unload while callbacks may
+// still be finishing.
+void DisableLoggingContext();
+
 // Returns the module-scoped detached context established during initialization.
 // It is nullptr before initialization, so early load failures retain the
 // server's generic "module" log prefix.

--- a/vmsdk/src/log.h
+++ b/vmsdk/src/log.h
@@ -44,10 +44,6 @@ void SetSinkFormatter(LogFormatterFunc formatter);
 class ValkeyLogSink : public absl::LogSink {
  public:
   void Send(const absl::LogEntry& entry) override;
-  void SetContext(ValkeyModuleCtx* ctx) { ctx_ = ctx; }
-
- private:
-  ValkeyModuleCtx* ctx_{nullptr};
 };
 
 class ValkeyIOLogSink : public absl::LogSink {
@@ -62,22 +58,27 @@ class ValkeyIOLogSink : public absl::LogSink {
 absl::Status InitLogging(
     ValkeyModuleCtx* ctx,
     std::optional<std::string> log_level_str = std::nullopt);
+// Releases the detached context owned by the logging subsystem. This must run
+// on the main thread after all module worker threads have stopped.
+void ShutdownLogging();
+
+// Returns the module-scoped detached context established during initialization.
+// It is nullptr before initialization, so early load failures retain the
+// server's generic "module" log prefix.
+ValkeyModuleCtx* GetLoggingContext();
 
 static thread_local ValkeyLogSink log_sink;
 static thread_local ValkeyIOLogSink io_log_sink;
 
 }  // namespace vmsdk
 
-#define VMSDK_LOG(log_level, ctx)  \
-  vmsdk::log_sink.SetContext(ctx); \
+#define VMSDK_LOG(log_level) \
   VLOG(static_cast<int>(log_level)).ToSinkOnly(&vmsdk::log_sink)
 
-#define VMSDK_LOG_EVERY_N(log_level, ctx, n) \
-  vmsdk::log_sink.SetContext(ctx);           \
+#define VMSDK_LOG_EVERY_N(log_level, n) \
   VLOG_EVERY_N(static_cast<int>(log_level), n).ToSinkOnly(&vmsdk::log_sink)
 
-#define VMSDK_LOG_EVERY_N_SEC(log_level, ctx, n) \
-  vmsdk::log_sink.SetContext(ctx);               \
+#define VMSDK_LOG_EVERY_N_SEC(log_level, n) \
   VLOG_EVERY_N_SEC(static_cast<int>(log_level), n).ToSinkOnly(&vmsdk::log_sink)
 
 #define VMSDK_IO_LOG(log_level, module_io)   \

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -84,16 +84,17 @@ int OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
     return VALKEYMODULE_ERR;
   }
   if (ValkeyModule_GetServerVersion == nullptr) {
-    VMSDK_LOG(WARNING, ctx)
+    VMSDK_LOG(WARNING)
         << "ValkeyModule_GetServerVersion function is not available";
     return VALKEYMODULE_ERR;
   }
   auto server_version = vmsdk::ValkeyVersion(ValkeyModule_GetServerVersion());
   if (server_version < options.minimum_valkey_server_version) {
-    VMSDK_LOG(WARNING, ctx)
-        << "Minimum required server version is "
-        << vmsdk::ValkeyVersion(options.minimum_valkey_server_version)
-        << ", Current version is " << vmsdk::ValkeyVersion(server_version);
+    VMSDK_LOG(WARNING) << "Minimum required server version is "
+                       << vmsdk::ValkeyVersion(
+                              options.minimum_valkey_server_version)
+                       << ", Current version is "
+                       << vmsdk::ValkeyVersion(server_version);
     return VALKEYMODULE_ERR;
   }
   if (auto status = AddACLCategories(ctx, options.acl_categories);
@@ -132,7 +133,7 @@ int OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
           if (it == seen_bases.end() &&
               line.find(" r-x") != std::string::npos) {
             seen_bases[base_addr] = module;
-            VMSDK_LOG(NOTICE, ctx)
+            VMSDK_LOG(NOTICE)
                 << ">>> Loaded Module: " << module << " Base: 0x" << base_addr;
           }
         }
@@ -145,12 +146,11 @@ int OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv, int argc,
 int OnLoadDone(absl::Status status, ValkeyModuleCtx *ctx,
                const Options &options) {
   if (status.ok()) {
-    VMSDK_LOG(NOTICE, ctx) << options.name
-                           << " module was successfully loaded!";
+    VMSDK_LOG(NOTICE) << options.name << " module was successfully loaded!";
     vmsdk::UseValkeyAlloc();
     return VALKEYMODULE_OK;
   }
-  VMSDK_LOG(WARNING, ctx) << status.message().data();
+  VMSDK_LOG(WARNING) << status.message().data();
   return VALKEYMODULE_ERR;
 }
 }  // namespace module

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -15,6 +15,7 @@
 #include "absl/functional/any_invocable.h"
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
+#include "vmsdk/src/log.h"
 #include "vmsdk/src/utils.h"  // IWYU pragma: keep
 #include "vmsdk/src/valkey_module_api/valkey_module.h"
 
@@ -24,7 +25,7 @@
   int ValkeyModule_OnLoad(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,  \
                           int argc) {                                       \
     if (!vmsdk::verifyLoadedOnlyOnce()) {                                   \
-      VMSDK_LOG(NOTICE, ctx) << "Module cannot be loaded more than once";   \
+      VMSDK_LOG(NOTICE) << "Module cannot be loaded more than once";        \
       return VALKEYMODULE_ERR;                                              \
     }                                                                       \
     vmsdk::TrackCurrentAsMainThread();                                      \
@@ -43,6 +44,7 @@
     if (options.on_unload.has_value()) {                                    \
       options.on_unload.value()(ctx, options);                              \
     }                                                                       \
+    vmsdk::ShutdownLogging();                                               \
     return VALKEYMODULE_OK;                                                 \
   }                                                                         \
   }                                                                         \

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -44,7 +44,7 @@
     if (options.on_unload.has_value()) {                                    \
       options.on_unload.value()(ctx, options);                              \
     }                                                                       \
-    vmsdk::ShutdownLogging();                                               \
+    vmsdk::DisableLoggingContext();                                         \
     return VALKEYMODULE_OK;                                                 \
   }                                                                         \
   }                                                                         \

--- a/vmsdk/src/module_config.cc
+++ b/vmsdk/src/module_config.cc
@@ -181,8 +181,8 @@ absl::Status ModuleConfigManager::UpdateConfigFromKeyVal(
         absl::StrFormat("Unknown command line argument: `%s`", key));
   }
   // update the configuration entry
-  VMSDK_LOG(NOTICE, ctx) << "Parsed command line argument: " << key << " -> "
-                         << value;
+  VMSDK_LOG(NOTICE) << "Parsed command line argument: " << key << " -> "
+                    << value;
   VMSDK_RETURN_IF_ERROR(where->second->FromString(value));
   return absl::OkStatus();
 }

--- a/vmsdk/src/module_config.h
+++ b/vmsdk/src/module_config.h
@@ -192,9 +192,8 @@ class ConfigBase : public Registerable {
   absl::Status SetValueOrLog(T value, LogLevel log_level) {
     auto res = Validate(value);
     if (!res.ok()) {
-      VMSDK_LOG(log_level, nullptr)
-          << "Failed to update configuration entry: " << GetName() << ". "
-          << res.message();
+      VMSDK_LOG(log_level) << "Failed to update configuration entry: "
+                           << GetName() << ". " << res.message();
       return res;
     }
 

--- a/vmsdk/src/module_type.cc
+++ b/vmsdk/src/module_type.cc
@@ -22,7 +22,7 @@ namespace vmsdk {
 void DoDeregister(ValkeyModuleCtx *ctx, ValkeyModuleKey *module_key,
                   absl::string_view key) {
   if (ValkeyModule_DeleteKey(module_key) != VALKEYMODULE_OK) {
-    VMSDK_LOG(WARNING, ctx) << "failed to delete Valkey key " << key;
+    VMSDK_LOG(WARNING) << "failed to delete Valkey key " << key;
     DCHECK(false);
   }
 }

--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -155,7 +155,7 @@ void ThreadPool::JoinWorkers() {
         hung.push_back(t->name);
       }
     });
-    VMSDK_LOG(WARNING, nullptr)
+    VMSDK_LOG(WARNING)
         << "ThreadPool shutdown timed out after 5s waiting for workers to exit;"
         << " hung threads: " << absl::StrJoin(hung, ", ");
     CHECK(false) << "ThreadPool shutdown timeout: " << hung.size()

--- a/vmsdk/src/utils.cc
+++ b/vmsdk/src/utils.cc
@@ -101,7 +101,7 @@ int RunByMain(absl::AnyInvocable<void()> fn, bool force_async) {
   // During shutdown the event loop is no longer processing one-shot
   // callbacks.
   if (IsShuttingDown()) {
-    VMSDK_LOG(DEBUG, nullptr) << "RunByMain: dropping callback during shutdown";
+    VMSDK_LOG(DEBUG) << "RunByMain: dropping callback during shutdown";
     return VALKEYMODULE_OK;
   }
   auto call_by_main = new absl::AnyInvocable<void()>(std::move(fn));
@@ -243,7 +243,7 @@ std::ostream &operator<<(std::ostream &os, const JsonQuotedStringView &s) {
             // Start of 2 byte sequence
             itr++;
             if (itr == s.view_.end() || ((*itr) & 0b11000000) != 0b10000000) {
-              VMSDK_LOG(DEBUG, nullptr) << "Invalid Json Encode";
+              VMSDK_LOG(DEBUG) << "Invalid Json Encode";
               codepoint = 0xFFFF;
             } else {
               codepoint = ((c & 0b11111) << 6) | ((*itr) & 0b00111111);
@@ -252,13 +252,13 @@ std::ostream &operator<<(std::ostream &os, const JsonQuotedStringView &s) {
             // Start of 3 byte sequence
             ++itr;
             if (itr == s.view_.end() || ((*itr) & 0b11000000) != 0b10000000) {
-              VMSDK_LOG(DEBUG, nullptr) << "Invalid Json Encode";
+              VMSDK_LOG(DEBUG) << "Invalid Json Encode";
               codepoint = 0xffff;
             } else {
               unsigned char d = *itr;
               ++itr;
               if (itr == s.view_.end() || ((*itr) & 0b11000000) != 0b10000000) {
-                VMSDK_LOG(DEBUG, nullptr) << "Invalid Json Encode";
+                VMSDK_LOG(DEBUG) << "Invalid Json Encode";
                 codepoint = 0xFFFF;
               } else {
                 codepoint = ((c & 0b00001111) << 12) | ((d & 0b00111111) << 6) |
@@ -266,7 +266,7 @@ std::ostream &operator<<(std::ostream &os, const JsonQuotedStringView &s) {
               }
             }
           } else {
-            VMSDK_LOG(DEBUG, nullptr) << "Invalid Json Encode";
+            VMSDK_LOG(DEBUG) << "Invalid Json Encode";
             codepoint = 0xFFFF;
           }
           os << "\\u" << std::hex << std::setfill('0') << std::setw(4)
@@ -288,7 +288,7 @@ std::optional<std::string> JsonUnquote(absl::string_view sv) {
     } else {
       ++itr;
       if (itr == sv.end()) {
-        VMSDK_LOG(DEBUG, nullptr) << "Invalid JSON (\\ at end)";
+        VMSDK_LOG(DEBUG) << "Invalid JSON (\\ at end)";
         return std::nullopt;
       }
       switch (*itr) {
@@ -321,7 +321,7 @@ std::optional<std::string> JsonUnquote(absl::string_view sv) {
           for (auto unichar = 0; unichar < 4; ++unichar) {
             itr++;
             if (itr == sv.end()) {
-              VMSDK_LOG(DEBUG, nullptr) << "Invalid JSON (Short unicode)";
+              VMSDK_LOG(DEBUG) << "Invalid JSON (Short unicode)";
               return std::nullopt;
             }
             char c = *itr;
@@ -332,8 +332,7 @@ std::optional<std::string> JsonUnquote(absl::string_view sv) {
             } else if (c >= 'A' && c <= 'F') {
               unicode = (unicode << 4) | (*itr - 'A' + 10);
             } else {
-              VMSDK_LOG(DEBUG, nullptr)
-                  << "Invalid JSON (invalid unicode char)";
+              VMSDK_LOG(DEBUG) << "Invalid JSON (invalid unicode char)";
               return std::nullopt;
             }
           }

--- a/vmsdk/testing/log_test.cc
+++ b/vmsdk/testing/log_test.cc
@@ -48,6 +48,13 @@ class LogTest : public vmsdk::ValkeyTest {
   void SetUp() override {
     SetSinkFormatter(nullptr);
     ValkeyTest::SetUp();
+    ON_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(testing::_))
+        .WillByDefault([](ValkeyModuleCtx* ctx) { return ctx; });
+  }
+
+  void TearDown() override {
+    ShutdownLogging();
+    ValkeyTest::TearDown();
   }
 };
 
@@ -59,16 +66,15 @@ TEST_F(LogTest, WithInitValue) {
       *kMockValkeyModule,
       Log(&ctx, testing::StrEq(VALKEYMODULE_LOGLEVEL_WARNING), testing::_))
       .Times(6);
-  VMSDK_LOG(NOTICE, &ctx) << "s1, expected" << stream_eval_cnt;
+  VMSDK_LOG(NOTICE) << "s1, expected" << stream_eval_cnt;
   for (int i = 0; i < 9; ++i) {
-    VMSDK_LOG_EVERY_N(VERBOSE, &ctx, 5) << "s2, expected " << stream_eval_cnt;
+    VMSDK_LOG_EVERY_N(VERBOSE, 5) << "s2, expected " << stream_eval_cnt;
   }
   for (int i = 0; i < 5; ++i) {
-    VMSDK_LOG_EVERY_N_SEC(VERBOSE, &ctx, 0.1)
-        << "s2, expected " << stream_eval_cnt;
+    VMSDK_LOG_EVERY_N_SEC(VERBOSE, 0.1) << "s2, expected " << stream_eval_cnt;
     absl::SleepFor(absl::Milliseconds(50));
   }
-  VMSDK_LOG(DEBUG, &ctx) << "s3, not expected! " << stream_eval_cnt;
+  VMSDK_LOG(DEBUG) << "s3, not expected! " << stream_eval_cnt;
   EXPECT_EQ(stream_eval_cnt.cnt_, 6);
 }
 std::atomic<int> custom_formatter_used;
@@ -85,18 +91,13 @@ TEST_F(LogTest, SinkOptions) {
   {
     ThreadPool thread_pool("test-pool-", 5);
     thread_pool.StartWorkers();
-    ValkeyModuleCtx fake_ctxes[10];
-    for (auto& fake_ctxe : fake_ctxes) {
-      EXPECT_CALL(*kMockValkeyModule,
-                  Log(&fake_ctxe, testing::StrEq(VALKEYMODULE_LOGLEVEL_WARNING),
-                      testing::_));
-    }
-    for (auto& fake_ctxe : fake_ctxes) {
-      thread_pool.Schedule(
-          [&fake_ctxes, &fake_ctxe]() mutable {
-            VMSDK_LOG(NOTICE, &fake_ctxe) << "s1, expected";
-          },
-          ThreadPool::Priority::kHigh);
+    EXPECT_CALL(
+        *kMockValkeyModule,
+        Log(&ctx, testing::StrEq(VALKEYMODULE_LOGLEVEL_WARNING), testing::_))
+        .Times(10);
+    for (int i = 0; i < 10; ++i) {
+      thread_pool.Schedule([]() { VMSDK_LOG(NOTICE) << "s1, expected"; },
+                           ThreadPool::Priority::kHigh);
     }
     thread_pool.JoinWorkers();
   }
@@ -132,9 +133,9 @@ TEST_F(LogTest, WithoutInitValue) {
   EXPECT_CALL(
       *kMockValkeyModule,
       Log(&ctx, testing::StrEq(VALKEYMODULE_LOGLEVEL_NOTICE), testing::_));
-  VMSDK_LOG(NOTICE, &ctx) << "s1, expected" << stream_eval_cnt;
-  VMSDK_LOG(DEBUG, &ctx) << "s2, not expected! " << stream_eval_cnt;
-  VMSDK_LOG(DEBUG, &ctx) << "s3, not expected! " << stream_eval_cnt;
+  VMSDK_LOG(NOTICE) << "s1, expected" << stream_eval_cnt;
+  VMSDK_LOG(DEBUG) << "s2, not expected! " << stream_eval_cnt;
+  VMSDK_LOG(DEBUG) << "s3, not expected! " << stream_eval_cnt;
   EXPECT_EQ(stream_eval_cnt.cnt_, 1);
 }
 
@@ -153,9 +154,9 @@ TEST_F(LogTest, WithoutInitValueConfigGetError) {
   EXPECT_CALL(
       *kMockValkeyModule,
       Log(&ctx, testing::StrEq(VALKEYMODULE_LOGLEVEL_NOTICE), testing::_));
-  VMSDK_LOG(NOTICE, &ctx) << "s1, expected" << stream_eval_cnt;
-  VMSDK_LOG(DEBUG, &ctx) << "s2, not expected! " << stream_eval_cnt;
-  VMSDK_LOG(DEBUG, &ctx) << "s3, not expected! " << stream_eval_cnt;
+  VMSDK_LOG(NOTICE) << "s1, expected" << stream_eval_cnt;
+  VMSDK_LOG(DEBUG) << "s2, not expected! " << stream_eval_cnt;
+  VMSDK_LOG(DEBUG) << "s3, not expected! " << stream_eval_cnt;
   EXPECT_EQ(stream_eval_cnt.cnt_, 1);
 }
 

--- a/vmsdk/testing/log_test.cc
+++ b/vmsdk/testing/log_test.cc
@@ -77,6 +77,18 @@ TEST_F(LogTest, WithInitValue) {
   VMSDK_LOG(DEBUG) << "s3, not expected! " << stream_eval_cnt;
   EXPECT_EQ(stream_eval_cnt.cnt_, 6);
 }
+
+TEST_F(LogTest, DisabledContextFallsBackToGenericModuleLog) {
+  ValkeyModuleCtx ctx;
+  VMSDK_EXPECT_OK(InitLogging(&ctx, "NOTICE"));
+  DisableLoggingContext();
+
+  EXPECT_CALL(
+      *kMockValkeyModule,
+      Log(nullptr, testing::StrEq(VALKEYMODULE_LOGLEVEL_WARNING), testing::_));
+  VMSDK_LOG(NOTICE) << "logged while unloading";
+}
+
 std::atomic<int> custom_formatter_used;
 std::string CustomSinkFormatter(const absl::LogEntry& entry) {
   ++custom_formatter_used;


### PR DESCRIPTION
Create and retain a module-scoped detached context during logging initialization.
remove per-call context arguments from VMSDK_LOG macros and update all call sites.

Closes : #1327 