### PR TITLE
Install gcc14 static libstdc++ for benchmark builds due to #1360

### DIFF
--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -67,7 +67,7 @@ function ensure_gcc_amazon_linux() {
         LOG_INFO "✓ GCC ${current_version} already available at /usr/local/bin/gcc (>= ${GCC_MIN_VERSION})"
     else
         LOG_INFO "GCC >= ${GCC_MIN_VERSION} not found (current: ${current_version}) — installing GCC 14 from AL2023 repos..."
-        sudo dnf install -y gcc14 gcc14-c++
+        sudo dnf install -y gcc14 gcc14-c++ gcc14-libstdc++-static
 
         # Create symlinks in /usr/local/bin so builds pick up GCC 14 by default.
         sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/gcc
@@ -79,6 +79,14 @@ function ensure_gcc_amazon_linux() {
 
     /usr/local/bin/gcc --version
     /usr/local/bin/g++ --version
+
+    local libstdcpp_a
+    libstdcpp_a=$(/usr/local/bin/g++ -print-file-name=libstdc++.a)
+    if [[ "${libstdcpp_a}" == "libstdc++.a" || ! -f "${libstdcpp_a}" ]]; then
+        LOG_ERROR "static libstdc++ for /usr/local/bin/g++ not found; on AL2023 install gcc14-libstdc++-static"
+        exit 1
+    fi
+    LOG_INFO "✓ static libstdc++ found at ${libstdcpp_a}"
 }
 
 # Detect the distro and dispatch. Add cases here (e.g. an apt-based branch for

--- a/ci/install_deps.sh
+++ b/ci/install_deps.sh
@@ -67,7 +67,7 @@ function ensure_gcc_amazon_linux() {
         LOG_INFO "✓ GCC ${current_version} already available at /usr/local/bin/gcc (>= ${GCC_MIN_VERSION})"
     else
         LOG_INFO "GCC >= ${GCC_MIN_VERSION} not found (current: ${current_version}) — installing GCC 14 from AL2023 repos..."
-        sudo dnf install -y gcc14 gcc14-c++ gcc14-libstdc++-static
+        sudo dnf install -y gcc14 gcc14-c++
 
         # Create symlinks in /usr/local/bin so builds pick up GCC 14 by default.
         sudo ln -sf /usr/bin/gcc14-gcc /usr/local/bin/gcc
@@ -76,6 +76,8 @@ function ensure_gcc_amazon_linux() {
         sudo ln -sf /usr/bin/gcc14-g++ /usr/local/bin/c++
         LOG_INFO "✓ GCC 14 installed and symlinked into /usr/local/bin"
     fi
+
+    sudo dnf install -y gcc14-libstdc++-static
 
     /usr/local/bin/gcc --version
     /usr/local/bin/g++ --version


### PR DESCRIPTION
## Summary

Fix the benchmark runner dependency setup for builds that link `libsearch` with `-static-libstdc++`.

#1360 made static libstdc++ a build requirement for non-sanitized module builds. The benchmark workflow uses `/usr/local/bin/g++` -> GCC 14 on AL2023, but some runners had `gcc14` and `gcc14-c++` installed without `gcc14-libstdc++-static`, which caused the link step to fail with:

```
/usr/bin/ld: cannot find -lstdc++
```

  ## Changes

  - install `gcc14-libstdc++-static` in `ci/install_deps.sh`

  ## Why

  This makes benchmark hosts provision the static libstdc++ archive required by the current module link flags, instead of relying on manual host state.