### PR TITLE
Skip reviewer triage board workflow in forks

### DIFF
--- a/.github/workflows/reviewer-issue-dashboard.yml
+++ b/.github/workflows/reviewer-issue-dashboard.yml
@@ -43,9 +43,10 @@ jobs:
     # gate still rejects and cleans up any such comment on the next scheduled
     # sweep, so this is a cost guard, not the only line of defense.
     if: >-
-      ${{ github.event_name != 'issue_comment' ||
+      !github.event.repository.fork &&
+      (${{ github.event_name != 'issue_comment' ||
           (github.event.issue.number == 1346 &&
-           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }}
+           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }})
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/reviewer-issue-dashboard.yml
+++ b/.github/workflows/reviewer-issue-dashboard.yml
@@ -43,8 +43,11 @@ jobs:
     # gate still rejects and cleans up any such comment on the next scheduled
     # sweep, so this is a cost guard, not the only line of defense.
     if: >-
-      !github.event.repository.fork &&
-      (${{ github.event_name != 'issue_comment' ||
+      if: >-
+        ${{ ! github.event.repository.fork &&
+            (github.event_name != 'issue_comment' ||
+             (github.event.issue.number == 1346 &&
+              contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) }}
           (github.event.issue.number == 1346 &&
            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The Reviewer Triage Board workflow owns a hardcoded issue (#1346) that only exists in the `valkey-io/valkey-search` repo.
- In forks, `issues.get` on that issue returns a 404, so the workflow crashes on every scheduled run and every push to main (e.g. `Gathered 0 open PRs ... RequestError [HttpError]: Not Found` on issue 1346).
- Guard the job with `!github.event.repository.fork` so the workflow only executes on the original repository; forks are skipped entirely.

## Verification
- The workflow's `if` now requires the repo to be a non-fork before evaluating the existing triggers.