### PR TITLE
Fix mangled job condition in Reviewer Triage Board workflow

### DIFF
--- a/.github/workflows/reviewer-issue-dashboard.yml
+++ b/.github/workflows/reviewer-issue-dashboard.yml
@@ -43,13 +43,10 @@ jobs:
     # gate still rejects and cleans up any such comment on the next scheduled
     # sweep, so this is a cost guard, not the only line of defense.
     if: >-
-      if: >-
-        ${{ ! github.event.repository.fork &&
-            (github.event_name != 'issue_comment' ||
-             (github.event.issue.number == 1346 &&
-              contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) }}
-          (github.event.issue.number == 1346 &&
-           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }})
+      ${{ ! github.event.repository.fork &&
+          (github.event_name != 'issue_comment' ||
+           (github.event.issue.number == 1346 &&
+            contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

The `if:` on the `build` job in `.github/workflows/reviewer-issue-dashboard.yml` carries a duplicated `if: >-` line plus two leftover fragment lines from an earlier edit:

```yaml
    if: >-
      if: >-
        ${{ ! github.event.repository.fork && ... }}
          (github.event.issue.number == 1346 &&
           contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)) }})
```

YAML parses that value as a string that begins with the literal text `if: >-`, not as an expression. Parentheses are unbalanced as well, 7 open against 8 close.

GitHub substitutes the embedded `${{ }}` in such a string and then evaluates the result for truthiness. The result is always a non-empty string, so the job runs unconditionally and neither guard in the condition has any effect.

Two consequences:

- **The fork guard never applied.** Every fork of this repo runs the board on the `*/15` cron and on each push to `main`. It fails there every time with `HttpError: Not Found`, since issue 1346 does not exist in the fork, and each failure emails the fork owner. In one fork's last 100 runs, 34 of the 41 failures were this workflow.
- **The cost guard never applied.** The issue-number and `author_association` check was inert, so a comment on any issue from any author started a run.

## Fix

Remove the duplicated line and the leftover fragment, leaving a single well-formed expression. This restores the condition the surrounding comment already describes. No other behavior changes.

## Verification

Parsed the file before and after with `yaml.safe_load` and inspected `jobs.build.if`:

| | before | after |
|---|---|---|
| value starts with `${{` | no | yes |
| parentheses open / close | 7 / 8 | balanced |

Upstream evaluation is unchanged: on `schedule`, `push` and `workflow_dispatch` the condition is true, and on `issue_comment` it is true only for issue 1346 with an `OWNER`, `MEMBER` or `COLLABORATOR` author.

One thing worth a reviewer's eye: this keeps the original author's `! github.event.repository.fork`. The sibling workflow `search-benchmark-pr.yml` guards forks with `github.repository == 'valkey-io/valkey-search'` instead, which is available in every event context. If you would rather the two workflows match, say so and I will switch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01556wbNGrGXnm5rW5HcZrLB