### PR TITLE
Fix ThreadPool: surface pthread_create() failures instead of silently…

### DIFF
--- a/src/valkey_search.cc
+++ b/src/valkey_search.cc
@@ -1178,15 +1178,15 @@ absl::Status ValkeySearch::Startup(ValkeyModuleCtx *ctx) {
   reader_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
       "read-worker-", options::GetReaderThreadCount().GetValue(),
       options::GetThreadPoolWaitTimeSamples().GetValue());
-  reader_thread_pool_->StartWorkers();
+  VMSDK_RETURN_IF_ERROR(reader_thread_pool_->StartWorkers());
   writer_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
       "write-worker-", options::GetWriterThreadCount().GetValue(),
       options::GetThreadPoolWaitTimeSamples().GetValue());
-  writer_thread_pool_->StartWorkers();
+  VMSDK_RETURN_IF_ERROR(writer_thread_pool_->StartWorkers());
   utility_thread_pool_ = std::make_unique<vmsdk::ThreadPool>(
       "util-worker-", options::GetUtilityThreadCount().GetValue(),
       options::GetThreadPoolWaitTimeSamples().GetValue());
-  utility_thread_pool_->StartWorkers();
+  VMSDK_RETURN_IF_ERROR(utility_thread_pool_->StartWorkers());
 
   VMSDK_LOG(NOTICE, ctx) << "use_coordinator: "
                          << options::GetUseCoordinator().GetValue()

--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -45,7 +45,12 @@ void UpdateThreadPoolCount(vmsdk::ThreadPool *pool, long long new_value) {
   if (!pool) {
     return;
   }
-  pool->Resize(new_value);
+  auto status = pool->Resize(new_value);
+  if (!status.ok()) {
+    VMSDK_LOG(WARNING, nullptr)
+        << "Failed to resize thread pool to " << new_value
+        << " threads: " << status.message();
+  }
 }
 
 absl::Status ValidateLogLevel(const int value) {

--- a/testing/common.cc
+++ b/testing/common.cc
@@ -18,6 +18,7 @@
 #include <variant>
 #include <vector>
 
+#include "absl/log/check.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "absl/synchronization/blocking_counter.h"
@@ -58,17 +59,17 @@ void TestableValkeySearch::InitThreadPools(std::optional<size_t> readers,
   if (readers) {
     reader_thread_pool_ =
         std::make_unique<vmsdk::ThreadPool>("reader-pool", *readers);
-    reader_thread_pool_->StartWorkers();
+    CHECK_OK(reader_thread_pool_->StartWorkers());
   }
   if (writers) {
     writer_thread_pool_ =
         std::make_unique<vmsdk::ThreadPool>("writer-pool", *writers);
-    writer_thread_pool_->StartWorkers();
+    CHECK_OK(writer_thread_pool_->StartWorkers());
   }
   if (utility) {
     utility_thread_pool_ =
         std::make_unique<vmsdk::ThreadPool>("utility-pool", *utility);
-    utility_thread_pool_->StartWorkers();
+    CHECK_OK(utility_thread_pool_->StartWorkers());
   }
 }
 

--- a/testing/index_schema_test.cc
+++ b/testing/index_schema_test.cc
@@ -119,7 +119,7 @@ class IndexSchemaSubscriptionTest
 TEST_P(IndexSchemaSubscriptionTest, OnKeyspaceNotificationTest) {
   const IndexSchemaSubscriptionTestCase &test_case = GetParam();
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   // Get initial metrics values to compare after operations
   auto &metrics = Metrics::GetStats();
@@ -629,7 +629,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, DropIndexPrematurely) {
   // is dropped prematurely while there are pending mutations in the worker
   // thread pool
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   VMSDK_EXPECT_OK(mutations_thread_pool.SuspendWorkers());
   std::vector<absl::string_view> key_prefixes = {"prefix:"};
   std::string index_schema_name_str("index_schema_name");
@@ -700,7 +700,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, DropIndexPrematurely) {
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, EmptyKeyPrefixesTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -714,7 +714,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, EmptyKeyPrefixesTest) {
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, DuplicateKeyPrefixesTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   std::vector<absl::string_view> key_prefixes = {"pre", "pre"};
   std::string index_schema_name_str("index_schema_name");
@@ -730,7 +730,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, DuplicateKeyPrefixesTest) {
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, PrefixIsPrefixedByAnotherTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {"pre", "prefix"};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -745,7 +745,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, PrefixIsPrefixedByAnotherTest) {
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, IndexSchemaInDifferentDBTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -770,7 +770,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, IndexSchemaInDifferentDBTest) {
 TEST_F(IndexSchemaSubscriptionSimpleTest,
        DBHasMatchingKeyWithWrongModuleTypeTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -798,7 +798,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest,
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, KeyspaceNotificationWithNullptrTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -819,7 +819,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, KeyspaceNotificationWithNullptrTest) {
 TEST_F(IndexSchemaSubscriptionSimpleTest,
        ReplaceKeyTypeHashToJsonTriggersDeletion) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {"prefix:"};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -864,7 +864,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest,
 TEST_F(IndexSchemaSubscriptionSimpleTest,
        ReplaceKeyTypeJsonToHashTriggersDeletion) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {"prefix:"};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -907,7 +907,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest,
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, GetKeyPrefixesTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {
       "prefix:", "prefix1:", "prefix2:"};
   std::string index_schema_name_str("index_schema_name");
@@ -923,7 +923,7 @@ TEST_F(IndexSchemaSubscriptionSimpleTest, GetKeyPrefixesTest) {
 
 TEST_F(IndexSchemaSubscriptionSimpleTest, GetEventTypesTest) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes = {"unused"};
   std::string index_schema_name_str("index_schema_name");
   auto index_schema =
@@ -957,7 +957,7 @@ class IndexSchemaBackfillTest
 TEST_P(IndexSchemaBackfillTest, PerformBackfillTest) {
   const auto &test_case = GetParam();
   MockThreadPool thread_pool("writer-thread-pool-", 5);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   std::vector<absl::string_view> key_prefixes;
   std::ranges::transform(test_case.key_prefixes,
                          std::back_inserter(key_prefixes),
@@ -1071,7 +1071,7 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_NoOngoingBackfillTest) {
   std::vector<absl::string_view> key_prefixes = {"unused"};
   std::string index_schema_name_str("index_schema_name");
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   ValkeyModuleCtx parent_ctx;
   ValkeyModuleCtx scan_ctx;
   EXPECT_CALL(*kMockValkeyModule, GetDetachedThreadSafeContext(&parent_ctx))
@@ -1099,7 +1099,7 @@ TEST_F(IndexSchemaBackfillTest, PerformBackfill_SwapDB) {
   std::vector<absl::string_view> key_prefixes = {"unused"};
   std::string index_schema_name_str("index_schema_name");
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   int starting_db = 0;
   int db_to_swap = 1;
   ValkeyModuleCtx parent_ctx;
@@ -1730,7 +1730,7 @@ ABSL_NO_THREAD_SAFETY_ANALYSIS {
 
 TEST_F(IndexSchemaRDBTest, LoadEndedDeletesOrphanedKeys) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
   auto mock_index = std::make_shared<MockIndex>();
   absl::flat_hash_map<std::string, uint64_t> keys_in_index = {
       {"key1", 1}, {"key2", 2}, {"key3", 3}};
@@ -1792,7 +1792,7 @@ TEST_F(IndexSchemaRDBTest, LoadEndedDeletesOrphanedKeys) {
 class IndexSchemaFriendTest : public ValkeySearchTest {
   void SetUp() override {
     ValkeySearchTest::SetUp();
-    mutations_thread_pool.StartWorkers();
+    VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
     index_schema =
         MockIndexSchema::Create(&fake_ctx, index_schema_name_str, key_prefixes,
                                 std::make_unique<HashAttributeDataType>(),
@@ -2381,7 +2381,7 @@ TEST_F(IndexSchemaRDBTest, DrainMutationQueueOnSaveEnabled) {
   VMSDK_EXPECT_OK(drain_config.SetValue(true));
 
   vmsdk::ThreadPool mutations_thread_pool("test-mutations-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   std::vector<absl::string_view> key_prefixes = {"test:"};
   std::string index_schema_name_str("drain_test_index");
@@ -3015,7 +3015,7 @@ class IndexSchemaScoreFieldTest : public ValkeySearchTest {};
 
 TEST_F(IndexSchemaScoreFieldTest, IngestsDocumentScoreFromScoreField) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   std::vector<absl::string_view> key_prefixes = {"product:"};
   // Create schema with SCORE_FIELD "priority" and default score 0.5
@@ -3086,7 +3086,7 @@ TEST_F(IndexSchemaScoreFieldTest, IngestsDocumentScoreFromScoreField) {
 
 TEST_F(IndexSchemaScoreFieldTest, FallsBackToDefaultScoreWhenFieldMissing) {
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   std::vector<absl::string_view> key_prefixes = {"product:"};
   auto index_schema =

--- a/testing/vector_registry_test.cc
+++ b/testing/vector_registry_test.cc
@@ -400,7 +400,7 @@ TEST_F(VectorRegistryTest,
   SetHashRegistrationSupported(registry, false);
 
   vmsdk::ThreadPool mutations_thread_pool("writer-thread-pool-", 1);
-  mutations_thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(mutations_thread_pool.StartWorkers());
 
   auto dimensions = 100;
   auto hnsw_index = indexes::VectorHNSW<float>::Create(

--- a/vmsdk/src/thread_pool.cc
+++ b/vmsdk/src/thread_pool.cc
@@ -8,8 +8,10 @@
 #include "vmsdk/src/thread_pool.h"
 
 #include <algorithm>
+#include <cerrno>
 #include <chrono>
 #include <cstddef>
+#include <cstring>
 #include <memory>
 #include <numeric>
 #include <ranges>
@@ -20,6 +22,7 @@
 #include "absl/functional/any_invocable.h"
 #include "absl/log/check.h"
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
 #include "absl/strings/str_join.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/time/clock.h"
@@ -63,10 +66,10 @@ ThreadPool::ThreadPool(const std::string &name_prefix, size_t num_threads,
       sample_queue_size_(sample_queue_size),
       wait_time_samples_(sample_queue_size, 0.0) {}
 
-void ThreadPool::StartWorkers() {
+absl::Status ThreadPool::StartWorkers() {
   CHECK(!started_);
   started_ = true;
-  IncrThreadCountBy(initial_thread_count_);
+  return IncrThreadCountBy(initial_thread_count_);
 }
 
 absl::StatusOr<double> ThreadPool::GetAvgCPUPercentage() {
@@ -294,11 +297,22 @@ size_t ThreadPool::QueueSize() const {
       [](size_t sum, const auto &tasks) { return sum + tasks.size(); });
 }
 
-void ThreadPool::IncrThreadCountBy(size_t count) {
+absl::Status ThreadPool::IncrThreadCountBy(size_t count) {
   for (size_t i = 0; i < count; ++i) {
     std::shared_ptr<Thread> thread_ptr = std::make_shared<Thread>();
     ThreadRunContext *context = new ThreadRunContext{this, thread_ptr};
-    pthread_create(&thread_ptr->thread_id, nullptr, RunWorkerThread, context);
+    int rc = CreateThread(&thread_ptr->thread_id, RunWorkerThread, context);
+    if (rc != 0) {
+      delete context;
+      if (rc == EAGAIN) {
+        return absl::ResourceExhaustedError(absl::StrCat(
+            "Failed to create worker thread ", i + 1, " of ", count,
+            " for pool \"", name_prefix_, "\": ", std::strerror(rc)));
+      }
+      return absl::InternalError(absl::StrCat(
+          "Failed to create worker thread ", i + 1, " of ", count,
+          " for pool \"", name_prefix_, "\": ", std::strerror(rc)));
+    }
     size_t thread_num = threads_.Size();
     thread_ptr->name = name_prefix_ + std::to_string(thread_num);
 #ifndef __APPLE__
@@ -306,6 +320,7 @@ void ThreadPool::IncrThreadCountBy(size_t count) {
 #endif
     threads_.Add(thread_ptr);
   }
+  return absl::OkStatus();
 }
 
 void ThreadPool::DecrThreadCountBy(size_t count, bool sync) {
@@ -346,16 +361,17 @@ size_t ThreadPool::Size() const {
   });
 }
 
-void ThreadPool::Resize(size_t count, bool wait_for_resize) {
+absl::Status ThreadPool::Resize(size_t count, bool wait_for_resize) {
   size_t current_size = Size();
   if (count == current_size) {
-    return;
+    return absl::OkStatus();
   } else if (count > current_size) {
     // We need to add more threads
-    IncrThreadCountBy(count - current_size);
+    return IncrThreadCountBy(count - current_size);
   } else {
     // Shutdown "current_size - count" threads
     DecrThreadCountBy(current_size - count, wait_for_resize);
+    return absl::OkStatus();
   }
 }
 

--- a/vmsdk/src/thread_pool.h
+++ b/vmsdk/src/thread_pool.h
@@ -48,7 +48,10 @@ class ThreadPool {
   ThreadPool& operator=(const ThreadPool&) = delete;
   enum class StopMode { kGraceful, kAbrupt };
 
-  void StartWorkers();
+  /// Start the pool's initial workers. Returns an error if any worker's
+  /// pthread_create() fails; workers started before the failure remain
+  /// usable.
+  absl::Status StartWorkers();
 
   /// Notify all active workers to terminate and join them. In addition, this
   /// method will internally call `JoinTerminatedWorkers`
@@ -78,8 +81,10 @@ class ThreadPool {
 
   /// Resize the pool size to `count` threads. If `wait_for_resize` is `true`,
   /// this method waits for resize operation to complete; otherwise, the resize
-  /// operation is done asynchronously.
-  void Resize(size_t count, bool wait_for_resize = false);
+  /// operation is done asynchronously. Returns an error if growing the pool
+  /// hits a pthread_create() failure; the pool is left at whatever size was
+  /// reached before the failure.
+  absl::Status Resize(size_t count, bool wait_for_resize = false);
 
   /// A struct representing a worker thread
   struct Thread {
@@ -128,6 +133,16 @@ class ThreadPool {
   /// Resize the sample queue and clear existing samples
   void ResizeSampleQueue(size_t new_size);
 
+ protected:
+  /// Creates one worker pthread. Overridable so tests can inject a
+  /// pthread_create() failure deterministically instead of relying on actual
+  /// resource exhaustion (e.g. ulimit -u, which isn't enforced in every
+  /// environment tests run in).
+  virtual int CreateThread(pthread_t* thread_id, void* (*start_routine)(void*),
+                           void* arg) {
+    return pthread_create(thread_id, nullptr, start_routine, arg);
+  }
+
  private:
   /// Track wait time sample and update running average
   void AddWaitTimeSample(std::chrono::steady_clock::time_point enqueue_time)
@@ -139,7 +154,7 @@ class ThreadPool {
   /// Returns nullopt if no tasks available
   std::optional<absl::AnyInvocable<void()>> TryGetNextTask()
       ABSL_EXCLUSIVE_LOCKS_REQUIRED(queue_mutex_);
-  void IncrThreadCountBy(size_t count);
+  absl::Status IncrThreadCountBy(size_t count);
   void DecrThreadCountBy(size_t count, bool sync);
 
   /// Wait while the pool is suspended, unless `thread` is already retired.

--- a/vmsdk/testing/thread_pool_test.cc
+++ b/vmsdk/testing/thread_pool_test.cc
@@ -948,9 +948,16 @@ TEST(ThreadPoolPthreadCreateFailureTest, StartWorkersSurfacesFailure) {
   // was never added to the pool.
   EXPECT_EQ(pool.Size(), 2);
 
+  // The failed worker never ran WorkerThread(), so it never registered as an
+  // active worker; suspension must not wait on it and must complete quickly.
+  StopWatch stop_watch;
+  VMSDK_EXPECT_OK(pool.SuspendWorkers());
+  EXPECT_LT(stop_watch.Duration(), absl::Seconds(1));
+  VMSDK_EXPECT_OK(pool.ResumeWorkers());
+
   // The pool must remain internally consistent: no dead entry should be left
   // behind to hang or crash JoinWorkers().
-  StopWatch stop_watch;
+  stop_watch.Reset();
   pool.JoinWorkers();
   EXPECT_LT(stop_watch.Duration(), absl::Seconds(1));
 }

--- a/vmsdk/testing/thread_pool_test.cc
+++ b/vmsdk/testing/thread_pool_test.cc
@@ -8,13 +8,16 @@
 #include "vmsdk/src/thread_pool.h"
 
 #include <atomic>
+#include <cerrno>
 #include <condition_variable>  // NOLINT(build/c++11)
 #include <cstddef>
 #include <memory>
-#include <mutex>   // NOLINT(build/c++11)
+#include <mutex>  // NOLINT(build/c++11)
+#include <string>
 #include <thread>  // NOLINT(build/c++11)
 #include <vector>
 
+#include "absl/status/status.h"
 #include "absl/synchronization/blocking_counter.h"
 #include "absl/synchronization/mutex.h"
 #include "absl/synchronization/notification.h"
@@ -50,7 +53,7 @@ TEST_F(ThreadPoolTest, StartAndJoin) {
   ThreadPool thread_pool("test-pool", 10);
   EXPECT_FALSE(thread_pool.SuspendWorkers().ok());
   StopWatch stop_watch;
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   thread_pool.JoinWorkers();
   EXPECT_LT(stop_watch.Duration(), absl::Seconds(1));
   EXPECT_FALSE(thread_pool.SuspendWorkers().ok());
@@ -61,7 +64,7 @@ TEST_P(ThreadPoolTest, StartSuspendAndJoin) {
   auto priority = GetParam();
   ThreadPool thread_pool("test-pool", 10);
   StopWatch stop_watch;
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   VMSDK_EXPECT_OK(thread_pool.SuspendWorkers());
   thread_pool.JoinWorkers();
   EXPECT_LT(stop_watch.Duration(), absl::Seconds(1));
@@ -73,7 +76,7 @@ TEST_P(ThreadPoolTest, SuspendAndResume) {
   auto priority = GetParam();
   ThreadPool thread_pool("test-pool", 3);
   StopWatch stop_watch;
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   absl::Notification notification;
   VMSDK_EXPECT_OK(thread_pool.SuspendWorkers());
   EXPECT_TRUE(thread_pool.Schedule([&notification]() { notification.Notify(); },
@@ -88,7 +91,7 @@ TEST_P(ThreadPoolTest, AbruptMarkForStop) {
   const size_t thread_count = 3;
   ThreadPool thread_pool("test-pool", thread_count);
 
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   absl::BlockingCounter blocking_refcount(thread_count);
 
   for (size_t i = 0; i < thread_count * 10; ++i) {
@@ -120,7 +123,7 @@ TEST_P(ThreadPoolTest, GracefulMarkForStop) {
   const size_t thread_count = 3;
   ThreadPool thread_pool("test-pool", thread_count);
 
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   absl::BlockingCounter blocking_refcount(thread_count * 3);
 
   for (size_t i = 0; i < thread_count * 3; ++i) {
@@ -147,7 +150,7 @@ TEST_P(ThreadPoolTest, SuspendAndResumeLongTask) {
   auto test = [](bool with_delay, ThreadPool::Priority priority) {
     ThreadPool thread_pool("test-pool", 3);
     absl::BlockingCounter blocking_refcount(3);
-    thread_pool.StartWorkers();
+    VMSDK_EXPECT_OK(thread_pool.StartWorkers());
     StopWatch stop_watch;
     EXPECT_TRUE(thread_pool.Schedule(
         [&blocking_refcount]() {
@@ -182,7 +185,7 @@ TEST_P(ThreadPoolTest, SuspendAndResumeLongTask) {
 TEST_P(ThreadPoolTest, EnqueueAndExecuteTasks) {
   auto priority = GetParam();
   ThreadPool thread_pool("test-pool", 10);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   auto blocking_refcount =
       std::make_shared<absl::BlockingCounter>(thread_pool.Size());
   for (size_t i = 0; i < thread_pool.Size(); ++i) {
@@ -201,7 +204,7 @@ TEST_P(ThreadPoolTest, EnqueueAndExecuteTasks) {
 TEST_P(ThreadPoolTest, VerifyFifo) {
   auto priority = GetParam();
   ThreadPool thread_pool("test-pool", 1);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   std::vector<MockTask> mock_tasks(1000);
   absl::BlockingCounter blocking_refcount(mock_tasks.size());
   size_t task_id = 0;
@@ -222,7 +225,7 @@ TEST_P(ThreadPoolTest, VerifyFifo) {
 TEST_P(ThreadPoolTest, ConcurrentWorkers) {
   auto priority = GetParam();
   ThreadPool thread_pool("test-pool", 5);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   std::vector<MockTask> mock_tasks(thread_pool.Size());
   std::mutex mutex;
   std::condition_variable condition;
@@ -278,23 +281,23 @@ TEST_F(ThreadPoolTest, priority) {
   }
   EXPECT_GE(thread_pool.QueueSize(), tasks * 2);
   // Now that tasks have been loaded to the thread pool, start the workers
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   // Wait for all tasks to finish
   pending_tasks.Wait();
 }
 TEST_F(ThreadPoolTest, DynamicSizing) {
   const size_t thread_count = 10;
   ThreadPool thread_pool("test-pool", thread_count);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   EXPECT_EQ(thread_pool.Size(), thread_count);
 
-  thread_pool.Resize(5, true);
+  VMSDK_EXPECT_OK(thread_pool.Resize(5, true));
   EXPECT_EQ(thread_pool.Size(), 5);
 
   thread_pool.JoinTerminatedWorkers();
 
   EXPECT_EQ(thread_pool.Size(), 5);
-  thread_pool.Resize(15, true);
+  VMSDK_EXPECT_OK(thread_pool.Resize(15, true));
 
   EXPECT_EQ(thread_pool.Size(), 15);
   thread_pool.JoinWorkers();
@@ -304,14 +307,14 @@ TEST_F(ThreadPoolTest, DynamicSizing) {
 
 TEST_F(ThreadPoolTest, ResizeWhileSuspended) {
   ThreadPool thread_pool("test-pool", 4);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   VMSDK_EXPECT_OK(thread_pool.SuspendWorkers());
 
   // CONFIG SET can resize a pool at any time, including while a fork holds it
   // suspended.
-  thread_pool.Resize(16);
-  thread_pool.Resize(2);
-  thread_pool.Resize(8);
+  VMSDK_EXPECT_OK(thread_pool.Resize(16));
+  VMSDK_EXPECT_OK(thread_pool.Resize(2));
+  VMSDK_EXPECT_OK(thread_pool.Resize(8));
 
   // Workers created during the suspension must wait before taking a task.
   absl::Notification notification;
@@ -329,15 +332,15 @@ TEST_F(ThreadPoolTest, ResizeWhileSuspended) {
 
 TEST_F(ThreadPoolTest, RepeatedResizeWhileSuspended) {
   ThreadPool thread_pool("test-pool", 1);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   VMSDK_EXPECT_OK(thread_pool.SuspendWorkers());
 
   // Workers retired while suspended must exit and get cleaned up on their
   // own; otherwise each resize up adds replacements and threads accumulate.
   constexpr size_t kCycles = 20;
   for (size_t i = 0; i < kCycles; ++i) {
-    thread_pool.Resize(8);
-    thread_pool.Resize(1);
+    VMSDK_EXPECT_OK(thread_pool.Resize(8));
+    VMSDK_EXPECT_OK(thread_pool.Resize(1));
     thread_pool.JoinTerminatedWorkers();
   }
 
@@ -360,13 +363,13 @@ TEST_F(ThreadPoolTest, RepeatedResizeWhileSuspended) {
 
 TEST_F(ThreadPoolTest, SynchronousResizeWhileSuspended) {
   ThreadPool thread_pool("test-pool", 4);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   VMSDK_EXPECT_OK(thread_pool.SuspendWorkers());
 
   // A synchronous resize waits for the retired workers to finish, which they
   // can only do if the suspension lets them exit.
   StopWatch stop_watch;
-  thread_pool.Resize(1, /*wait_for_resize=*/true);
+  VMSDK_EXPECT_OK(thread_pool.Resize(1, /*wait_for_resize=*/true));
   EXPECT_LT(stop_watch.Duration(), absl::Seconds(5));
   EXPECT_EQ(thread_pool.Size(), 1u);
 
@@ -376,7 +379,7 @@ TEST_F(ThreadPoolTest, SynchronousResizeWhileSuspended) {
 
 TEST_F(ThreadPoolTest, ResizeDownWithQueuedTasks) {
   ThreadPool thread_pool("test-pool", 1);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
 
   // Keep the only worker busy so tasks pile up behind it.
   absl::Notification started, release;
@@ -394,7 +397,7 @@ TEST_F(ThreadPoolTest, ResizeDownWithQueuedTasks) {
   started.WaitForNotification();
 
   // A retired worker must exit without draining the queue.
-  thread_pool.Resize(0);
+  VMSDK_EXPECT_OK(thread_pool.Resize(0));
   release.Notify();
   const absl::Time deadline = absl::Now() + absl::Seconds(5);
   while (thread_pool.threads_.Size() > 0 && absl::Now() < deadline) {
@@ -406,20 +409,20 @@ TEST_F(ThreadPoolTest, ResizeDownWithQueuedTasks) {
   EXPECT_EQ(thread_pool.QueueSize(), 5u);
 
   // The queued tasks run once the pool is resized back up.
-  thread_pool.Resize(1);
+  VMSDK_EXPECT_OK(thread_pool.Resize(1));
   thread_pool.JoinWorkers();
   EXPECT_EQ(executed.load(), 5);
 }
 
 TEST_F(ThreadPoolTest, ConcurrentResizeAndSuspendResume) {
   ThreadPool thread_pool("test-pool", 4);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   std::atomic_bool stop{false};
   // Stands in for the config-set path resizing the pool, plus the cron callback
   // cleaning up the workers it retired.
   std::thread resizer([&thread_pool, &stop]() {
     for (size_t i = 0; !stop; ++i) {
-      thread_pool.Resize(i % 2 == 0 ? 1 : 4);
+      VMSDK_EXPECT_OK(thread_pool.Resize(i % 2 == 0 ? 1 : 4));
       thread_pool.JoinTerminatedWorkers();
       absl::SleepFor(absl::Milliseconds(1));
     }
@@ -470,7 +473,7 @@ TEST_F(ThreadPoolTest, TestCPUUsage) {
   EXPECT_EQ(thread_pool.GetAvgCPUPercentage().value(), 0.0);
   // Initializing the threads with first simple tasks
   auto blocking_counter = ScheduleTasks(thread_pool, atomic_flag, modulo);
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   blocking_counter->Wait();
   absl::SleepFor(absl::Milliseconds(100));
   // Expect current CPU avg to be around 0
@@ -511,7 +514,7 @@ class ThreadPoolFairnessTest : public ::testing::Test {
  protected:
   ThreadPoolFairnessTest() : thread_pool_("fairness-test-pool", 4) {}
 
-  void SetUp() override { thread_pool_.StartWorkers(); }
+  void SetUp() override { VMSDK_EXPECT_OK(thread_pool_.StartWorkers()); }
 
   void TearDown() override { thread_pool_.JoinWorkers(); }
 
@@ -763,7 +766,7 @@ TEST_P(ThreadPoolFairnessDistributionTest, StatisticalDistribution) {
   EXPECT_EQ(thread_pool.QueueSize(), total_tasks);
 
   // 3. Start the worker and let it execute exactly half the tasks
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
 
   // 4. Wait for exactly half the tasks to complete (pool will auto-suspend)
   counter.Wait();
@@ -831,7 +834,7 @@ TEST_P(ThreadPoolFairnessDistributionTest, MaxPriorityPreservation) {
         ThreadPool::Priority::kMax));
   }
 
-  thread_pool.StartWorkers();
+  VMSDK_EXPECT_OK(thread_pool.StartWorkers());
   counter.Wait();
 
   // Validate only  kMax tasks should have executed
@@ -855,7 +858,7 @@ TEST_P(ThreadPoolFairnessDistributionTest, MaxPriorityPreservation) {
 TEST_F(ThreadPoolTest, QueueWaitTimeTracking) {
   // Test that our queue wait time tracking works correctly
   ThreadPool pool("test", 2);
-  pool.StartWorkers();
+  VMSDK_EXPECT_OK(pool.StartWorkers());
 
   // Initially, no queue wait time should be recorded
   auto initial_wait_time = pool.GetRecentQueueWaitTime();
@@ -883,7 +886,7 @@ TEST_F(ThreadPoolTest, QueueWaitTimeTracking) {
 TEST_F(ThreadPoolTest, QueueWaitTimeWithDifferentPriorities) {
   // Test queue wait time tracking with different priority tasks
   ThreadPool pool("test", 1);  // Single thread to ensure queuing
-  pool.StartWorkers();
+  VMSDK_EXPECT_OK(pool.StartWorkers());
 
   // Schedule high priority tasks
   for (int i = 0; i < 3; ++i) {
@@ -906,6 +909,61 @@ TEST_F(ThreadPoolTest, QueueWaitTimeWithDifferentPriorities) {
   auto wait_time = pool.GetRecentQueueWaitTime();
   ASSERT_TRUE(wait_time.ok());
   EXPECT_GT(wait_time.value(), 0.0);
+
+  pool.JoinWorkers();
+}
+
+namespace {
+// A ThreadPool that fails pthread_create() on a chosen 0-indexed call,
+// instead of relying on actual resource exhaustion (e.g. ulimit -u, which
+// isn't enforced by every environment tests run in).
+class FailAtNthThreadCreationPool : public ThreadPool {
+ public:
+  FailAtNthThreadCreationPool(const std::string& name, size_t num_threads,
+                              size_t fail_at_index)
+      : ThreadPool(name, num_threads), fail_at_index_(fail_at_index) {}
+
+ protected:
+  int CreateThread(pthread_t* thread_id, void* (*start_routine)(void*),
+                   void* arg) override {
+    if (call_count_++ == fail_at_index_) {
+      return EAGAIN;
+    }
+    return ThreadPool::CreateThread(thread_id, start_routine, arg);
+  }
+
+ private:
+  size_t fail_at_index_;
+  size_t call_count_ = 0;
+};
+}  // namespace
+
+TEST(ThreadPoolPthreadCreateFailureTest, StartWorkersSurfacesFailure) {
+  // Fail creation of the 3rd worker (0-indexed: 2) out of 5.
+  FailAtNthThreadCreationPool pool("test-pool", 5, /*fail_at_index=*/2);
+  absl::Status status = pool.StartWorkers();
+
+  EXPECT_TRUE(absl::IsResourceExhausted(status)) << status;
+  // Only the workers created before the failure are counted; the failed one
+  // was never added to the pool.
+  EXPECT_EQ(pool.Size(), 2);
+
+  // The pool must remain internally consistent: no dead entry should be left
+  // behind to hang or crash JoinWorkers().
+  StopWatch stop_watch;
+  pool.JoinWorkers();
+  EXPECT_LT(stop_watch.Duration(), absl::Seconds(1));
+}
+
+TEST(ThreadPoolPthreadCreateFailureTest, ResizeSurfacesFailure) {
+  FailAtNthThreadCreationPool pool("test-pool", 2, /*fail_at_index=*/3);
+  VMSDK_EXPECT_OK(pool.StartWorkers());
+  EXPECT_EQ(pool.Size(), 2);
+
+  // Grow to 5: creation attempts for indices 2, 3, 4 -- index 3 fails.
+  absl::Status status = pool.Resize(5, /*wait_for_resize=*/true);
+  EXPECT_TRUE(absl::IsResourceExhausted(status)) << status;
+  EXPECT_EQ(pool.Size(), 3);
 
   pool.JoinWorkers();
 }


### PR DESCRIPTION
## Problem

`ThreadPool::IncrThreadCountBy()` ignores `pthread_create()`'s return
value. When thread creation fails (typically `EAGAIN` under
process/thread resource limits), the failed worker is still added to
`threads_` with a garbage `thread_id`, its `ThreadRunContext` leaks,
and `pthread_setname_np()` is called on the invalid id.

That dead entry never becomes joinable:
- `JoinWorkers()` stalls for 5s waiting on it, then aborts via
  `CHECK(false)`.
- A synchronous `Resize()` down (`wait_for_resize=true`) can hang
  indefinitely if it targets that entry (no timeout on that wait).

`AtForkPrepare()` suspends the writer/reader/utility pools
synchronously, so this is reachable from the fork path (BGSAVE,
AOF-rewrite, replica full sync).

## Fix

Detect the `pthread_create()` failure before naming or adding the
worker to `threads_`, clean up the leaked context, and surface the
failure as `absl::Status` (`ResourceExhausted` for `EAGAIN`) through
`IncrThreadCountBy`/`StartWorkers`/`Resize`, propagated to their real
callers (`ValkeySearch::Startup`, the thread-count config callback).

Added a virtual, overridable thread-creation seam so tests can inject
a `pthread_create` failure deterministically -- `ulimit -u`-based
resource exhaustion isn't enforced consistently across environments
(confirmed: it's a no-op under WSL2).

## Testing

- New regression tests in `thread_pool_test.cc`:
  `StartWorkersSurfacesFailure`, `ResizeSurfacesFailure`.
- `thread_pool_test`: 45/45 pass.
- `indexes_test` (includes `index_schema_test.cc`,
  `vector_registry_test.cc`): 380/380 pass (pre-existing skips/disabled
  test unrelated to this change).

Fixes #1344