### PR TITLE
Scoring: score all-text OR by fanning out fetchers instead of building a OR composite iterator

### DIFF
--- a/integration/test_scoring.py
+++ b/integration/test_scoring.py
@@ -206,6 +206,34 @@ class TestScoring(ValkeySearchTestCaseBase):
         assert or_groups == pytest.approx({**hello_world, "doc:6": 3.404279},
                                           abs=SCORE_ABS_TOL)
 
+        # A nested OR is still one flat union: doc:6 matches both inner branches
+        # and accumulates rare + unique, doc:8 only rare.
+        _, rare = search(client, IDX_MAIN, "rare")
+        _, unique = search(client, IDX_MAIN, "unique")
+        keys, nested_or = search(client, IDX_MAIN, "hello | (rare | unique)")
+        assert keys == ["doc:6", "doc:8", "doc:5", "doc:4", "doc:3", "doc:2",
+                        "doc:7", "doc:1"]
+        assert nested_or == pytest.approx(
+            {**hello,
+             "doc:6": rare["doc:6"] + unique["doc:6"],
+             "doc:8": rare["doc:8"]},
+            abs=SCORE_ABS_TOL)
+
+        # Group weights accumulate down both OR levels before reaching a leaf:
+        # hello scales by 2*2, rare by 2*2*3, unique by 2*2*2. doc:6 sums the two
+        # inner branches at their own multipliers.
+        keys, weighted_nested_or = search(
+            client, IDX_MAIN,
+            "((hello)=>{$weight:2} | ((rare)=>{$weight:3} | "
+            "(unique)=>{$weight:2})=>{$weight:2})=>{$weight:2}")
+        assert keys == ["doc:6", "doc:8", "doc:5", "doc:4", "doc:3", "doc:2",
+                        "doc:7", "doc:1"]
+        assert weighted_nested_or == pytest.approx(
+            {**{k: 4 * v for k, v in hello.items()},
+             "doc:6": 12 * rare["doc:6"] + 8 * unique["doc:6"],
+             "doc:8": 12 * rare["doc:8"]},
+            abs=SCORE_ABS_TOL)
+
         # Three-leaf AND accumulates every leaf.
         keys, three_leaf = search(client, IDX_MAIN, "hello world one")
         assert keys == ["doc:2", "doc:7", "doc:3", "doc:1", "doc:4"]

--- a/src/indexes/text.cc
+++ b/src/indexes/text.cc
@@ -144,8 +144,8 @@ uint32_t Text::GetMutationWeight() const {
 size_t Text::EntriesFetcher::Size() const { return size_; }
 
 std::unique_ptr<EntriesFetcherIteratorBase> Text::EntriesFetcher::Begin() {
-  auto iter = predicate_->BuildTextIterator(text_index_, field_mask_,
-                                            require_positions_);
+  auto iter = predicate_->BuildTextIterator(
+      text_index_, field_mask_, require_positions_, or_weight_multiplier_);
   return std::make_unique<text::TextFetcher>(std::move(iter));
 }
 
@@ -174,7 +174,8 @@ bool TryAddWordKeyIterator(
 
 std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
-    FieldMaskPredicate field_mask, bool require_positions) const {
+    FieldMaskPredicate field_mask, bool require_positions,
+    float or_weight_multiplier) const {
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
       key_iterators;
@@ -223,13 +224,14 @@ std::unique_ptr<indexes::text::TextIterator> TermPredicate::BuildTextIterator(
   // first pass)
   return std::make_unique<indexes::text::TermIterator>(
       std::move(key_iterators), field_mask, require_positions, stem_field_mask,
-      found_original, GetWeight(), num_doc_contain_term,
+      found_original, GetWeight() * or_weight_multiplier, num_doc_contain_term,
       GetTextIndexSchema().get(), GetScorer());
 }
 
 std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
-    FieldMaskPredicate field_mask, bool require_positions) const {
+    FieldMaskPredicate field_mask, bool require_positions,
+    float or_weight_multiplier) const {
   auto word_iter = text_index->GetPrefix().GetWordIterator(GetTextString());
   absl::InlinedVector<indexes::text::Postings::KeyIterator,
                       indexes::text::kWordExpansionInlineCapacity>
@@ -248,7 +250,8 @@ std::unique_ptr<indexes::text::TextIterator> PrefixPredicate::BuildTextIterator(
 
 std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
-    FieldMaskPredicate field_mask, bool require_positions) const {
+    FieldMaskPredicate field_mask, bool require_positions,
+    float or_weight_multiplier) const {
   CHECK(text_index->GetSuffix().has_value())
       << "Text index does not have suffix trie enabled.";
   std::string reversed_word(GetTextString().rbegin(), GetTextString().rend());
@@ -271,13 +274,15 @@ std::unique_ptr<indexes::text::TextIterator> SuffixPredicate::BuildTextIterator(
 
 std::unique_ptr<indexes::text::TextIterator> InfixPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
-    FieldMaskPredicate field_mask, bool require_positions) const {
+    FieldMaskPredicate field_mask, bool require_positions,
+    float or_weight_multiplier) const {
   CHECK(false) << "Unsupported TextPredicate type";
 }
 
 std::unique_ptr<indexes::text::TextIterator> FuzzyPredicate::BuildTextIterator(
     const std::shared_ptr<indexes::text::TextIndex> &text_index,
-    FieldMaskPredicate field_mask, bool require_positions) const {
+    FieldMaskPredicate field_mask, bool require_positions,
+    float or_weight_multiplier) const {
   // Limit the number of term word expansions
   uint32_t max_words = options::GetMaxTermExpansions().GetValue();
   auto key_iterators = indexes::text::FuzzySearch::Search(

--- a/src/indexes/text.h
+++ b/src/indexes/text.h
@@ -114,11 +114,13 @@ class Text : public IndexBase {
    public:
     EntriesFetcher(size_t size,
                    const std::shared_ptr<text::TextIndex> &text_index,
-                   text::FieldMaskPredicate field_mask, bool require_positions)
+                   text::FieldMaskPredicate field_mask, bool require_positions,
+                   float or_weight_multiplier)
         : size_(size),
           text_index_(text_index),
           field_mask_(field_mask),
-          require_positions_(require_positions) {}
+          require_positions_(require_positions),
+          or_weight_multiplier_(or_weight_multiplier) {}
 
     size_t Size() const override;
 
@@ -134,6 +136,8 @@ class Text : public IndexBase {
     const query::TextPredicate *predicate_;
     text::FieldMaskPredicate field_mask_;
     bool require_positions_;
+    // Product of the enclosing OR group weights, which no iterator carries.
+    float or_weight_multiplier_;
   };
 
   size_t GetTextFieldNumber() const { return text_field_number_; }

--- a/src/indexes/text/orproximity.h
+++ b/src/indexes/text/orproximity.h
@@ -51,17 +51,15 @@ class OrProximityIterator : public TextIterator {
   bool IsIteratorValid() const override;
 
   // OR semantics: every term present in the document is scored; sum the
-  // weighted scores of active children on the current key.
+  // already-weighted scores of active children on the current key, scaled by
+  // this group's own weight.
   float GetScore() const override {
     float total = 0.0f;
     for (size_t idx : current_key_indices_) {
-      total += iters_[idx]->GetScore() * iters_[idx]->GetWeight();
+      total += iters_[idx]->GetScore();
     }
-    return total;
+    return total * weight_;
   }
-
-  // Group weight applied by the parent (or read at the root) to this composite.
-  float GetWeight() const override { return weight_; }
 
  private:
   absl::InlinedVector<std::unique_ptr<TextIterator>,

--- a/src/indexes/text/proximity.h
+++ b/src/indexes/text/proximity.h
@@ -73,17 +73,15 @@ class ProximityIterator : public TextIterator {
            current_field_mask_ != 0ULL && query_field_mask_ != 0ULL;
   }
 
-  // Aggregate score: sum of children's weighted scores.
+  // Aggregate score: sum of children's already-weighted scores, scaled by this
+  // group's own weight.
   float GetScore() const override {
     float total = 0.0f;
     for (const auto& iter : iters_) {
-      total += iter->GetScore() * iter->GetWeight();
+      total += iter->GetScore();
     }
-    return total;
+    return total * weight_;
   }
-
-  // Group weight applied by the parent (or read at the root) to this composite.
-  float GetWeight() const override { return weight_; }
 
  private:
   // List of all the Text Predicates contained in the Proximity AND.

--- a/src/indexes/text/text_iterator.h
+++ b/src/indexes/text/text_iterator.h
@@ -104,13 +104,11 @@ class TextIterator {
   // and field)
   virtual bool IsIteratorValid() const = 0;
 
-  // Scoring: returns the relevance score for the current document.
-  // Leaf iterators compute this via the active scoring algorithm.
+  // Scoring: returns the relevance score for the current document, already
+  // multiplied by this iterator's own query-tree weight, so callers never
+  // apply it. Leaf iterators compute this via the active scoring algorithm.
   // Composite iterators aggregate children's scores.
   virtual float GetScore() const { return 0.0f; }
-
-  // Weight multiplier for this iterator's contribution to the parent score.
-  virtual float GetWeight() const { return 1.0f; }
 };
 
 }  // namespace valkey_search::indexes::text

--- a/src/query/predicate.h
+++ b/src/query/predicate.h
@@ -205,9 +205,12 @@ class TextPredicate : public Predicate {
   virtual std::shared_ptr<indexes::text::TextIndexSchema> GetTextIndexSchema()
       const = 0;
   virtual const FieldMaskPredicate GetFieldMask() const = 0;
+  // Enclosing OR group weights, folded in here because an OR is a sum: it
+  // distributes onto the leaf exactly, unlike an AND with slop.
   virtual std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const = 0;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const = 0;
   virtual size_t EstimateSize(bool is_vec_query) const = 0;
 
   // Query-selected scorer, stamped on during planning so the scored
@@ -241,7 +244,8 @@ class TermPredicate : public TextPredicate {
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const override;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   bool IsExact() const { return exact_; }
   size_t EstimateSize(bool is_vec_query) const override;
@@ -271,7 +275,8 @@ class PrefixPredicate : public TextPredicate {
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const override;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize(bool is_vec_query) const override;
 
@@ -299,7 +304,8 @@ class SuffixPredicate : public TextPredicate {
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const override;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize(bool is_vec_query) const override;
 
@@ -327,7 +333,8 @@ class InfixPredicate : public TextPredicate {
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const override;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize(bool is_vec_query) const override;
 
@@ -356,7 +363,8 @@ class FuzzyPredicate : public TextPredicate {
       bool require_positions) const override;
   std::unique_ptr<indexes::text::TextIterator> BuildTextIterator(
       const std::shared_ptr<indexes::text::TextIndex>& text_index,
-      FieldMaskPredicate field_mask, bool require_positions) const override;
+      FieldMaskPredicate field_mask, bool require_positions,
+      float or_weight_multiplier) const override;
   const FieldMaskPredicate GetFieldMask() const override { return field_mask_; }
   size_t EstimateSize(bool is_vec_query) const override;
 

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -231,10 +231,12 @@ inline bool NeedsDeduplication(QueryOperations query_operations) {
 
 // Builds TextIterator for text predicates. Returns pair of iterator and
 // estimated size.
+// or_weight_multiplier lands on this node only; children are built with 1.0f.
 std::pair<std::unique_ptr<indexes::text::TextIterator>, size_t>
 BuildTextIterator(const Predicate *predicate, bool negate,
                   bool require_positions, bool is_vec_query,
-                  const indexes::scoring::Scorer *scorer) {
+                  const indexes::scoring::Scorer *scorer,
+                  float or_weight_multiplier = 1.0f) {
   if (predicate->GetType() == PredicateType::kComposedAnd ||
       predicate->GetType() == PredicateType::kComposedOr) {
     auto composed_predicate =
@@ -266,7 +268,7 @@ BuildTextIterator(const Predicate *predicate, bool negate,
       size_t total_size = min_size == SIZE_MAX ? 0 : min_size;
       return {std::make_unique<indexes::text::ProximityIterator>(
                   std::move(iterators), slop, inorder, skip_positional,
-                  composed_predicate->GetWeight()),
+                  composed_predicate->GetWeight() * or_weight_multiplier),
               total_size};
     } else {
       absl::InlinedVector<std::unique_ptr<indexes::text::TextIterator>,
@@ -290,7 +292,8 @@ BuildTextIterator(const Predicate *predicate, bool negate,
         return {nullptr, 0};
       }
       return {std::make_unique<indexes::text::OrProximityIterator>(
-                  std::move(iterators), composed_predicate->GetWeight()),
+                  std::move(iterators),
+                  composed_predicate->GetWeight() * or_weight_multiplier),
               total_size};
     }
   }
@@ -302,8 +305,8 @@ BuildTextIterator(const Predicate *predicate, bool negate,
     // Stamp the query-selected scorer so TermPredicate::BuildTextIterator can
     // build a scored TermIterator without a hardcoded scorer.
     text_predicate->SetScorer(scorer);
-    auto result = text_predicate->BuildTextIterator(text_index, field_mask,
-                                                    require_positions);
+    auto result = text_predicate->BuildTextIterator(
+        text_index, field_mask, require_positions, or_weight_multiplier);
     return {std::move(result), size};
   }
   if (predicate->GetType() == PredicateType::kNegate) {
@@ -317,7 +320,7 @@ BuildTextIterator(const Predicate *predicate, bool negate,
 size_t EvaluateFilterAsPrimary(
     const SearchParameters &parameters, const Predicate *predicate,
     std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> &entries_fetchers,
-    bool negate) {
+    bool negate, float or_weight_multiplier) {
   const QueryOperations query_operations =
       parameters.filter_parse_results.query_operations;
   const IndexSchema *index_schema = parameters.index_schema.get();
@@ -341,9 +344,9 @@ size_t EvaluateFilterAsPrimary(
     auto predicate_type =
         EvaluateAsComposedPredicate(composed_predicate, negate);
     if (predicate_type == PredicateType::kComposedAnd) {
-      auto [text_iter, size] =
-          BuildTextIterator(composed_predicate, negate, false, is_vec_query,
-                            indexes::scoring::GetScorer(parameters.scorer));
+      auto [text_iter, size] = BuildTextIterator(
+          composed_predicate, negate, false, is_vec_query,
+          indexes::scoring::GetScorer(parameters.scorer), or_weight_multiplier);
       if (text_iter) {
         entries_fetchers.push(
             std::make_unique<indexes::text::TextIteratorFetcher>(
@@ -354,8 +357,8 @@ size_t EvaluateFilterAsPrimary(
       std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> best_fetchers;
       for (const auto &child : composed_predicate->GetChildren()) {
         std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> child_fetchers;
-        size_t child_size = EvaluateFilterAsPrimary(parameters, child.get(),
-                                                    child_fetchers, negate);
+        size_t child_size = EvaluateFilterAsPrimary(
+            parameters, child.get(), child_fetchers, negate, or_weight_multiplier);
         if (child_size < min_size) {
           min_size = child_size;
           best_fetchers = std::move(child_fetchers);
@@ -364,25 +367,16 @@ size_t EvaluateFilterAsPrimary(
       AppendQueue(entries_fetchers, best_fetchers);
       return min_size;
     } else {
-      // TODO: optimize with eliminate BuildTextIterator for OR in followup PR
-      // All-text OR: build a single OrProximityIterator so a doc matching
-      // multiple branches is scored on the sum of those branches (and any group
-      // weight applies). Falls back to per-child fetchers when the OR mixes in
-      // non-text predicates.
-      auto [text_iter, size] =
-          BuildTextIterator(composed_predicate, negate, false, is_vec_query,
-                            indexes::scoring::GetScorer(parameters.scorer));
-      if (text_iter) {
-        entries_fetchers.push(
-            std::make_unique<indexes::text::TextIteratorFetcher>(
-                std::move(text_iter), size));
-        return size;
-      }
+      // Per-child fetchers union the OR by concatenation + dedup and the drain
+      // loop sums the branch scores, so the group weight rides down instead of
+      // onto a composite iterator.
+      const float child_multiplier =
+          or_weight_multiplier * composed_predicate->GetWeight();
       size_t total_size = 0;
       for (const auto &child : composed_predicate->GetChildren()) {
         std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> child_fetchers;
-        size_t child_size = EvaluateFilterAsPrimary(parameters, child.get(),
-                                                    child_fetchers, negate);
+        size_t child_size = EvaluateFilterAsPrimary(
+            parameters, child.get(), child_fetchers, negate, child_multiplier);
         AppendQueue(entries_fetchers, child_fetchers);
         total_size += child_size;
       }
@@ -409,7 +403,7 @@ size_t EvaluateFilterAsPrimary(
     size_t size = text_predicate->EstimateSize(is_vec_query);
     auto fetcher = std::make_unique<indexes::Text::EntriesFetcher>(
         size, text_predicate->GetTextIndexSchema()->GetTextIndex(),
-        text_predicate->GetFieldMask(), false);
+        text_predicate->GetFieldMask(), false, or_weight_multiplier);
     fetcher->predicate_ = text_predicate;
     // Stamp the query-selected scorer so the TermIterator built lazily in
     // EntriesFetcher::Begin() is scored (not the unscored stub).
@@ -419,9 +413,9 @@ size_t EvaluateFilterAsPrimary(
   }
   if (predicate->GetType() == PredicateType::kNegate) {
     auto negate_predicate = dynamic_cast<const NegatePredicate *>(predicate);
-    size_t result =
-        EvaluateFilterAsPrimary(parameters, negate_predicate->GetPredicate(),
-                                entries_fetchers, !negate);
+    size_t result = EvaluateFilterAsPrimary(
+        parameters, negate_predicate->GetPredicate(), entries_fetchers, !negate,
+        or_weight_multiplier);
     return result;
   }
   CHECK(false);
@@ -1144,11 +1138,13 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
       (QueryOperations::kContainsNumeric | QueryOperations::kContainsTag |
        QueryOperations::kContainsNegate);
 
-  // In-iterator scoring runs only for pure text queries (when enabled by the
-  // switch), and only when the text index has at least one indexed document.
-  const bool iterator_scoring_enabled =
+  // In-iterator scoring runs only for pure text queries over a non-empty text
+  // index; match-all is excluded because its universal-set scan carries no
+  // TextIterator. Everything else is scored by the extra step below.
+  const bool score_in_drain =
       !has_non_text_predicate && text_index_schema &&
-      text_index_schema->GetTrackedKeyCount() > 0;
+      text_index_schema->GetTrackedKeyCount() > 0 &&
+      !parameters.filter_parse_results.is_match_all;
 
   std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> entries_fetchers;
   size_t qualified_entries = 0;
@@ -1190,9 +1186,13 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
   if (!requires_prefilter_evaluation) {
     bool needs_dedup =
         NeedsDeduplication(parameters.filter_parse_results.query_operations);
-    absl::flat_hash_set<const char *> seen_keys;
+    // Key -> slot in `borrowed`, so every OR branch matching a doc adds its
+    // score to the one entry instead of the repeats being dropped. Only
+    // pure-text OR accumulates: score_in_drain excludes tag/numeric/negate, so
+    // the other dedup user (tag) adds 0 and is scored by the extra step.
+    absl::flat_hash_map<const char *, size_t> seen_at;
     if (needs_dedup) {
-      seen_keys.reserve(std::min(qualified_entries, static_cast<size_t>(5000)));
+      seen_at.reserve(std::min(qualified_entries, static_cast<size_t>(5000)));
     }
     while (!entries_fetchers.empty()) {
       auto fetcher = std::move(entries_fetchers.front());
@@ -1201,12 +1201,25 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
       while (!iterator->Done()) {
         const auto &key = **iterator;
         BACKGROUND_PAUSEPOINT("search_entries_fetcher");
+        // Read before dedup: a repeat sighting is another branch's match.
+        float raw = 0.0f;
+        if (score_in_drain) {
+          if (auto *text_iter = iterator->GetTextIterator()) {
+            raw = text_iter->GetScore() * text_iter->GetWeight();
+          }
+        }
         if (needs_dedup) {
-          if (seen_keys.contains(key->Str().data())) {
+          // try_emplace records the slot the push_back below will fill, so on
+          // the max_keys break the index is left one past the end. Safe only
+          // because that break is mirrored by the outer loop and nothing reads
+          // seen_at afterward.
+          auto [it, inserted] =
+              seen_at.try_emplace(key->Str().data(), borrowed.size());
+          if (!inserted) {
+            borrowed[it->second].score += raw;
             iterator->Next();
             continue;
           }
-          seen_keys.insert(key->Str().data());
         }
         // Check if we've reached the limit
         if (borrowed.size() >= max_keys) {
@@ -1215,17 +1228,7 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
         }
         borrowed.push_back({.key = BorrowedInternedStringPtr(key),
                             .distance = 0.0f,
-                            .score = 0.0f});
-        // Set the per-document relevance score when scoring is enabled.
-        // Only used by pure text queries
-        if (iterator_scoring_enabled) {
-          if (auto *text_iter = iterator->GetTextIterator()) {
-            float raw = text_iter->GetScore() * text_iter->GetWeight();
-            borrowed.back().score = scorer->ComposeDocumentScore(
-                raw,
-                index_schema->GetDocumentScore(BorrowedInternedStringPtr(key)));
-          }
-        }
+                            .score = raw});
         iterator->Next();
         if (parameters.cancellation_token->IsCancelled()) {
           break;
@@ -1234,6 +1237,14 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
       if (borrowed.size() >= max_keys ||
           parameters.cancellation_token->IsCancelled()) {
         break;
+      }
+    }
+    // `score` held the raw branch sum: compose once so the result matches the
+    // composite iterator exactly, without relying on compose being additive.
+    if (score_in_drain) {
+      for (auto &neighbor : borrowed) {
+        neighbor.score = scorer->ComposeDocumentScore(
+            neighbor.score, index_schema->GetDocumentScore(neighbor.key));
       }
     }
   } else {
@@ -1247,13 +1258,10 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
   if (fetch_limited) {
     nonvector_results_fetched_limited_count.Increment();
   }
-  // extra step scoring logic: score all the candidates after prefilter. Used by
-  // combined (text + numeric/tag/negate) queries and by match-all (`*`): its
-  // universal-set scan carries no TextIterator, so in-iterator scoring is inert
-  // for it (iterator_scoring_enabled may still be true) and it must be scored
-  // here via the null-predicate wildcard branch in ScoreTextQuery.
-  if (!borrowed.empty() && (parameters.filter_parse_results.is_match_all ||
-                            !iterator_scoring_enabled)) {
+  // Extra step scoring: everything the drain loop did not score, i.e. combined
+  // (text + numeric/tag/negate) queries and match-all, which reaches
+  // ScoreTextQuery's null-predicate wildcard branch.
+  if (!borrowed.empty() && !score_in_drain) {
     ScoreTextQuery(*parameters.index_schema,
                    parameters.filter_parse_results.root_predicate.get(), scorer,
                    borrowed);

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -357,8 +357,9 @@ size_t EvaluateFilterAsPrimary(
       std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> best_fetchers;
       for (const auto &child : composed_predicate->GetChildren()) {
         std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> child_fetchers;
-        size_t child_size = EvaluateFilterAsPrimary(
-            parameters, child.get(), child_fetchers, negate, or_weight_multiplier);
+        size_t child_size =
+            EvaluateFilterAsPrimary(parameters, child.get(), child_fetchers,
+                                    negate, or_weight_multiplier);
         if (child_size < min_size) {
           min_size = child_size;
           best_fetchers = std::move(child_fetchers);
@@ -1141,10 +1142,9 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
   // In-iterator scoring runs only for pure text queries over a non-empty text
   // index; match-all is excluded because its universal-set scan carries no
   // TextIterator. Everything else is scored by the extra step below.
-  const bool score_in_drain =
-      !has_non_text_predicate && text_index_schema &&
-      text_index_schema->GetTrackedKeyCount() > 0 &&
-      !parameters.filter_parse_results.is_match_all;
+  const bool score_in_drain = !has_non_text_predicate && text_index_schema &&
+                              text_index_schema->GetTrackedKeyCount() > 0 &&
+                              !parameters.filter_parse_results.is_match_all;
 
   std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> entries_fetchers;
   size_t qualified_entries = 0;

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -1205,7 +1205,7 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
         float raw = 0.0f;
         if (score_in_drain) {
           if (auto *text_iter = iterator->GetTextIterator()) {
-            raw = text_iter->GetScore() * text_iter->GetWeight();
+            raw = text_iter->GetScore();
           }
         }
         if (needs_dedup) {

--- a/src/query/search.h
+++ b/src/query/search.h
@@ -339,7 +339,7 @@ class Predicate;
 size_t EvaluateFilterAsPrimary(
     const SearchParameters &parameters, const Predicate *predicate,
     std::queue<std::unique_ptr<indexes::EntriesFetcherBase>> &entries_fetchers,
-    bool negate);
+    bool negate, float or_weight_multiplier = 1.0f);
 
 // Defined in the header to support testing
 absl::StatusOr<std::vector<indexes::Neighbor>> PerformVectorSearch(


### PR DESCRIPTION
# Score all-text OR by fanning out fetchers instead of building a composite iterator

## Motivation

Follows up the `TODO: optimize with eliminate BuildTextIterator for OR in followup PR` left in `EvaluateFilterAsPrimary` by #1287.

Before this change, a pure-text OR was planned as a **single** fetcher wrapping an `OrProximityIterator`: `BuildTextIterator` was called on the whole `kComposedOr` subtree, the iterator unioned the branches internally, and it emitted each matching doc once with the branch scores already summed. That works, but it means OR is the only operator that has to construct a composite iterator purely to compute a sum the drain loop is already positioned to compute, and it forces every leaf type to be reachable through `OrProximityIterator` before it can participate in an OR.

This PR removes that block. OR now recurses per child like every other multi-child case, appending one fetcher per branch to `entries_fetchers`.

## Performance
```
# Before the change (build OR composite iterator)
OR of two          7551 (73.73)         4895 (115.33)            -35.6%     +56.6%
OR of three        5404 (105.54)        3377 (165.12)            -37.5%     +56.5%

# After the change (populate or_weight_multiple in entry fetcher)
OR of two          7619 (73.73)         6549 (84.86)             -14.8%     +15.1%
OR of three        5376 (105.79)        4690 (119.81)            -12.7%     +13.7%
```
The refactor brings significant performance improvement, augmenting throughoutput regression from -35% to -13%, and latency regression from +56% to +14%. This closes a significant performance gap specifically on pure-text OR queries.

## Changes

**1. Group weights ride down to the leaf.** `OrProximityIterator` was the thing applying a group weight for OR; with it gone, the weight has to reach the leaf another way. `EvaluateFilterAsPrimary` and `TextPredicate::BuildTextIterator` take a new `or_weight_multiplier` (default `1.0f`), and the OR branch multiplies it by its own group weight before recursing:

```cpp
const float child_multiplier = or_weight_multiplier * composed_predicate->GetWeight();
```

`TermPredicate::BuildTextIterator` folds it into the leaf as `GetWeight() * or_weight_multiplier`. This is sound specifically because **OR is a sum**, so a group weight distributes onto the leaves exactly — unlike an AND with slop, where the group weight is not a per-leaf scalar. AND therefore keeps applying its weight at the node, unchanged.

**2. Dedup accumulates instead of dropping.** `absl::flat_hash_set<const char*> seen_keys` becomes `absl::flat_hash_map<const char*, size_t> seen_at`, mapping the interned key pointer to the doc's slot in `borrowed`. A repeat sighting adds into that slot rather than skipping.

**3. Compose once, after the drain.** The per-doc `ComposeDocumentScore` moved out of the loop into a trailing pass over `borrowed`.

## Why dedup-add rather than dedup-drop

Dedup used to be lossless, and it stopped being lossless for one reason: **the OR union moved out of the iterator and into the dedup map.**

In the old plan, the only paths that produced duplicate sightings were tag and (on the prefilter path) negate — and on both, in-iterator scoring was off, so a dropped sighting carried a score of `0.0f`. Nothing was lost. Pure-text OR, the one case where a duplicate *would* have carried real score, never produced duplicates at all, because `OrProximityIterator` had already merged the branches upstream. The `seen_keys` set was dead weight on that path.

Fanning out inverts that. A doc matching *k* branches is now emitted *k* times, once per fetcher, and each sighting carries **only that branch's contribution** — its own leaf score times its own accumulated multiplier. So for `hello | (rare | unique)`, `doc:6` arrives twice: once worth `rare`, once worth `unique`. Dropping the second sighting would report `doc:6` scored on `rare` alone and silently under-rank it. The doc's true score only exists as the sum across sightings, so dedup has to be the thing that sums it:

```cpp
auto [it, inserted] = seen_at.try_emplace(key->Str().data(), borrowed.size());
if (!inserted) {
  borrowed[it->second].score += raw;   // another branch matched this doc
  iterator->Next();
  continue;
}
```

The score is also read *before* the dedup check now, since under the old ordering a repeat sighting returned early and never reached the score read.

The map stores an index rather than a pointer or reference because `borrowed` keeps growing via `push_back` during the drain, and reallocation would invalidate either of those. Pointer keys remain valid identity because `InternedStringPtr` guarantees one allocation per distinct string — unchanged from `seen_keys`.

## Why compose moved out of the loop

`ComposeDocumentScore(sum_of_terms, document_score)` is a transform on the *final* sum, and with fan-out the final sum isn't known until the whole fetcher queue is drained — the branch that bumps a doc may be several fetchers later. Composing at push time would compose a partial sum and then pile raw addends on top of an already-composed value.

`Bm25StdScorer` happens to be a multiply, so it algebraically distributes over addition; but it is a virtual on the `Scorer` interface, nothing binds a future scorer to being linear, the inf short-circuits are not linear, and `a*d + b*d` is not bit-identical to `(a+b)*d` in float. Summing first and composing once reproduces the old `OrProximityIterator` ordering exactly. It also drops a `GetDocumentScore` lookup and a `BorrowedInternedStringPtr` construction per *sighting* down to one per unique doc.

## Blast radius

The accumulation only ever fires for pure-text OR. `score_in_drain` requires `!has_non_text_predicate`, which excludes numeric, tag, and negate; `needs_dedup` is `has_or || has_tag || has_negate`; intersecting the two collapses the disjunction to `has_or`. Concretely:

- **tag** reaches the dedup path but with `score_in_drain == false`, so `raw` stays `0.0f` and `+= raw` is a no-op — identical zeros, then scored by `ScoreTextQuery` as before.
- **negate** never reaches it: `IsUnsolvedQuery` returns true for any `kContainsNegate`, so control goes to the prefilter branch and the drain loop doesn't run.
- **pure-text AND** has `needs_dedup == false` and one fetcher, so no map is built and repeats are impossible.

`iterator_scoring_enabled` was renamed `score_in_drain` and gained `&& !is_match_all`, which folds a condition that was previously re-tested at the extra-step call site into the flag itself — match-all's universal-set scan carries no `TextIterator`, so in-iterator scoring was already inert for it.

## Testing

Two cases added to `test_scoring.py` Group 2 (`test_and_or`):

- `hello | (rare | unique)` — a nested OR is one flat union; `doc:6` matches both inner branches and must accumulate `rare + unique`, `doc:8` only `rare`.
- `((hello)=>{$weight:2} | ((rare)=>{$weight:3} | (unique)=>{$weight:2})=>{$weight:2})=>{$weight:2}` — multipliers accumulate down both OR levels (2, then 4), so hello lands at 4×, rare at 12×, unique at 8×, and `doc:6` sums its two inner branches at *different* multipliers.

Expectations are written against baselines fetched in-test rather than hardcoded floats, so they assert the multiplier algebra rather than a transcription of it. Full scoring suite passes (22/22, including `test_scoring_cluster.py`). Confirmed the new assertions are discriminating by mutating `12 *` → `11 *` and observing the expected failure.

## Known gap (pre-existing, not introduced here)

`PrefixPredicate`, `SuffixPredicate`, `FuzzyPredicate` accept `or_weight_multiplier` but ignore it — they construct `TermIterator` via the defaulted `leaf_weight = 1.0f, scorer = nullptr` path, so they are unscored entirely and already ignore their own `GetWeight()`. This PR doesn't regress them, but it does add a parameter they silently discard. Worth a follow-up to either wire them into the scored constructor or document the limitation.