### PR TITLE
Fix CMake build-type, target-arch, compiler gate, proto regen, and build.sh issues

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,6 +17,7 @@ ARGV=$@
 EXIT_CODE=0
 INTEG_RETRIES=1
 JOBS=""
+TEST_PATTERN=""
 CMAKE_GENERATOR=${CMAKE_GENERATOR:-"Ninja"}
 
 echo "Root directory: ${ROOT_DIR}"
@@ -182,12 +183,6 @@ export SAN_BUILD
 export ROOT_DIR
 . "${ROOT_DIR}/scripts/common.rc"
 
-if [[ "${CMAKE_GENERATOR}" == "Ninja" ]]; then
-  BUILD_TOOL="ninja"
-else
-  BUILD_TOOL="make -j$(num_proc)"
-fi
-
 function build_icu_if_needed() {
     printf "${BOLD_PINK}Checking ICU dependencies...${RESET}\n"
     
@@ -242,7 +237,7 @@ function build_icu_if_needed() {
     printf "Building ICU static libraries...\n"
     
     # Build with static data mode (output saved to log file)
-    if ! make PKGDATA_MODE=static -j$(num_proc) >> "${ICU_LOG}" 2>&1; then
+    if ! make PKGDATA_MODE=static -j"${JOBS:-$(num_proc)}" >> "${ICU_LOG}" 2>&1; then
         printf "${RED}ICU build failed. See ${ICU_LOG}${RESET}\n"
         tail -50 "${ICU_LOG}"
         exit 1
@@ -396,12 +391,18 @@ function check_and_clean_on_branch_change() {
     if [ -d "${BUILD_DIR}" ] && [ -f "${branch_stamp}" ] && [ "$(cat "${branch_stamp}")" != "${current_branch}" ]; then
         printf "${BOLD_PINK}Notice: Branch changed from $(cat "${branch_stamp}") to ${current_branch}. Cleaning stale protobuf artifacts...${RESET}\n"
         rm -f "${BUILD_DIR}"/src/*.pb.* 2>/dev/null || true
+        # The .pb.* files are generated at CMake configure time (not by a build
+        # rule), so deleting them requires a reconfigure to regenerate them.
+        RUN_CMAKE="yes"
     fi
     mkdir -p "${BUILD_DIR}"
     echo "${current_branch}" > "${branch_stamp}"
 }
 
-# If any of the CMake files is newer than our "build.ninja" file, force "cmake" before building
+# Configure is required only when the user explicitly asks (--configure) or
+# when the build tree does not exist yet. Once configured, Ninja/Make re-run
+# CMake automatically whenever a CMakeLists.txt or included .cmake file changes,
+# so there is no need to scan the tree ourselves.
 function is_configure_required() {
     if [[ "${BUILD_TOOL}" =~ ninja ]]; then
       local top_level_build_file=${BUILD_DIR}/build.ninja
@@ -416,20 +417,11 @@ function is_configure_required() {
     fi
 
     if [ ! -f "${top_level_build_file}" ] || [ ! -f "${BUILD_DIR}/CMakeCache.txt" ]; then
+        # No build tree yet: the generator cannot bootstrap itself.
         echo "yes"
         return
     fi
 
-    local build_file_lastmodified=$(get_file_last_modified "${top_level_build_file}")
-    local IFS=$'\n'
-    local cmake_files=$(find "${ROOT_DIR}" -name "CMakeLists.txt" -o -name "*.cmake" | grep -v "\.build-")
-    for cmake_file in $cmake_files; do
-        local cmake_file_modified=$(get_file_last_modified "${cmake_file}")
-        if [ "${cmake_file_modified}" -gt "${build_file_lastmodified}" ]; then
-            echo "yes"
-            return
-        fi
-    done
     echo "no"
 }
 
@@ -465,6 +457,20 @@ fi
 
 TESTS_DIR=${BUILD_DIR}/tests
 TEST_OUTPUT_FILE=${BUILD_DIR}/tests.out
+
+# Handle --clean directly: run the build tool's clean target against an existing
+# build directory and exit, without running ICU setup, configure, or a build.
+if [[ "${CMAKE_TARGET}" == "clean" ]]; then
+    if [ -d "${BUILD_DIR}" ]; then
+        printf "${BOLD_PINK}Cleaning${RESET} ${BUILD_DIR}\n"
+        cd "${BUILD_DIR}"
+        ${BUILD_TOOL} clean
+        cd "${ROOT_DIR}"
+    else
+        printf "Nothing to clean: ${BUILD_DIR} does not exist\n"
+    fi
+    exit 0
+fi
 
 check_and_clean_on_branch_change
 

--- a/cmake/Modules/protobuf_generate.cmake
+++ b/cmake/Modules/protobuf_generate.cmake
@@ -52,7 +52,7 @@ function(valkey_search_create_proto_grpc_library PROTO_PATH TARGET_NAME)
                                        GEN_H_REQUIRED)
   _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_CC}
                                        GEN_CC_REQUIRED)
-  if(${GEN_CC_REQUIRED} OR ${GEN_FILE_H})
+  if(GEN_CC_REQUIRED OR GEN_H_REQUIRED)
     message(STATUS "Generating files from ${PROTO_PATH} (gRPC)")
     execute_process(
       COMMAND ${protoc_EXE} --grpc_out=${PROTO_OUT_DIR} -I${CMAKE_SOURCE_DIR}
@@ -101,7 +101,7 @@ function(valkey_search_create_proto_library PROTO_PATH TARGET_NAME)
                                        GEN_H_REQUIRED)
   _valkey_search_is_proto_gen_required(${PROTO_PATH} ${GEN_FILE_CC}
                                        GEN_CC_REQUIRED)
-  if(${GEN_CC_REQUIRED} OR ${GEN_FILE_H})
+  if(GEN_CC_REQUIRED OR GEN_H_REQUIRED)
     message(STATUS "Generating files from ${PROTO_PATH}")
     execute_process(
       COMMAND ${protoc_EXE} --cpp_out=${PROTO_OUT_DIR} -I${CMAKE_SOURCE_DIR}

--- a/cmake/Modules/valkey_search.cmake
+++ b/cmake/Modules/valkey_search.cmake
@@ -1,20 +1,26 @@
 # Determine if we are building in Release or Debug mode
-if(CMAKE_BUILD_TYPE MATCHES Release)
+# Classify the build. Use exact matches (STREQUAL), not `MATCHES Release`,
+# which would misclassify RelWithDebInfo and MinSizeRel.
+if(CMAKE_BUILD_TYPE STREQUAL "Release"
+   OR CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo"
+   OR CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
   set(VALKEY_SEARCH_DEBUG_BUILD 0)
   set(VALKEY_SEARCH_RELEASE_BUILD 1)
-  message(STATUS "Building in release mode")
+  message(STATUS "Building in release mode (${CMAKE_BUILD_TYPE})")
 else()
   set(VALKEY_SEARCH_DEBUG_BUILD 1)
   set(VALKEY_SEARCH_RELEASE_BUILD 0)
-  message(STATUS "Building in debug mode")
+  message(STATUS "Building in debug mode (${CMAKE_BUILD_TYPE})")
 endif()
 
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  message(STATUS "Current platform is x86_64")
+# Select target ISA from the target processor (CMAKE_SYSTEM_PROCESSOR), not the
+# host, so cross-compilation emits code for the right architecture.
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  message(STATUS "Target processor: ${CMAKE_SYSTEM_PROCESSOR} (x86)")
   set(VALKEY_SEARCH_IS_ARM 0)
   set(VALKEY_SEARCH_IS_X86 1)
 else()
-  message(STATUS "Current platform is aarch64")
+  message(STATUS "Target processor: ${CMAKE_SYSTEM_PROCESSOR} (non-x86, generic path)")
   set(VALKEY_SEARCH_IS_ARM 1)
   set(VALKEY_SEARCH_IS_X86 0)
 endif()
@@ -22,10 +28,7 @@ endif()
 # Check for compiler compatibility
 if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   # We require GCC v12 and later
-  string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" GCC_VERSION_MATCH
-               ${CMAKE_CXX_COMPILER_VERSION})
-  set(GCC_MAJOR_VERSION ${CMAKE_MATCH_1})
-  if(GCC_MAJOR_VERSION LESS 12)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
     message(
       FATAL_ERROR
         "Minimum GCC required is 12 and later. Your GCC version is ${CMAKE_CXX_COMPILER_VERSION}"
@@ -33,10 +36,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   # We require Clang v16 and later
-  string(REGEX MATCH "^([0-9]+)\\.([0-9]+)\\.([0-9]+)" CLANG_VERSION_MATCH
-               ${CMAKE_CXX_COMPILER_VERSION})
-  set(CLANG_MAJOR_VERSION ${CMAKE_MATCH_1})
-  if(CLANG_MAJOR_VERSION LESS 16)
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 16)
     message(
       FATAL_ERROR
         "Minimum Clang required is 16 and later. Your Clang version is ${CMAKE_CXX_COMPILER_VERSION}"
@@ -44,7 +44,7 @@ elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
   endif()
 else()
   message(
-    WARN
+    WARNING
     "Using unknown compiler ${CMAKE_CXX_COMPILER_ID}. Version: ${CMAKE_CXX_COMPILER_VERSION}"
   )
 endif()
@@ -134,7 +134,6 @@ function(valkey_search_target_update_compile_flags TARGET)
   elseif(VALKEY_SEARCH_DEBUG_BUILD)
     target_compile_options(${TARGET} PRIVATE -O0)
     target_compile_options(${TARGET} PRIVATE -fno-omit-frame-pointer)
-    target_compile_definitions(${TARGET} PRIVATE NDEBUG)
     target_compile_options(${TARGET} PRIVATE -fno-lto)
   else()
     # Release build, dump both IR & obj so we can defer the lto to the link time

--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -219,55 +219,58 @@ function setup_valkey_server() {
       LOG_INFO "Forcing libstdc++ into valkey-server DT_NEEDED for reliable ASAN __cxa_throw interception (LDFLAGS: ${LDFLAGS})"
     fi
 
-    # Temporary workaround until these are merged into core upstream.
-    # Each patch is guarded: skip if already applied (the clone is cached and
-    # reused), and fail loudly if neither the pre- nor post-patch marker is
-    # found -- that means upstream drifted and the sed silently matched nothing
-    # (sed exits 0 either way), which would otherwise produce a confusing TSAN
-    # build failure much later.
-    # apply_tsan_patch <file> <already-applied-marker> <expected-source> <sed-script>
-    apply_tsan_patch() {
-      local file="$1" applied_marker="$2" expected="$3" sed_script="$4"
-      if grep -qF "${applied_marker}" "${file}"; then
-        LOG_INFO "TSAN patch already applied to $(basename "${file}")"
-        return 0
-      fi
-      if ! grep -qF "${expected}" "${file}"; then
-        LOG_ERROR "TSAN patch target not found in ${file}. Upstream valkey may have drifted; the patch needs updating."
-        exit 1
-      fi
-      sed -i "${sed_script}" "${file}"
-      if ! grep -qF "${applied_marker}" "${file}"; then
-        LOG_ERROR "TSAN patch failed to apply to ${file} (marker absent after sed)."
-        exit 1
-      fi
-    }
+    # These three patches are needed only for thread-sanitizer (TSAN) builds.
+    # Do not run them for address-sanitizer (ASAN) builds.
+    if [[ "${SAN_BUILD}" == "thread" ]]; then
+      # Temporary workaround until these are merged into core upstream.
+      # Each patch is guarded: skip if already applied (the clone is cached and
+      # reused), and fail loudly if the text it expects to patch is missing --
+      # that means upstream drifted and the sed matched nothing (sed exits 0
+      # either way), which would otherwise fail the TSAN build much later.
+      # apply_tsan_patch <file> <already-applied-marker> <expected-source> <sed-script>
+      apply_tsan_patch() {
+        local file="$1" applied_marker="$2" expected="$3" sed_script="$4"
+        if grep -qF "${applied_marker}" "${file}"; then
+          LOG_INFO "TSAN patch already applied to $(basename "${file}")"
+          return 0
+        fi
+        if ! grep -qF "${expected}" "${file}"; then
+          LOG_ERROR "TSAN patch target not found in ${file}. Upstream valkey may have drifted; the patch needs updating."
+          exit 1
+        fi
+        sed -i "${sed_script}" "${file}"
+        if ! grep -qF "${applied_marker}" "${file}"; then
+          LOG_ERROR "TSAN patch failed to apply to ${file} (marker absent after sed)."
+          exit 1
+        fi
+      }
 
-    # 1. IFUNC resolvers run before TSAN runtime initializes, so no_sanitize("thread") is required.
-    # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/util.c#L640-L642
-    apply_tsan_patch \
-      "${VALKEY_SERVER_HOME_DIR}/src/util.c" \
-      'no_sanitize("thread"), used)) static int (*string2ll_resolver' \
-      'no_sanitize_address, used)) static int (*string2ll_resolver' \
-      's/__attribute__((no_sanitize_address, used)) static int (\*string2ll_resolver/__attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver/'
+      # 1. IFUNC resolvers run before TSAN runtime initializes, so no_sanitize("thread") is required.
+      # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/util.c#L640-L642
+      apply_tsan_patch \
+        "${VALKEY_SERVER_HOME_DIR}/src/util.c" \
+        'no_sanitize("thread"), used)) static int (*string2ll_resolver' \
+        'no_sanitize_address, used)) static int (*string2ll_resolver' \
+        's/__attribute__((no_sanitize_address, used)) static int (\*string2ll_resolver/__attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver/'
 
-    # 2. RTLD_DEEPBIND is incompatible with TSAN; exclude it like ASAN already does.
-    # https://github.com/valkey-io/valkey/blame/ab3c953b80289d88991095f53c1235fc2f8b44d6/src/module.c#L12548
-    apply_tsan_patch \
-      "${VALKEY_SERVER_HOME_DIR}/src/module.c" \
-      '!defined(VALKEY_ADDRESS_SANITIZER) && !defined(VALKEY_THREAD_SANITIZER) && __has_include(<dlfcn.h>)' \
-      '!defined(VALKEY_ADDRESS_SANITIZER) && __has_include(<dlfcn.h>)' \
-      's/!defined(VALKEY_ADDRESS_SANITIZER) \&\& __has_include(<dlfcn.h>)/!defined(VALKEY_ADDRESS_SANITIZER) \&\& !defined(VALKEY_THREAD_SANITIZER) \&\& __has_include(<dlfcn.h>)/'
+      # 2. RTLD_DEEPBIND is incompatible with TSAN; exclude it like ASAN already does.
+      # https://github.com/valkey-io/valkey/blame/ab3c953b80289d88991095f53c1235fc2f8b44d6/src/module.c#L12548
+      apply_tsan_patch \
+        "${VALKEY_SERVER_HOME_DIR}/src/module.c" \
+        '!defined(VALKEY_ADDRESS_SANITIZER) && !defined(VALKEY_THREAD_SANITIZER) && __has_include(<dlfcn.h>)' \
+        '!defined(VALKEY_ADDRESS_SANITIZER) && __has_include(<dlfcn.h>)' \
+        's/!defined(VALKEY_ADDRESS_SANITIZER) \&\& __has_include(<dlfcn.h>)/!defined(VALKEY_ADDRESS_SANITIZER) \&\& !defined(VALKEY_THREAD_SANITIZER) \&\& __has_include(<dlfcn.h>)/'
 
-    # 3. Define VALKEY_THREAD_SANITIZER via __SANITIZE_THREAD__ (mirrors VALKEY_ADDRESS_SANITIZER pattern).
-    # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/config.h#L175-L181
-    if ! grep -q 'VALKEY_THREAD_SANITIZER' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
-      if ! grep -q '^#if defined(__SANITIZE_ADDRESS__)' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
-        LOG_ERROR "TSAN patch anchor '#if defined(__SANITIZE_ADDRESS__)' not found in config.h. Upstream valkey may have drifted."
-        exit 1
+      # 3. Define VALKEY_THREAD_SANITIZER via __SANITIZE_THREAD__ (mirrors VALKEY_ADDRESS_SANITIZER pattern).
+      # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/config.h#L175-L181
+      if ! grep -q 'VALKEY_THREAD_SANITIZER' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
+        if ! grep -q '^#if defined(__SANITIZE_ADDRESS__)' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
+          LOG_ERROR "TSAN patch anchor '#if defined(__SANITIZE_ADDRESS__)' not found in config.h. Upstream valkey may have drifted."
+          exit 1
+        fi
+        sed -i '/^#if defined(__SANITIZE_ADDRESS__)/i #if defined(__SANITIZE_THREAD__)\n#define VALKEY_THREAD_SANITIZER 1\n#endif\n' \
+          "${VALKEY_SERVER_HOME_DIR}/src/config.h"
       fi
-      sed -i '/^#if defined(__SANITIZE_ADDRESS__)/i #if defined(__SANITIZE_THREAD__)\n#define VALKEY_THREAD_SANITIZER 1\n#endif\n' \
-        "${VALKEY_SERVER_HOME_DIR}/src/config.h"
     fi
   fi
 

--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -219,22 +219,56 @@ function setup_valkey_server() {
       LOG_INFO "Forcing libstdc++ into valkey-server DT_NEEDED for reliable ASAN __cxa_throw interception (LDFLAGS: ${LDFLAGS})"
     fi
 
-    # Temporary workaround until these are merged into core upstream:
+    # Temporary workaround until these are merged into core upstream.
+    # Each patch is guarded: skip if already applied (the clone is cached and
+    # reused), and fail loudly if neither the pre- nor post-patch marker is
+    # found -- that means upstream drifted and the sed silently matched nothing
+    # (sed exits 0 either way), which would otherwise produce a confusing TSAN
+    # build failure much later.
+    # apply_tsan_patch <file> <already-applied-marker> <expected-source> <sed-script>
+    apply_tsan_patch() {
+      local file="$1" applied_marker="$2" expected="$3" sed_script="$4"
+      if grep -qF "${applied_marker}" "${file}"; then
+        LOG_INFO "TSAN patch already applied to $(basename "${file}")"
+        return 0
+      fi
+      if ! grep -qF "${expected}" "${file}"; then
+        LOG_ERROR "TSAN patch target not found in ${file}. Upstream valkey may have drifted; the patch needs updating."
+        exit 1
+      fi
+      sed -i "${sed_script}" "${file}"
+      if ! grep -qF "${applied_marker}" "${file}"; then
+        LOG_ERROR "TSAN patch failed to apply to ${file} (marker absent after sed)."
+        exit 1
+      fi
+    }
+
     # 1. IFUNC resolvers run before TSAN runtime initializes, so no_sanitize("thread") is required.
     # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/util.c#L640-L642
-    sed -i 's/__attribute__((no_sanitize_address, used)) static int (\*string2ll_resolver/__attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver/' \
-      "${VALKEY_SERVER_HOME_DIR}/src/util.c"
+    apply_tsan_patch \
+      "${VALKEY_SERVER_HOME_DIR}/src/util.c" \
+      'no_sanitize("thread"), used)) static int (*string2ll_resolver' \
+      'no_sanitize_address, used)) static int (*string2ll_resolver' \
+      's/__attribute__((no_sanitize_address, used)) static int (\*string2ll_resolver/__attribute__((no_sanitize_address, no_sanitize("thread"), used)) static int (*string2ll_resolver/'
 
     # 2. RTLD_DEEPBIND is incompatible with TSAN; exclude it like ASAN already does.
     # https://github.com/valkey-io/valkey/blame/ab3c953b80289d88991095f53c1235fc2f8b44d6/src/module.c#L12548
-    sed -i 's/!defined(VALKEY_ADDRESS_SANITIZER) \&\& __has_include(<dlfcn.h>)/!defined(VALKEY_ADDRESS_SANITIZER) \&\& !defined(VALKEY_THREAD_SANITIZER) \&\& __has_include(<dlfcn.h>)/' \
-      "${VALKEY_SERVER_HOME_DIR}/src/module.c"
+    apply_tsan_patch \
+      "${VALKEY_SERVER_HOME_DIR}/src/module.c" \
+      '!defined(VALKEY_ADDRESS_SANITIZER) && !defined(VALKEY_THREAD_SANITIZER) && __has_include(<dlfcn.h>)' \
+      '!defined(VALKEY_ADDRESS_SANITIZER) && __has_include(<dlfcn.h>)' \
+      's/!defined(VALKEY_ADDRESS_SANITIZER) \&\& __has_include(<dlfcn.h>)/!defined(VALKEY_ADDRESS_SANITIZER) \&\& !defined(VALKEY_THREAD_SANITIZER) \&\& __has_include(<dlfcn.h>)/'
 
     # 3. Define VALKEY_THREAD_SANITIZER via __SANITIZE_THREAD__ (mirrors VALKEY_ADDRESS_SANITIZER pattern).
     # https://github.com/valkey-io/valkey/blob/4dee322edeb9c96029d89cfaf1600abad2afead0/src/config.h#L175-L181
-    grep -q 'VALKEY_THREAD_SANITIZER' "${VALKEY_SERVER_HOME_DIR}/src/config.h" || \
+    if ! grep -q 'VALKEY_THREAD_SANITIZER' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
+      if ! grep -q '^#if defined(__SANITIZE_ADDRESS__)' "${VALKEY_SERVER_HOME_DIR}/src/config.h"; then
+        LOG_ERROR "TSAN patch anchor '#if defined(__SANITIZE_ADDRESS__)' not found in config.h. Upstream valkey may have drifted."
+        exit 1
+      fi
       sed -i '/^#if defined(__SANITIZE_ADDRESS__)/i #if defined(__SANITIZE_THREAD__)\n#define VALKEY_THREAD_SANITIZER 1\n#endif\n' \
         "${VALKEY_SERVER_HOME_DIR}/src/config.h"
+    fi
   fi
 
   LOG_INFO "Working directory: ${VALKEY_SERVER_BUILD_DIR}"


### PR DESCRIPTION
## Summary

This PR corrects a few build-system issues in the CMake modules and `build.sh`. The current `build.sh` flow does not hit them, but they affect `RelWithDebInfo`/`MinSizeRel` builds, cross-compilation, some compiler version strings, and regeneration of stale protobuf files.

## Changes

**`cmake/Modules/valkey_search.cmake`**
- Build-type classification used `if(CMAKE_BUILD_TYPE MATCHES Release)`, a regex substring test. `RelWithDebInfo` and `MinSizeRel` do not contain the literal `Release`, so they fell into the debug branch and got `-O0`, `-fno-lto`, and `NDEBUG` — an unoptimized binary with assertions stripped. Now uses exact `STREQUAL` checks for the three optimized build types.
- Stopped defining `NDEBUG` in the debug branch, so `assert()` stays active in debug builds.
- Target ISA flags now key off `CMAKE_SYSTEM_PROCESSOR` (target) instead of `CMAKE_HOST_SYSTEM_PROCESSOR` (build host), so cross-compilation emits the right code. Non-x86 behavior is unchanged.
- Compiler-version gate uses `CMAKE_CXX_COMPILER_VERSION VERSION_LESS` instead of a 3-component version regex that left the major version empty (and silently bypassed the check) for 1- or 2-component version strings.
- `message(WARN)` → `message(WARNING)` (`WARN` is not a valid mode; it was printed as literal text).

**`cmake/Modules/protobuf_generate.cmake`**
- Proto regeneration used `if(${GEN_CC_REQUIRED} OR ${GEN_FILE_H})`, which expands to `if(OFF OR /path/foo.pb.h)`; a bare path string is falsy, so header staleness (`GEN_H_REQUIRED`) was never consulted and a stale/missing `.pb.h` would not be regenerated. Now compares the `GEN_H_REQUIRED` boolean.

**`build.sh`**
- Added a `TEST_PATTERN=""` default so a later reference is safe under `set -u`.
- Removed a dead `BUILD_TOOL` assignment (always overwritten before use; the dead copy also used `ninja`, wrong on RedHat where it is `ninja-build`).
- `--clean` now runs the clean target on an existing build dir and exits, instead of also doing ICU setup and a conditional configure.
- `--jobs` is now honored by the ICU build (was hardcoded to all cores).
- Removed the CMake-file mtime scan from `is_configure_required`; Ninja and Make already re-run CMake when a `CMakeLists.txt`/`.cmake` file changes. `check_and_clean_on_branch_change` now sets `RUN_CMAKE=yes` when it deletes the configure-time `.pb.*` outputs, so a branch switch still forces a reconfigure.

**`scripts/common.rc`**
- The three TSAN valkey-server `sed` patches now fail loudly if the text they expect is missing (upstream drift), instead of silently doing nothing (`sed` returns success even when it matches nothing). The helper is idempotent for the cached clone.

## Testing
Individual changes were checked with CMake script-mode parse checks, `bash -n`, and small standalone reproductions of the changed logic. A full local build did not complete due to unrelated dependency issues in the local environment. Relying on CI for the full build and test run. Opening as a **draft** for that reason.

