### PR TITLE
Scoring: scoring-disabled dev only config

### DIFF
--- a/integration/test_scoring.py
+++ b/integration/test_scoring.py
@@ -12,7 +12,10 @@ import struct
 
 import pytest
 from valkey import ResponseError
-from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkey_search_test_case import (
+    ValkeySearchTestCaseBase,
+    ValkeySearchTestCaseDebugMode,
+)
 from valkeytestframework.conftest import resource_port_tracker
 from utils import IndexingTestHelper
 from valkeytestframework.util import waiters
@@ -574,3 +577,29 @@ class TestScoring(ValkeySearchTestCaseBase):
         wait_indexed(client, IDX_MAIN, 8)
         _, restored = search(client, IDX_MAIN, "hello")
         assert restored == pytest.approx(before, abs=SCORE_ABS_TOL)
+
+
+# The kill switch is a dev config, so it needs debug-mode to be settable.
+class TestScoringDisabled(ValkeySearchTestCaseDebugMode):
+
+    def test_scoring_disabled_zeroes_scores(self):
+        client = self.server.get_new_client()
+        load(client, IDX_MAIN, PARTIAL_TEXT_DOCS)
+
+        # Pure text is scored in-iterator; text+tag takes the extra step.
+        queries = ["hello", "hello @cat:{a}"]
+
+        # Baseline: scores are non-zero, so the zeroes below are the switch
+        # working rather than an empty result.
+        for query in queries:
+            _, scores = search(client, IDX_MAIN, query)
+            assert scores and all(v > 0.0 for v in scores.values()), \
+                f"expected non-zero scores for {query!r}, got {scores}"
+
+        client.execute_command("CONFIG", "SET", "search.scoring-disabled", "yes")
+
+        # Same queries still match the same docs; every score is now 0.
+        for query in queries:
+            keys, scores = search(client, IDX_MAIN, query)
+            assert keys and scores == pytest.approx({k: 0.0 for k in keys}), \
+                f"expected all-zero scores for {query!r}, got {scores}"

--- a/integration/test_scoring.py
+++ b/integration/test_scoring.py
@@ -17,7 +17,7 @@ from valkey_search_test_case import (
     ValkeySearchTestCaseDebugMode,
 )
 from valkeytestframework.conftest import resource_port_tracker
-from utils import IndexingTestHelper
+from utils import IndexingTestHelper, run_in_thread
 from valkeytestframework.util import waiters
 
 SCORE_ABS_TOL = 1e-5
@@ -603,3 +603,41 @@ class TestScoringDisabled(ValkeySearchTestCaseDebugMode):
             keys, scores = search(client, IDX_MAIN, query)
             assert keys and scores == pytest.approx({k: 0.0 for k in keys}), \
                 f"expected all-zero scores for {query!r}, got {scores}"
+
+    def test_scoring_disabled_zeroes_recomputed_scores(self):
+        client = self.server.get_new_client()
+        load(client, IDX_MAIN, PARTIAL_TEXT_DOCS)
+        stat = lambda field: int(client.info("SEARCH")["search_" + field])
+        pausepoint = lambda verb: client.execute_command(
+            "FT._DEBUG PAUSEPOINT", verb, "block_mutation_queue")
+
+        def score_across_mutation(body):
+            """Parks doc:1's index update so its db sequence number runs ahead
+            of the index's: the query blocks on the contention check, then
+            resumes into the content fetch, which rescores doc:1 through
+            SingleDocumentScorer. Returns (scores, docs rescored there)."""
+            revals, blocked = stat("predicate_revalidation"), stat(
+                "text_query_blocked_count")
+            pausepoint("SET")
+            hset = run_in_thread(lambda: self.server.get_new_client().hset(
+                "doc:1", "body", body))[0]
+            waiters.wait_for_true(lambda: int(pausepoint("TEST")) > 0)
+            searcher, res, _ = run_in_thread(
+                lambda: search(self.server.get_new_client(), IDX_MAIN, "hello"))
+            waiters.wait_for_true(
+                lambda: stat("text_query_blocked_count") > blocked)
+            pausepoint("RESET")
+            for thread in (hset, searcher):
+                thread.join()
+            return res[0][1], stat("predicate_revalidation") - revals
+
+        # Baseline: the recompute runs and yields a non-zero score.
+        scores, rescored = score_across_mutation("hello hello world")
+        assert rescored >= 1 and scores["doc:1"] > 0.0, scores
+
+        client.execute_command("CONFIG", "SET", "search.scoring-disabled", "yes")
+
+        # Same window, switch on: still revalidated and kept, now scored 0.
+        scores, rescored = score_across_mutation("hello hello")
+        assert rescored >= 1, "recompute path never ran"
+        assert scores == pytest.approx({k: 0.0 for k in scores}), scores

--- a/integration/test_scoring.py
+++ b/integration/test_scoring.py
@@ -640,4 +640,5 @@ class TestScoringDisabled(ValkeySearchTestCaseDebugMode):
         # Same window, switch on: still revalidated and kept, now scored 0.
         scores, rescored = score_across_mutation("hello hello")
         assert rescored >= 1, "recompute path never ran"
+        assert "doc:1" in scores, scores
         assert scores == pytest.approx({k: 0.0 for k in scores}), scores

--- a/src/query/search.cc
+++ b/src/query/search.cc
@@ -931,7 +931,7 @@ void ScoreTextQuery(const IndexSchema &index_schema,
                     const indexes::scoring::Scorer *scorer,
                     std::vector<indexes::BorrowedNeighbor> &candidates) {
   CHECK(scorer != nullptr);
-  if (candidates.empty()) return;
+  if (candidates.empty() || options::IsScoringDisabled()) return;
 
   const uint32_t total_docs = index_schema.GetIndexKeyInfoSize();
   // Candidates came from this index, so total_docs should be > 0; degrade to
@@ -1046,6 +1046,10 @@ SingleDocumentScorer::SingleDocumentScorer(
   CHECK(root_predicate != nullptr);
   CHECK(scorer != nullptr);
 
+  // Kill switch: leave total_docs at 0 so Score() returns nullopt (callers
+  // score 0) and none of the resolve work below runs.
+  if (options::IsScoringDisabled()) return;
+
   // Runs on the main thread during content fetch, outside the background
   // search's reader lock, so acquire our own to read index_key_info_ /
   // text-index metadata safely against background mutations.
@@ -1138,8 +1142,10 @@ absl::StatusOr<std::vector<indexes::BorrowedNeighbor>> DoSearchNonVector(
 
   // In-iterator scoring runs only for pure text queries over a non-empty text
   // index; match-all is excluded because its universal-set scan carries no
-  // TextIterator. Everything else is scored by the extra step below.
-  const bool score_in_drain = !has_non_text_predicate && text_index_schema &&
+  // TextIterator. Everything else is scored by the extra step below, which the
+  // kill switch short-circuits inside ScoreTextQuery.
+  const bool score_in_drain = !options::IsScoringDisabled() &&
+                              !has_non_text_predicate && text_index_schema &&
                               text_index_schema->GetTrackedKeyCount() > 0 &&
                               !parameters.filter_parse_results.is_match_all;
 

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -234,6 +234,14 @@ static auto default_scorer = [] {
       .Build();
 }();
 
+/// Kill switch for relevance scoring. When set, both scoring paths are skipped
+/// (in-iterator for pure-text queries and the extra step for combined,
+/// match-all, hybrid, and recompute) and every result keeps a 0 score.
+constexpr absl::string_view kScoringDisabled{"scoring-disabled"};
+static auto scoring_disabled = config::BooleanBuilder(kScoringDisabled, false)
+                                   .Dev()  // can only be set in debug mode
+                                   .Build();
+
 /// Prefer partial results by default of not
 /// If set to true, search will use SOMESHARDS if user does not explicitly
 /// provide an option in the command
@@ -620,6 +628,8 @@ absl::Status Reset() {
 config::Enum &GetDefaultScorer() {
   return dynamic_cast<config::Enum &>(*default_scorer);
 }
+
+bool IsScoringDisabled() { return scoring_disabled->GetValue(); }
 
 const vmsdk::config::Boolean &GetPreferPartialResults() {
   return static_cast<vmsdk::config::Boolean &>(prefer_partial_results);

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -65,6 +65,9 @@ config::Enum &GetLogLevel();
 /// Return the scorer FT.SEARCH uses when the query omits SCORER
 config::Enum &GetDefaultScorer();
 
+/// Return true when the scoring kill switch is engaged
+bool IsScoringDisabled();
+
 /// Return the configuration entry for HNSW allow_replace_deleted flag
 const config::Boolean &GetHNSWAllowReplaceDeleted();
 


### PR DESCRIPTION
Creating scoring-disabled dev-only config. This is helpful for perf testing and keeping old behavior for developers.