### PR TITLE
Triage board: include only reviewers GitHub lists on the PR

### DIFF
--- a/.github/scripts/reviewer-dashboard.js
+++ b/.github/scripts/reviewer-dashboard.js
@@ -109,7 +109,13 @@ function shape(node, firstPassPool, maintainerPool) {
     if (!latest[login] || (r.submittedAt || '') >= (latest[login].submittedAt || '')) latest[login] = r;
   }
 
-  const universe = new Set([...requested, ...Object.keys(latest), autoFP, autoMT]
+  // Include only reviewers GitHub itself lists in the PR's Reviewers box:
+  // currently-requested reviewers (`requested`) plus anyone who has submitted a
+  // review (`latest`). The auto-assign comment (autoFP/autoMT) is NOT an
+  // inclusion source — it's a permanent record that survives reviewer swaps, so
+  // adding from it kept showing people who were later un-requested and never
+  // reviewed. It's still used below to *label* an included reviewer as 🤖 auto.
+  const universe = new Set([...requested, ...Object.keys(latest)]
     .filter(Boolean).filter(l => l !== author));
 
   const firstPass = [], maintainers = [], other = [];
@@ -122,7 +128,7 @@ function shape(node, firstPassPool, maintainerPool) {
     else other.push(entry);
   }
 
-  const hasAuto = !!(autoFP || autoMT);
+  const hasAuto = [...universe].some(l => l === autoFP || l === autoMT);
   const hasManual = [...universe].some(l => l !== autoFP && l !== autoMT);
   let via = '—';
   if (hasAuto && hasManual) via = 'Mixed';


### PR DESCRIPTION
## What this changes

The Reviewer Triage Board (#1346) was listing people on PRs where GitHub no longer shows them as reviewers.

For each PR, the board built its reviewer set as the union of **three** sources:
1. currently-requested reviewers,
2. anyone who had submitted a review, and
3. anyone named in the auto-assign bot's comment (`**First Pass Reviewer: @…**` / `**Maintainer Reviewer: @…**`).

Source 3 is the problem: that comment is a **permanent** record. When reviewers are later swapped (the assign workflow calls `removeRequestedReviewers`), GitHub drops the person from the PR's Reviewers box — but the comment stays, so the board kept counting them. Result: a reviewer's per-person queue showed PRs they'd been un-requested from and never reviewed (e.g. one maintainer saw ~2× the PRs that `review-requested:` returns).

## The fix

Drop the auto-assign comment as an **inclusion** source. The board now mirrors the PR's **Reviewers box** exactly — currently-requested reviewers plus anyone who has submitted a review. The comment is still parsed to **label** an included reviewer as auto (🤖) vs. manually requested (✋), so the How column is unchanged; swapped-out reviewers simply no longer appear.

One-line change to the reviewer `universe` set, plus a small tidy so the PR-level auto/manual summary reflects only included reviewers. No change to state, commands, rendering, or the size-trim tiers.
