### PR TITLE
vmsdk: keep std symbols local in versionscript.lds required due to recent change in allocation strategy

### DIFF
--- a/vmsdk/versionscript.lds
+++ b/vmsdk/versionscript.lds
@@ -34,4 +34,15 @@ local:
   _Znam*;
   _ZdlPv*;
   _ZdaPv*;
+  /*
+   * libstdc++ symbols instantiated in direct translation units (e.g. in debug
+   * builds without inlining) must remain local so they do not collide with
+   * libstdc++.so.6.
+   */
+  _ZNSt*;
+  _ZNKSt*;
+  _ZSt*;
+  _ZTISt*;
+  _ZTVSt*;
+  _ZTSSt*;
 };

--- a/vmsdk/versionscript.lds
+++ b/vmsdk/versionscript.lds
@@ -35,7 +35,7 @@ local:
   _ZdlPv*;
   _ZdaPv*;
   /*
-   * libstdc++ symbols instantiated in direct translation units (e.g. in debug
+   * libstdc++ symbols instantiated in direct translation units (in debug
    * builds without inlining) must remain local so they do not collide with
    * libstdc++.so.6.
    */


### PR DESCRIPTION
In debug builds without inlining, standard library member functions instantiated directly in translation units linked into libsearch.so (e.g., module_loader.cc.o) were being exported in .dynsym due to 'global: *;'. This triggered a check_module_allocators.sh failure due to symbols colliding with libstdc++.so.6. Marking std symbols local prevents these collisions.

This is required due to recent merging of the new allocation strategy.