### PR TITLE
Run integration tests in parallel (reduces runtime from ~12 minutes to ~95 seconds)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,6 +36,7 @@ Usage: build.sh [options...]
     --no-build                        By default, build.sh always triggers a build. This option disables this behavior.
     --test-errors-stdout              When a test fails, dump the captured tests output to stdout.
     --run-integration-tests[=pattern] Run integration tests.
+    --parallel[=N] | -j[=N]           Run integration tests in parallel with N workers (default: all CPU cores).
     --no-system-modules               Disable system dependencies and force building from submodules.
     --asan                            Build with address sanitizer enabled.
     --tsan                            Build with thread sanitizer enabled.
@@ -64,6 +65,17 @@ Example usage:
 
 EOF
 }
+
+function is_valid_parallel_workers() {
+    local val="$1"
+    [[ "$val" == "auto" || "$val" == "logical" || "$val" =~ ^[0-9]+$ ]]
+}
+
+PARALLEL_WORKERS="${PARALLEL_WORKERS:=auto}"
+if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+    echo "ERROR: Invalid PARALLEL_WORKERS environment variable: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer." >&2
+    exit 1
+fi
 
 ## Parse command line arguments
 while [ $# -gt 0 ]; do
@@ -125,6 +137,30 @@ while [ $# -gt 0 ]; do
         TEST_PATTERN=${1#*=}
         shift || true
         echo "Running integration tests with pattern=${TEST_PATTERN}"
+        ;;
+    --parallel | -j)
+        shift || true
+        if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+            if is_valid_parallel_workers "$1"; then
+                PARALLEL_WORKERS="$1"
+                shift || true
+            else
+                echo "ERROR: Invalid value for --parallel: '$1'. Supported values: 0, auto, logical, or positive integer." >&2
+                exit 1
+            fi
+        else
+            PARALLEL_WORKERS="auto"
+        fi
+        echo "Running integration tests in parallel (workers=${PARALLEL_WORKERS})"
+        ;;
+    --parallel=* | -j=*)
+        PARALLEL_WORKERS="${1#*=}"
+        shift || true
+        if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+            echo "ERROR: Invalid value for --parallel: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer." >&2
+            exit 1
+        fi
+        echo "Running integration tests in parallel (workers=${PARALLEL_WORKERS})"
         ;;
     --retries=*)
         INTEG_RETRIES=${1#*=}
@@ -205,6 +241,111 @@ if [[ "${CMAKE_GENERATOR}" == "Ninja" ]]; then
 else
   BUILD_TOOL="make -j$(num_proc)"
 fi
+
+function determine_ninja() {
+    local os_name=$(uname -s)
+    if [[ "${os_name}" == "Darwin" ]]; then
+        # ninja can be installed via "brew"
+        echo "ninja"
+    else
+        # Check for ninja. On RedHat based Linux, it is called ninja-build, while on Debian based Linux, it is simply ninja
+        # Ubuntu / Mint et al will report "ID_LIKE=debian"
+        local debian_output=$(cat /etc/*-release 2>/dev/null | grep -i debian | wc -l)
+        if [ ${debian_output} -gt 0 ]; then
+            echo "ninja"
+        else
+            echo "ninja-build"
+        fi
+    fi
+}
+
+function check_subcommand_dependencies() {
+    local subcommands=()
+    if [[ "${INTEGRATION_TEST}" == "yes" ]]; then
+        subcommands+=("--run-integration-tests")
+    fi
+    if [[ -n "${RUN_TEST}" ]]; then
+        subcommands+=("--run-tests")
+    fi
+    if [[ "${RUN_BUILD}" == "yes" && ${#subcommands[@]} -eq 0 ]]; then
+        subcommands+=("build")
+    fi
+
+    if [[ ${#subcommands[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    local build_tool=$(determine_ninja)
+    if [[ "${BUILD_TOOL}" =~ make ]]; then
+        build_tool="make"
+    fi
+
+    local missing=()
+
+    # Build tools needed for compilation
+    if ! command -v cmake &>/dev/null; then
+        missing+=("cmake")
+    fi
+    if ! command -v "${build_tool}" &>/dev/null && ! command -v ninja &>/dev/null && ! command -v ninja-build &>/dev/null && ! command -v make &>/dev/null; then
+        missing+=("${build_tool}")
+    fi
+    if ! command -v git &>/dev/null; then
+        missing+=("git")
+    fi
+
+    local has_c_compiler=false
+    for c_comp in gcc clang cc; do
+        if command -v "${c_comp}" &>/dev/null; then
+            has_c_compiler=true
+            break
+        fi
+    done
+    if [[ "${has_c_compiler}" == "false" ]]; then
+        missing+=("gcc or clang")
+    fi
+
+    local has_cxx_compiler=false
+    for cxx_comp in g++ clang++ c++; do
+        if command -v "${cxx_comp}" &>/dev/null; then
+            has_cxx_compiler=true
+            break
+        fi
+    done
+    if [[ "${has_cxx_compiler}" == "false" ]]; then
+        missing+=("g++ or clang++")
+    fi
+
+    # Integration test specific external dependencies
+    if [[ "${INTEGRATION_TEST}" == "yes" ]]; then
+        if ! command -v python3 &>/dev/null; then
+            missing+=("python3")
+        fi
+        if ! command -v memtier_benchmark &>/dev/null; then
+            missing+=("memtier_benchmark")
+        fi
+        if ! command -v script &>/dev/null; then
+            missing+=("script")
+        fi
+    fi
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "" >&2
+        printf "${RED}ERROR: Missing required CLI binaries for %s:${RESET}\n" "${subcommands[*]}" >&2
+        for tool in "${missing[@]}"; do
+            printf "  ${RED}- %s${RESET}\n" "${tool}" >&2
+        done
+        echo "" >&2
+        printf "${YELLOW}Note: It is strongly recommended to run within the repository devcontainer where all dependencies are pre-installed:${RESET}\n" >&2
+        local run_cmd=".devcontainer/run_in_docker.sh ./build.sh"
+        if [ -n "${ARGV}" ]; then
+            run_cmd="${run_cmd} ${ARGV}"
+        fi
+        printf "    ${GREEN}%s${RESET}\n\n" "${run_cmd}" >&2
+        exit 1
+    fi
+}
+
+check_subcommand_dependencies
 
 function build_icu_if_needed() {
     printf "${BOLD_PINK}Checking ICU dependencies...${RESET}\n"
@@ -335,45 +476,6 @@ function format() {
     printf "Applied clang-format\n"
 }
 
-function check_tool() {
-    local tool_name=$1
-    local message=$2
-    printf "Checking for ${tool_name}..."
-    command -v "${tool_name}" >/dev/null ||
-        (printf "${RED}failed${RESET}.\n${RED}ERROR${RESET} - could not locate tool '${tool_name}'. ${message}\n" && exit 1)
-    printf "${GREEN}ok${RESET}\n"
-}
-
-function determine_ninja() {
-    local os_name=$(uname -s)
-    if [[ "${os_name}" == "Darwin" ]]; then
-        # ninja is can be installed via "brew"
-        echo "ninja"
-    else
-        # Check for ninja. On RedHat based Linux, it is called ninja-build, while on Debian based Linux, it is simply ninja
-        # Ubuntu / Mint et al will report "ID_LIKE=debian"
-        local debian_output=$(cat /etc/*-release | grep -i debian | wc -l)
-        if [ ${debian_output} -gt 0 ]; then
-            echo "ninja"
-        else
-            echo "ninja-build"
-        fi
-    fi
-}
-
-function check_tools() {
-    local tools="cmake g++ gcc"
-    for tool in $tools; do
-        check_tool ${tool}
-    done
-
-    local build_tool=$(determine_ninja)
-    if [[ "${BUILD_TOOL}" =~ make ]]; then
-        build_tool="make"
-    fi
-    check_tool ${build_tool}
-}
-
 function check_and_clean_on_branch_change() {
     local current_branch=$(git -C "${ROOT_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
     local branch_stamp="${BUILD_DIR}/.last_build_branch"
@@ -453,7 +555,6 @@ printf "Checking if configure is required..."
 
 FORCE_CMAKE=$(is_configure_required)
 printf "${GREEN}${FORCE_CMAKE}${RESET}\n"
-check_tools
 
 START_TIME=$(date +%s)
 
@@ -524,8 +625,12 @@ elif [[ "${INTEGRATION_TEST}" == "yes" ]]; then
     else
         # Abseil based tests do not support filtering tests based on "-k" flag
         # so when the TEST_PATTERN env variable is found, skip Abseil based tests
+        absl_params="${params}"
+        if [[ -n "${PARALLEL_WORKERS}" ]]; then
+            absl_params="${absl_params} --parallel=${PARALLEL_WORKERS}"
+        fi
         pushd testing/integration >/dev/null
-        ./run.sh ${params}
+        ./run.sh ${absl_params} || EXIT_CODE=1
         popd >/dev/null
     fi
 
@@ -537,8 +642,12 @@ elif [[ "${INTEGRATION_TEST}" == "yes" ]]; then
     export TEST_PATTERN=${TEST_PATTERN}
     export INTEG_RETRIES=${INTEG_RETRIES}
     export MODULE_PATH=${BUILD_DIR}/libsearch.${MODULE_EXT}
+    integ_params="${params}"
+    if [[ -n "${PARALLEL_WORKERS}" ]]; then
+        integ_params="${integ_params} --parallel=${PARALLEL_WORKERS}"
+    fi
     # Run will run ASan or normal tests based on the environment variable SAN_BUILD
-    ./run.sh ${params} || EXIT_CODE=1
+    ./run.sh ${integ_params} || EXIT_CODE=1
     popd >/dev/null
 fi
 

--- a/integration/compatibility_test.py
+++ b/integration/compatibility_test.py
@@ -588,8 +588,11 @@ def _load_answers_with_hash_check(answer_file_name):
     Set SKIP_COMPATIBILITY_HASH_CHECK=1 to bypass the hash check (useful when
     manually generating a small pickle for local testing).
     """
+    root_dir = os.getenv("ROOT_DIR") or os.path.abspath(
+        os.path.join(os.path.dirname(__file__), "..")
+    )
     pickle_path = os.path.join(
-        os.getenv("ROOT_DIR"), "integration/compatibility", answer_file_name
+        root_dir, "integration/compatibility", answer_file_name
     )
     with gzip.open(pickle_path, "rb") as f:
         payload = pickle.load(f)

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,0 +1,180 @@
+"""
+Pytest configuration and collision-free port tracking for Valkey Search integration tests.
+Ensures concurrent workers allocated via pytest-xdist never collide on client ports,
+cluster bus ports, or search coordinator ports.
+"""
+
+import fcntl
+import logging
+import os
+import socket
+import tempfile
+from pathlib import Path
+import pytest
+
+# If running under pytest-xdist, isolate the LOGS_DIR per worker process
+worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+if worker_id and "LOGS_DIR" in os.environ:
+    base_logs_dir = os.environ["LOGS_DIR"]
+    if not base_logs_dir.endswith(f"/{worker_id}"):
+        worker_logs_dir = os.path.join(base_logs_dir, worker_id)
+        os.environ["LOGS_DIR"] = worker_logs_dir
+        os.makedirs(worker_logs_dir, exist_ok=True)
+
+
+class SafePortTracker(object):
+    """Provides collision-free ports for valkey-server across concurrent pytest workers.
+
+    Port ranges are partitioned by xdist worker ID into disjoint blocks.
+    Within each worker's block, ports are allocated monotonically with wraparound
+    to prevent reusing sockets in TIME_WAIT.
+    Persistent file locks (flock) without unlinking protect against cross-process
+    and external collisions without inode recreation races.
+    """
+
+    CLUSTER_BUS_PORT_OFFSET = 10000
+    SEARCH_COORDINATOR_PORT_OFFSET = 20294
+
+    # Worker base ports: [10000, 19999] (stride = 100 ports per worker, up to 100 workers)
+    # Cluster bus ports: [20000, 29999]
+    # Coordinator ports: [30294, 40294]
+    # None of the three bands overlap with each other.
+    BASE_PORT = 10000
+    PORTS_PER_WORKER = 100
+    MAX_WORKERS = 100
+
+    LOCKS_DIR = os.path.join(
+        tempfile.gettempdir(),
+        f"valkey_port_locks_{os.getuid() if hasattr(os, 'getuid') else 0}",
+    )
+
+    # Worker-local monotonic offset for round-robin port cycling
+    _worker_port_offset = 0
+
+    def __init__(self, node_id=None):
+        self.node_id = node_id
+        os.makedirs(self.LOCKS_DIR, exist_ok=True)
+        self.locked_fds = {}  # port -> fd
+
+        w_id = os.environ.get("PYTEST_XDIST_WORKER", "master")
+        if w_id.startswith("gw"):
+            try:
+                self.worker_idx = int(w_id[2:])
+            except ValueError:
+                self.worker_idx = 0
+        else:
+            self.worker_idx = 0
+
+        if self.worker_idx >= self.MAX_WORKERS:
+            raise RuntimeError(
+                f"Worker index {self.worker_idx} exceeds maximum supported workers ({self.MAX_WORKERS})"
+            )
+
+        self.worker_start_port = (
+            self.BASE_PORT + self.worker_idx * self.PORTS_PER_WORKER
+        )
+        self.worker_end_port = self.worker_start_port + self.PORTS_PER_WORKER
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        for port, fd in list(self.locked_fds.items()):
+            self._unlock_fd(fd)
+        self.locked_fds.clear()
+
+    @classmethod
+    def _unlock_fd(cls, fd):
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+    def _try_lock_port(self, port):
+        lock_path = os.path.join(self.LOCKS_DIR, f"port_{port}.lock")
+        fd = None
+        try:
+            fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o666)
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except (OSError, BlockingIOError):
+            if fd is not None:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            return None
+
+        # Verify the port can actually be bound
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+            try:
+                sock.bind(("0.0.0.0", port))
+            except OSError:
+                self._unlock_fd(fd)
+                return None
+
+        return fd
+
+    def get_unused_port(self):
+        num_candidates = self.PORTS_PER_WORKER
+        for _ in range(num_candidates):
+            candidate_port = (
+                self.worker_start_port + SafePortTracker._worker_port_offset
+            )
+            SafePortTracker._worker_port_offset = (
+                SafePortTracker._worker_port_offset + 1
+            ) % self.PORTS_PER_WORKER
+
+            ports_to_lock = [
+                candidate_port,
+                candidate_port + self.CLUSTER_BUS_PORT_OFFSET,
+                candidate_port + self.SEARCH_COORDINATOR_PORT_OFFSET,
+            ]
+
+            attempt_fds = {}
+            success = True
+            for p in ports_to_lock:
+                fd = self._try_lock_port(p)
+                if fd is None:
+                    success = False
+                    break
+                attempt_fds[p] = fd
+
+            if success:
+                self.locked_fds.update(attempt_fds)
+                return candidate_port
+
+            # Release locks acquired in this failed attempt
+            for fd in attempt_fds.values():
+                self._unlock_fd(fd)
+
+        raise RuntimeError(
+            f"Failed to find an available port in worker {self.worker_idx} range "
+            f"[{self.worker_start_port}, {self.worker_end_port}) after {num_candidates} attempts"
+        )
+
+
+# Monkey-patch valkeytestframework.conftest to use SafePortTracker
+try:
+    import valkeytestframework.conftest
+    valkeytestframework.conftest.PortTracker = SafePortTracker
+except (ImportError, AttributeError):
+    pass
+
+
+@pytest.fixture(scope="function", autouse=True)
+def resource_port_tracker(request):
+    """Fixture providing collision-free port tracking per test."""
+    with SafePortTracker(request.node.nodeid) as tracker:
+        yield tracker
+
+
+try:
+    import valkeytestframework.conftest
+    valkeytestframework.conftest.resource_port_tracker = resource_port_tracker
+except (ImportError, AttributeError):
+    pass

--- a/integration/run.sh
+++ b/integration/run.sh
@@ -2,11 +2,18 @@
 
 # Find the rood folder
 ROOT_DIR=$(readlink -f $(readlink -f $(dirname $0))/..)
+export ROOT_DIR
 
 . ${ROOT_DIR}/scripts/common.rc
-setup_valkey_server
 
 LOG_NOTICE "Root directory is: ${ROOT_DIR}"
+
+function cleanup() {
+  if [ -n "${LOGS_DIR:-}" ]; then
+    pkill -9 -f "valkey-server.*${LOGS_DIR}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
 
 function print_usage() {
   cat <<EOF
@@ -16,6 +23,7 @@ Usage: run.sh [options...]
     --asan                  When passed, the integration will load the module under .build-release-asan/ | .build-debug-asan/
     --tsan                  When passed, the integration will load the module under .build-release-tsan/ | .build-debug-tsan/
     --capture               Disable pytest output capture (shows print statements in real-time).
+    --parallel[=N] | -j[=N] Run tests in parallel with N workers (default: all CPU cores).
     --help | -h             Print this help message and exit.
 
 EOF
@@ -30,6 +38,11 @@ function check_existence() {
 
 ## Parse command line arguments
 BUILD_CONFIG="release"
+PARALLEL_WORKERS="${PARALLEL_WORKERS:=auto}"
+if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+  LOG_ERROR "Invalid PARALLEL_WORKERS environment variable: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer."
+  exit 1
+fi
 while [ $# -gt 0 ]; do
   arg=$1
   case $arg in
@@ -58,6 +71,38 @@ while [ $# -gt 0 ]; do
     export PYTEST_CAPTURE_DISABLED=1
     LOG_INFO "pytest capture mode will be disabled"
     ;;
+  --parallel | -j)
+    shift || true
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+      if is_valid_parallel_workers "$1"; then
+        PARALLEL_WORKERS="$1"
+        shift || true
+      else
+        LOG_ERROR "Invalid value for --parallel: '$1'. Supported values: 0, auto, logical, or positive integer."
+        exit 1
+      fi
+    else
+      PARALLEL_WORKERS="auto"
+    fi
+    ;;
+  --parallel=* | -j=*)
+    PARALLEL_WORKERS="${arg#*=}"
+    shift || true
+    if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+      LOG_ERROR "Invalid value for --parallel: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer."
+      exit 1
+    fi
+    ;;
+  -k | --filter)
+    shift || true
+    if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+      TEST_PATTERN="$1"
+      shift || true
+    else
+      LOG_ERROR "Option $arg requires an argument."
+      exit 1
+    fi
+    ;;
   --help | -h)
     print_usage
     exit 0
@@ -79,8 +124,32 @@ if [ -z "${SAN_SUFFIX}" ] && [ ! -z "${SAN_BUILD}" ]; then
   fi
 fi
 
-BUILD_DIR=${ROOT_DIR}/.build-${BUILD_CONFIG}${SAN_SUFFIX}
+# Early sanity check for required external CLI binaries
+missing=()
+if ! command -v python3 &>/dev/null; then
+  missing+=("python3")
+fi
+if ! command -v script &>/dev/null; then
+  missing+=("script")
+fi
+if ! command -v git &>/dev/null; then
+  missing+=("git")
+fi
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "" >&2
+  printf "${RED}ERROR: Missing required CLI binaries for integration tests:${RESET}\n" >&2
+  for tool in "${missing[@]}"; do
+    printf "  ${RED}- %s${RESET}\n" "${tool}" >&2
+  done
+  echo "" >&2
+  printf "${YELLOW}Note: It is strongly recommended to run within the repository devcontainer where all dependencies are pre-installed:${RESET}\n" >&2
+  printf "    ${GREEN}.devcontainer/run_in_docker.sh ./build.sh --run-integration-tests${RESET}\n\n" >&2
+  exit 1
+fi
+
+BUILD_DIR=${ROOT_DIR}/.build-${BUILD_CONFIG}${BUILD_DIR_SUFFIX:-}${SAN_SUFFIX}
 WD=${BUILD_DIR}/integration
+export LOGS_DIR=${WD}/.valkey-test-framework
 
 # Check for user provided module path
 MODULE_PATH="${MODULE_PATH:=}"
@@ -137,9 +206,9 @@ export VALKEY_SERVER_PATH=${VALKEY_SERVER_PATH}
 export JSON_MODULE_PATH=${JSON_MODULE_PATH}
 export SKIPLOGCLEAN=1
 
-FILTER_ARGS=""
+FILTER_ARGS=()
 if [ ! -z "${TEST_PATTERN}" ]; then
-  FILTER_ARGS=" -k ${TEST_PATTERN}"
+  FILTER_ARGS=(-k "${TEST_PATTERN}")
   LOG_INFO "TEST_PATTERN is set to: '${TEST_PATTERN}'"
 else
   LOG_INFO "TEST_PATTERN is not set. Running all integration tests."
@@ -155,7 +224,9 @@ mkdir -p ${LOGS_DIR}
 PYTEST_OUTPUT_LOG=${LOGS_DIR}/pytest_output.log
 
 function run_pytest() {
-  zap valkey-server
+  if [ -n "${LOGS_DIR:-}" ]; then
+    pkill -9 -f "valkey-server.*${LOGS_DIR}" 2>/dev/null || true
+  fi
   
   # Check if PYTEST_CAPTURE_DISABLED is set
   CAPTURE_ARG="--capture=sys"
@@ -164,12 +235,41 @@ function run_pytest() {
     LOG_INFO "pytest capture mode is disabled"
   fi
   
-  LOG_INFO "Running: ${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/"
+  PARALLEL_WORKERS="${PARALLEL_WORKERS:=auto}"
+  XDIST_ARGS=""
+  if [ -n "${PARALLEL_WORKERS}" ] && [ "${PARALLEL_WORKERS}" != "0" ] && [ "${PARALLEL_WORKERS}" != "1" ]; then
+    if [ "${PARALLEL_WORKERS}" == "auto" ] || [ "${PARALLEL_WORKERS}" == "logical" ]; then
+      PARALLEL_WORKERS=$(num_proc)
+      if [ ${PARALLEL_WORKERS} -gt 32 ]; then
+        PARALLEL_WORKERS=32
+      elif [ ${PARALLEL_WORKERS} -lt 1 ]; then
+        PARALLEL_WORKERS=1
+      fi
+    fi
+    if [ "${PARALLEL_WORKERS}" != "1" ]; then
+      XDIST_ARGS="-n ${PARALLEL_WORKERS} --dist=loadscope"
+      LOG_INFO "Running integration tests in parallel with ${PARALLEL_WORKERS} workers"
+    fi
+  fi
+
+  PYTEST_CMD=("${PYTHON_PATH}" -m pytest)
+  if [ ${#FILTER_ARGS[@]} -gt 0 ]; then
+    PYTEST_CMD+=("${FILTER_ARGS[@]}")
+  fi
+  PYTEST_CMD+=("${CAPTURE_ARG}")
+  if [ -n "${XDIST_ARGS}" ]; then
+    # shellcheck disable=SC2206
+    XDIST_ARRAY=(${XDIST_ARGS})
+    PYTEST_CMD+=("${XDIST_ARRAY[@]}")
+  fi
+  PYTEST_CMD+=(--cache-clear -v "${ROOT_DIR}/integration/")
+
+  LOG_INFO "Running: ${PYTEST_CMD[*]}"
   # Capture pytest output to check for sanitizer errors
   if [[ "$(uname -s)" == "Darwin" ]]; then
-    script -q ${PYTEST_OUTPUT_LOG} ${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/
+    script -q "${PYTEST_OUTPUT_LOG}" "${PYTEST_CMD[@]}"
   else
-    script -q -e -c "${PYTHON_PATH} -m pytest ${FILTER_ARGS} ${CAPTURE_ARG} --cache-clear -v ${ROOT_DIR}/integration/" ${PYTEST_OUTPUT_LOG}
+    script -q -e -c "$(printf '%q ' "${PYTEST_CMD[@]}")" "${PYTEST_OUTPUT_LOG}"
   fi
   RUN_SUCCESS=$?
 }
@@ -203,7 +303,9 @@ run_with_retries
 if [[ "${SAN_BUILD}" != "no" ]]; then
   printf "Checking for errors...\n"
   # Terminate valkey-server so the logs will be flushed
-  pkill valkey-server || true
+  if [ -n "${LOGS_DIR:-}" ]; then
+    pkill -f "valkey-server.*${LOGS_DIR}" 2>/dev/null || true
+  fi
   # Wait for 3 seconds making sure the processes terminated
   sleep 3
   # And now we can check the logs

--- a/integration/test_postfilter.py
+++ b/integration/test_postfilter.py
@@ -18,7 +18,14 @@ class TestPostFilter(ValkeySearchTestCaseDebugMode):
         self.thread = threading.Thread(target=f)
         self.thread.start()
         waiters.wait_for_true(lambda: index.info(self.client).mutation_queue_size > 0)
-        assert int(self.client.execute_command("ft._debug PAUSEPOINT test block_mutation_queue")) > 0
+        waiters.wait_for_true(
+            lambda: int(
+                self.client.execute_command(
+                    "ft._debug PAUSEPOINT test block_mutation_queue"
+                )
+            )
+            > 0
+        )
 
     def release_modification(self, index):
         self.client.execute_command("ft._debug PAUSEPOINT RESET block_mutation_queue")

--- a/integration/valkey_search_test_case.py
+++ b/integration/valkey_search_test_case.py
@@ -20,6 +20,11 @@ LOGS_DIR = "/tmp/valkey-test-framework-files"
 if "LOGS_DIR" in os.environ:
     LOGS_DIR = os.environ["LOGS_DIR"]
 
+# Ensure worker-specific subdirectory under LOGS_DIR when running with pytest-xdist
+worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+if worker_id and not LOGS_DIR.endswith(f"/{worker_id}"):
+    LOGS_DIR = os.path.join(LOGS_DIR, worker_id)
+
 
 class Node:
     """This class represents a valkey server instance, regardless of its role"""
@@ -131,16 +136,25 @@ class ReplicationGroup:
         if not rg:
             return
 
-        if rg.primary:
-            if rg.primary.server is not None:
+        first_error = None
+        if getattr(rg, "primary", None) and rg.primary.server is not None:
+            try:
                 rg.primary.server.exit()
+            except Exception as e:
+                logging.error(f"Error during primary exit: {e}")
+                first_error = e
 
-        if not rg.replicas:
-            return
+        for replica in getattr(rg, "replicas", []):
+            if replica and replica.server is not None:
+                try:
+                    replica.server.exit()
+                except Exception as e:
+                    logging.error(f"Error during replica exit: {e}")
+                    if first_error is None:
+                        first_error = e
 
-        for replica in rg.replicas:
-            if replica.server:
-                replica.server.exit()
+        if first_error is not None:
+            raise first_error
 
 
 class ValkeySearchTestCaseCommon(ValkeyTestCase):
@@ -178,26 +192,28 @@ class ValkeySearchTestCaseCommon(ValkeyTestCase):
 
         os.makedirs(testdir, exist_ok=True)
         curdir = os.getcwd()
-        os.chdir(testdir)
-        lines = self.get_config_file_lines(testdir, port)
+        try:
+            os.chdir(testdir)
+            lines = self.get_config_file_lines(testdir, port)
 
-        conf_file = f"{testdir}/valkey_{port}.conf"
-        with open(conf_file, "w+") as f:
-            for line in lines:
-                f.write(f"{line}\n")
-            f.write("\n")
-            f.close()
+            conf_file = f"{testdir}/valkey_{port}.conf"
+            with open(conf_file, "w+") as f:
+                for line in lines:
+                    f.write(f"{line}\n")
+                f.write("\n")
+                f.close()
 
-        role = "primary" if is_primary else "replica"
-        logfile = f"{testdir}/logfile-{role}-{port}.log"
-        server, client = self.create_server(
-            testdir=testdir,
-            server_path=server_path,
-            args=self.append_startup_args({"logfile": logfile}),
-            port=port,
-            conf_file=conf_file,
-        )
-        os.chdir(curdir)
+            role = "primary" if is_primary else "replica"
+            logfile = f"{testdir}/logfile-{role}-{port}.log"
+            server, client = self.create_server(
+                testdir=testdir,
+                server_path=server_path,
+                args=self.append_startup_args({"logfile": logfile}),
+                port=port,
+                conf_file=conf_file,
+            )
+        finally:
+            os.chdir(curdir)
         self.wait_for_logfile(logfile, "Ready to accept connections")
         client.ping()
         return server, client, logfile
@@ -230,36 +246,77 @@ class ValkeySearchTestCaseCommon(ValkeyTestCase):
         assert search_loaded, "search module not loaded"
         assert json_loaded, "json module not loaded"
 
+    def teardown_method(self, method=None):
+        first_error = None
+        if hasattr(self, "server_list"):
+            for s in list(self.server_list):
+                if s:
+                    try:
+                        s.exit()
+                    except Exception as e:
+                        logging.error(f"Error during server exit: {e}")
+                        if first_error is None:
+                            first_error = e
+            self.server_list.clear()
+        if hasattr(self, "teardown"):
+            try:
+                self.teardown()
+            except Exception as e:
+                if first_error is None:
+                    first_error = e
+        if first_error is not None:
+            raise first_error
+
+    def tearDown(self):
+        self.teardown_method()
+        if hasattr(super(), "tearDown"):
+            super().tearDown()
+
 
 class ValkeySearchTestCaseBase(ValkeySearchTestCaseCommon):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, request):
-        # Setup
-        test_name = self.normalize_dir_name(request.node.name)
-        self.test_name = test_name
+        try:
+            # Setup
+            test_name = self.normalize_dir_name(request.node.name)
+            self.test_name = test_name
 
-        replica_count = 0
-        if hasattr(request, "param") and request.param["replica_count"]:
-            replica_count = request.param["replica_count"]
+            replica_count = 0
+            if hasattr(request, "param") and request.param["replica_count"]:
+                replica_count = request.param["replica_count"]
 
-        primary = self.start_new_server(is_primary=True)
-        replicas: List[Node] = []
-        for _ in range(0, replica_count):
-            replicas.append(self.start_new_server(is_primary=False))
+            primary = self.start_new_server(is_primary=True)
+            replicas: List[Node] = []
+            for _ in range(0, replica_count):
+                replicas.append(self.start_new_server(is_primary=False))
 
-        self.rg = ReplicationGroup(primary=primary, replicas=replicas)
-        self.rg.setup_replications_cmd()
-        self.server = self.rg.primary.server
-        self.client = self.rg.primary.client
+            self.rg = ReplicationGroup(primary=primary, replicas=replicas)
+            self.rg.setup_replications_cmd()
+            self.server = self.rg.primary.server
+            self.client = self.rg.primary.client
 
-        self.nodes: List[Node] = [self.rg.primary]
-        self.nodes += self.rg.replicas
+            self.nodes: List[Node] = [self.rg.primary]
+            self.nodes += self.rg.replicas
 
-        yield
-
-        # Cleanup
-        ReplicationGroup.cleanup(self.rg)
+            yield
+        finally:
+            # Cleanup - always executed even if setup failed
+            cleanup_err = None
+            if hasattr(self, "rg") and self.rg:
+                try:
+                    ReplicationGroup.cleanup(self.rg)
+                except Exception as e:
+                    logging.error(f"Error during ReplicationGroup.cleanup: {e}")
+                    cleanup_err = e
+            try:
+                self.teardown_method()
+            except Exception as e:
+                logging.error(f"Error during teardown_method: {e}")
+                if cleanup_err is None:
+                    cleanup_err = e
+            if cleanup_err is not None:
+                raise cleanup_err
 
     def get_config_file_lines(self, testdir, port) -> List[str]:
         return [
@@ -379,102 +436,117 @@ class ValkeySearchClusterTestCase(ValkeySearchTestCaseCommon):
 
     @pytest.fixture(autouse=True)
     def setup_test(self, request):
-        replica_count = self.REPLICAS_COUNT
-        if hasattr(request, "param") and request.param["replica_count"]:
-            replica_count = request.param["replica_count"]
-
         self.replication_groups: list[ReplicationGroup] = list()
-        ports = []
-        for i in range(0, self.CLUSTER_SIZE):
-            ports.append(self.get_bind_port())
-            for _ in range(0, replica_count):
-                ports.append(self.get_bind_port())
-
-        test_name = self.normalize_dir_name(request.node.name)
-        testdir_base = f"{LOGS_DIR}/{test_name}"
-
-        if os.path.exists(testdir_base):
-            shutil.rmtree(testdir_base)
-
-        for i in range(0, len(ports), replica_count + 1):
-            primary_port = ports[i]
-            server, client, logfile = self.start_server(
-                port=primary_port,
-                test_name=test_name,
-                cluster_enabled=True,
-                is_primary=True,
-            )
-
-            replicas = []
-            for _ in range(0, replica_count):
-                # Start the replicas
-                i = i + 1
-                replica_port = ports[i]
-                replica_server, replica_client, replica_logfile = (
-                    self.start_server(
-                        port=replica_port,
-                        test_name=test_name,
-                        cluster_enabled=True,
-                        is_primary=False,
-                    )
-                )
-                replicas.append(
-                    Node(
-                        server=replica_server,
-                        client=replica_client,
-                        logfile=replica_logfile,
-                    )
-                )
-
-            primary_node = Node(
-                server=server,
-                client=client,
-                logfile=logfile,
-            )
-            rg = ReplicationGroup(primary=primary_node, replicas=replicas)
-            self.replication_groups.append(rg)
-
         self.nodes: List[Node] = list()
-        for rg in self.replication_groups:
-            self.nodes.append(rg.primary)
-            self.nodes += rg.replicas
+        try:
+            replica_count = self.REPLICAS_COUNT
+            if hasattr(request, "param") and request.param["replica_count"]:
+                replica_count = request.param["replica_count"]
 
-        # Split the slots
-        ranges = self._split_range_pairs(0, 16384, self.CLUSTER_SIZE)
-        node_idx = 0
-        for start, end in ranges:
-            self.add_slots(node_idx, start, end)
-            node_idx = node_idx + 1
+            ports = []
+            for i in range(0, self.CLUSTER_SIZE):
+                ports.append(self.get_bind_port())
+                for _ in range(0, replica_count):
+                    ports.append(self.get_bind_port())
 
-        # Perform cluster meet
-        for node_idx in range(0, self.CLUSTER_SIZE):
-            self.cluster_meet(node_idx, self.CLUSTER_SIZE)
+            test_name = self.normalize_dir_name(request.node.name)
+            testdir_base = f"{LOGS_DIR}/{test_name}"
 
-        waiters.wait_for_equal(
-            lambda: self._wait_for_meet(
-                self.CLUSTER_SIZE + (self.CLUSTER_SIZE * replica_count)
-            ),
-            True,
-        )
+            if os.path.exists(testdir_base):
+                shutil.rmtree(testdir_base)
 
-        # Wait for the cluster to be up
-        for rg in self.replication_groups:
-            logging.info(
-                f"Waiting for cluster to change state...{rg.primary.logfile}"
+            for i in range(0, len(ports), replica_count + 1):
+                primary_port = ports[i]
+                server, client, logfile = self.start_server(
+                    port=primary_port,
+                    test_name=test_name,
+                    cluster_enabled=True,
+                    is_primary=True,
+                )
+
+                replicas = []
+                for _ in range(0, replica_count):
+                    # Start the replicas
+                    i = i + 1
+                    replica_port = ports[i]
+                    replica_server, replica_client, replica_logfile = (
+                        self.start_server(
+                            port=replica_port,
+                            test_name=test_name,
+                            cluster_enabled=True,
+                            is_primary=False,
+                        )
+                    )
+                    replicas.append(
+                        Node(
+                            server=replica_server,
+                            client=replica_client,
+                            logfile=replica_logfile,
+                        )
+                    )
+
+                primary_node = Node(
+                    server=server,
+                    client=client,
+                    logfile=logfile,
+                )
+                rg = ReplicationGroup(primary=primary_node, replicas=replicas)
+                self.replication_groups.append(rg)
+
+            for rg in self.replication_groups:
+                self.nodes.append(rg.primary)
+                self.nodes += rg.replicas
+
+            # Split the slots
+            ranges = self._split_range_pairs(0, 16384, self.CLUSTER_SIZE)
+            node_idx = 0
+            for start, end in ranges:
+                self.add_slots(node_idx, start, end)
+                node_idx = node_idx + 1
+
+            # Perform cluster meet
+            for node_idx in range(0, self.CLUSTER_SIZE):
+                self.cluster_meet(node_idx, self.CLUSTER_SIZE)
+
+            waiters.wait_for_equal(
+                lambda: self._wait_for_meet(
+                    self.CLUSTER_SIZE + (self.CLUSTER_SIZE * replica_count)
+                ),
+                True,
             )
-            self.wait_for_logfile(
-                rg.primary.logfile, "Cluster state changed: ok"
-            )
-            rg.setup_replications_cluster()
-        logging.info("Cluster is up and running!")
 
-        # Wait for cluster topology to settle
-        self.wait_for_cluster_topology_to_settle()
-        yield
+            # Wait for the cluster to be up
+            for rg in self.replication_groups:
+                logging.info(
+                    f"Waiting for cluster to change state...{rg.primary.logfile}"
+                )
+                self.wait_for_logfile(
+                    rg.primary.logfile, "Cluster state changed: ok"
+                )
+                rg.setup_replications_cluster()
+            logging.info("Cluster is up and running!")
 
-        # Cleanup
-        for rg in self.replication_groups:
-            ReplicationGroup.cleanup(rg)
+            # Wait for cluster topology to settle
+            self.wait_for_cluster_topology_to_settle()
+            yield
+        finally:
+            # Cleanup - always executed even on setup failure
+            cleanup_err = None
+            for rg in getattr(self, "replication_groups", []):
+                try:
+                    ReplicationGroup.cleanup(rg)
+                except Exception as e:
+                    logging.error(f"Error during ReplicationGroup.cleanup: {e}")
+                    if cleanup_err is None:
+                        cleanup_err = e
+            try:
+                self.teardown_method()
+            except Exception as e:
+                logging.error(f"Error during teardown_method: {e}")
+                if cleanup_err is None:
+                    cleanup_err = e
+            if cleanup_err is not None:
+                raise cleanup_err
 
     def get_config_file_lines(self, testdir, port) -> List[str]:
         return [

--- a/scripts/common.rc
+++ b/scripts/common.rc
@@ -43,6 +43,11 @@ function num_proc() {
   fi
 }
 
+function is_valid_parallel_workers() {
+  local val="$1"
+  [[ "$val" == "auto" || "$val" == "logical" || "$val" =~ ^[0-9]+$ ]]
+}
+
 function findup() {
   # Check if a filename was provided
   if [ -z "$1" ]; then
@@ -124,6 +129,15 @@ function pip_check_if_module_installed() {
 }
 
 function install_test_framework() {
+  local xdist_module_installed=$(pip_check_if_module_installed pytest-xdist)
+  if [[ "${xdist_module_installed}" == "no" ]]; then
+    LOG_INFO "Installing pytest-xdist dependency"
+    local testing_requirements_txt=${_WORKSPACE_HOME}/testing/integration/requirements.txt
+    if [ -f ${testing_requirements_txt} ]; then
+      ${PIP_PATH} install -r ${testing_requirements_txt}
+    fi
+  fi
+
   if [ ! -z "${VALKEY_TEST_FRAMEWORK}" ] &&
     [ -f "${VALKEY_TEST_FRAMEWORK}/LICENSE" ]; then
     LOG_INFO "Using valkey-test-framework => ${VALKEY_TEST_FRAMEWORK}"
@@ -141,14 +155,16 @@ function install_test_framework() {
 
   pushd ${test_framework_path} >/dev/null
   valkey_module_installed=$(pip_check_if_module_installed valkey)
-  if [[ "${valkey_module_installed}" == "no" ]]; then
+  xdist_module_installed=$(pip_check_if_module_installed pytest-xdist)
+  if [[ "${valkey_module_installed}" == "no" ]] || [[ "${xdist_module_installed}" == "no" ]]; then
     LOG_INFO "Installing dependencies"
     local requirements_txt=${test_framework_path}/requirements.txt
     local testing_requirements_txt=${_WORKSPACE_HOME}/testing/integration/requirements.txt
     if [ -f ${requirements_txt} ]; then
       LOG_INFO "Installing requirements file"
-      ${PIP_PATH} install -r ${requirements_txt} -r ${testing_requirements_txt}
+      ${PIP_PATH} install -r ${requirements_txt}
       ${PIP_PATH} install --upgrade pytest
+      ${PIP_PATH} install -r ${testing_requirements_txt}
     else
       LOG_ERROR "Missing ${requirements_txt} file. Broken installation?"
     fi

--- a/testing/integration/requirements.txt
+++ b/testing/integration/requirements.txt
@@ -2,3 +2,4 @@ valkey==6.0.2
 absl-py==2.1.0
 numpy==2.2.2
 pyarrow>=15.0.0
+pytest-xdist>=3.5.0

--- a/testing/integration/run.sh
+++ b/testing/integration/run.sh
@@ -33,11 +33,22 @@ Usage: test.sh [options...]
     --test-errors-stdout     When a test fails, dump the captured tests output to stdout.
     --asan                   Build the ASan version of the module.
     --tsan                   Build the TSan version of the module.
+    --parallel[=N] | -j[=N]  Run tests in parallel with N workers (default: all CPU cores).
 
 EOF
 }
 SAN_BUILD="no"
 san_suffix=""
+function is_valid_parallel_workers() {
+    local val="$1"
+    [[ "$val" == "auto" || "$val" == "logical" || "$val" =~ ^[0-9]+$ ]]
+}
+
+PARALLEL_WORKERS="${PARALLEL_WORKERS:=auto}"
+if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+    printf "\n${RED}ERROR: Invalid PARALLEL_WORKERS environment variable: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer.${RESET}\n\n" >&2
+    exit 1
+fi
 ## Parse command line arguments
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -55,9 +66,39 @@ while [[ $# -gt 0 ]]; do
         SAN_BUILD="thread"
         san_suffix="-tsan"
         ;;
+    --parallel | -j)
+        shift || true
+        if [[ $# -gt 0 && ! "$1" =~ ^- ]]; then
+            if is_valid_parallel_workers "$1"; then
+                PARALLEL_WORKERS="$1"
+                shift || true
+            else
+                printf "\n${RED}ERROR: Invalid value for --parallel: '$1'. Supported values: 0, auto, logical, or positive integer.${RESET}\n\n" >&2
+                exit 1
+            fi
+        else
+            PARALLEL_WORKERS="auto"
+        fi
+        ;;
+    --parallel=* | -j=*)
+        PARALLEL_WORKERS="${1#*=}"
+        shift || true
+        if ! is_valid_parallel_workers "${PARALLEL_WORKERS}"; then
+            printf "\n${RED}ERROR: Invalid value for --parallel: '${PARALLEL_WORKERS}'. Supported values: 0, auto, logical, or positive integer.${RESET}\n\n" >&2
+            exit 1
+        fi
+        ;;
     --test)
+        if [[ $# -lt 2 || "$2" =~ ^- ]]; then
+            printf "\n${RED}ERROR: Option --test requires an argument.${RESET}\n\n" >&2
+            exit 1
+        fi
         TEST="$2"
         shift 2
+        ;;
+    --test=*)
+        TEST="${1#*=}"
+        shift || true
         ;;
    --debug)
         shift || true
@@ -108,6 +149,11 @@ function is_cmake_required() {
         echo "yes"
         return
     fi
+    local req_file_lastmodified=$(get_file_last_modified ${ROOT_DIR}/requirements.txt)
+    if [ ${req_file_lastmodified} -gt ${cmake_cache_modified} ]; then
+        echo "yes"
+        return
+    fi
     echo "no"
 }
 
@@ -143,6 +189,9 @@ function configure() {
 function build() {
     cd ${BUILD_DIR}
     source venv/bin/activate
+    if ! python3 -c "import pytest, xdist" 2>/dev/null; then
+        pip install -r ${ROOT_DIR}/requirements.txt
+    fi
     make
 }
 
@@ -152,6 +201,7 @@ else
     BUILD_DIR_BASENAME=.build-${BUILD_CONFIG}${BUILD_DIR_SUFFIX}
 fi
 BUILD_DIR=${ROOT_DIR}/${BUILD_DIR_BASENAME}
+export TEST_TMPDIR="$BUILD_DIR/tmp"
 VALKEY_SEARCH_PATH=${MODULE_ROOT}/${BUILD_DIR_BASENAME}/libsearch.${MODULE_EXT}
 
 if [[ "${CLEAN}" == "yes" ]]; then
@@ -162,7 +212,9 @@ fi
 function cleanup() {
     local exit_code=$1
     printf "Cleanup before exit..."
-    pkill valkey-server || true
+    if [ -n "${TEST_TMPDIR:-}" ]; then
+        pkill -9 -f "valkey-server.*${TEST_TMPDIR}" 2>/dev/null || true
+    fi
     deactivate >/dev/null 2>&1 || true
     cd ${ROOT_DIR}
     printf "${GREEN}done${RESET}\n"
@@ -174,15 +226,31 @@ function cleanup() {
 }
 
 # Ensure cleanup runs on exit
-trap 'exit_code=$?; cleanup ${exit_code}; exit $exit_code' EXIT
+trap 'exit_code=$?; cleanup ${exit_code}; exit $exit_code' EXIT INT TERM
+
+# Early sanity check for required external CLI binaries
+missing=()
+if ! command -v memtier_benchmark &>/dev/null; then
+    missing+=("memtier_benchmark")
+fi
+if ! command -v python3 &>/dev/null; then
+    missing+=("python3")
+fi
+if ! command -v cmake &>/dev/null; then
+    missing+=("cmake")
+fi
+if [[ ${#missing[@]} -gt 0 ]]; then
+    printf "\n${RED}ERROR: Missing required CLI binaries for integration tests:${RESET}\n" >&2
+    for tool in "${missing[@]}"; do
+        printf "  ${RED}- %s${RESET}\n" "${tool}" >&2
+    done
+    printf "\n${YELLOW}Note: It is strongly recommended to run within the repository devcontainer where all dependencies are pre-installed:${RESET}\n" >&2
+    printf "    ${GREEN}.devcontainer/run_in_docker.sh ./build.sh --run-integration-tests${RESET}\n\n" >&2
+    exit 1
+fi
 
 configure
 build
-
-if ! command -v memtier_benchmark &> /dev/null; then
-    printf "\n${RED}Error: memtier_benchmark is not installed or not in PATH.${RESET}\n\n" >&2
-    exit 1
-fi
 
 export MEMTIER_PATH=memtier_benchmark
 export VALKEY_SEARCH_PATH=${VALKEY_SEARCH_PATH}
@@ -203,24 +271,55 @@ print_environment_var TEST_UNDECLARED_OUTPUTS_DIR ${TEST_UNDECLARED_OUTPUTS_DIR}
 print_environment_var TEST_TMPDIR ${TEST_TMPDIR}
 
 mkdir -p $TEST_TMPDIR
-pkill -9 valkey-server || true
+if [ -n "${TEST_TMPDIR:-}" ]; then
+    pkill -9 -f "valkey-server.*${TEST_TMPDIR}" 2>/dev/null || true
+fi
+
+# Ensure virtual environment is active
+if [ -f "${BUILD_DIR}/venv/bin/activate" ]; then
+    source "${BUILD_DIR}/venv/bin/activate"
+fi
+
+PARALLEL_WORKERS="${PARALLEL_WORKERS:=auto}"
+if [ -n "${PARALLEL_WORKERS}" ] && [ "${PARALLEL_WORKERS}" != "0" ] && [ "${PARALLEL_WORKERS}" != "1" ]; then
+    if [ "${PARALLEL_WORKERS}" == "auto" ] || [ "${PARALLEL_WORKERS}" == "logical" ]; then
+        PARALLEL_WORKERS=$(num_proc)
+        if [ ${PARALLEL_WORKERS} -gt 32 ]; then
+            PARALLEL_WORKERS=32
+        elif [ ${PARALLEL_WORKERS} -lt 1 ]; then
+            PARALLEL_WORKERS=1
+        fi
+    fi
+fi
 
 ALL_FILES="vector_search_integration_test.py stability_test.py"
 
-if [[ "${TEST}" == "all" ]]; then
-    for file in $ALL_FILES; do
-        python3 ${ROOT_DIR}/${file}
-    done
+if [ -n "${PARALLEL_WORKERS}" ] && [ "${PARALLEL_WORKERS}" != "0" ] && [ "${PARALLEL_WORKERS}" != "1" ]; then
+    XDIST_ARGS="-n ${PARALLEL_WORKERS} --dist=load"
+    echo "Running integration tests in parallel with ${PARALLEL_WORKERS} workers"
+    if [[ "${TEST}" == "all" ]]; then
+        python3 -m pytest ${XDIST_ARGS} -v ${ROOT_DIR}/vector_search_integration_test.py ${ROOT_DIR}/stability_test.py
+    else
+        python3 -m pytest ${XDIST_ARGS} -v ${ROOT_DIR}/${TEST}_test.py
+    fi
 else
-    python3 ${ROOT_DIR}/${TEST}_test.py
+    if [[ "${TEST}" == "all" ]]; then
+        for file in $ALL_FILES; do
+            python3 ${ROOT_DIR}/${file}
+        done
+    else
+        python3 ${ROOT_DIR}/${TEST}_test.py
+    fi
 fi
 
 if [[ "${SAN_BUILD}" != "no" ]]; then
     printf "Checking for errors...\n"
     # Terminate valkey-server so the logs will be flushed
-    pkill valkey-server || true
+    if [ -n "${TEST_TMPDIR:-}" ]; then
+        pkill -f "valkey-server.*${TEST_TMPDIR}" 2>/dev/null || true
+    fi
     # Wait for 3 seconds making sure the processes terminated
     sleep 3
     # And now we can check the logs
-    check_for_san_errors "$(ls ${TEST_UNDECLARED_OUTPUTS_DIR}/*_stdout.txt | grep -v valkey_cli_stdout)"
+    check_for_san_errors "$(find ${TEST_UNDECLARED_OUTPUTS_DIR} -name "*_stdout.txt" | grep -v valkey_cli_stdout)"
 fi

--- a/testing/integration/stability_test.py
+++ b/testing/integration/stability_test.py
@@ -657,19 +657,25 @@ class StabilityTests(parameterized.TestCase):
         ),
     )
     def test_valkeyquery_stability(self, config):
-        valkey_server_stdout_dir = os.environ["TEST_UNDECLARED_OUTPUTS_DIR"]
+        valkey_server_stdout_dir = utils.get_worker_stdoutdir()
         valkey_server_path = os.environ["VALKEY_SERVER_PATH"]
         valkey_cli_path = os.environ["VALKEY_CLI_PATH"]
         memtier_path = os.environ["MEMTIER_PATH"]
         valkey_search_path = os.environ["VALKEY_SEARCH_PATH"]
 
-        config = config._replace(memtier_path=memtier_path)
+        worker_ports = utils.get_worker_cluster_ports(
+            len(config.ports), default_ports=config.ports
+        )
+        config = config._replace(
+            memtier_path=memtier_path,
+            ports=tuple(worker_ports),
+        )
 
         self.valkey_cluster_under_test = utils.start_valkey_cluster(
             valkey_server_path,
             valkey_cli_path,
             config.ports,
-            os.environ["TEST_TMPDIR"],
+            utils.get_worker_tmpdir(),
             valkey_server_stdout_dir,
             {
                 "loglevel": "debug",

--- a/testing/integration/utils.py
+++ b/testing/integration/utils.py
@@ -1,11 +1,13 @@
 """Utilities for ValkeySearch testing."""
 
 from abc import abstractmethod
+import atexit
 import fcntl
 import logging
 import os
 import random
 import re
+import shutil
 import subprocess
 import threading
 import time
@@ -42,10 +44,41 @@ class ValkeyServerUnderTest:
         self.port = port
 
     def terminate(self):
-        self.process_handle.terminate()
+        try:
+            self.process_handle.terminate()
+            self.process_handle.wait(timeout=5)
+            return
+        except ProcessLookupError:
+            return
+        except subprocess.TimeoutExpired:
+            logging.warning(
+                "Process on port %d did not exit within 5s of SIGTERM; escalating to SIGKILL",
+                self.port,
+            )
+        except Exception as e:
+            logging.warning(
+                "Unexpected error during SIGTERM for port %d: %s; escalating to SIGKILL",
+                self.port,
+                e,
+            )
+
+        try:
+            self.process_handle.kill()
+            self.process_handle.wait(timeout=5)
+        except ProcessLookupError:
+            pass
+        except subprocess.TimeoutExpired:
+            logging.error(
+                "CRITICAL: Process on port %d failed to terminate even after SIGKILL!",
+                self.port,
+            )
+        except Exception as e:
+            logging.error(
+                "Error during SIGKILL for process on port %d: %s", self.port, e
+            )
 
     def terminated(self):
-        return self.process_handle.poll()
+        return self.process_handle.poll() is not None
 
     def ping(self) -> Any:
         return valkey.Valkey(port=self.port).ping()
@@ -72,7 +105,7 @@ def start_valkey_process(
         for k, v in modules.items():
             f.write(f"loadmodule {k} {v}\n")
 
-    command = f"ulimit -c unlimited && {valkey_server_path} {conf_path}"
+    command = f"ulimit -c unlimited && exec {valkey_server_path} {conf_path}"
     logging.info("Starting valkey process with config: %s", conf_path)
 
     process = subprocess.Popen(
@@ -101,6 +134,34 @@ def start_valkey_process(
         ):
             time.sleep(1)
     if not connected:
+        try:
+            process.terminate()
+            process.wait(timeout=5)
+        except ProcessLookupError:
+            pass
+        except subprocess.TimeoutExpired:
+            logging.warning(
+                "Process on port %d did not exit within 5s of SIGTERM; escalating to SIGKILL",
+                port,
+            )
+            try:
+                process.kill()
+                process.wait(timeout=5)
+            except ProcessLookupError:
+                pass
+            except subprocess.TimeoutExpired:
+                logging.error(
+                    "CRITICAL: Process on port %d failed to terminate even after SIGKILL!",
+                    port,
+                )
+            except Exception as e:
+                logging.error(
+                    "Error during SIGKILL for process on port %d: %s", port, e
+                )
+        except Exception as e:
+            logging.warning(
+                "Unexpected error terminating process on port %d: %s", port, e
+            )
         raise valkey.exceptions.ConnectionError(
             f"Failed to connect to valkey server on port {port}"
         )
@@ -110,11 +171,35 @@ def start_valkey_process(
 
 
 class ValkeyClusterUnderTest:
-    def __init__(self, servers: List[ValkeyServerUnderTest], stdout_files: List[TextIO] = None):
-        self.servers = servers
-        self.stdout_files = stdout_files or []
+    active_clusters = set()
+    active_cluster = None
+
+    def __init__(
+        self,
+        servers: List[ValkeyServerUnderTest],
+        stdout_files: List[TextIO] = None,
+        node_dirs: List[str] = None,
+    ):
+        self.servers = list(servers)
+        self.stdout_files = list(stdout_files or [])
+        self.node_dirs = list(node_dirs or [])
+        ValkeyClusterUnderTest.active_clusters.add(self)
+        ValkeyClusterUnderTest.active_cluster = self
+
+    def register_server(
+        self, server: ValkeyServerUnderTest, stdout_file: TextIO | None = None
+    ):
+        """Register a replacement or restarted server (e.g. during failover)."""
+        self.servers = [s for s in self.servers if s.port != server.port] + [server]
+        if stdout_file is not None and stdout_file not in self.stdout_files:
+            self.stdout_files.append(stdout_file)
 
     def terminate(self):
+        ValkeyClusterUnderTest.active_clusters.discard(self)
+        if ValkeyClusterUnderTest.active_cluster is self:
+            ValkeyClusterUnderTest.active_cluster = next(
+                iter(ValkeyClusterUnderTest.active_clusters), None
+            )
         for server in self.servers:
             server.terminate()
         # Close all stdout files
@@ -123,6 +208,10 @@ class ValkeyClusterUnderTest:
                 stdout_file.close()
             except Exception as e:
                 logging.warning("Failed to close stdout file: %s", e)
+        # Clean up node directories
+        for node_dir in self.node_dirs:
+            if os.path.exists(node_dir):
+                shutil.rmtree(node_dir, ignore_errors=True)
 
     def get_terminated_servers(self) -> List[int]:
         result = []
@@ -138,6 +227,81 @@ class ValkeyClusterUnderTest:
         return result
 
 
+def _cleanup_active_clusters():
+    for cluster in list(ValkeyClusterUnderTest.active_clusters):
+        try:
+            cluster.terminate()
+        except Exception:
+            pass
+
+
+atexit.register(_cleanup_active_clusters)
+
+
+_worker_port_cycle = 0
+
+
+def get_worker_cluster_ports(
+    num_nodes: int = 3,
+    default_ports: Union[List[int], tuple, None] = None,
+) -> List[int]:
+    """Return collision-free ports partitioned by worker ID (e.g. pytest-xdist)."""
+    global _worker_port_cycle
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if not worker_id and default_ports:
+        return list(default_ports)
+    worker_idx = 0
+    if worker_id and worker_id.startswith("gw"):
+        try:
+            worker_idx = int(worker_id[2:])
+        except ValueError:
+            worker_idx = 0
+    if worker_idx >= 100:
+        raise RuntimeError(
+            f"Worker index {worker_idx} exceeds maximum supported workers (100)"
+        )
+    # Base ports for testing/integration: 7000 + worker_idx * 50
+    # Client ports: [7000, 11999] (stride = 50 ports per worker, up to 100 workers)
+    # Cluster bus:  [17000, 21999]
+    # Coordinator:  [27294, 32294]
+    # Cycle across tests on the same worker to prevent immediate port reuse.
+    # Dynamically compute slot_size to prevent overlapping port ranges.
+    slot_size = max(num_nodes * 2, 12)
+    max_slots = 48 // slot_size
+    if max_slots < 1:
+        raise ValueError(
+            f"num_nodes {num_nodes} exceeds maximum supported cluster size for worker port allocation"
+        )
+    cycle_offset = (_worker_port_cycle % max_slots) * slot_size
+    _worker_port_cycle += 1
+    base = 7000 + worker_idx * 50 + cycle_offset
+    return [base + i * 2 for i in range(num_nodes)]
+
+
+def get_worker_tmpdir(base_dir: str | None = None) -> str:
+    """Return isolated temporary directory for the current worker process."""
+    if not base_dir:
+        base_dir = os.environ.get("TEST_TMPDIR", "/tmp")
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id and os.path.basename(os.path.normpath(base_dir)) != worker_id:
+        path = os.path.join(base_dir, worker_id)
+        os.makedirs(path, exist_ok=True)
+        return path
+    return base_dir
+
+
+def get_worker_stdoutdir(base_dir: str | None = None) -> str:
+    """Return isolated stdout directory for the current worker process."""
+    if not base_dir:
+        base_dir = os.environ.get("TEST_UNDECLARED_OUTPUTS_DIR", "/tmp")
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id and os.path.basename(os.path.normpath(base_dir)) != worker_id:
+        path = os.path.join(base_dir, worker_id)
+        os.makedirs(path, exist_ok=True)
+        return path
+    return base_dir
+
+
 def start_valkey_cluster(
     valkey_server_path: str,
     valkey_cli_path: str,
@@ -148,7 +312,7 @@ def start_valkey_cluster(
     modules: Dict[str, str],
     replica_count: int = 0,
     password: str | None = None,
-) -> Dict[int, subprocess.Popen[Any]]:
+) -> ValkeyClusterUnderTest:
     """Starts a valkey cluster.
 
     Starts a valkey cluster with the given ports and arguments, with zero replicas.
@@ -164,72 +328,102 @@ def start_valkey_cluster(
     Returns:
       Dictionary of port to valkey process.
     """
+    directory = get_worker_tmpdir(directory)
+    stdout_directory = get_worker_stdoutdir(stdout_directory)
     cluster_args = dict(args)
     processes = []
     stdout_files = []
+    node_dirs = []
 
-    for port in ports:
-        stdout_path = os.path.join(stdout_directory, f"{port}_stdout.txt")
-        # Open file without buffering - will be closed when cluster terminates
-        stdout_file = open(stdout_path, "w", buffering=1)
-        stdout_files.append(stdout_file)
-        node_dir = os.path.join(directory, f"nodes{port}")
-        cluster_args["cluster-enabled"] = "yes"
-        cluster_args["cluster-config-file"] = os.path.join(
-            node_dir, "nodes.conf"
-        )
-        cluster_args["cluster-node-timeout"] = "10000"
-        os.mkdir(node_dir)
-        processes.append(start_valkey_process(
-            valkey_server_path,
-            port,
-            node_dir,
-            stdout_file,
-            cluster_args,
-            modules,
-            password,
-        ))
-
-    cli_stdout_path = os.path.join(stdout_directory, "valkey_cli_stdout.txt")
-    # Close file after subprocess completes
-    with open(cli_stdout_path, "w") as cli_stdout_file:
-        valkey_cli_args = [valkey_cli_path, "--cluster-yes", "--cluster", "create"]
+    try:
         for port in ports:
-            valkey_cli_args.append(f"127.0.0.1:{port}")
-        valkey_cli_args.extend(["--cluster-replicas", str(replica_count)])
-        if password:
-            valkey_cli_args.extend(["-a", password])
-
-        logging.info("Creating valkey cluster with command: %s", valkey_cli_args)
-
-        timeout = 60
-        now = time.time()
-        cluster_created = False
-        while time.time() - now < timeout:
-            try:
-                subprocess.run(
-                    valkey_cli_args,
-                    check=True,
-                    stdout=cli_stdout_file,
-                    stderr=cli_stdout_file,
-                )
-                cluster_created = True
-                break
-            except subprocess.CalledProcessError:
-                time.sleep(1)
-
-        if not cluster_created:
-            raise RuntimeError(
-                f"Failed to create valkey cluster within {timeout}s. Check {cli_stdout_path}"
+            stdout_path = os.path.join(stdout_directory, f"{port}_stdout.txt")
+            # Open file without buffering - will be closed when cluster terminates
+            stdout_file = open(stdout_path, "w", buffering=1)
+            stdout_files.append(stdout_file)
+            node_dir = os.path.join(directory, f"nodes{port}")
+            node_dirs.append(node_dir)
+            cluster_args["cluster-enabled"] = "yes"
+            cluster_args["cluster-config-file"] = os.path.join(
+                node_dir, "nodes.conf"
             )
+            cluster_args["cluster-node-timeout"] = "10000"
+            if os.path.exists(node_dir):
+                shutil.rmtree(node_dir, ignore_errors=True)
+            os.makedirs(node_dir, exist_ok=True)
+            processes.append(start_valkey_process(
+                valkey_server_path,
+                port,
+                node_dir,
+                stdout_file,
+                cluster_args,
+                modules,
+                password,
+            ))
 
-    # This is also ugly, but we need to wait for the cluster to be ready. There
-    # doesn't seem to be a way to do that with the valkey-server, since it seems to
-    # be ready immediately, but returns an CLUSTERDOWN error when we try to search
-    # too early, even after checking with ping.
-    time.sleep(10)
+        cli_stdout_path = os.path.join(stdout_directory, "valkey_cli_stdout.txt")
+        # Close file after subprocess completes
+        with open(cli_stdout_path, "w") as cli_stdout_file:
+            valkey_cli_args = [valkey_cli_path, "--cluster-yes", "--cluster", "create"]
+            for port in ports:
+                valkey_cli_args.append(f"127.0.0.1:{port}")
+            valkey_cli_args.extend(["--cluster-replicas", str(replica_count)])
+            if password:
+                valkey_cli_args.extend(["-a", password])
 
-    return ValkeyClusterUnderTest(processes, stdout_files)
+            display_args = [
+                "***" if i > 0 and valkey_cli_args[i - 1] == "-a" else arg
+                for i, arg in enumerate(valkey_cli_args)
+            ]
+            logging.info("Creating valkey cluster with command: %s", display_args)
+
+            timeout = 60
+            now = time.time()
+            while time.time() - now < timeout:
+                try:
+                    subprocess.run(
+                        valkey_cli_args,
+                        check=True,
+                        stdout=cli_stdout_file,
+                        stderr=cli_stdout_file,
+                        timeout=10,
+                    )
+                    break
+                except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+                    time.sleep(1)
+            else:
+                raise RuntimeError(
+                    f"Timed out creating Valkey cluster on ports {ports} after {timeout} seconds. Check {cli_stdout_path}"
+                )
+
+        # This is also ugly, but we need to wait for the cluster to be ready. There
+        # doesn't seem to be a way to do that with the valkey-server, since it seems to
+        # be ready immediately, but returns an CLUSTERDOWN error when we try to search
+        # too early, even after checking with ping.
+        time.sleep(10)
+
+        return ValkeyClusterUnderTest(processes, stdout_files, node_dirs)
+    except Exception:
+        for p in processes:
+            try:
+                p.terminate()
+            except Exception as e:
+                logging.warning(
+                    "Error terminating server process during startup failure cleanup: %s",
+                    e,
+                )
+        for f in stdout_files:
+            try:
+                f.close()
+            except Exception as e:
+                logging.warning(
+                    "Error closing stdout file during startup failure cleanup: %s",
+                    e,
+                )
+        for d in node_dirs:
+            if os.path.exists(d):
+                shutil.rmtree(d, ignore_errors=True)
+        raise
 
 
 class AttributeDefinition:
@@ -1544,7 +1738,10 @@ def restart_node(
     Returns:
         ValkeyServerUnderTest object if restart succeeds, None otherwise
     """
+    stdout_file = None
     try:
+        config_dir = get_worker_tmpdir(config_dir)
+        stdout_dir = get_worker_stdoutdir(stdout_dir)
         node_dir = os.path.join(config_dir, f"nodes{port}")
         stdout_path = os.path.join(stdout_dir, f"{port}_restart_stdout.txt")
         
@@ -1565,7 +1762,7 @@ def restart_node(
         
         # Reuse start_valkey_process to ensure identical configuration
         # This guarantees same module loading order, argument parsing, etc.
-        return start_valkey_process(
+        server = start_valkey_process(
             valkey_server_path=valkey_server_path,
             port=port,
             directory=node_dir,
@@ -1574,8 +1771,25 @@ def restart_node(
             modules=modules,
             password=password
         )
+        for cluster in ValkeyClusterUnderTest.active_clusters:
+            if any(s.port == port for s in cluster.servers) or any(
+                d == node_dir for d in cluster.node_dirs
+            ):
+                cluster.register_server(server, stdout_file)
+                break
+        else:
+            if ValkeyClusterUnderTest.active_cluster is not None:
+                ValkeyClusterUnderTest.active_cluster.register_server(
+                    server, stdout_file
+                )
+        return server
         
     except Exception as e:
+        if stdout_file is not None:
+            try:
+                stdout_file.close()
+            except Exception:
+                pass
         logging.error("Error restarting node on port %d: %s", port, e)
         return None
 

--- a/testing/integration/vector_search_integration_test.py
+++ b/testing/integration/vector_search_integration_test.py
@@ -429,17 +429,19 @@ class VectorSearchIntegrationTest(VSSTestCase):
         handler.setFormatter(formatter)
         valkey_logger.addHandler(handler)
 
-        valkey_server_stdout_dir = os.environ["TEST_UNDECLARED_OUTPUTS_DIR"]
+        valkey_server_stdout_dir = utils.get_worker_stdoutdir()
         valkey_server_path = os.environ["VALKEY_SERVER_PATH"]
         valkey_cli_path = os.environ["VALKEY_CLI_PATH"]
         valkey_search_path = os.environ["VALKEY_SEARCH_PATH"]
 
-        cls.valkey_ports = [6379, 6380, 6381]
+        cls.valkey_ports = utils.get_worker_cluster_ports(
+            3, default_ports=[6379, 6380, 6381]
+        )
         cls.valkey_cluster_under_test = utils.start_valkey_cluster(
             valkey_server_path,
             valkey_cli_path,
             cls.valkey_ports,
-            os.environ["TEST_TMPDIR"],
+            utils.get_worker_tmpdir(),
             valkey_server_stdout_dir,
             {
                 "loglevel": "debug",
@@ -465,6 +467,8 @@ class VectorSearchIntegrationTest(VSSTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if hasattr(cls, "valkey_cluster_under_test") and cls.valkey_cluster_under_test:
+            cls.valkey_cluster_under_test.terminate()
         super().tearDownClass()
 
     def tearDown(self):


### PR DESCRIPTION
### Summary

This PR enables parallel test execution across both integration test suites:
1. **Pytest Integration Test Suite** (`integration/`)
2. **Legacy Abseil Integration Test Suite** (`testing/integration/`)

By default, `--parallel` / `-j` now automatically detects and utilizes all available CPU cores (`auto`), **reducing the overall integration test runtime from ~12 minutes down to ~95 seconds** (e.g. on 48 cores):
- **Legacy Abseil suite**: reduced from **~113s to 21.6s**
- **Pytest integration suite**: reduced from **~10+ minutes to ~75s**
- **Full test suite total**: reduced from **~12 minutes to ~95 seconds**

---

### Key Changes

#### 1. Parallel Execution Orchestration
- **Top-Level `build.sh`**: Added `--parallel[=N]` / `-j[=N]` CLI options (defaulting to `auto`). Forwards the parallelism configuration to both test runners.
- **Legacy Abseil Suite (`testing/integration/run.sh`)**: Added `pytest-xdist>=3.5.0` integration with `--dist=load`. Automatically detects and provisions `pytest-xdist` in the test venv.
- **Pytest Suite (`integration/run.sh`)**: Runs pytest with `-n <workers> --dist=loadscope` by default.

#### 2. Collision-Free Port & Directory Partitioning
- **Band Partitioning (`integration/conftest.py`)**: Introduced `SafePortTracker` using non-overlapping port bands across workers:
  - Base client ports: `[10000, 19999]` (stride of 100 ports per worker, up to 100 workers)
  - Cluster bus ports: `[20000, 29999]` (`+10000` offset)
  - Coordinator gRPC / TLS: `[30294, 40294]` (`+20294` / `+20295` offset)
  - User-scoped lock directories (`/tmp/valkey_port_locks_<uid>`) to prevent permission conflicts in shared environments.
- **Legacy Port Tracker (`testing/integration/utils.py`)**: Partitioned cluster ports per worker (`7000 + (worker_idx % 100) * 50`) and isolated worker directories for `TEST_TMPDIR` and `TEST_UNDECLARED_OUTPUTS_DIR`.

#### 3. Robust Server Lifecycle & Leak Prevention
- **Pytest Teardown Support**: Added `teardown_method` to `ValkeySearchTestCaseCommon` in `integration/valkey_search_test_case.py` (since framework base classes do not inherit from `unittest.TestCase`, Pytest ignores `tearDown()`).
- **Guaranteed Cleanup on Setup Failure**: Wrapped `setup_test` fixtures in `try ... yield ... finally:` in both `ValkeySearchTestCaseBase` and `ValkeySearchClusterTestCase`, ensuring nodes started prior to any setup timeout or error are always cleanly shut down.
- **Best-Effort Cleanup with Error Aggregation**: In `ReplicationGroup.cleanup` and `teardown_method`, every server is given an opportunity to exit before any recorded teardown errors are re-raised, preventing both process leaks and silent failure masking.
- **Safety-Net Signal Traps**: Added `EXIT INT TERM` traps in both test runners invoking `pkill -9 valkey-server` upon script completion, error, or manual cancellation (`Ctrl+C`).

#### 4. Stability & Timing Under High CPU Contention
- In `integration/test_postfilter.py`, converted immediate assertions on `ft._debug PAUSEPOINT test` to `waiters.wait_for_true` to prevent thread scheduling races under 48-worker loads.

---

### Verification

- **Legacy Abseil Tests**: 47/47 passed concurrently across 48 workers in **21.63s** (down from ~113s sequentially).
- **Pytest Tests**: 393/393 passed across 48 workers in **~75s**.
- **Process Cleanup**: Verified with `ps -ef | grep valkey-server` on both host and inside the devcontainer: **zero** leaked or zombie processes.
- **Formatting**: Checked and passed via `.devcontainer/run_in_docker.sh ./ci/clang-format-changes.sh`.
