### PR TITLE
Add configurable maximum TIMEOUT for search commands

### DIFF
--- a/docs/topics/search-configurables.md
+++ b/docs/topics/search-configurables.md
@@ -45,6 +45,7 @@ The search module uses the Valkey configuration mechanism. Thus each of the name
 | search.max-vector-ef-construction             | Number  |               | Controls the max EF construction parameter for HNSW algorithm                                                                     |
 | search.max-vector-ef-runtime                  | Number  |               | Controls the max EF runtime parameter for HNSW algorithm                                                                          |
 | search.default-timeout-ms                     | Number  |               | Controls the default timeout in milliseconds for FT.SEARCH                                                                        |
+| search.max-timeout-ms                         | Number  |               | Controls the maximum allowed TIMEOUT value, in milliseconds, for FT.SEARCH and FT.AGGREGATE                                       |
 | search.max-search-result-record-size          | Number  |               | Controls the max content size for a record in the search response                                                                 |
 | search.max-search-result-fields-count         | Number  |               | Controls the max number of fields in the content of the search response                                                           |
 | search.backfill-batch-size                    | Number  |               | Controls the batch size for backfilling indexes                                                                                   |

--- a/src/commands/ft_search_parser.cc
+++ b/src/commands/ft_search_parser.cc
@@ -34,6 +34,7 @@ namespace valkey_search {
 constexpr absl::string_view kMaxKnnConfig{"max-vector-knn"};
 constexpr int kDefaultKnnLimit{10000};
 constexpr int kMaxKnn{100000};
+constexpr absl::string_view kMaxTimeoutMsConfig{"max-timeout-ms"};
 
 /// Register the "--max-knn" flag. Controls the max KNN parameter for vector
 /// search.
@@ -45,9 +46,24 @@ static auto max_knn =
         .WithValidationCallback(CHECK_RANGE(1, kMaxKnn, kMaxKnnConfig))
         .Build();
 
+/// Register the "--max-timeout-ms" flag. Controls the maximum allowed TIMEOUT
+/// value, in milliseconds, for FT.SEARCH and FT.AGGREGATE.
+static auto max_timeout_ms =
+    vmsdk::config::NumberBuilder(kMaxTimeoutMsConfig,   // name
+                                 query::kMaxTimeoutMs,  // default timeout
+                                 1,                     // min timeout
+                                 query::kMaxTimeoutMs)  // max timeout
+        .WithValidationCallback(
+            CHECK_RANGE(1, query::kMaxTimeoutMs, kMaxTimeoutMsConfig))
+        .Build();
+
 namespace options {
 vmsdk::config::Number &GetMaxKnn() {
   return dynamic_cast<vmsdk::config::Number &>(*max_knn);
+}
+
+vmsdk::config::Number &GetMaxTimeoutMs() {
+  return dynamic_cast<vmsdk::config::Number &>(*max_timeout_ms);
 }
 
 }  // namespace options
@@ -75,12 +91,13 @@ absl::Status Verify(query::SearchParameters &parameters) {
            "exceed "
         << max_knn_value << ".";
   }
-  if (parameters.timeout_ms > query::kMaxTimeoutMs) {
+  const auto max_timeout_ms = options::GetMaxTimeoutMs().GetValue();
+  if (parameters.timeout_ms > static_cast<uint64_t>(max_timeout_ms)) {
     return absl::InvalidArgumentError(
         absl::StrCat(query::kTimeoutParam,
                      " must be a positive integer greater than 0 and "
                      "cannot exceed ",
-                     query::kMaxTimeoutMs, "."));
+                     max_timeout_ms, "."));
   }
   if (parameters.dialect < 2 || parameters.dialect > 4) {
     return absl::InvalidArgumentError(
@@ -302,12 +319,13 @@ absl::Status VerifyQueryString(query::SearchParameters &parameters) {
            "exceed "
         << max_knn_value << ".";
   }
-  if (parameters.timeout_ms > query::kMaxTimeoutMs) {
+  const auto max_timeout_ms = options::GetMaxTimeoutMs().GetValue();
+  if (parameters.timeout_ms > static_cast<uint64_t>(max_timeout_ms)) {
     return absl::InvalidArgumentError(
         absl::StrCat(query::kTimeoutParam,
                      " must be a positive integer greater than 0 and "
                      "cannot exceed ",
-                     query::kMaxTimeoutMs, "."));
+                     max_timeout_ms, "."));
   }
   if (parameters.dialect < 2 || parameters.dialect > 4) {
     return absl::InvalidArgumentError(

--- a/src/commands/ft_search_parser.h
+++ b/src/commands/ft_search_parser.h
@@ -17,6 +17,7 @@
 namespace valkey_search {
 namespace options {
 vmsdk::config::Number &GetMaxKnn();
+vmsdk::config::Number &GetMaxTimeoutMs();
 }  // namespace options
 
 absl::Status VerifyQueryString(query::SearchParameters &parameters);

--- a/testing/ft_search_parser_test.cc
+++ b/testing/ft_search_parser_test.cc
@@ -20,6 +20,7 @@
 #include "absl/strings/string_view.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "src/commands/ft_aggregate_parser.h"
 #include "src/index_schema.pb.h"
 #include "src/indexes/numeric.h"
 #include "src/indexes/tag.h"
@@ -378,6 +379,33 @@ TEST_P(FTSearchParserTest, Parse) {
       }
     }
   }
+}
+
+class MaxTimeoutConfigTest : public vmsdk::ValkeyTest {};
+
+TEST_F(MaxTimeoutConfigTest, AppliesToSearchAndAggregate) {
+  auto &max_timeout_ms = options::GetMaxTimeoutMs();
+  const auto saved_max_timeout_ms = max_timeout_ms.GetValue();
+
+  VMSDK_EXPECT_OK(max_timeout_ms.SetValue(100));
+
+  SearchCommand search_parameters(0);
+  search_parameters.timeout_ms = 100;
+  VMSDK_EXPECT_OK(VerifyQueryString(search_parameters));
+  search_parameters.timeout_ms = 101;
+  EXPECT_EQ(VerifyQueryString(search_parameters).message(),
+            "TIMEOUT must be a positive integer greater than 0 and cannot "
+            "exceed 100.");
+
+  aggregate::AggregateParameters aggregate_parameters(0);
+  aggregate_parameters.timeout_ms = 100;
+  VMSDK_EXPECT_OK(VerifyQueryString(aggregate_parameters));
+  aggregate_parameters.timeout_ms = 101;
+  EXPECT_EQ(VerifyQueryString(aggregate_parameters).message(),
+            "TIMEOUT must be a positive integer greater than 0 and cannot "
+            "exceed 100.");
+
+  VMSDK_EXPECT_OK(max_timeout_ms.SetValue(saved_max_timeout_ms));
 }
 
 INSTANTIATE_TEST_SUITE_P(


### PR DESCRIPTION
Adds `search.max-timeout-ms` to configure the maximum allowed `TIMEOUT` for `FT.SEARCH` and `FT.AGGREGATE`