### PR TITLE
Enforce command arity at registration via SetCommandInfo

### DIFF
--- a/integration/test_command_arity.py
+++ b/integration/test_command_arity.py
@@ -1,0 +1,26 @@
+"""Command arity is enforced by the engine (via SetCommandInfo at
+registration), so a wrong-arity call is rejected before the handler runs."""
+
+import pytest
+import valkey
+from valkey_search_test_case import ValkeySearchTestCaseBase
+from valkeytestframework.conftest import resource_port_tracker
+
+
+class TestCommandArity(ValkeySearchTestCaseBase):
+    # (command, args) pairs the engine must reject: FT.DROPINDEX is arity 2,
+    # FT.INFO is -2 (at least 2), FT._LIST is 1.
+    @pytest.mark.parametrize(
+        "command",
+        [
+            ["FT.DROPINDEX"],  # too few
+            ["FT.DROPINDEX", "idx", "extra"],  # too many
+            ["FT.INFO"],  # too few
+            ["FT._LIST", "extra"],  # too many
+        ],
+    )
+    def test_wrong_arity_is_rejected(self, command):
+        with pytest.raises(
+            valkey.exceptions.ResponseError, match="wrong number of arguments"
+        ):
+            self.client.execute_command(*command)

--- a/src/commands/ft_dropindex.cc
+++ b/src/commands/ft_dropindex.cc
@@ -106,9 +106,6 @@ class DropConsistencyCheckFanoutOperation
 
 absl::Status FTDropIndexCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                             int argc) {
-  if (argc != 2) {
-    return absl::InvalidArgumentError(vmsdk::WrongArity(kDropIndexCommand));
-  }
   auto index_schema_name = vmsdk::ToStringView(argv[1]);
 
   VMSDK_ASSIGN_OR_RETURN(

--- a/src/commands/ft_info.cc
+++ b/src/commands/ft_info.cc
@@ -29,10 +29,6 @@ namespace valkey_search {
 
 absl::Status FTInfoCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                        int argc) {
-  if (argc < 2) {
-    ValkeyModule_ReplyWithError(ctx, vmsdk::WrongArity(kInfoCommand).c_str());
-    return absl::OkStatus();
-  }
   vmsdk::ArgsIterator itr{argv, argc};
   itr.Next();
 

--- a/src/commands/ft_list.cc
+++ b/src/commands/ft_list.cc
@@ -19,9 +19,6 @@ namespace valkey_search {
 
 absl::Status FTListCmd(ValkeyModuleCtx *ctx, ValkeyModuleString **argv,
                        int argc) {
-  if (argc > 1) {
-    return absl::InvalidArgumentError(vmsdk::WrongArity(kListCommand));
-  }
   absl::flat_hash_set<std::string> names =
       SchemaManager::Instance().GetIndexSchemasInDB(
           ValkeyModule_GetSelectedDb(ctx));

--- a/src/module_loader.cc
+++ b/src/module_loader.cc
@@ -55,6 +55,7 @@ vmsdk::module::Options options = {
                 .flags = {vmsdk::module::kWriteFlag, vmsdk::module::kFastFlag},
                 .cmd_func =
                     &vmsdk::CreateCommand<valkey_search::FTDropIndexCmd>,
+                .arity = 2,
             },
             {
                 .cmd_name = valkey_search::kInfoCommand,
@@ -63,6 +64,7 @@ vmsdk::module::Options options = {
                 .flags = {vmsdk::module::kReadOnlyFlag,
                           vmsdk::module::kFastFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTInfoCmd>,
+                .arity = -2,
             },
             {
                 .cmd_name = valkey_search::kListCommand,
@@ -71,6 +73,7 @@ vmsdk::module::Options options = {
                 .flags = {vmsdk::module::kReadOnlyFlag,
                           vmsdk::module::kAdminFlag},
                 .cmd_func = &vmsdk::CreateCommand<valkey_search::FTListCmd>,
+                .arity = 1,
             },
             {
                 .cmd_name = valkey_search::kSearchCommand,

--- a/testing/ft_dropindex_test.cc
+++ b/testing/ft_dropindex_test.cc
@@ -156,16 +156,6 @@ INSTANTIATE_TEST_SUITE_P(
                 },
         },
         {
-            .test_name = "incorrect_param_count",
-            .test_cases =
-                {
-                    {
-                        .argv = {"FT.DROPINDEX"},
-                        .return_code = absl::StatusCode::kInvalidArgument,
-                    },
-                },
-        },
-        {
             .test_name = "index_schema_does_not_exist",
             .test_cases =
                 {

--- a/testing/ft_info_test.cc
+++ b/testing/ft_info_test.cc
@@ -410,19 +410,6 @@ INSTANTIATE_TEST_SUITE_P(
                 },
         },
         {
-            .test_name = "incorrect_param_count",
-            .test_cases =
-                {
-                    {
-                        .argv = {"FT.Info"},
-                        .expect_return_failure = true,
-                        .expected_output =
-                            "-ERR wrong number of "
-                            "arguments for 'FT.INFO' command\r\n",
-                    },
-                },
-        },
-        {
             .test_name = "index_schema_does_not_exist",
             .test_cases =
                 {

--- a/vmsdk/src/module.cc
+++ b/vmsdk/src/module.cc
@@ -65,6 +65,16 @@ absl::Status RegisterCommands(ValkeyModuleCtx *ctx,
           absl::StrCat("Failed to set ACL categories `", permissions,
                        "` for the command: ", command.cmd_name.data()));
     }
+    if (command.arity != 0) {
+      ValkeyModuleCommandInfo info = {
+          .version = VALKEYMODULE_COMMAND_INFO_VERSION,
+          .arity = command.arity,
+      };
+      if (ValkeyModule_SetCommandInfo(cmd, &info) == VALKEYMODULE_ERR) {
+        return absl::InternalError(absl::StrCat(
+            "Failed to set command info for: ", command.cmd_name.data()));
+      }
+    }
   }
   return absl::OkStatus();
 }

--- a/vmsdk/src/module.h
+++ b/vmsdk/src/module.h
@@ -69,6 +69,9 @@ struct CommandOptions {
   int first_key{0};
   int last_key{0};
   int key_step{0};
+  // Fixed arity: positive N means exactly N args (including command name).
+  // Use -N for "at least N". 0 = no enforcement (default).
+  int arity{0};
 };
 
 struct Options {


### PR DESCRIPTION
Move the arity checks for FT.DROPINDEX, FT.INFO and FT._LIST out of the command handlers and into command registration, so the engine rejects wrong-arity calls before dispatch instead of each handler re-checking argc.

Add an optional `arity` field to vmsdk CommandOptions (positive N = exactly N args including the command name, -N = at least N, 0 = no enforcement) and have RegisterCommands publish it through ValkeyModule_SetCommandInfo. Set the arity for FT.DROPINDEX (2), FT.INFO (-2) and FT._LIST (1), and drop the now redundant in-handler argc checks and their unit cases.

Add an integration test asserting the engine rejects wrong-arity calls for these commands.