### PR TITLE
Skip orphan multi/exec keys in SaveIndexExtension instead of aborting

### DIFF
--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -341,6 +341,57 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         self.server.restart(remove_rdb=False)
         verify_data(self.client, index)
 
+    def test_multi_exec_orphan_key_saved_on_first_save(self):
+        """A first SAVE must survive a runtime orphaned multi/exec key."""
+        self.client.execute_command("CONFIG SET search.info-developer-visible yes")
+        self.client.execute_command("CONFIG SET search.writer-threads 2")
+        non_vector_index.create(self.client, True)
+
+        key = non_vector_index.keyname(0)
+        initial_data = non_vector_index.make_data(0)
+        updated_data = non_vector_index.make_data(0)
+        updated_data["n"] = "1"
+
+        self.client.execute_command("FT._DEBUG PAUSEPOINT SET block_mutation_queue")
+        writer_client = self.server.get_new_client()
+        writer_error = []
+
+        def write_initial_data():
+            try:
+                non_vector_index.write_data(writer_client, 0, initial_data)
+            except BaseException as exc:
+                writer_error.append(exc)
+
+        writer_thread = threading.Thread(target=write_initial_data)
+        writer_thread.start()
+
+        waiters.wait_for_true(
+            lambda: self.get_pausepoint("block_mutation_queue") > 0
+        )
+
+        # The regular write has already been tracked, but its worker is paused.
+        # The MULTI/EXEC write appends the key to the multi queue and merges
+        # into the existing mutation record.
+        self.client.execute_command("MULTI")
+        non_vector_index.write_data(self.client, 0, updated_data)
+        self.client.execute_command("EXEC")
+
+        self.client.execute_command("FT._DEBUG PAUSEPOINT RESET block_mutation_queue")
+        writer_thread.join()
+        assert writer_error == []
+        assert self.client.ping()
+
+        # The regular worker consumes the merged mutation and erases the map
+        # entry, while the multi/exec queue still contains this key. This is
+        # the state that caused the first production BGSAVE to abort.
+        self.client.execute_command("SAVE")
+        assert self.client.ping()
+        self.client.execute_command("CONFIG SET search.info-developer-visible yes")
+        info = self.client.info("search")
+        assert info["search_rdb_save_multi_exec_orphans_skipped"] == 1
+        assert info["search_rdb_save_multi_exec_entries"] == 0
+        assert self.client.exists(key)
+
     def test_saverestore_backfill(self):
         #
         # Delay the backfill and ensure that with new format we will trigger the backfill....

--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -194,6 +194,7 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
     def append_startup_args(self, args):
         args["search.rdb_write_v2"] = "yes"
         args["search.rdb_read_v2"] = "yes"
+        args["search.writer-threads"] = "20"
         return args
     
     def mutation_queue_size(self):
@@ -251,7 +252,6 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
     def test_multi_exec_queue(self):
         self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
-        self.client.execute_command("config set search.writer-threads 20")
         index.create(self.client, True)
         records = make_data()
         #
@@ -284,7 +284,6 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
 
     def test_multi_exec_orphan_key_skipped_still_searchable(self):
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
-        self.client.execute_command("config set search.writer-threads 20")
         index.create(self.client, True)
         records = make_data()
 
@@ -406,7 +405,6 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         #
         # test that overwrites of keys that are marked as backfilling properly get converted to non-backfills
         #
-        self.client.execute_command("config set search.writer-threads 20")
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
         load_data(self.client)

--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -305,6 +305,8 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         self.server.restart(remove_rdb=False)
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         assert self.client.info("search")["search_rdb_load_multi_exec_entries"] == len(records)
+        # Let reload mutations drain so the queued keys are orphaned.
+        waiters.wait_for_true(lambda: self.mutation_queue_size() == 0)
 
         # The orphan must be skipped and the rewritten RDB must remain readable.
         self.client.execute_command("save")

--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -281,6 +281,66 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         ]
         assert reads == [len(records)]
 
+    def test_multi_exec_orphan_key_skipped_still_searchable(self):
+        # Verifies the orphan-skip path end to end:
+        #   1. reach deque/map divergence (multi/exec queue keys with no
+        #      matching mutation-map entry),
+        #   2. a save over that divergence runs correctly (no crash, keys
+        #      skipped),
+        #   3. reads still return every record.
+        #
+        # Note the divergence is NOT produced by MULTI/EXEC itself — right after
+        # EXEC the deque and map hold the same keys. It is produced by a
+        # save+reload: on load the multi/exec deque is repopulated from the RDB
+        # while the mutation map is rebuilt and then drained, so the reloaded
+        # deque keys end up with no map entry.
+        self.client.execute_command("CONFIG SET search.info-developer-visible yes")
+        self.client.execute_command("config set search.writer-threads 20")
+        index.create(self.client, True)
+        records = make_data()
+
+        # --- Persist a multi/exec queue into the RDB ------------------------
+        # Block the writers so the multi/exec entries stay queued through the
+        # save (both deque and map hold the keys here — still consistent) and
+        # thus land in the RDB multi/exec section.
+        self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
+        self.client.execute_command("MULTI")
+        for i in range(len(records)):
+            index.write_data(self.client, i, records[i])
+        self.client.execute_command("EXEC")
+        self.client.execute_command("save")
+        assert self.client.info("search")["search_rdb_save_multi_exec_entries"] == len(records)
+        self.client.execute_command("ft._debug pausepoint reset block_mutation_queue")
+        while self.get_pausepoint("block_mutation_queue") > 0:
+            time.sleep(0.1)
+
+        # --- 1. Divergence: reload -----------------------------------------
+        # On reload the multi/exec deque is repopulated from the saved list, but
+        # the mutation map is rebuilt and drained during load, so the reloaded
+        # deque keys have no matching map entry.
+        os.environ["SKIPLOGCLEAN"] = "1"
+        self.server.restart(remove_rdb=False)
+        self.client.execute_command("CONFIG SET search.info-developer-visible yes")
+        assert self.client.info("search")["search_rdb_load_multi_exec_entries"] == len(records)
+
+        # --- 2. Save runs correctly -----------------------------------------
+        # This save serializes the reloaded multi/exec queue against the drained
+        # map, so every reloaded queue key is an orphan. Pre-fix this aborted the
+        # forked RDB writer; now the orphans are skipped and the save succeeds.
+        self.client.execute_command("save")
+        assert self.client.ping()  # server survived the save
+        i = self.client.info("search")
+        assert i["search_rdb_save_multi_exec_orphans_skipped"] == len(records)
+        assert i["search_rdb_save_multi_exec_entries"] == 0
+
+        # --- 3. Reads still return every record -----------------------------
+        # In the running server (membership came from the key list, not the
+        # skipped queue entries)...
+        verify_data(self.client, index)
+        # ...and after reloading the orphan-skipped RDB (it is self-consistent).
+        self.server.restart(remove_rdb=False)
+        verify_data(self.client, index)
+
     def test_saverestore_backfill(self):
         #
         # Delay the backfill and ensure that with new format we will trigger the backfill....

--- a/integration/test_saverestore.py
+++ b/integration/test_saverestore.py
@@ -13,6 +13,7 @@ from indexes import *
 import pytest
 import logging
 from util import waiters
+from utils import run_in_thread
 import threading
 from ft_info_parser import FTInfoParser
 from typing import Any, List
@@ -282,27 +283,12 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         assert reads == [len(records)]
 
     def test_multi_exec_orphan_key_skipped_still_searchable(self):
-        # Verifies the orphan-skip path end to end:
-        #   1. reach deque/map divergence (multi/exec queue keys with no
-        #      matching mutation-map entry),
-        #   2. a save over that divergence runs correctly (no crash, keys
-        #      skipped),
-        #   3. reads still return every record.
-        #
-        # Note the divergence is NOT produced by MULTI/EXEC itself — right after
-        # EXEC the deque and map hold the same keys. It is produced by a
-        # save+reload: on load the multi/exec deque is repopulated from the RDB
-        # while the mutation map is rebuilt and then drained, so the reloaded
-        # deque keys end up with no map entry.
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         self.client.execute_command("config set search.writer-threads 20")
         index.create(self.client, True)
         records = make_data()
 
-        # --- Persist a multi/exec queue into the RDB ------------------------
-        # Block the writers so the multi/exec entries stay queued through the
-        # save (both deque and map hold the keys here — still consistent) and
-        # thus land in the RDB multi/exec section.
+        # Persist a consistent queue so reload can create the orphan.
         self.client.execute_command("ft._debug PAUSEPOINT SET block_mutation_queue")
         self.client.execute_command("MULTI")
         for i in range(len(records)):
@@ -314,35 +300,25 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         while self.get_pausepoint("block_mutation_queue") > 0:
             time.sleep(0.1)
 
-        # --- 1. Divergence: reload -----------------------------------------
-        # On reload the multi/exec deque is repopulated from the saved list, but
-        # the mutation map is rebuilt and drained during load, so the reloaded
-        # deque keys have no matching map entry.
+        # Reload drains the mutation map but restores the queued keys.
         os.environ["SKIPLOGCLEAN"] = "1"
         self.server.restart(remove_rdb=False)
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         assert self.client.info("search")["search_rdb_load_multi_exec_entries"] == len(records)
 
-        # --- 2. Save runs correctly -----------------------------------------
-        # This save serializes the reloaded multi/exec queue against the drained
-        # map, so every reloaded queue key is an orphan. Pre-fix this aborted the
-        # forked RDB writer; now the orphans are skipped and the save succeeds.
+        # The orphan must be skipped and the rewritten RDB must remain readable.
         self.client.execute_command("save")
-        assert self.client.ping()  # server survived the save
+        assert self.client.ping()
         i = self.client.info("search")
         assert i["search_rdb_save_multi_exec_orphans_skipped"] == len(records)
         assert i["search_rdb_save_multi_exec_entries"] == 0
 
-        # --- 3. Reads still return every record -----------------------------
-        # In the running server (membership came from the key list, not the
-        # skipped queue entries)...
+        # The serialized key list keeps the records searchable.
         verify_data(self.client, index)
-        # ...and after reloading the orphan-skipped RDB (it is self-consistent).
         self.server.restart(remove_rdb=False)
         verify_data(self.client, index)
 
     def test_multi_exec_orphan_key_saved_on_first_save(self):
-        """A first SAVE must survive a runtime orphaned multi/exec key."""
         self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         self.client.execute_command("CONFIG SET search.writer-threads 2")
         non_vector_index.create(self.client, True)
@@ -352,41 +328,30 @@ class TestMutationQueue(ValkeySearchTestCaseDebugMode):
         updated_data = non_vector_index.make_data(0)
         updated_data["n"] = "1"
 
+        # Keep the queued key below the two-worker drain threshold.
         self.client.execute_command("FT._DEBUG PAUSEPOINT SET block_mutation_queue")
         writer_client = self.server.get_new_client()
-        writer_error = []
-
-        def write_initial_data():
-            try:
-                non_vector_index.write_data(writer_client, 0, initial_data)
-            except BaseException as exc:
-                writer_error.append(exc)
-
-        writer_thread = threading.Thread(target=write_initial_data)
-        writer_thread.start()
+        writer_thread, _, writer_error = run_in_thread(
+            lambda: non_vector_index.write_data(writer_client, 0, initial_data)
+        )
 
         waiters.wait_for_true(
             lambda: self.get_pausepoint("block_mutation_queue") > 0
         )
 
-        # The regular write has already been tracked, but its worker is paused.
-        # The MULTI/EXEC write appends the key to the multi queue and merges
-        # into the existing mutation record.
+        # MULTI/EXEC merges into the tracked record and leaves K queued.
         self.client.execute_command("MULTI")
         non_vector_index.write_data(self.client, 0, updated_data)
         self.client.execute_command("EXEC")
 
+        # The worker now erases K from the map while the queue retains it.
         self.client.execute_command("FT._DEBUG PAUSEPOINT RESET block_mutation_queue")
         writer_thread.join()
-        assert writer_error == []
-        assert self.client.ping()
+        assert writer_error[0] is None
 
-        # The regular worker consumes the merged mutation and erases the map
-        # entry, while the multi/exec queue still contains this key. This is
-        # the state that caused the first production BGSAVE to abort.
+        # The first SAVE must skip the orphan instead of aborting.
         self.client.execute_command("SAVE")
         assert self.client.ping()
-        self.client.execute_command("CONFIG SET search.info-developer-visible yes")
         info = self.client.info("search")
         assert info["search_rdb_save_multi_exec_orphans_skipped"] == 1
         assert info["search_rdb_save_multi_exec_entries"] == 0

--- a/src/index_schema.cc
+++ b/src/index_schema.cc
@@ -127,6 +127,7 @@ DEV_INTEGER_COUNTER(rdb_stats, rdb_save_sections);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_load_sections);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_load_sections_skipped);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_save_multi_exec_entries);
+DEV_INTEGER_COUNTER(rdb_stats, rdb_save_multi_exec_orphans_skipped);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_load_multi_exec_entries);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_save_mutation_entries);
 DEV_INTEGER_COUNTER(rdb_stats, rdb_load_mutation_entries);
@@ -1601,15 +1602,33 @@ absl::Status IndexSchema::SaveIndexExtension(RDBChunkOutputStream out) const {
   }
   CHECK(count == 0);
   //
-  // Write out the multi/exec queued keys
+  // Write out the multi/exec queued keys.
   //
-  VMSDK_RETURN_IF_ERROR(
-      out.SaveObject<size_t>(multi_mutations_keys_.Get().size()));
-  rdb_save_multi_exec_entries.Increment(multi_mutations_keys_.Get().size());
-  VMSDK_LOG(DEBUG, nullptr) << "Writing Multi/Exec Queue, records = "
-                            << multi_mutations_keys_.Get().size();
+  // A key in multi_mutations_keys_ may no longer have an entry in
+  // tracked_mutated_records_ by the time we serialize: the queue and the map
+  // are updated on different threads, so an RDB write can observe a key whose
+  // mutation was already consumed. Serialize only keys that still have a map
+  // entry and write that count; a skipped key is re-derived from the key list /
+  // backfill on load. This mirrors ConsumeTrackedMutatedAttribute, which also
+  // treats a key missing from the map as a no-op.
+  std::vector<Key> live_multi_keys;
+  live_multi_keys.reserve(multi_mutations_keys_.Get().size());
   for (const auto &key : multi_mutations_keys_.Get()) {
-    CHECK(tracked_mutated_records_.find(key) != tracked_mutated_records_.end());
+    if (ABSL_PREDICT_FALSE(tracked_mutated_records_.find(key) ==
+                           tracked_mutated_records_.end())) {
+      rdb_save_multi_exec_orphans_skipped.Increment();
+      VMSDK_LOG(WARNING, nullptr)
+          << "Skipping orphan multi/exec key not present in mutation map: "
+          << vmsdk::config::RedactIfNeeded(key->Str());
+      continue;
+    }
+    live_multi_keys.push_back(key);
+  }
+  VMSDK_RETURN_IF_ERROR(out.SaveObject<size_t>(live_multi_keys.size()));
+  rdb_save_multi_exec_entries.Increment(live_multi_keys.size());
+  VMSDK_LOG(DEBUG, nullptr)
+      << "Writing Multi/Exec Queue, records = " << live_multi_keys.size();
+  for (const auto &key : live_multi_keys) {
     VMSDK_RETURN_IF_ERROR(out.SaveString(key->Str()));
   }
   return absl::OkStatus();

--- a/src/index_schema.h
+++ b/src/index_schema.h
@@ -616,6 +616,8 @@ class IndexSchema : public KeyspaceEventSubscription,
   FRIEND_TEST(IndexSchemaFriendTest, InvalidDataDropsKey);
   FRIEND_TEST(IndexSchemaFriendTest,
               InTrackedMutationRecordsAfterConsumeNoCrash);
+  // Orphan multi/exec key is skipped on save (test-only access).
+  FRIEND_TEST(IndexSchemaFriendTest, OrphanMultiKeySkippedOnSave);
   FRIEND_TEST(ValkeySearchTest, Info);
   FRIEND_TEST(OnSwapDBCallbackTest, OnSwapDBCallback);
 };

--- a/testing/index_schema_test.cc
+++ b/testing/index_schema_test.cc
@@ -3278,4 +3278,37 @@ TEST(IndexSchemaMinVersionTest, LowPrecisionDominatesOtherContributors) {
 
 }  // namespace
 
+// A multi/exec key whose mutation record has already been consumed (in the
+// deque, absent from the map) is skipped by SaveIndexExtension, not fatal.
+TEST_F(IndexSchemaFriendTest, OrphanMultiKeySkippedOnSave)
+ABSL_NO_THREAD_SAFETY_ANALYSIS {
+  auto k = StringInternStore::Intern("prefix1_orphan");
+  index_schema->SetDbMutationSequenceNumber(k, 1);
+  index_schema->EnqueueMultiMutation(k);  // deque=[K]
+  {
+    auto a = CreateMutatedAttributes(attribute_identifier, "d1");
+    index_schema->TrackMutatedRecord(nullptr, k, std::move(a), 1, false, false,
+                                     /*from_multi=*/true, 0);  // map={K}
+  }
+  // Drive the real consumer (the writer-pool task body) to index and erase the
+  // mutation record, leaving K referenced only by the deque.
+  index_schema->ProcessSingleMutationAsync(&fake_ctx, /*from_backfill=*/false,
+                                           k,
+                                           /*delay_capturer=*/nullptr);
+
+  // Confirm the state under test: K is in the deque but not the map.
+  {
+    absl::MutexLock lock(&index_schema->mutated_records_mutex_);
+    ASSERT_EQ(index_schema->multi_mutations_keys_.Get().size(), 1u);
+    EXPECT_EQ(index_schema->multi_mutations_keys_.Get().front()->Str(),
+              "prefix1_orphan");
+    EXPECT_EQ(index_schema->tracked_mutated_records_.find(k),
+              index_schema->tracked_mutated_records_.end());
+  }
+
+  FakeSafeRDB rdb;
+  EXPECT_TRUE(
+      index_schema->SaveIndexExtension(RDBChunkOutputStream(&rdb)).ok());
+}
+
 }  // namespace valkey_search


### PR DESCRIPTION
## Problem

`IndexSchema::SaveIndexExtension` assumes every key in `multi_mutations_keys_` also exists in `tracked_mutated_records_`. That assumption is not guaranteed at an RDB save boundary: the main thread updates the queue while writer threads consume the mutation map.

This patch addresses a production ElastiCache crash where a forked RDB writer aborted during replication full sync. The primary process stayed up, but repeated child aborts caused full-sync failures. The initial failure can occur at the first save boundary; a save/reload/save cycle is not required.

```mermaid
sequenceDiagram
    participant M as Main thread
    participant Q as Multi exec queue
    participant MAP as Mutation map
    participant W as Writer thread
    participant S as RDB save

    M->>MAP: Normal write K
    M->>W: Schedule K
    Note over W: Writer is paused
    M->>Q: MULTI EXEC write K
    M->>MAP: Merge K
    Note over Q: Queue length is below threshold
    W->>MAP: Consume K
    Note over Q,MAP: Queue has K and map has no K
    S->>Q: Walk queued K
    S->>MAP: Check K
    S-->>S: RDB writer aborts
```

## Fix

Skip queued keys that no longer have a mutation-map entry, and write the retained-key count so the RDB stream remains self-consistent. A skipped key's index membership is re-derived from the serialized key list or backfill on load; the load path needs no change.

## Tests

- `IndexSchemaFriendTest.OrphanMultiKeySkippedOnSave` verifies that `SaveIndexExtension` succeeds when the queue contains a map-less key.
- `TestMutationQueue.test_multi_exec_orphan_key_saved_on_first_save` reproduces the production runtime sequence without a reload and verifies that the first `SAVE` succeeds.
- `TestMutationQueue.test_multi_exec_orphan_key_skipped_still_searchable` covers the save/reload/save path and verifies that the data remains searchable after another restart.
- Focused integration run: 2 passed, 503 deselected.
- Full Debug integration run: the C++ harness passed all 47 tests, and the orphan-save integration tests passed.

## Note

Draining the multi/exec queue in the pre-fork callback could reduce the chance of forming this inconsistency at snapshot time. The save-time guard is still required for an RDB that already contains the inconsistency.
